### PR TITLE
Integration rollup: remote-build certification, gzip private sources, validation campaigns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
+ "toml",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
@@ -1994,6 +1995,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2416,6 +2426,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3120,6 +3171,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tower-http = { version = "0.5", features = ["cors", "trace"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+toml = "0.8"
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }

--- a/dashboard/src/lib/api/index.ts
+++ b/dashboard/src/lib/api/index.ts
@@ -65,6 +65,25 @@ export {
   resumeMission,
 } from "./missions";
 
+export {
+  type ValidationMode,
+  type GateStatus,
+  type ValidationCandidate,
+  type ValidationGateSpec,
+  type ValidationMatrix,
+  type ValidationGate,
+  type ValidationExecutionRef,
+  type ValidationReceiptInput,
+  type ValidationCampaign,
+  listValidationCampaigns,
+  getValidationCampaign,
+  createValidationCampaign,
+  getReadyValidationGates,
+  claimValidationGate,
+  recordValidationReceipt,
+  markValidationCampaignMerged,
+} from "./validation";
+
 // Workspaces
 export {
   type WorkspaceType,

--- a/dashboard/src/lib/api/validation.ts
+++ b/dashboard/src/lib/api/validation.ts
@@ -1,0 +1,144 @@
+import { apiGet, apiPost } from "./core";
+
+export type ValidationMode = "incremental" | "clean";
+export type GateStatus =
+  | "pending"
+  | "ready"
+  | "running"
+  | "passed"
+  | "failed"
+  | "blocked"
+  | "stale";
+
+export interface ValidationCandidate {
+  repo: string;
+  commit: string;
+  expected_head?: string;
+  source_bundle_digest?: string;
+}
+
+export interface ValidationGateSpec {
+  id: string;
+  description?: string;
+  command: string[];
+  cwd?: string;
+  dependencies?: string[];
+  required?: boolean;
+  mode?: ValidationMode;
+  reuse?: boolean;
+  toolchain?: string;
+  timeout_secs?: number;
+  artifacts?: string[];
+}
+
+export interface ValidationMatrix {
+  version: 1;
+  project: string;
+  profile?: string;
+  gates: ValidationGateSpec[];
+}
+
+export interface ValidationGate {
+  id: string;
+  spec: ValidationGateSpec;
+  status: GateStatus;
+  outcome?: "passed" | "failed" | "blocked";
+  freshness?: "exact_head" | "stale";
+  validation_key: string;
+  reused_receipt_id?: string;
+}
+
+export type ValidationExecutionRef =
+  | { kind: "mission_run"; run_id: string; mission_id: string }
+  | { kind: "workspace_job"; job_id: string; workspace_id: string }
+  | { kind: "remote_job"; job_id: string; node_id: string };
+
+export interface ValidationReceiptInput {
+  execution: ValidationExecutionRef;
+  exit_code?: number;
+  blocked_reason?: string;
+  observed_head?: string;
+  toolchain?: string;
+  environment_digest?: string;
+  cache?: {
+    mode?: string;
+    key?: string;
+    hit?: boolean;
+    clean_checkout?: boolean;
+  };
+  artifacts?: Array<{ path: string; sha256: string; size_bytes: number }>;
+  diagnostics?: string;
+  started_at?: string;
+  finished_at?: string;
+}
+
+export interface ValidationCampaign {
+  id: string;
+  project: string;
+  profile?: string;
+  workspace_id?: string;
+  candidate: ValidationCandidate;
+  candidate_id: string;
+  matrix_version: number;
+  status: "active" | "completed" | "failed" | "blocked" | "merged";
+  certifying: boolean;
+  gates: ValidationGate[];
+  receipts: unknown[];
+  created_at: string;
+  updated_at: string;
+}
+
+export function listValidationCampaigns(): Promise<ValidationCampaign[]> {
+  return apiGet("/api/validation-campaigns/", "Failed to list validation campaigns");
+}
+
+export function getValidationCampaign(id: string): Promise<ValidationCampaign> {
+  return apiGet(`/api/validation-campaigns/${id}`, "Failed to load validation campaign");
+}
+
+export function createValidationCampaign(input: {
+  candidate: ValidationCandidate;
+  matrix: ValidationMatrix;
+  workspace_id?: string;
+}): Promise<ValidationCampaign> {
+  return apiPost("/api/validation-campaigns/", input);
+}
+
+export function getReadyValidationGates(id: string): Promise<ValidationGate[]> {
+  return apiGet(
+    `/api/validation-campaigns/${id}/ready`,
+    "Failed to load ready validation gates",
+  );
+}
+
+export function claimValidationGate(
+  campaignId: string,
+  gateId: string,
+  execution: ValidationExecutionRef,
+): Promise<ValidationGate> {
+  return apiPost(
+    `/api/validation-campaigns/${campaignId}/gates/${gateId}/claim`,
+    { execution },
+    "Failed to claim validation gate",
+  );
+}
+
+export function recordValidationReceipt(
+  campaignId: string,
+  gateId: string,
+  receipt: ValidationReceiptInput,
+): Promise<ValidationCampaign> {
+  return apiPost(
+    `/api/validation-campaigns/${campaignId}/gates/${gateId}/receipts`,
+    receipt,
+    "Failed to record validation receipt",
+  );
+}
+
+export function markValidationCampaignMerged(id: string): Promise<ValidationCampaign> {
+  return apiPost(
+    `/api/validation-campaigns/${id}/merged`,
+    undefined,
+    "Campaign is not certifying",
+  );
+}

--- a/dashboard/src/lib/api/validation.ts
+++ b/dashboard/src/lib/api/validation.ts
@@ -58,6 +58,9 @@ export interface ValidationReceiptInput {
   exit_code?: number;
   blocked_reason?: string;
   observed_head?: string;
+  /** Required for exact-head classification of dirty-overlay candidates:
+   * must match the campaign candidate's source_bundle_digest. */
+  source_bundle_digest?: string;
   toolchain?: string;
   environment_digest?: string;
   cache?: {

--- a/docs/validation-campaigns.md
+++ b/docs/validation-campaigns.md
@@ -25,8 +25,16 @@ mode = "clean"
 timeout_secs = 7200
 ```
 
+Gate `dependencies` unlock only on an exact-head pass of every dependency. A
+required gate may not depend on an optional gate: the matrix is rejected at
+validation time, because an optional gate's failure would leave the required
+dependant pending forever without failing the campaign. When set,
+`candidate.expected_head` must equal `candidate.commit` — exact receipts
+certify the pinned candidate commit, never a different revision.
+
 Create a campaign with `POST /api/validation-campaigns/from-workspace`, claim
-ready gates with a typed mission/workspace/remote execution reference, then
+dispatchable gates (status `ready` or `stale`, as listed by the `/ready`
+endpoint) with a typed mission/workspace/remote execution reference, then
 submit their receipts. A receipt records actual toolchain, cache provenance,
 exit code, artifacts, diagnostics, observed head and, for dirty-overlay
 candidates, the source bundle digest. A passed receipt is classified
@@ -36,7 +44,8 @@ bundle-attesting receipt and vice versa), and the gate's pinned `toolchain`
 when one is configured; any other pass is `stale`. Passed stale receipts are
 retained as evidence but never unlock dependent gates and never certify. Stale
 gates remain claimable, so a later exact-head execution can replace the stale
-evidence.
+evidence. Once a campaign is marked merged it is terminal: late receipts never
+recompute its status and its gates can no longer be claimed.
 
 The durable outbox emits only `candidate_changed`, `blocker_changed`,
 `campaign_terminal`, and `merged`. When the Paloma/Hermes webhook is configured,

--- a/docs/validation-campaigns.md
+++ b/docs/validation-campaigns.md
@@ -1,0 +1,37 @@
+# Validation campaigns
+
+Validation campaigns pin one candidate and evaluate a project-owned DAG of
+gates. Development gates may reuse a persistent workspace cache; only required
+`clean` gates can produce a certifying campaign.
+
+Projects define `.sandboxed/validation.toml`:
+
+```toml
+version = 1
+project = "verity"
+profile = "lean-4.31"
+
+[[gates]]
+id = "compiler-targeted"
+command = ["lake", "build", "Compiler"]
+mode = "incremental"
+timeout_secs = 1800
+
+[[gates]]
+id = "ci-local"
+command = ["lake", "build"]
+dependencies = ["compiler-targeted"]
+mode = "clean"
+timeout_secs = 7200
+```
+
+Create a campaign with `POST /api/validation-campaigns/from-workspace`, claim
+ready gates with a typed mission/workspace/remote execution reference, then
+submit their receipts. A receipt records actual toolchain, cache provenance,
+exit code, artifacts, diagnostics and observed head. Passed stale receipts are
+retained as evidence but never unlock dependent gates.
+
+The durable outbox emits only `candidate_changed`, `blocker_changed`,
+`campaign_terminal`, and `merged`. When the Paloma/Hermes webhook is configured,
+delivery uses stable event IDs, exponential retries, HMAC signing and a dead
+letter threshold.

--- a/docs/validation-campaigns.md
+++ b/docs/validation-campaigns.md
@@ -28,8 +28,15 @@ timeout_secs = 7200
 Create a campaign with `POST /api/validation-campaigns/from-workspace`, claim
 ready gates with a typed mission/workspace/remote execution reference, then
 submit their receipts. A receipt records actual toolchain, cache provenance,
-exit code, artifacts, diagnostics and observed head. Passed stale receipts are
-retained as evidence but never unlock dependent gates.
+exit code, artifacts, diagnostics, observed head and, for dirty-overlay
+candidates, the source bundle digest. A passed receipt is classified
+`exact_head` only when it attests the candidate's expected head, the
+candidate's `source_bundle_digest` exactly (a bundle-less candidate rejects a
+bundle-attesting receipt and vice versa), and the gate's pinned `toolchain`
+when one is configured; any other pass is `stale`. Passed stale receipts are
+retained as evidence but never unlock dependent gates and never certify. Stale
+gates remain claimable, so a later exact-head execution can replace the stale
+evidence.
 
 The durable outbox emits only `candidate_changed`, `blocker_changed`,
 `campaign_terminal`, and `merged`. When the Paloma/Hermes webhook is configured,

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -41,8 +41,17 @@ if [ "$#" -eq 0 ]; then set -- lake build; fi
 request_file="$(mktemp)" || die "cannot create temporary request file" 75
 python3 - "$REMOTE_BUILD_MISSION_ID" "$REMOTE_BUILD_TOKEN" "$repo" "$commit" "$cwd_rel" "$@" > "$request_file" <<'PY'
 import base64, hashlib, json, os, pathlib, subprocess, sys
+from urllib.parse import urlsplit, urlunsplit
 mission_id, token, repo, commit, cwd_rel = sys.argv[1:6]
 command = sys.argv[6:]
+parsed_repo = urlsplit(repo)
+if parsed_repo.scheme in {"http", "https"}:
+    host = parsed_repo.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed_repo.port is not None:
+        host = f"{host}:{parsed_repo.port}"
+    repo = urlunsplit((parsed_repo.scheme, host, parsed_repo.path, "", ""))
 req = {
     "mission_id": mission_id,
     "token": token,

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -392,11 +392,6 @@ PY
 }
 
 if [ -z "$job_id" ]; then
-    # Pre-create the durable blocker while no remote request has been made.
-    # Cleanup removes it on known pre-acceptance outcomes; ambiguous/accepted
-    # failures retain it so a dead owner PID can never permit a duplicate job.
-    printf '%s\n' "armed" > "$submit_recovery_blocker" \
-        || die "cannot arm the remote-build recovery blocker before submission" 75
     # Full snapshots contain base64 and therefore inflate substantially in
     # JSON. Compress the wire copy so reverse proxies only buffer the compact
     # request; keep the plain request locally for fingerprinting and receipts.
@@ -407,6 +402,11 @@ with open(sys.argv[1], "rb") as source, open(sys.argv[2], "wb") as output:
     with gzip.GzipFile(fileobj=output, mode="wb", compresslevel=6, mtime=0) as destination:
         shutil.copyfileobj(source, destination)
 PY
+    # Arm immediately before curl. Cleanup removes this on known
+    # pre-acceptance outcomes; ambiguous/accepted failures retain it so a dead
+    # owner PID can never permit a duplicate job.
+    printf '%s\n' "armed" > "$submit_recovery_blocker" \
+        || die "cannot arm the remote-build recovery blocker before submission" 75
     echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -16,7 +16,7 @@
 #
 # Exit codes:
 #   remote build's exit code on success/failure of the build itself
-#   2   unsupported local deletion/symlink or oversized source overlay
+#   2   unsafe symlink or oversized source overlay
 #   75  remote build unavailable (EX_TEMPFAIL: placement failed / nodes down /
 #       not configured) — fall back to a local build
 set -u
@@ -70,13 +70,30 @@ def git_paths(*args):
     raw = subprocess.check_output(["git", "-C", str(repo_root), *args])
     return [item.decode("utf-8") for item in raw.split(b"\0") if item]
 
-deleted = git_paths("diff", "--name-only", "-z", "--diff-filter=DR", "HEAD")
-if deleted:
-    raise SystemExit(
-        "remote source bundles do not encode deletions or renames; commit/stash these paths first: "
-        + ", ".join(deleted[:8])
-    )
-tracked = git_paths("diff", "--name-only", "-z", "--diff-filter=ACMRTUXB", "HEAD")
+status_items = git_paths("diff", "--name-status", "-z", "--find-renames", "HEAD")
+tracked, deleted = [], []
+index = 0
+while index < len(status_items):
+    status = status_items[index]
+    index += 1
+    kind = status[:1]
+    if kind in {"R", "C"}:
+        if index + 1 >= len(status_items):
+            raise SystemExit("malformed git rename/copy status")
+        old_path, new_path = status_items[index:index + 2]
+        index += 2
+        if kind == "R":
+            deleted.append(old_path)
+        tracked.append(new_path)
+    else:
+        if index >= len(status_items):
+            raise SystemExit("malformed git status")
+        path = status_items[index]
+        index += 1
+        if kind == "D":
+            deleted.append(path)
+        else:
+            tracked.append(path)
 untracked = git_paths("ls-files", "--full-name", "--others", "--exclude-standard", "-z")
 untracked_source = [
     path for path in untracked
@@ -93,16 +110,20 @@ if ignored_untracked:
         file=sys.stderr,
     )
 paths = sorted(set(tracked + untracked_source))
+deleted = sorted(set(deleted) - set(paths))
 max_files = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_FILES", "256"))
 max_bytes = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES", str(1 << 20)))
 if max_files <= 0 or max_bytes <= 0:
     raise SystemExit("remote source bundle limits must be positive integers")
-if len(paths) > max_files:
-    raise SystemExit(f"source bundle has {len(paths)} files; maximum is {max_files}")
+if len(paths) + len(deleted) > max_files:
+    raise SystemExit(
+        f"source bundle has {len(paths) + len(deleted)} operations; maximum is {max_files}"
+    )
 files = []
 total = 0
 manifest = hashlib.sha256(b"sandboxed-source-bundle-v1\n")
-for rel in paths:
+operations = hashlib.sha256(b"sandboxed-source-bundle-ops-v1\n")
+def validate_path(rel):
     components = rel.split("/")
     if (
         not rel
@@ -116,6 +137,8 @@ for rel in paths:
         )
     ):
         raise SystemExit(f"unsafe source bundle path: {rel!r}")
+for rel in paths:
+    validate_path(rel)
     path = repo_root / rel
     if path.is_symlink() or not path.is_file():
         raise SystemExit(f"source bundle path must be a regular file, not a symlink: {rel}")
@@ -128,15 +151,29 @@ for rel in paths:
     manifest.update(b"\0")
     manifest.update(digest.encode())
     manifest.update(b"\n")
+    executable = bool(path.stat().st_mode & 0o111)
+    operations.update(b"file\0")
+    operations.update(rel.encode())
+    operations.update(b"\0")
+    operations.update(b"x" if executable else b"-")
+    operations.update(b"\n")
     files.append({
         "path": rel,
         "sha256": digest,
         "data_base64": base64.b64encode(data).decode("ascii"),
+        "executable": executable,
     })
-if files:
+for rel in deleted:
+    validate_path(rel)
+    operations.update(b"delete\0")
+    operations.update(rel.encode())
+    operations.update(b"\n")
+if files or deleted:
     req["source_bundle"] = {
         "manifest_sha256": manifest.hexdigest(),
         "files": files,
+        "deleted_paths": deleted,
+        "operations_sha256": operations.hexdigest(),
     }
 if cwd_rel:
     req["cwd_rel"] = cwd_rel

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -74,6 +74,8 @@ if toolchain_path.is_file():
 expected_head = os.environ.get("REMOTE_BUILD_EXPECTED_HEAD", "").strip()
 if expected_head:
     req["expected_head"] = expected_head
+if os.environ.get("REMOTE_BUILD_FORCE_NEW", "0") == "1":
+    req["force_new"] = True
 
 source_mode = os.environ.get("REMOTE_BUILD_SOURCE_MODE", "overlay").strip().lower()
 if source_mode not in {"overlay", "full"}:

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -321,6 +321,11 @@ request.pop("resume_mission_on_terminal", None)
 # identity. A retry after the branch advances must resume the accepted job for
 # the pinned commit and report it as stale, never submit a duplicate.
 request.pop("expected_head", None)
+# `force_new` is a submission control knob, not build identity: the server
+# also excludes it from the immutable job identity. A forced result must
+# replace the receipt for the same immutable request so ordinary retries
+# resume it instead of replaying a stale local terminal state.
+request.pop("force_new", None)
 fingerprint = {"endpoint": sys.argv[2], "request": request}
 canonical = json.dumps(fingerprint, sort_keys=True, separators=(",", ":")).encode()
 print(hashlib.sha256(canonical).hexdigest())

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -223,6 +223,7 @@ esac
 [ "$lock_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_LOCK_TIMEOUT_SECS must be greater than zero"
 
 response_file="$(mktemp)"
+wire_request_file="$(mktemp)"
 submit_lock_held=0
 submit_lock_persistent=0
 submit_lock_dir="$state_file.lock"
@@ -237,7 +238,7 @@ release_submit_lock() {
 }
 cleanup() {
     release_submit_lock
-    rm -f "$response_file" "$request_file"
+    rm -f "$response_file" "$request_file" "$wire_request_file"
 }
 trap cleanup EXIT
 
@@ -396,11 +397,22 @@ if [ -z "$job_id" ]; then
     # failures retain it so a dead owner PID can never permit a duplicate job.
     printf '%s\n' "armed" > "$submit_recovery_blocker" \
         || die "cannot arm the remote-build recovery blocker before submission" 75
+    # Full snapshots contain base64 and therefore inflate substantially in
+    # JSON. Compress the wire copy so reverse proxies only buffer the compact
+    # request; keep the plain request locally for fingerprinting and receipts.
+    python3 - "$request_file" "$wire_request_file" <<'PY' \
+        || die "cannot compress remote-build request" 75
+import gzip, shutil, sys
+with open(sys.argv[1], "rb") as source, open(sys.argv[2], "wb") as output:
+    with gzip.GzipFile(fileobj=output, mode="wb", compresslevel=6, mtime=0) as destination:
+        shutil.copyfileobj(source, destination)
+PY
     echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \
+        -H 'Content-Encoding: gzip' \
         --max-time "$submit_timeout_secs" \
-        --data-binary "@$request_file" "$REMOTE_BUILD_URL")"
+        --data-binary "@$wire_request_file" "$REMOTE_BUILD_URL")"
     curl_status=$?
     if [ "$curl_status" -ne 0 ]; then
         case "$curl_status" in

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -8480,6 +8480,7 @@ async fn poll_recovered_remote_build(
             {
                 let terminal_state = status.state.clone();
                 let terminal_exit_code = status.exit_code;
+                let terminal_artifacts = status.artifacts.clone();
                 state
                     .fleet
                     .record_outcome(crate::remote_node::DispatchOutcome {
@@ -8492,11 +8493,12 @@ async fn poll_recovered_remote_build(
                         started_at,
                         finished_at: Some(chrono::Utc::now()),
                     });
-                match crate::remote_node::job_ledger::finalize(
+                match crate::remote_node::job_ledger::finalize_with_artifacts(
                     &working_dir,
                     job_id,
                     &terminal_state,
                     terminal_exit_code,
+                    terminal_artifacts,
                 )
                 .await
                 {
@@ -11646,6 +11648,7 @@ async fn paloma_webhook_forwarder_loop(
                                 "finished_at": receipt.finished_at,
                                 "exit_status": receipt.exit_status,
                                 "identity": receipt.identity,
+                                "artifacts": receipt.artifacts,
                             })
                         }),
                     );

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -65,6 +65,7 @@ pub mod system;
 pub mod telegram;
 pub mod types;
 pub mod usage_optimize;
+pub mod validation;
 pub mod workspaces;
 
 pub use routes::serve;

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -328,6 +328,11 @@ pub struct RemoteBuildRequest {
     /// fire-and-forget clients leave it false.
     #[serde(default)]
     pub resume_mission_on_terminal: bool,
+    /// Deliberately request independent evidence instead of reusing an
+    /// equivalent successful receipt. Intended for explicit multi-node
+    /// certification; ordinary builds should leave this false.
+    #[serde(default)]
+    pub force_new: bool,
     /// Artifact patterns (relative to the checkout root) to digest after a
     /// successful build.
     #[serde(default)]
@@ -951,7 +956,7 @@ async fn submit_remote_build(
     // Reuse completed evidence even when every runner is currently offline.
     // This optimistic read is repeated under the placement lock after any
     // explicit network probe, which closes the concurrent-submit race.
-    if req.source_archive.is_none() {
+    if req.source_archive.is_none() && !req.force_new {
         if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
         {
             return response;
@@ -966,7 +971,7 @@ async fn submit_remote_build(
     // tentative-handle persistence. No network probe runs while this mutex is
     // held, so a slow explicit runner cannot block unrelated auto placement.
     let placement_guard = placement_lock().lock().await;
-    if req.source_archive.is_none() {
+    if req.source_archive.is_none() && !req.force_new {
         if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
         {
             return response;
@@ -2109,6 +2114,7 @@ printf '503'
             .env("REMOTE_BUILD_TOKEN", "test-token")
             .env("REMOTE_BUILD_MISSION_ID", Uuid::new_v4().to_string())
             .env("REMOTE_BUILD_EXPECTED_HEAD", "a".repeat(40))
+            .env("REMOTE_BUILD_FORCE_NEW", "1")
             .env("REMOTE_BUILD_TEST_CAPTURE", &capture)
             .output()
             .unwrap();
@@ -2135,6 +2141,12 @@ printf '503'
                 .get("expected_head")
                 .and_then(serde_json::Value::as_str),
             Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        assert_eq!(
+            request
+                .get("force_new")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
         );
         let archive = request.get("source_archive").unwrap();
         let archive_bytes = base64::engine::general_purpose::STANDARD

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -325,7 +325,16 @@ fn default_wait() -> bool {
 
 fn minimum_node_protocol_version(source_bundle: Option<&SourceBundle>) -> u32 {
     match source_bundle {
-        Some(bundle) if bundle.complete => crate::remote_node::protocol::NODE_PROTOCOL_VERSION,
+        // Complete snapshots and extended operations (deletions, executable
+        // bits) are both v4 features. An older node would silently ignore the
+        // unknown fields and build the wrong tree, so fail placement instead.
+        Some(bundle)
+            if bundle.complete
+                || !bundle.deleted_paths.is_empty()
+                || bundle.operations_sha256.is_some() =>
+        {
+            crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+        }
         Some(_) => 3,
         None => 1,
     }
@@ -1676,15 +1685,28 @@ mod tests {
         };
         let complete = SourceBundle {
             manifest_sha256: "c".repeat(64),
-            files: vec![file],
+            files: vec![file.clone()],
             complete: true,
             deleted_paths: Vec::new(),
             operations_sha256: None,
+        };
+        let extended_overlay = SourceBundle {
+            manifest_sha256: "d".repeat(64),
+            files: vec![file],
+            complete: false,
+            deleted_paths: vec!["Removed.lean".to_string()],
+            operations_sha256: Some("e".repeat(64)),
         };
         assert_eq!(minimum_node_protocol_version(None), 1);
         assert_eq!(minimum_node_protocol_version(Some(&overlay)), 3);
         assert_eq!(
             minimum_node_protocol_version(Some(&complete)),
+            crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+        );
+        // Deletions and executable-bit digests would be silently dropped by a
+        // v3 node, so extended overlays must also require the current version.
+        assert_eq!(
+            minimum_node_protocol_version(Some(&extended_overlay)),
             crate::remote_node::protocol::NODE_PROTOCOL_VERSION
         );
     }

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -58,11 +58,16 @@ fn parse_remote_build_request(
     use flate2::read::GzDecoder;
     use std::io::Read;
 
-    let encoding = headers
-        .get(header::CONTENT_ENCODING)
-        .and_then(|value| value.to_str().ok())
-        .unwrap_or("identity")
-        .trim();
+    let encoding = match headers.get(header::CONTENT_ENCODING) {
+        Some(value) => value.to_str().map_err(|_| {
+            (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "remote build Content-Encoding must be valid ASCII".to_string(),
+            )
+        })?,
+        None => "identity",
+    }
+    .trim();
     let reader: Box<dyn Read> = if encoding.eq_ignore_ascii_case("gzip") {
         Box::new(GzDecoder::new(body))
     } else if encoding.is_empty() || encoding.eq_ignore_ascii_case("identity") {
@@ -1783,6 +1788,27 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         let parsed = parse_remote_build_request(&headers, &compressed).unwrap();
         assert_eq!(parsed.repo, "https://github.com/private/example.git");
         assert_eq!(parsed.commit, "a".repeat(40));
+
+        let parsed_identity = parse_remote_build_request(&HeaderMap::new(), &plain).unwrap();
+        assert_eq!(
+            parsed_identity.repo,
+            "https://github.com/private/example.git"
+        );
+
+        let truncated = &compressed[..compressed.len() - 4];
+        let error = parse_remote_build_request(&headers, truncated).unwrap_err();
+        assert_eq!(error.0, StatusCode::BAD_REQUEST);
+
+        let error = parse_remote_build_request(&headers, b"not a gzip stream").unwrap_err();
+        assert_eq!(error.0, StatusCode::BAD_REQUEST);
+
+        let mut invalid_encoding = HeaderMap::new();
+        invalid_encoding.insert(
+            header::CONTENT_ENCODING,
+            header::HeaderValue::from_bytes(b"\xff").unwrap(),
+        );
+        let error = parse_remote_build_request(&invalid_encoding, &plain).unwrap_err();
+        assert_eq!(error.0, StatusCode::UNSUPPORTED_MEDIA_TYPE);
 
         let oversized = vec![b' '; MAX_REMOTE_BUILD_JSON_BYTES as usize + 1];
         let error = parse_remote_build_request(&HeaderMap::new(), &oversized).unwrap_err();

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -331,7 +331,8 @@ fn minimum_node_protocol_version(source_bundle: Option<&SourceBundle>) -> u32 {
         Some(bundle)
             if bundle.complete
                 || !bundle.deleted_paths.is_empty()
-                || bundle.operations_sha256.is_some() =>
+                || bundle.operations_sha256.is_some()
+                || bundle.files.iter().any(|file| file.executable.is_some()) =>
         {
             crate::remote_node::protocol::NODE_PROTOCOL_VERSION
         }
@@ -912,6 +913,21 @@ async fn equivalent_remote_validation_response(
     identity: &crate::remote_node::job_ledger::RemoteJobIdentity,
     reuse_succeeded_receipt: bool,
 ) -> Option<axum::response::Response> {
+    let active_conflict = |handle: &crate::remote_node::job_ledger::JobHandle| {
+        (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "code": "REMOTE_VALIDATION_ALREADY_ACTIVE",
+                "message": "an equivalent immutable remote validation is already unresolved; reconcile or attach to its canonical job before retrying",
+                "job_id": handle.job_id,
+                "node_id": handle.node_id,
+                "mission_id": handle.mission_id,
+                "accepted": handle.accepted_at.is_some(),
+                "validation": identity,
+            })),
+        )
+            .into_response()
+    };
     match crate::remote_node::job_ledger::equivalent_remote_validation(
         &state.config.working_dir,
         identity,
@@ -921,11 +937,29 @@ async fn equivalent_remote_validation_response(
         Ok(Some(crate::remote_node::job_ledger::EquivalentRemoteValidation::Succeeded(
             receipt,
         ))) => {
-            // Forced certification runs must still fail closed on an
-            // unresolved equivalent job (handled below), but may bypass
-            // successful-receipt replay to produce an independent receipt.
+            // Forced certification runs may bypass successful-receipt replay
+            // to produce an independent receipt, but must still fail closed on
+            // an unresolved equivalent job: the combined lookup gives receipts
+            // precedence, so probe active handles explicitly here.
             if !reuse_succeeded_receipt {
-                return None;
+                return match crate::remote_node::job_ledger::active_equivalent_remote_validation(
+                    &state.config.working_dir,
+                    identity,
+                )
+                .await
+                {
+                    Ok(Some(handle)) => Some(active_conflict(&handle)),
+                    Ok(None) => None,
+                    Err(error) => Some(
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!(
+                                "remote validation ledger could not be reconciled before submission: {error}"
+                            ),
+                        )
+                            .into_response(),
+                    ),
+                };
             }
             tracing::info!(
                 mission_id = %req.mission_id,
@@ -973,21 +1007,7 @@ async fn equivalent_remote_validation_response(
             }
         }
         Ok(Some(crate::remote_node::job_ledger::EquivalentRemoteValidation::Active(handle))) => {
-            Some(
-                (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "code": "REMOTE_VALIDATION_ALREADY_ACTIVE",
-                        "message": "an equivalent immutable remote validation is already unresolved; reconcile or attach to its canonical job before retrying",
-                        "job_id": handle.job_id,
-                        "node_id": handle.node_id,
-                        "mission_id": handle.mission_id,
-                        "accepted": handle.accepted_at.is_some(),
-                        "validation": identity,
-                    })),
-                )
-                    .into_response(),
-            )
+            Some(active_conflict(&handle))
         }
         Ok(None) => None,
         Err(error) => Some(
@@ -1692,10 +1712,20 @@ mod tests {
         };
         let extended_overlay = SourceBundle {
             manifest_sha256: "d".repeat(64),
-            files: vec![file],
+            files: vec![file.clone()],
             complete: false,
             deleted_paths: vec!["Removed.lean".to_string()],
             operations_sha256: Some("e".repeat(64)),
+        };
+        let executable_overlay = SourceBundle {
+            manifest_sha256: "f".repeat(64),
+            files: vec![crate::remote_node::SourceBundleFile {
+                executable: Some(true),
+                ..file
+            }],
+            complete: false,
+            deleted_paths: Vec::new(),
+            operations_sha256: None,
         };
         assert_eq!(minimum_node_protocol_version(None), 1);
         assert_eq!(minimum_node_protocol_version(Some(&overlay)), 3);
@@ -1707,6 +1737,12 @@ mod tests {
         // v3 node, so extended overlays must also require the current version.
         assert_eq!(
             minimum_node_protocol_version(Some(&extended_overlay)),
+            crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+        );
+        // Executable metadata alone must not fall back to v3 either: a v3
+        // node would build with the wrong file mode and still report success.
+        assert_eq!(
+            minimum_node_protocol_version(Some(&executable_overlay)),
             crate::remote_node::protocol::NODE_PROTOCOL_VERSION
         );
     }

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -25,6 +25,7 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use sha2::Digest;
 use uuid::Uuid;
 
 use super::routes::AppState;
@@ -371,7 +372,21 @@ fn remote_job_identity(
         source_bundle_digest: req
             .source_bundle
             .as_ref()
-            .map(|bundle| bundle.manifest_sha256.clone()),
+            .map(source_bundle_identity_digest),
+    }
+}
+
+fn source_bundle_identity_digest(bundle: &SourceBundle) -> String {
+    match bundle.operations_sha256.as_deref() {
+        None => bundle.manifest_sha256.clone(),
+        Some(operations) => {
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(b"sandboxed-source-bundle-identity-v2\0");
+            hasher.update(bundle.manifest_sha256.as_bytes());
+            hasher.update(b"\0");
+            hasher.update(operations.as_bytes());
+            hex::encode(hasher.finalize())
+        }
     }
 }
 
@@ -668,8 +683,17 @@ async fn finalize_remote_build_handle(
     job_id: Uuid,
     state: &str,
     exit_status: Option<i32>,
+    artifacts: Vec<ArtifactEntry>,
 ) -> bool {
-    match crate::remote_node::job_ledger::finalize(working_dir, job_id, state, exit_status).await {
+    match crate::remote_node::job_ledger::finalize_with_artifacts(
+        working_dir,
+        job_id,
+        state,
+        exit_status,
+        artifacts,
+    )
+    .await
+    {
         Ok(_) => true,
         Err(error) => {
             tracing::warn!(%job_id, ?error, "remote build receipt finalization failed; observation will retry");
@@ -722,6 +746,7 @@ fn spawn_remote_build_observer(
                             job_id,
                             "lost",
                             None,
+                            Vec::new(),
                         )
                         .await
                         {
@@ -747,6 +772,7 @@ fn spawn_remote_build_observer(
                         job_id,
                         &status.state,
                         status.exit_code,
+                        status.artifacts.clone(),
                     )
                     .await
                     {
@@ -755,8 +781,14 @@ fn spawn_remote_build_observer(
                     }
                 }
                 Err(error) if cancel_requested && error.is_not_found() => {
-                    if finalize_remote_build_handle(&state.config.working_dir, job_id, "lost", None)
-                        .await
+                    if finalize_remote_build_handle(
+                        &state.config.working_dir,
+                        job_id,
+                        "lost",
+                        None,
+                        Vec::new(),
+                    )
+                    .await
                     {
                         super::control::deliver_pending_remote_build_wakes(&state).await;
                         return;
@@ -826,7 +858,7 @@ async fn equivalent_remote_validation_response(
                             log_tail: "reused durable terminal receipt".to_string(),
                             node_id: receipt.node_id,
                             job_id: receipt.job_id,
-                            artifacts: Vec::new(),
+                            artifacts: receipt.artifacts,
                         }),
                     )
                         .into_response(),
@@ -971,11 +1003,11 @@ async fn submit_remote_build(
         mission_id: req.mission_id,
         lease_token,
         payload: JobPayload::LeanBuild {
-            source: JobSource {
+            source: Box::new(JobSource {
                 repo: req.repo.clone(),
                 commit: req.commit.clone(),
                 bundle: req.source_bundle.clone(),
-            },
+            }),
             cwd_rel: req.cwd_rel.clone(),
             command: req.command.clone(),
             timeout_secs: req.timeout_secs,
@@ -1162,6 +1194,7 @@ async fn submit_remote_build(
                 job_id,
                 &status.state,
                 status.exit_code,
+                status.artifacts.clone(),
             )
             .await
             {
@@ -1260,7 +1293,7 @@ fn remote_build_status_from_receipt(
         finished_at: Some(receipt.finished_at.to_rfc3339()),
         error: None,
         log_tail: Some("reused durable terminal receipt".to_string()),
-        artifacts: Vec::new(),
+        artifacts: receipt.artifacts,
     };
     RemoteBuildStatusResponse {
         status,
@@ -1416,6 +1449,7 @@ async fn get_remote_build(
             job_id,
             &status.state,
             status.exit_code,
+            status.artifacts.clone(),
         )
         .await
         {
@@ -1453,6 +1487,7 @@ mod tests {
                 Uuid::new_v4(),
                 "succeeded",
                 Some(0),
+                Vec::new(),
             )
             .await
         );
@@ -1762,6 +1797,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                     toolchain: Some("leanprover/lean4:v4.19.0".to_string()),
                     source_bundle_digest: None,
                 },
+                artifacts: Vec::new(),
                 continuation_expected: false,
                 wake_required: false,
                 wake_delivered_at: None,
@@ -1984,8 +2020,14 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         git(&["config", "user.name", "Remote Build Test"]);
         git(&["config", "user.email", "remote-build@example.invalid"]);
         std::fs::write(repo.join("Theory/Proof.lean"), "old\n").unwrap();
+        std::fs::write(repo.join("Theory/Obsolete.lean"), "obsolete\n").unwrap();
         std::fs::write(repo.join("lean-toolchain"), "leanprover/lean4:v4.19.0\n").unwrap();
-        git(&["add", "Theory/Proof.lean", "lean-toolchain"]);
+        git(&[
+            "add",
+            "Theory/Proof.lean",
+            "Theory/Obsolete.lean",
+            "lean-toolchain",
+        ]);
         git(&[
             "-c",
             "commit.gpgsign=false",
@@ -2002,6 +2044,12 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         ]);
         std::fs::write(repo.join("Theory/Proof.lean"), "new proof\n").unwrap();
         std::fs::write(repo.join("Theory/Witness.lean"), "new witness\n").unwrap();
+        std::fs::remove_file(repo.join("Theory/Obsolete.lean")).unwrap();
+        let mut witness_permissions = std::fs::metadata(repo.join("Theory/Witness.lean"))
+            .unwrap()
+            .permissions();
+        witness_permissions.set_mode(0o755);
+        std::fs::set_permissions(repo.join("Theory/Witness.lean"), witness_permissions).unwrap();
 
         let fake_curl = bin.join("curl");
         std::fs::write(
@@ -2090,6 +2138,19 @@ printf '503'
             bundle.get("manifest_sha256").unwrap().as_str().unwrap(),
             crate::node::lean::bundle_manifest_sha256(&manifest)
         );
+        assert_eq!(
+            bundle.get("deleted_paths").unwrap().as_array().unwrap(),
+            &[serde_json::Value::String(
+                "Theory/Obsolete.lean".to_string()
+            )]
+        );
+        let decoded: SourceBundle = serde_json::from_value(bundle.clone()).unwrap();
+        let operations_digest = crate::node::lean::bundle_operations_sha256(&decoded);
+        assert_eq!(
+            decoded.operations_sha256.as_deref(),
+            Some(operations_digest.as_str())
+        );
+        assert_eq!(decoded.files[1].executable, Some(true));
     }
 
     #[cfg(unix)]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -421,6 +421,16 @@ fn repository_identity(repo: &str) -> String {
     parsed.to_string()
 }
 
+fn repository_url_has_credentials(repo: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(repo) else {
+        return false;
+    };
+    parsed.password().is_some()
+        || (matches!(parsed.scheme(), "http" | "https") && !parsed.username().is_empty())
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+}
+
 fn remote_job_identity(
     req: &RemoteBuildRequest,
 ) -> crate::remote_node::job_ledger::RemoteJobIdentity {
@@ -960,6 +970,13 @@ async fn submit_remote_build(
     }
     if req.command.is_empty() {
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
+    }
+    if repository_url_has_credentials(&req.repo) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "repository URL must not contain credentials, query parameters, or a fragment",
+        )
+            .into_response();
     }
     if let Err(message) = validate_expected_head(&req.commit, req.expected_head.as_deref()) {
         return (StatusCode::CONFLICT, message).into_response();
@@ -1686,7 +1703,7 @@ mod tests {
             "remote",
             "add",
             "origin",
-            "https://example.invalid/repo.git",
+            "https://build-user:secret-token@example.invalid/repo.git?token=secret#fragment",
         ]);
 
         let fake_curl = bin.join("curl");
@@ -1911,6 +1928,8 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             identity.toolchain.as_deref(),
             Some("leanprover/lean4:v4.19.0")
         );
+        assert!(repository_url_has_credentials(&req.repo));
+        assert!(!repository_url_has_credentials(&identity.repository));
     }
 
     #[test]
@@ -2242,6 +2261,10 @@ printf '503'
             std::fs::File::open(&capture).unwrap(),
         ))
         .unwrap();
+        assert_eq!(
+            request.get("repo").and_then(serde_json::Value::as_str),
+            Some("https://example.invalid/repo.git")
+        );
         assert_eq!(
             request
                 .get("estimated_disk_bytes")

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -18,6 +18,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use axum::{
+    body::Bytes,
     extract::{Path, Query, State},
     http::{header, HeaderMap, StatusCode},
     response::IntoResponse,
@@ -48,6 +49,56 @@ const DEFAULT_ESTIMATED_DISK_GB: u64 = 12;
 const MAX_ESTIMATED_DISK_GB: u64 = 512;
 const DEFAULT_NODE_MIN_DISK_GB: u64 = 20;
 const DEFAULT_NODE_DISK_EMERGENCY_GB: u64 = 10;
+const MAX_REMOTE_BUILD_JSON_BYTES: u64 = 32 * 1024 * 1024;
+
+fn parse_remote_build_request(
+    headers: &HeaderMap,
+    body: &[u8],
+) -> Result<RemoteBuildRequest, (StatusCode, String)> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let encoding = headers
+        .get(header::CONTENT_ENCODING)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("identity")
+        .trim();
+    let reader: Box<dyn Read> = if encoding.eq_ignore_ascii_case("gzip") {
+        Box::new(GzDecoder::new(body))
+    } else if encoding.is_empty() || encoding.eq_ignore_ascii_case("identity") {
+        Box::new(body)
+    } else {
+        return Err((
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "remote build Content-Encoding must be gzip or identity".to_string(),
+        ));
+    };
+    let mut decoded = Vec::new();
+    reader
+        .take(MAX_REMOTE_BUILD_JSON_BYTES + 1)
+        .read_to_end(&mut decoded)
+        .map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("invalid gzip remote build request: {error}"),
+            )
+        })?;
+    if decoded.len() as u64 > MAX_REMOTE_BUILD_JSON_BYTES {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "remote build JSON exceeds {} bytes after decompression",
+                MAX_REMOTE_BUILD_JSON_BYTES
+            ),
+        ));
+    }
+    serde_json::from_slice(&decoded).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid remote build JSON: {error}"),
+        )
+    })
+}
 
 fn env_gib(name: &str, default: u64) -> u64 {
     std::env::var(name)
@@ -881,8 +932,13 @@ async fn equivalent_remote_validation_response(
 
 async fn submit_remote_build(
     State(state): State<Arc<AppState>>,
-    Json(req): Json<RemoteBuildRequest>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> axum::response::Response {
+    let req = match parse_remote_build_request(&headers, &body) {
+        Ok(req) => req,
+        Err(error) => return error.into_response(),
+    };
     let expects_mission_continuation = req.wait || req.resume_mission_on_terminal;
     // Auth: per-mission, scope-bound capability token (NOT the dashboard JWT
     // and NOT a node bearer token) — a leak only authorizes remote builds
@@ -1705,6 +1761,82 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
     }
 
     #[test]
+    fn remote_build_request_accepts_gzip_and_caps_decompressed_json() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        let request = serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "token": "mission-capability",
+            "repo": "https://github.com/private/example.git",
+            "commit": "a".repeat(40),
+            "command": ["lake", "build"],
+        });
+        let plain = serde_json::to_vec(&request).unwrap();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&plain).unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert!(compressed.len() < plain.len());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let parsed = parse_remote_build_request(&headers, &compressed).unwrap();
+        assert_eq!(parsed.repo, "https://github.com/private/example.git");
+        assert_eq!(parsed.commit, "a".repeat(40));
+
+        let oversized = vec![b' '; MAX_REMOTE_BUILD_JSON_BYTES as usize + 1];
+        let error = parse_remote_build_request(&HeaderMap::new(), &oversized).unwrap_err();
+        assert_eq!(error.0, StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[test]
+    fn full_snapshot_crosses_five_mib_as_json_but_fits_when_gzipped() {
+        use base64::Engine;
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        // Model the reported 4.35 MiB raw snapshot with deterministic,
+        // incompressible-ish bytes. Base64 JSON crosses a 5 MiB gateway
+        // buffer while gzip returns close to the raw source size.
+        let mut state = 0x9e37_79b9_u32;
+        let raw = (0..4_560_000)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state as u8
+            })
+            .collect::<Vec<_>>();
+        let request = serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "token": "mission-capability",
+            "repo": "https://github.com/private/example.git",
+            "commit": "a".repeat(40),
+            "command": ["lake", "build"],
+            "source_bundle": {
+                "manifest_sha256": "b".repeat(64),
+                "complete": true,
+                "files": [{
+                    "path": "Lido.lean",
+                    "sha256": "c".repeat(64),
+                    "data_base64": base64::engine::general_purpose::STANDARD.encode(raw),
+                }],
+            },
+        });
+        let plain = serde_json::to_vec(&request).unwrap();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&plain).unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert!(plain.len() > 5 * 1024 * 1024);
+        assert!(compressed.len() < 5 * 1024 * 1024);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let parsed = parse_remote_build_request(&headers, &compressed).unwrap();
+        assert!(parsed.source_bundle.is_some_and(|bundle| bundle.complete));
+    }
+
+    #[test]
     fn token_expiry_is_enforced() {
         let mission = Uuid::new_v4();
         let now = chrono::Utc::now().timestamp();
@@ -2080,8 +2212,10 @@ printf '503'
             .unwrap();
         assert_eq!(output.status.code(), Some(75));
 
-        let request: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(&capture).unwrap()).unwrap();
+        let request: serde_json::Value = serde_json::from_reader(flate2::read::GzDecoder::new(
+            std::fs::File::open(&capture).unwrap(),
+        ))
+        .unwrap();
         assert_eq!(
             request
                 .get("estimated_disk_bytes")
@@ -2145,8 +2279,10 @@ printf '503'
             .unwrap();
         assert_eq!(full_output.status.code(), Some(75));
 
-        let full_request: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+        let full_request: serde_json::Value = serde_json::from_reader(
+            flate2::read::GzDecoder::new(std::fs::File::open(capture).unwrap()),
+        )
+        .unwrap();
         let full_bundle = full_request.get("source_bundle").unwrap();
         assert_eq!(
             full_bundle

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1656,16 +1656,21 @@ mod tests {
             path: "lean-toolchain".to_string(),
             sha256: "a".repeat(64),
             data_base64: String::new(),
+            executable: None,
         };
         let overlay = SourceBundle {
             manifest_sha256: "b".repeat(64),
             files: vec![file.clone()],
             complete: false,
+            deleted_paths: Vec::new(),
+            operations_sha256: None,
         };
         let complete = SourceBundle {
             manifest_sha256: "c".repeat(64),
             files: vec![file],
             complete: true,
+            deleted_paths: Vec::new(),
+            operations_sha256: None,
         };
         assert_eq!(minimum_node_protocol_version(None), 1);
         assert_eq!(minimum_node_protocol_version(Some(&overlay)), 3);

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -901,6 +901,7 @@ async fn equivalent_remote_validation_response(
     state: &AppState,
     req: &RemoteBuildRequest,
     identity: &crate::remote_node::job_ledger::RemoteJobIdentity,
+    reuse_succeeded_receipt: bool,
 ) -> Option<axum::response::Response> {
     match crate::remote_node::job_ledger::equivalent_remote_validation(
         &state.config.working_dir,
@@ -911,6 +912,12 @@ async fn equivalent_remote_validation_response(
         Ok(Some(crate::remote_node::job_ledger::EquivalentRemoteValidation::Succeeded(
             receipt,
         ))) => {
+            // Forced certification runs must still fail closed on an
+            // unresolved equivalent job (handled below), but may bypass
+            // successful-receipt replay to produce an independent receipt.
+            if !reuse_succeeded_receipt {
+                return None;
+            }
             tracing::info!(
                 mission_id = %req.mission_id,
                 canonical_mission_id = %receipt.mission_id,
@@ -1049,8 +1056,9 @@ async fn submit_remote_build(
     // Reuse completed evidence even when every runner is currently offline.
     // This optimistic read is repeated under the placement lock after any
     // explicit network probe, which closes the concurrent-submit race.
-    if req.source_archive.is_none() && !req.force_new {
-        if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
+    if req.source_archive.is_none() {
+        if let Some(response) =
+            equivalent_remote_validation_response(&state, &req, &identity, !req.force_new).await
         {
             return response;
         }
@@ -1064,8 +1072,9 @@ async fn submit_remote_build(
     // tentative-handle persistence. No network probe runs while this mutex is
     // held, so a slow explicit runner cannot block unrelated auto placement.
     let placement_guard = placement_lock().lock().await;
-    if req.source_archive.is_none() && !req.force_new {
-        if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
+    if req.source_archive.is_none() {
+        if let Some(response) =
+            equivalent_remote_validation_response(&state, &req, &identity, !req.force_new).await
         {
             return response;
         }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -157,6 +157,8 @@ pub struct AppState {
     /// Cached remote-runner-node statuses + recent dispatch outcomes, kept
     /// fresh by the background fleet monitor (see `remote_node::monitor`).
     pub fleet: Arc<crate::remote_node::FleetMonitor>,
+    /// Persistent project validation campaigns, gates, receipts, and delivery outbox.
+    pub validation: super::validation::SharedValidationStore,
 }
 
 /// Start the HTTP server.
@@ -493,6 +495,12 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     );
     control_state.set_telegram_bridge(Arc::clone(&telegram_bridge));
 
+    let validation = Arc::new(super::validation::ValidationStore::open(
+        config
+            .working_dir
+            .join(".sandboxed-sh/validation-campaigns.db"),
+    )?);
+
     let state = Arc::new(AppState {
         config: config.clone(),
         tasks: RwLock::new(HashMap::new()),
@@ -541,7 +549,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         provider_usage_cache: super::provider_usage_cache::ProviderUsageCache::new(),
         codex_usage: super::codex_usage::CodexUsageStore::new(),
         fleet: Arc::new(crate::remote_node::FleetMonitor::new()),
+        validation,
     });
+
+    super::validation::spawn_outbox_forwarder(Arc::clone(&state));
 
     // Remote-node fleet monitor: periodic heartbeat polling so
     // `/api/remote-nodes` and dispatch decisions read cached statuses
@@ -1195,6 +1206,8 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .nest("/api/desktop", desktop::routes())
         // Durable background jobs launched outside ephemeral agent-turn shells
         .nest("/api/durable-jobs", durable_jobs::routes())
+        // Project-native validation campaigns and structured receipts.
+        .nest("/api/validation-campaigns", super::validation::routes())
         // System component management endpoints
         .nest("/api/system", system_api::routes())
         // Auth management endpoints

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -292,6 +292,8 @@ struct RecordReceiptRequest {
     #[serde(default)]
     observed_head: Option<String>,
     #[serde(default)]
+    source_bundle_digest: Option<String>,
+    #[serde(default)]
     toolchain: Option<String>,
     #[serde(default)]
     environment_digest: Option<String>,
@@ -380,6 +382,8 @@ pub struct ValidationReceipt {
     pub exit_code: Option<i32>,
     pub blocked_reason: Option<String>,
     pub observed_head: Option<String>,
+    #[serde(default)]
+    pub source_bundle_digest: Option<String>,
     pub toolchain: Option<String>,
     pub environment_digest: Option<String>,
     pub cache: CacheReceipt,
@@ -514,6 +518,242 @@ impl ValidationStore {
     fn get(&self, id: Uuid) -> Result<CampaignView, String> {
         let connection = self.lock()?;
         load_campaign(&connection, id)?.ok_or_else(|| format!("campaign {id} not found"))
+    }
+
+    fn claim(
+        &self,
+        campaign_id: Uuid,
+        gate_id: &str,
+        execution: &ExecutionRef,
+    ) -> Result<GateView, ApiError> {
+        let mut connection = self.lock().map_err(internal)?;
+        let transaction = connection.transaction().map_err(internal)?;
+        let current = load_gate(&transaction, campaign_id, gate_id)
+            .map_err(internal)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    "validation gate not found".to_string(),
+                )
+            })?;
+        if current.status == "running" && current.execution.as_ref() == Some(execution) {
+            return Ok(current);
+        }
+        // Stale gates hold retained evidence that can never unlock dependants
+        // or certify, so they stay claimable: a later exact-head execution can
+        // replace the stale receipt instead of wedging the campaign.
+        if current.status != "ready" && current.status != "stale" {
+            return Err((
+                StatusCode::CONFLICT,
+                format!("gate '{gate_id}' is {}, not claimable", current.status),
+            ));
+        }
+        transaction
+            .execute(
+                "UPDATE validation_gates SET status='running', execution_json=?3,
+                 started_at=?4 WHERE campaign_id=?1 AND gate_id=?2",
+                params![
+                    campaign_id.to_string(),
+                    gate_id,
+                    json_string(execution).map_err(internal)?,
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .map_err(internal)?;
+        transaction.commit().map_err(internal)?;
+        load_gate(&connection, campaign_id, gate_id)
+            .map_err(internal)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    "validation gate not found".to_string(),
+                )
+            })
+    }
+
+    fn record(
+        &self,
+        campaign_id: Uuid,
+        gate_id: &str,
+        request: RecordReceiptRequest,
+    ) -> Result<(), ApiError> {
+        let mut connection = self.lock().map_err(internal)?;
+        let transaction = connection.transaction().map_err(internal)?;
+        let campaign = load_campaign_row(&transaction, campaign_id)
+            .map_err(internal)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    "validation campaign not found".to_string(),
+                )
+            })?;
+        let gate = load_gate(&transaction, campaign_id, gate_id)
+            .map_err(internal)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    "validation gate not found".to_string(),
+                )
+            })?;
+        let execution_key = request.execution.key();
+        if transaction
+            .query_row(
+                "SELECT 1 FROM validation_receipts
+                 WHERE campaign_id=?1 AND gate_id=?2 AND execution_key=?3",
+                params![campaign_id.to_string(), gate_id, execution_key],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(internal)?
+            .is_some()
+        {
+            transaction.commit().map_err(internal)?;
+            return Ok(());
+        }
+        if gate.status != "running" || gate.execution.as_ref() != Some(&request.execution) {
+            return Err((
+                StatusCode::CONFLICT,
+                "receipt execution does not own a running gate".to_string(),
+            ));
+        }
+
+        if let Some(head) = request.observed_head.as_deref() {
+            validate_digest("observed_head", head, 40).map_err(bad_request)?;
+        }
+        if let Some(digest) = request.source_bundle_digest.as_deref() {
+            validate_digest("source_bundle_digest", digest, 64).map_err(bad_request)?;
+        }
+        let outcome = if request
+            .blocked_reason
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty())
+        {
+            "blocked"
+        } else if request.exit_code == Some(0) {
+            "passed"
+        } else {
+            "failed"
+        };
+        if outcome == "passed"
+            && gate.spec.mode == ValidationMode::Clean
+            && !request.cache.clean_checkout
+        {
+            return Err(bad_request(
+                "a passed clean gate receipt must attest cache.clean_checkout=true".to_string(),
+            ));
+        }
+        let expected_head = campaign
+            .candidate
+            .expected_head
+            .as_deref()
+            .unwrap_or(&campaign.candidate.commit);
+        // Exact evidence must attest the pinned candidate in full: the Git
+        // head, the exact source bundle (a clean-base or foreign-overlay run
+        // sharing the head must not certify a pinned bundle, and a bundle
+        // attestation must not certify a bundle-less candidate), and the
+        // gate's pinned toolchain. Anything else is retained as stale.
+        let head_matches = request.observed_head.as_deref() == Some(expected_head);
+        let bundle_matches = request.source_bundle_digest.as_deref()
+            == campaign.candidate.source_bundle_digest.as_deref();
+        let toolchain_matches = match gate.spec.toolchain.as_deref() {
+            Some(pinned) => request.toolchain.as_deref() == Some(pinned),
+            None => true,
+        };
+        let freshness = if head_matches && bundle_matches && toolchain_matches {
+            "exact_head"
+        } else {
+            "stale"
+        };
+        let now = Utc::now();
+        let receipt = ValidationReceipt {
+            id: Uuid::new_v4(),
+            campaign_id,
+            gate_id: gate_id.to_string(),
+            candidate_id: campaign.candidate_id,
+            execution: request.execution,
+            outcome: outcome.to_string(),
+            freshness: freshness.to_string(),
+            exit_code: request.exit_code,
+            blocked_reason: request.blocked_reason.clone(),
+            observed_head: request.observed_head,
+            source_bundle_digest: request.source_bundle_digest,
+            toolchain: request.toolchain,
+            environment_digest: request.environment_digest,
+            cache: request.cache,
+            artifacts: request.artifacts,
+            diagnostic_clusters: request
+                .diagnostics
+                .as_deref()
+                .map(cluster_diagnostics)
+                .unwrap_or_default(),
+            started_at: request.started_at.or(gate.started_at).unwrap_or(now),
+            finished_at: request.finished_at.unwrap_or(now),
+            reused_from: None,
+        };
+        transaction
+            .execute(
+                "INSERT INTO validation_receipts
+                 (id, campaign_id, gate_id, execution_key, validation_key, receipt_json,
+                  outcome, freshness, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    receipt.id.to_string(),
+                    campaign_id.to_string(),
+                    gate_id,
+                    execution_key,
+                    gate.validation_key,
+                    json_string(&receipt).map_err(internal)?,
+                    outcome,
+                    freshness,
+                    now.to_rfc3339(),
+                ],
+            )
+            .map_err(internal)?;
+        let gate_status = match (outcome, freshness) {
+            ("passed", "exact_head") => "passed",
+            ("passed", _) => "stale",
+            ("blocked", _) => "blocked",
+            _ => "failed",
+        };
+        let blocker_fingerprint = request.blocked_reason.as_deref().map(hash_text);
+        transaction
+            .execute(
+                "UPDATE validation_gates SET status=?3, outcome=?4, freshness=?5,
+                 execution_json=?6, blocker_fingerprint=?7, finished_at=?8
+                 WHERE campaign_id=?1 AND gate_id=?2",
+                params![
+                    campaign_id.to_string(),
+                    gate_id,
+                    gate_status,
+                    outcome,
+                    freshness,
+                    json_string(&receipt.execution).map_err(internal)?,
+                    blocker_fingerprint,
+                    receipt.finished_at.to_rfc3339(),
+                ],
+            )
+            .map_err(internal)?;
+        if let (Some(reason), Some(fingerprint)) = (
+            request.blocked_reason.as_deref(),
+            blocker_fingerprint.as_deref(),
+        ) {
+            insert_outbox(
+                &transaction,
+                campaign_id,
+                "blocker_changed",
+                fingerprint,
+                serde_json::json!({
+                    "campaign_id": campaign_id,
+                    "gate_id": gate_id,
+                    "reason": reason,
+                    "fingerprint": fingerprint,
+                }),
+            )
+            .map_err(internal)?;
+        }
+        recompute_campaign(&transaction, campaign_id).map_err(internal)?;
+        transaction.commit().map_err(internal)?;
+        Ok(())
     }
 }
 
@@ -683,47 +923,10 @@ async fn claim_gate(
     AxumPath((campaign_id, gate_id)): AxumPath<(Uuid, String)>,
     Json(request): Json<ClaimGateRequest>,
 ) -> Result<Json<GateView>, ApiError> {
-    let mut connection = state.validation.lock().map_err(internal)?;
-    let transaction = connection.transaction().map_err(internal)?;
-    let current = load_gate(&transaction, campaign_id, &gate_id)
-        .map_err(internal)?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                "validation gate not found".to_string(),
-            )
-        })?;
-    if current.status == "running" && current.execution.as_ref() == Some(&request.execution) {
-        return Ok(Json(current));
-    }
-    if current.status != "ready" {
-        return Err((
-            StatusCode::CONFLICT,
-            format!("gate '{gate_id}' is {}, not ready", current.status),
-        ));
-    }
-    transaction
-        .execute(
-            "UPDATE validation_gates SET status='running', execution_json=?3,
-             started_at=?4 WHERE campaign_id=?1 AND gate_id=?2",
-            params![
-                campaign_id.to_string(),
-                gate_id,
-                json_string(&request.execution).map_err(internal)?,
-                Utc::now().to_rfc3339(),
-            ],
-        )
-        .map_err(internal)?;
-    transaction.commit().map_err(internal)?;
-    load_gate(&connection, campaign_id, &gate_id)
-        .map_err(internal)?
+    state
+        .validation
+        .claim(campaign_id, &gate_id, &request.execution)
         .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                "validation gate not found".to_string(),
-            )
-        })
 }
 
 async fn record_receipt(
@@ -731,172 +934,7 @@ async fn record_receipt(
     AxumPath((campaign_id, gate_id)): AxumPath<(Uuid, String)>,
     Json(request): Json<RecordReceiptRequest>,
 ) -> Result<Json<CampaignView>, ApiError> {
-    let mut connection = state.validation.lock().map_err(internal)?;
-    let transaction = connection.transaction().map_err(internal)?;
-    let campaign = load_campaign_row(&transaction, campaign_id)
-        .map_err(internal)?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                "validation campaign not found".to_string(),
-            )
-        })?;
-    let gate = load_gate(&transaction, campaign_id, &gate_id)
-        .map_err(internal)?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                "validation gate not found".to_string(),
-            )
-        })?;
-    let execution_key = request.execution.key();
-    if transaction
-        .query_row(
-            "SELECT 1 FROM validation_receipts
-             WHERE campaign_id=?1 AND gate_id=?2 AND execution_key=?3",
-            params![campaign_id.to_string(), gate_id, execution_key],
-            |_| Ok(()),
-        )
-        .optional()
-        .map_err(internal)?
-        .is_some()
-    {
-        transaction.commit().map_err(internal)?;
-        drop(connection);
-        return state
-            .validation
-            .get(campaign_id)
-            .map(Json)
-            .map_err(internal);
-    }
-    if gate.status != "running" || gate.execution.as_ref() != Some(&request.execution) {
-        return Err((
-            StatusCode::CONFLICT,
-            "receipt execution does not own a running gate".to_string(),
-        ));
-    }
-
-    if let Some(head) = request.observed_head.as_deref() {
-        validate_digest("observed_head", head, 40).map_err(bad_request)?;
-    }
-    let outcome = if request
-        .blocked_reason
-        .as_ref()
-        .is_some_and(|value| !value.trim().is_empty())
-    {
-        "blocked"
-    } else if request.exit_code == Some(0) {
-        "passed"
-    } else {
-        "failed"
-    };
-    if outcome == "passed"
-        && gate.spec.mode == ValidationMode::Clean
-        && !request.cache.clean_checkout
-    {
-        return Err(bad_request(
-            "a passed clean gate receipt must attest cache.clean_checkout=true".to_string(),
-        ));
-    }
-    let expected_head = campaign
-        .candidate
-        .expected_head
-        .as_deref()
-        .unwrap_or(&campaign.candidate.commit);
-    let freshness = if request.observed_head.as_deref() == Some(expected_head) {
-        "exact_head"
-    } else {
-        "stale"
-    };
-    let now = Utc::now();
-    let receipt = ValidationReceipt {
-        id: Uuid::new_v4(),
-        campaign_id,
-        gate_id: gate_id.clone(),
-        candidate_id: campaign.candidate_id,
-        execution: request.execution,
-        outcome: outcome.to_string(),
-        freshness: freshness.to_string(),
-        exit_code: request.exit_code,
-        blocked_reason: request.blocked_reason.clone(),
-        observed_head: request.observed_head,
-        toolchain: request.toolchain,
-        environment_digest: request.environment_digest,
-        cache: request.cache,
-        artifacts: request.artifacts,
-        diagnostic_clusters: request
-            .diagnostics
-            .as_deref()
-            .map(cluster_diagnostics)
-            .unwrap_or_default(),
-        started_at: request.started_at.or(gate.started_at).unwrap_or(now),
-        finished_at: request.finished_at.unwrap_or(now),
-        reused_from: None,
-    };
-    transaction
-        .execute(
-            "INSERT INTO validation_receipts
-             (id, campaign_id, gate_id, execution_key, validation_key, receipt_json,
-              outcome, freshness, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![
-                receipt.id.to_string(),
-                campaign_id.to_string(),
-                gate_id,
-                execution_key,
-                gate.validation_key,
-                json_string(&receipt).map_err(internal)?,
-                outcome,
-                freshness,
-                now.to_rfc3339(),
-            ],
-        )
-        .map_err(internal)?;
-    let gate_status = match (outcome, freshness) {
-        ("passed", "exact_head") => "passed",
-        ("passed", _) => "stale",
-        ("blocked", _) => "blocked",
-        _ => "failed",
-    };
-    let blocker_fingerprint = request.blocked_reason.as_deref().map(hash_text);
-    transaction
-        .execute(
-            "UPDATE validation_gates SET status=?3, outcome=?4, freshness=?5,
-             execution_json=?6, blocker_fingerprint=?7, finished_at=?8
-             WHERE campaign_id=?1 AND gate_id=?2",
-            params![
-                campaign_id.to_string(),
-                gate_id,
-                gate_status,
-                outcome,
-                freshness,
-                json_string(&receipt.execution).map_err(internal)?,
-                blocker_fingerprint,
-                receipt.finished_at.to_rfc3339(),
-            ],
-        )
-        .map_err(internal)?;
-    if let (Some(reason), Some(fingerprint)) = (
-        request.blocked_reason.as_deref(),
-        blocker_fingerprint.as_deref(),
-    ) {
-        insert_outbox(
-            &transaction,
-            campaign_id,
-            "blocker_changed",
-            fingerprint,
-            serde_json::json!({
-                "campaign_id": campaign_id,
-                "gate_id": gate_id,
-                "reason": reason,
-                "fingerprint": fingerprint,
-            }),
-        )
-        .map_err(internal)?;
-    }
-    recompute_campaign(&transaction, campaign_id).map_err(internal)?;
-    transaction.commit().map_err(internal)?;
-    drop(connection);
+    state.validation.record(campaign_id, &gate_id, request)?;
     state
         .validation
         .get(campaign_id)
@@ -1522,6 +1560,8 @@ fn internal(error: impl std::fmt::Display) -> ApiError {
 mod tests {
     use super::*;
 
+    const PINNED_TOOLCHAIN: &str = "leanprover/lean4:v4.31.0";
+
     fn candidate(commit: char) -> ValidationCandidate {
         ValidationCandidate {
             repo: "https://github.com/example/verity.git".to_string(),
@@ -1569,6 +1609,62 @@ mod tests {
                 },
             ],
         }
+    }
+
+    fn execution() -> ExecutionRef {
+        ExecutionRef::WorkspaceJob {
+            job_id: Uuid::new_v4(),
+            workspace_id: Uuid::new_v4(),
+        }
+    }
+
+    fn passing_receipt(
+        execution: ExecutionRef,
+        observed_head: Option<&str>,
+        toolchain: Option<&str>,
+        source_bundle_digest: Option<&str>,
+    ) -> RecordReceiptRequest {
+        RecordReceiptRequest {
+            execution,
+            exit_code: Some(0),
+            blocked_reason: None,
+            observed_head: observed_head.map(str::to_string),
+            source_bundle_digest: source_bundle_digest.map(str::to_string),
+            toolchain: toolchain.map(str::to_string),
+            environment_digest: None,
+            cache: CacheReceipt::default(),
+            artifacts: vec![],
+            diagnostics: None,
+            started_at: None,
+            finished_at: None,
+        }
+    }
+
+    fn claim_and_record(
+        store: &ValidationStore,
+        campaign_id: Uuid,
+        gate_id: &str,
+        observed_head: Option<&str>,
+        toolchain: Option<&str>,
+        source_bundle_digest: Option<&str>,
+    ) {
+        let execution = execution();
+        store.claim(campaign_id, gate_id, &execution).unwrap();
+        store
+            .record(
+                campaign_id,
+                gate_id,
+                passing_receipt(execution, observed_head, toolchain, source_bundle_digest),
+            )
+            .unwrap();
+    }
+
+    fn gate_status(store: &ValidationStore, campaign_id: Uuid, gate_id: &str) -> String {
+        let connection = store.lock().unwrap();
+        load_gate(&connection, campaign_id, gate_id)
+            .unwrap()
+            .unwrap()
+            .status
     }
 
     #[test]
@@ -1692,6 +1788,170 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn exact_head_requires_matching_bundle_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let mut pinned = candidate('a');
+        pinned.source_bundle_digest = Some("b".repeat(64));
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: pinned,
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap();
+        let head = "a".repeat(40);
+
+        // Same head from the clean base checkout (no bundle attested) is not
+        // exact evidence for a pinned dirty overlay.
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&head),
+            Some(PINNED_TOOLCHAIN),
+            None,
+        );
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "stale");
+        assert_eq!(gate_status(&store, campaign.id, "clean-final"), "pending");
+
+        // Same head from a different dirty overlay is not exact evidence.
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&head),
+            Some(PINNED_TOOLCHAIN),
+            Some(&"c".repeat(64)),
+        );
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "stale");
+
+        // Matching bundle digest is exact and unlocks the dependant.
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&head),
+            Some(PINNED_TOOLCHAIN),
+            Some(&"b".repeat(64)),
+        );
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "passed");
+        assert_eq!(gate_status(&store, campaign.id, "clean-final"), "ready");
+    }
+
+    #[test]
+    fn bundle_less_candidate_rejects_bundle_attesting_receipt() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: candidate('a'),
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap();
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&"a".repeat(40)),
+            Some(PINNED_TOOLCHAIN),
+            Some(&"b".repeat(64)),
+        );
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "stale");
+    }
+
+    #[test]
+    fn pinned_toolchain_mismatch_does_not_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: candidate('a'),
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap();
+        let head = "a".repeat(40);
+
+        // Omitted toolchain on a pinned gate must not pass.
+        claim_and_record(&store, campaign.id, "targeted", Some(&head), None, None);
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "stale");
+
+        // A different toolchain must not pass either.
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&head),
+            Some("leanprover/lean4:v4.30.0"),
+            None,
+        );
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "stale");
+
+        // The pinned toolchain passes.
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&head),
+            Some(PINNED_TOOLCHAIN),
+            None,
+        );
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "passed");
+    }
+
+    #[test]
+    fn stale_gate_is_reclaimable_until_exact_head_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: candidate('a'),
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap();
+
+        // A pass observed at the wrong head is retained as stale evidence and
+        // neither unlocks dependants nor certifies.
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&"b".repeat(40)),
+            Some(PINNED_TOOLCHAIN),
+            None,
+        );
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "stale");
+        let view = store.get(campaign.id).unwrap();
+        assert_eq!(view.status, "active");
+        assert!(!view.certifying);
+        assert_eq!(gate_status(&store, campaign.id, "clean-final"), "pending");
+
+        // The stale gate stays claimable and a later exact-head execution
+        // replaces the stale evidence and unlocks the dependant.
+        let retry = execution();
+        let claimed = store.claim(campaign.id, "targeted", &retry).unwrap();
+        assert_eq!(claimed.status, "running");
+        store
+            .record(
+                campaign.id,
+                "targeted",
+                passing_receipt(retry, Some(&"a".repeat(40)), Some(PINNED_TOOLCHAIN), None),
+            )
+            .unwrap();
+        assert_eq!(gate_status(&store, campaign.id, "targeted"), "passed");
+        assert_eq!(gate_status(&store, campaign.id, "clean-final"), "ready");
+
+        // A passed gate is not claimable.
+        let error = store
+            .claim(campaign.id, "targeted", &execution())
+            .unwrap_err();
+        assert_eq!(error.0, StatusCode::CONFLICT);
     }
 
     #[test]

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -1,0 +1,1713 @@
+//! Persistent project validation campaigns.
+//!
+//! A campaign pins one immutable candidate and evaluates a versioned DAG of
+//! gates. Execution remains delegated to the existing workspace/remote job
+//! APIs; typed execution references attach their durable outcomes here. This
+//! module owns freshness, dependency advancement, structured receipts, and a
+//! material-change outbox.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use axum::{
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::routes::AppState;
+
+pub type SharedValidationStore = Arc<ValidationStore>;
+type ApiError = (StatusCode, String);
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/", post(create_campaign).get(list_campaigns))
+        .route("/from-workspace", post(create_from_workspace))
+        .route("/outbox", get(list_outbox))
+        .route("/outbox/:event_id/ack", post(ack_outbox))
+        .route("/:campaign_id", get(get_campaign))
+        .route("/:campaign_id/ready", get(get_ready_gates))
+        .route("/:campaign_id/gates/:gate_id/claim", post(claim_gate))
+        .route(
+            "/:campaign_id/gates/:gate_id/receipts",
+            post(record_receipt),
+        )
+        .route("/:campaign_id/merged", post(mark_merged))
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationMode {
+    Incremental,
+    Clean,
+}
+
+fn default_mode() -> ValidationMode {
+    ValidationMode::Incremental
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationCandidate {
+    pub repo: String,
+    pub commit: String,
+    #[serde(default)]
+    pub expected_head: Option<String>,
+    #[serde(default)]
+    pub source_bundle_digest: Option<String>,
+}
+
+impl ValidationCandidate {
+    fn validate(&self) -> Result<(), String> {
+        if self.repo.trim().is_empty() {
+            return Err("candidate.repo is required".to_string());
+        }
+        validate_digest("candidate.commit", &self.commit, 40)?;
+        if let Some(head) = self.expected_head.as_deref() {
+            validate_digest("candidate.expected_head", head, 40)?;
+        }
+        if let Some(digest) = self.source_bundle_digest.as_deref() {
+            validate_digest("candidate.source_bundle_digest", digest, 64)?;
+        }
+        Ok(())
+    }
+
+    pub fn id(&self) -> String {
+        digest_json(self)
+    }
+}
+
+fn validate_digest(label: &str, value: &str, len: usize) -> Result<(), String> {
+    if value.len() == len
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ('a'..='f').contains(&ch))
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "{label} must be {len} lowercase hexadecimal characters"
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GateSpec {
+    pub id: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default, alias = "depends_on")]
+    pub dependencies: Vec<String>,
+    #[serde(default = "default_true")]
+    pub required: bool,
+    #[serde(default = "default_mode")]
+    pub mode: ValidationMode,
+    #[serde(default = "default_true")]
+    pub reuse: bool,
+    #[serde(default)]
+    pub toolchain: Option<String>,
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub artifacts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationMatrix {
+    #[serde(default = "matrix_version")]
+    pub version: u32,
+    pub project: String,
+    #[serde(default)]
+    pub profile: Option<String>,
+    pub gates: Vec<GateSpec>,
+}
+
+fn matrix_version() -> u32 {
+    1
+}
+
+impl ValidationMatrix {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.version != 1 {
+            return Err(format!(
+                "unsupported validation matrix version {}",
+                self.version
+            ));
+        }
+        if self.project.trim().is_empty() {
+            return Err("matrix.project is required".to_string());
+        }
+        if self.gates.is_empty() {
+            return Err("matrix.gates must not be empty".to_string());
+        }
+        let mut ids = HashSet::new();
+        for gate in &self.gates {
+            if !valid_gate_id(&gate.id) {
+                return Err(format!("invalid gate id '{}'", gate.id));
+            }
+            if !ids.insert(gate.id.as_str()) {
+                return Err(format!("duplicate gate id '{}'", gate.id));
+            }
+            if gate.command.is_empty() || gate.command.iter().any(|arg| arg.contains('\0')) {
+                return Err(format!(
+                    "gate '{}' requires a safe, non-empty argv",
+                    gate.id
+                ));
+            }
+            if gate.timeout_secs == Some(0) {
+                return Err(format!("gate '{}' timeout_secs must be positive", gate.id));
+            }
+        }
+        for gate in &self.gates {
+            for dependency in &gate.dependencies {
+                if dependency == &gate.id || !ids.contains(dependency.as_str()) {
+                    return Err(format!(
+                        "gate '{}' has invalid dependency '{}'",
+                        gate.id, dependency
+                    ));
+                }
+            }
+        }
+        detect_cycle(&self.gates)?;
+        Ok(())
+    }
+}
+
+fn valid_gate_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 80
+        && id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+}
+
+fn detect_cycle(gates: &[GateSpec]) -> Result<(), String> {
+    fn visit<'a>(
+        id: &'a str,
+        by_id: &HashMap<&'a str, &'a GateSpec>,
+        visiting: &mut HashSet<&'a str>,
+        visited: &mut HashSet<&'a str>,
+    ) -> Result<(), String> {
+        if visited.contains(id) {
+            return Ok(());
+        }
+        if !visiting.insert(id) {
+            return Err(format!("validation gate dependency cycle contains '{id}'"));
+        }
+        for dependency in &by_id[id].dependencies {
+            visit(dependency, by_id, visiting, visited)?;
+        }
+        visiting.remove(id);
+        visited.insert(id);
+        Ok(())
+    }
+
+    let by_id = gates
+        .iter()
+        .map(|gate| (gate.id.as_str(), gate))
+        .collect::<HashMap<_, _>>();
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    for gate in gates {
+        visit(&gate.id, &by_id, &mut visiting, &mut visited)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateCampaignRequest {
+    pub candidate: ValidationCandidate,
+    pub matrix: ValidationMatrix,
+    #[serde(default)]
+    pub workspace_id: Option<Uuid>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateFromWorkspaceRequest {
+    workspace_id: Uuid,
+    candidate: ValidationCandidate,
+    #[serde(default)]
+    path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExecutionRef {
+    MissionRun { run_id: Uuid, mission_id: Uuid },
+    WorkspaceJob { job_id: Uuid, workspace_id: Uuid },
+    RemoteJob { job_id: Uuid, node_id: String },
+}
+
+impl ExecutionRef {
+    fn key(&self) -> String {
+        match self {
+            Self::MissionRun { run_id, .. } => format!("mission_run:{run_id}"),
+            Self::WorkspaceJob { job_id, .. } => format!("workspace_job:{job_id}"),
+            Self::RemoteJob { job_id, .. } => format!("remote_job:{job_id}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CacheReceipt {
+    pub mode: Option<String>,
+    pub key: Option<String>,
+    pub hit: Option<bool>,
+    #[serde(default)]
+    pub clean_checkout: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceiptArtifact {
+    pub path: String,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaimGateRequest {
+    execution: ExecutionRef,
+}
+
+#[derive(Debug, Deserialize)]
+struct RecordReceiptRequest {
+    execution: ExecutionRef,
+    exit_code: Option<i32>,
+    #[serde(default)]
+    blocked_reason: Option<String>,
+    #[serde(default)]
+    observed_head: Option<String>,
+    #[serde(default)]
+    toolchain: Option<String>,
+    #[serde(default)]
+    environment_digest: Option<String>,
+    #[serde(default)]
+    cache: CacheReceipt,
+    #[serde(default)]
+    artifacts: Vec<ReceiptArtifact>,
+    #[serde(default)]
+    diagnostics: Option<String>,
+    #[serde(default)]
+    started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    finished_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiagnosticCluster {
+    pub fingerprint: String,
+    pub representative: String,
+    pub count: usize,
+}
+
+pub fn cluster_diagnostics(raw: &str) -> Vec<DiagnosticCluster> {
+    let mut clusters = BTreeMap::<String, DiagnosticCluster>::new();
+    for line in raw.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        let normalized = normalize_diagnostic(line);
+        let fingerprint = hex::encode(Sha256::digest(normalized.as_bytes()));
+        clusters
+            .entry(fingerprint.clone())
+            .and_modify(|cluster| cluster.count += 1)
+            .or_insert_with(|| DiagnosticCluster {
+                fingerprint,
+                representative: line.to_string(),
+                count: 1,
+            });
+    }
+    let mut clusters = clusters.into_values().collect::<Vec<_>>();
+    clusters.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then(a.representative.cmp(&b.representative))
+    });
+    clusters
+}
+
+fn normalize_diagnostic(line: &str) -> String {
+    let mut normalized = String::with_capacity(line.len());
+    let mut digits = false;
+    for ch in line.chars() {
+        if ch.is_ascii_digit() {
+            if !digits {
+                normalized.push('#');
+            }
+            digits = true;
+        } else {
+            digits = false;
+            normalized.push(ch.to_ascii_lowercase());
+        }
+    }
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GateView {
+    pub id: String,
+    pub spec: GateSpec,
+    pub status: String,
+    pub outcome: Option<String>,
+    pub freshness: Option<String>,
+    pub execution: Option<ExecutionRef>,
+    pub validation_key: String,
+    pub reused_receipt_id: Option<Uuid>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationReceipt {
+    pub id: Uuid,
+    pub campaign_id: Uuid,
+    pub gate_id: String,
+    pub candidate_id: String,
+    pub execution: ExecutionRef,
+    pub outcome: String,
+    pub freshness: String,
+    pub exit_code: Option<i32>,
+    pub blocked_reason: Option<String>,
+    pub observed_head: Option<String>,
+    pub toolchain: Option<String>,
+    pub environment_digest: Option<String>,
+    pub cache: CacheReceipt,
+    pub artifacts: Vec<ReceiptArtifact>,
+    pub diagnostic_clusters: Vec<DiagnosticCluster>,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub reused_from: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CampaignView {
+    pub id: Uuid,
+    pub project: String,
+    pub profile: Option<String>,
+    pub workspace_id: Option<Uuid>,
+    pub candidate: ValidationCandidate,
+    pub candidate_id: String,
+    pub matrix_version: u32,
+    pub status: String,
+    pub certifying: bool,
+    pub gates: Vec<GateView>,
+    pub receipts: Vec<ValidationReceipt>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OutboxEvent {
+    id: Uuid,
+    campaign_id: Uuid,
+    event_type: String,
+    fingerprint: String,
+    payload: serde_json::Value,
+    created_at: DateTime<Utc>,
+    attempts: u32,
+    next_attempt_at: Option<DateTime<Utc>>,
+}
+
+pub struct ValidationStore {
+    connection: Mutex<Connection>,
+}
+
+impl ValidationStore {
+    pub fn open(path: PathBuf) -> anyhow::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let connection = Connection::open(path)?;
+        connection.pragma_update(None, "journal_mode", "WAL")?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        connection.execute_batch(SCHEMA)?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    fn lock(&self) -> Result<MutexGuard<'_, Connection>, String> {
+        self.connection
+            .lock()
+            .map_err(|_| "validation database lock poisoned".to_string())
+    }
+
+    fn create(&self, request: CreateCampaignRequest) -> Result<CampaignView, String> {
+        request.candidate.validate()?;
+        request.matrix.validate()?;
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let candidate_id = request.candidate.id();
+        let candidate_json = json_string(&request.candidate)?;
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction().map_err(db_error)?;
+        transaction
+            .execute(
+                "INSERT INTO validation_campaigns
+                 (id, project, profile, workspace_id, candidate_json, candidate_id,
+                  matrix_version, status, certifying, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active', 0, ?8, ?8)",
+                params![
+                    id.to_string(),
+                    request.matrix.project,
+                    request.matrix.profile,
+                    request.workspace_id.map(|id| id.to_string()),
+                    candidate_json,
+                    candidate_id,
+                    request.matrix.version,
+                    now.to_rfc3339(),
+                ],
+            )
+            .map_err(db_error)?;
+        for gate in &request.matrix.gates {
+            let status = if gate.dependencies.is_empty() {
+                "ready"
+            } else {
+                "pending"
+            };
+            let validation_key = validation_key(&request.candidate, gate);
+            transaction
+                .execute(
+                    "INSERT INTO validation_gates
+                     (campaign_id, gate_id, spec_json, status, validation_key)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![
+                        id.to_string(),
+                        gate.id,
+                        json_string(gate)?,
+                        status,
+                        validation_key,
+                    ],
+                )
+                .map_err(db_error)?;
+        }
+        insert_outbox(
+            &transaction,
+            id,
+            "candidate_changed",
+            &candidate_id,
+            serde_json::json!({
+                "campaign_id": id,
+                "project": request.matrix.project,
+                "candidate": request.candidate,
+                "candidate_id": candidate_id,
+            }),
+        )?;
+        reuse_matching_receipts(&transaction, id, &request.candidate)?;
+        recompute_campaign(&transaction, id)?;
+        transaction.commit().map_err(db_error)?;
+        drop(connection);
+        self.get(id)
+    }
+
+    fn get(&self, id: Uuid) -> Result<CampaignView, String> {
+        let connection = self.lock()?;
+        load_campaign(&connection, id)?.ok_or_else(|| format!("campaign {id} not found"))
+    }
+}
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS validation_campaigns (
+    id TEXT PRIMARY KEY,
+    project TEXT NOT NULL,
+    profile TEXT,
+    workspace_id TEXT,
+    candidate_json TEXT NOT NULL,
+    candidate_id TEXT NOT NULL,
+    matrix_version INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    certifying INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS validation_campaign_project_idx
+    ON validation_campaigns(project, created_at DESC);
+CREATE TABLE IF NOT EXISTS validation_gates (
+    campaign_id TEXT NOT NULL REFERENCES validation_campaigns(id) ON DELETE CASCADE,
+    gate_id TEXT NOT NULL,
+    spec_json TEXT NOT NULL,
+    status TEXT NOT NULL,
+    outcome TEXT,
+    freshness TEXT,
+    execution_json TEXT,
+    validation_key TEXT NOT NULL,
+    reused_receipt_id TEXT,
+    blocker_fingerprint TEXT,
+    started_at TEXT,
+    finished_at TEXT,
+    PRIMARY KEY(campaign_id, gate_id)
+);
+CREATE INDEX IF NOT EXISTS validation_gate_key_idx
+    ON validation_gates(validation_key, status);
+CREATE TABLE IF NOT EXISTS validation_receipts (
+    id TEXT PRIMARY KEY,
+    campaign_id TEXT NOT NULL REFERENCES validation_campaigns(id) ON DELETE CASCADE,
+    gate_id TEXT NOT NULL,
+    execution_key TEXT NOT NULL,
+    validation_key TEXT NOT NULL,
+    receipt_json TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    freshness TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(campaign_id, gate_id, execution_key)
+);
+CREATE INDEX IF NOT EXISTS validation_receipt_key_idx
+    ON validation_receipts(validation_key, outcome, freshness, created_at DESC);
+CREATE TABLE IF NOT EXISTS validation_outbox (
+    id TEXT PRIMARY KEY,
+    campaign_id TEXT NOT NULL REFERENCES validation_campaigns(id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TEXT,
+    last_error TEXT,
+    delivered_at TEXT,
+    dead_lettered_at TEXT,
+    UNIQUE(campaign_id, event_type, fingerprint)
+);
+"#;
+
+async fn create_campaign(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<CreateCampaignRequest>,
+) -> Result<(StatusCode, Json<CampaignView>), ApiError> {
+    state
+        .validation
+        .create(request)
+        .map(|campaign| (StatusCode::CREATED, Json(campaign)))
+        .map_err(bad_request)
+}
+
+async fn create_from_workspace(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<CreateFromWorkspaceRequest>,
+) -> Result<(StatusCode, Json<CampaignView>), ApiError> {
+    let workspace = state
+        .workspaces
+        .get(request.workspace_id)
+        .await
+        .ok_or_else(|| (StatusCode::NOT_FOUND, "workspace not found".to_string()))?;
+    let relative = request
+        .path
+        .as_deref()
+        .unwrap_or(".sandboxed/validation.toml");
+    if relative.starts_with('/') || relative.split('/').any(|part| part == "..") {
+        return Err(bad_request(
+            "matrix path must be workspace-relative".to_string(),
+        ));
+    }
+    let workspace_root = tokio::fs::canonicalize(&workspace.path)
+        .await
+        .map_err(|error| bad_request(format!("resolve workspace root: {error}")))?;
+    let path = tokio::fs::canonicalize(workspace.path.join(relative))
+        .await
+        .map_err(|error| bad_request(format!("resolve validation matrix: {error}")))?;
+    if !path.starts_with(&workspace_root) {
+        return Err(bad_request(
+            "matrix path must remain inside the workspace".to_string(),
+        ));
+    }
+    let raw = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|error| bad_request(format!("read {}: {error}", path.display())))?;
+    let matrix = toml::from_str::<ValidationMatrix>(&raw)
+        .map_err(|error| bad_request(format!("parse {}: {error}", path.display())))?;
+    state
+        .validation
+        .create(CreateCampaignRequest {
+            candidate: request.candidate,
+            matrix,
+            workspace_id: Some(request.workspace_id),
+        })
+        .map(|campaign| (StatusCode::CREATED, Json(campaign)))
+        .map_err(bad_request)
+}
+
+async fn get_campaign(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<Uuid>,
+) -> Result<Json<CampaignView>, ApiError> {
+    state.validation.get(id).map(Json).map_err(not_found)
+}
+
+async fn list_campaigns(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<CampaignView>>, ApiError> {
+    let connection = state.validation.lock().map_err(internal)?;
+    let mut statement = connection
+        .prepare("SELECT id FROM validation_campaigns ORDER BY created_at DESC LIMIT 100")
+        .map_err(internal)?;
+    let ids = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(internal)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(internal)?;
+    let campaigns = ids
+        .into_iter()
+        .filter_map(|id| Uuid::parse_str(&id).ok())
+        .filter_map(|id| load_campaign(&connection, id).transpose())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(internal)?;
+    Ok(Json(campaigns))
+}
+
+async fn get_ready_gates(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<Uuid>,
+) -> Result<Json<Vec<GateView>>, ApiError> {
+    let campaign = state.validation.get(id).map_err(not_found)?;
+    Ok(Json(
+        campaign
+            .gates
+            .into_iter()
+            .filter(|gate| gate.status == "ready")
+            .collect(),
+    ))
+}
+
+async fn claim_gate(
+    State(state): State<Arc<AppState>>,
+    AxumPath((campaign_id, gate_id)): AxumPath<(Uuid, String)>,
+    Json(request): Json<ClaimGateRequest>,
+) -> Result<Json<GateView>, ApiError> {
+    let mut connection = state.validation.lock().map_err(internal)?;
+    let transaction = connection.transaction().map_err(internal)?;
+    let current = load_gate(&transaction, campaign_id, &gate_id)
+        .map_err(internal)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                "validation gate not found".to_string(),
+            )
+        })?;
+    if current.status == "running" && current.execution.as_ref() == Some(&request.execution) {
+        return Ok(Json(current));
+    }
+    if current.status != "ready" {
+        return Err((
+            StatusCode::CONFLICT,
+            format!("gate '{gate_id}' is {}, not ready", current.status),
+        ));
+    }
+    transaction
+        .execute(
+            "UPDATE validation_gates SET status='running', execution_json=?3,
+             started_at=?4 WHERE campaign_id=?1 AND gate_id=?2",
+            params![
+                campaign_id.to_string(),
+                gate_id,
+                json_string(&request.execution).map_err(internal)?,
+                Utc::now().to_rfc3339(),
+            ],
+        )
+        .map_err(internal)?;
+    transaction.commit().map_err(internal)?;
+    load_gate(&connection, campaign_id, &gate_id)
+        .map_err(internal)?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                "validation gate not found".to_string(),
+            )
+        })
+}
+
+async fn record_receipt(
+    State(state): State<Arc<AppState>>,
+    AxumPath((campaign_id, gate_id)): AxumPath<(Uuid, String)>,
+    Json(request): Json<RecordReceiptRequest>,
+) -> Result<Json<CampaignView>, ApiError> {
+    let mut connection = state.validation.lock().map_err(internal)?;
+    let transaction = connection.transaction().map_err(internal)?;
+    let campaign = load_campaign_row(&transaction, campaign_id)
+        .map_err(internal)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                "validation campaign not found".to_string(),
+            )
+        })?;
+    let gate = load_gate(&transaction, campaign_id, &gate_id)
+        .map_err(internal)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                "validation gate not found".to_string(),
+            )
+        })?;
+    let execution_key = request.execution.key();
+    if transaction
+        .query_row(
+            "SELECT 1 FROM validation_receipts
+             WHERE campaign_id=?1 AND gate_id=?2 AND execution_key=?3",
+            params![campaign_id.to_string(), gate_id, execution_key],
+            |_| Ok(()),
+        )
+        .optional()
+        .map_err(internal)?
+        .is_some()
+    {
+        transaction.commit().map_err(internal)?;
+        drop(connection);
+        return state
+            .validation
+            .get(campaign_id)
+            .map(Json)
+            .map_err(internal);
+    }
+    if gate.status != "running" || gate.execution.as_ref() != Some(&request.execution) {
+        return Err((
+            StatusCode::CONFLICT,
+            "receipt execution does not own a running gate".to_string(),
+        ));
+    }
+
+    if let Some(head) = request.observed_head.as_deref() {
+        validate_digest("observed_head", head, 40).map_err(bad_request)?;
+    }
+    let outcome = if request
+        .blocked_reason
+        .as_ref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        "blocked"
+    } else if request.exit_code == Some(0) {
+        "passed"
+    } else {
+        "failed"
+    };
+    if outcome == "passed"
+        && gate.spec.mode == ValidationMode::Clean
+        && !request.cache.clean_checkout
+    {
+        return Err(bad_request(
+            "a passed clean gate receipt must attest cache.clean_checkout=true".to_string(),
+        ));
+    }
+    let expected_head = campaign
+        .candidate
+        .expected_head
+        .as_deref()
+        .unwrap_or(&campaign.candidate.commit);
+    let freshness = if request.observed_head.as_deref() == Some(expected_head) {
+        "exact_head"
+    } else {
+        "stale"
+    };
+    let now = Utc::now();
+    let receipt = ValidationReceipt {
+        id: Uuid::new_v4(),
+        campaign_id,
+        gate_id: gate_id.clone(),
+        candidate_id: campaign.candidate_id,
+        execution: request.execution,
+        outcome: outcome.to_string(),
+        freshness: freshness.to_string(),
+        exit_code: request.exit_code,
+        blocked_reason: request.blocked_reason.clone(),
+        observed_head: request.observed_head,
+        toolchain: request.toolchain,
+        environment_digest: request.environment_digest,
+        cache: request.cache,
+        artifacts: request.artifacts,
+        diagnostic_clusters: request
+            .diagnostics
+            .as_deref()
+            .map(cluster_diagnostics)
+            .unwrap_or_default(),
+        started_at: request.started_at.or(gate.started_at).unwrap_or(now),
+        finished_at: request.finished_at.unwrap_or(now),
+        reused_from: None,
+    };
+    transaction
+        .execute(
+            "INSERT INTO validation_receipts
+             (id, campaign_id, gate_id, execution_key, validation_key, receipt_json,
+              outcome, freshness, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                receipt.id.to_string(),
+                campaign_id.to_string(),
+                gate_id,
+                execution_key,
+                gate.validation_key,
+                json_string(&receipt).map_err(internal)?,
+                outcome,
+                freshness,
+                now.to_rfc3339(),
+            ],
+        )
+        .map_err(internal)?;
+    let gate_status = match (outcome, freshness) {
+        ("passed", "exact_head") => "passed",
+        ("passed", _) => "stale",
+        ("blocked", _) => "blocked",
+        _ => "failed",
+    };
+    let blocker_fingerprint = request.blocked_reason.as_deref().map(hash_text);
+    transaction
+        .execute(
+            "UPDATE validation_gates SET status=?3, outcome=?4, freshness=?5,
+             execution_json=?6, blocker_fingerprint=?7, finished_at=?8
+             WHERE campaign_id=?1 AND gate_id=?2",
+            params![
+                campaign_id.to_string(),
+                gate_id,
+                gate_status,
+                outcome,
+                freshness,
+                json_string(&receipt.execution).map_err(internal)?,
+                blocker_fingerprint,
+                receipt.finished_at.to_rfc3339(),
+            ],
+        )
+        .map_err(internal)?;
+    if let (Some(reason), Some(fingerprint)) = (
+        request.blocked_reason.as_deref(),
+        blocker_fingerprint.as_deref(),
+    ) {
+        insert_outbox(
+            &transaction,
+            campaign_id,
+            "blocker_changed",
+            fingerprint,
+            serde_json::json!({
+                "campaign_id": campaign_id,
+                "gate_id": gate_id,
+                "reason": reason,
+                "fingerprint": fingerprint,
+            }),
+        )
+        .map_err(internal)?;
+    }
+    recompute_campaign(&transaction, campaign_id).map_err(internal)?;
+    transaction.commit().map_err(internal)?;
+    drop(connection);
+    state
+        .validation
+        .get(campaign_id)
+        .map(Json)
+        .map_err(internal)
+}
+
+async fn mark_merged(
+    State(state): State<Arc<AppState>>,
+    AxumPath(campaign_id): AxumPath<Uuid>,
+) -> Result<Json<CampaignView>, ApiError> {
+    let mut connection = state.validation.lock().map_err(internal)?;
+    let transaction = connection.transaction().map_err(internal)?;
+    let (status, certifying): (String, bool) = transaction
+        .query_row(
+            "SELECT status, certifying FROM validation_campaigns WHERE id=?1",
+            params![campaign_id.to_string()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(internal)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                "validation campaign not found".to_string(),
+            )
+        })?;
+    if status != "completed" || !certifying {
+        return Err((
+            StatusCode::CONFLICT,
+            "only a completed exact-head campaign with a required clean gate may be merged"
+                .to_string(),
+        ));
+    }
+    transaction
+        .execute(
+            "UPDATE validation_campaigns SET status='merged', updated_at=?2 WHERE id=?1",
+            params![campaign_id.to_string(), Utc::now().to_rfc3339()],
+        )
+        .map_err(internal)?;
+    insert_outbox(
+        &transaction,
+        campaign_id,
+        "merged",
+        "merged",
+        serde_json::json!({"campaign_id": campaign_id, "status": "merged"}),
+    )
+    .map_err(internal)?;
+    transaction.commit().map_err(internal)?;
+    drop(connection);
+    state
+        .validation
+        .get(campaign_id)
+        .map(Json)
+        .map_err(internal)
+}
+
+async fn list_outbox(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<OutboxEvent>>, ApiError> {
+    let connection = state.validation.lock().map_err(internal)?;
+    let mut statement = connection
+        .prepare(
+            "SELECT id, campaign_id, event_type, fingerprint, payload_json,
+                    created_at, attempts, next_attempt_at
+             FROM validation_outbox WHERE delivered_at IS NULL
+               AND dead_lettered_at IS NULL ORDER BY created_at LIMIT 200",
+        )
+        .map_err(internal)?;
+    let events = statement
+        .query_map([], |row| {
+            Ok(OutboxEvent {
+                id: parse_uuid_sql(row.get::<_, String>(0)?)?,
+                campaign_id: parse_uuid_sql(row.get::<_, String>(1)?)?,
+                event_type: row.get(2)?,
+                fingerprint: row.get(3)?,
+                payload: parse_json_sql(row.get::<_, String>(4)?)?,
+                created_at: parse_time_sql(row.get::<_, String>(5)?)?,
+                attempts: row.get(6)?,
+                next_attempt_at: row
+                    .get::<_, Option<String>>(7)?
+                    .map(parse_time_sql)
+                    .transpose()?,
+            })
+        })
+        .map_err(internal)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(internal)?;
+    Ok(Json(events))
+}
+
+/// Deliver semantic validation events from a durable outbox. The event id is
+/// stable across retries, consumers can deduplicate at-least-once delivery,
+/// and repeated process restarts resume from SQLite rather than losing a
+/// broadcast-only callback.
+pub fn spawn_outbox_forwarder(state: Arc<AppState>) {
+    let Some(url) = state.config.paloma_webhook_forward_url.clone() else {
+        return;
+    };
+    let secret = state.config.paloma_webhook_secret.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            let due = {
+                let Ok(connection) = state.validation.lock() else {
+                    continue;
+                };
+                load_due_outbox(&connection, Utc::now()).unwrap_or_default()
+            };
+            for event in due {
+                let body = serde_json::json!({
+                    "event_id": event.id,
+                    "type": event.event_type,
+                    "campaign_id": event.campaign_id,
+                    "fingerprint": event.fingerprint,
+                    "created_at": event.created_at,
+                    "payload": event.payload,
+                });
+                let Ok(bytes) = serde_json::to_vec(&body) else {
+                    continue;
+                };
+                let mut request = state
+                    .http_client
+                    .post(&url)
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .body(bytes.clone());
+                if let Some(secret) = secret.as_deref() {
+                    use hmac::{Hmac, Mac};
+                    if let Ok(mut mac) = Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes()) {
+                        mac.update(&bytes);
+                        request = request.header(
+                            "X-Hub-Signature-256",
+                            format!("sha256={}", hex::encode(mac.finalize().into_bytes())),
+                        );
+                    }
+                }
+                let result = request.send().await;
+                let (delivered, error) = match result {
+                    Ok(response) if response.status().is_success() => (true, None),
+                    Ok(response) => (false, Some(format!("HTTP {}", response.status()))),
+                    Err(error) => (false, Some(error.to_string())),
+                };
+                let Ok(connection) = state.validation.lock() else {
+                    continue;
+                };
+                if delivered {
+                    let _ = connection.execute(
+                        "UPDATE validation_outbox SET delivered_at=?2, attempts=attempts+1,
+                         last_error=NULL WHERE id=?1 AND delivered_at IS NULL",
+                        params![event.id.to_string(), Utc::now().to_rfc3339()],
+                    );
+                } else {
+                    let attempts = event.attempts.saturating_add(1);
+                    let delay = (5_i64.saturating_mul(2_i64.pow(attempts.min(10)))).min(3600);
+                    let dead_lettered = (attempts >= 12).then(|| Utc::now().to_rfc3339());
+                    let _ = connection.execute(
+                        "UPDATE validation_outbox SET attempts=?2, next_attempt_at=?3,
+                         last_error=?4, dead_lettered_at=?5 WHERE id=?1",
+                        params![
+                            event.id.to_string(),
+                            attempts,
+                            (Utc::now() + chrono::Duration::seconds(delay)).to_rfc3339(),
+                            error,
+                            dead_lettered,
+                        ],
+                    );
+                }
+            }
+        }
+    });
+}
+
+fn load_due_outbox(
+    connection: &Connection,
+    now: DateTime<Utc>,
+) -> Result<Vec<OutboxEvent>, rusqlite::Error> {
+    let mut statement = connection.prepare(
+        "SELECT id, campaign_id, event_type, fingerprint, payload_json,
+                created_at, attempts, next_attempt_at
+         FROM validation_outbox
+         WHERE delivered_at IS NULL AND dead_lettered_at IS NULL
+           AND (next_attempt_at IS NULL OR next_attempt_at <= ?1)
+         ORDER BY created_at LIMIT 32",
+    )?;
+    let events = statement
+        .query_map(params![now.to_rfc3339()], |row| {
+            Ok(OutboxEvent {
+                id: parse_uuid_sql(row.get::<_, String>(0)?)?,
+                campaign_id: parse_uuid_sql(row.get::<_, String>(1)?)?,
+                event_type: row.get(2)?,
+                fingerprint: row.get(3)?,
+                payload: parse_json_sql(row.get::<_, String>(4)?)?,
+                created_at: parse_time_sql(row.get::<_, String>(5)?)?,
+                attempts: row.get(6)?,
+                next_attempt_at: row
+                    .get::<_, Option<String>>(7)?
+                    .map(parse_time_sql)
+                    .transpose()?,
+            })
+        })?
+        .collect();
+    events
+}
+
+async fn ack_outbox(
+    State(state): State<Arc<AppState>>,
+    AxumPath(event_id): AxumPath<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    let connection = state.validation.lock().map_err(internal)?;
+    let changed = connection
+        .execute(
+            "UPDATE validation_outbox SET delivered_at=?2, attempts=attempts+1
+             WHERE id=?1 AND delivered_at IS NULL",
+            params![event_id.to_string(), Utc::now().to_rfc3339()],
+        )
+        .map_err(internal)?;
+    if changed == 0 {
+        Err((StatusCode::NOT_FOUND, "outbox event not found".to_string()))
+    } else {
+        Ok(StatusCode::NO_CONTENT)
+    }
+}
+
+#[derive(Debug)]
+struct CampaignRow {
+    project: String,
+    profile: Option<String>,
+    workspace_id: Option<Uuid>,
+    candidate: ValidationCandidate,
+    candidate_id: String,
+    matrix_version: u32,
+    status: String,
+    certifying: bool,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+fn load_campaign_row(
+    connection: &Connection,
+    id: Uuid,
+) -> Result<Option<CampaignRow>, rusqlite::Error> {
+    connection
+        .query_row(
+            "SELECT project, profile, workspace_id, candidate_json, candidate_id,
+                    matrix_version, status, certifying, created_at, updated_at
+             FROM validation_campaigns WHERE id=?1",
+            params![id.to_string()],
+            |row| {
+                Ok(CampaignRow {
+                    project: row.get(0)?,
+                    profile: row.get(1)?,
+                    workspace_id: row
+                        .get::<_, Option<String>>(2)?
+                        .map(parse_uuid_sql)
+                        .transpose()?,
+                    candidate: parse_json_sql(row.get::<_, String>(3)?)?,
+                    candidate_id: row.get(4)?,
+                    matrix_version: row.get(5)?,
+                    status: row.get(6)?,
+                    certifying: row.get(7)?,
+                    created_at: parse_time_sql(row.get::<_, String>(8)?)?,
+                    updated_at: parse_time_sql(row.get::<_, String>(9)?)?,
+                })
+            },
+        )
+        .optional()
+}
+
+fn load_campaign(connection: &Connection, id: Uuid) -> Result<Option<CampaignView>, String> {
+    let Some(row) = load_campaign_row(connection, id).map_err(db_error)? else {
+        return Ok(None);
+    };
+    let mut statement = connection
+        .prepare(
+            "SELECT gate_id, spec_json, status, outcome, freshness, execution_json,
+                    validation_key, reused_receipt_id, started_at, finished_at
+             FROM validation_gates WHERE campaign_id=?1 ORDER BY rowid",
+        )
+        .map_err(db_error)?;
+    let gates = statement
+        .query_map(params![id.to_string()], gate_from_row)
+        .map_err(db_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(db_error)?;
+    let mut statement = connection
+        .prepare(
+            "SELECT receipt_json FROM validation_receipts
+             WHERE campaign_id=?1 ORDER BY created_at",
+        )
+        .map_err(db_error)?;
+    let receipts = statement
+        .query_map(params![id.to_string()], |row| {
+            parse_json_sql(row.get::<_, String>(0)?)
+        })
+        .map_err(db_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(db_error)?;
+    Ok(Some(CampaignView {
+        id,
+        project: row.project,
+        profile: row.profile,
+        workspace_id: row.workspace_id,
+        candidate: row.candidate,
+        candidate_id: row.candidate_id,
+        matrix_version: row.matrix_version,
+        status: row.status,
+        certifying: row.certifying,
+        gates,
+        receipts,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    }))
+}
+
+fn load_gate(
+    connection: &Connection,
+    campaign_id: Uuid,
+    gate_id: &str,
+) -> Result<Option<GateView>, rusqlite::Error> {
+    connection
+        .query_row(
+            "SELECT gate_id, spec_json, status, outcome, freshness, execution_json,
+                    validation_key, reused_receipt_id, started_at, finished_at
+             FROM validation_gates WHERE campaign_id=?1 AND gate_id=?2",
+            params![campaign_id.to_string(), gate_id],
+            gate_from_row,
+        )
+        .optional()
+}
+
+fn gate_from_row(row: &rusqlite::Row<'_>) -> Result<GateView, rusqlite::Error> {
+    Ok(GateView {
+        id: row.get(0)?,
+        spec: parse_json_sql(row.get::<_, String>(1)?)?,
+        status: row.get(2)?,
+        outcome: row.get(3)?,
+        freshness: row.get(4)?,
+        execution: row
+            .get::<_, Option<String>>(5)?
+            .map(parse_json_sql)
+            .transpose()?,
+        validation_key: row.get(6)?,
+        reused_receipt_id: row
+            .get::<_, Option<String>>(7)?
+            .map(parse_uuid_sql)
+            .transpose()?,
+        started_at: row
+            .get::<_, Option<String>>(8)?
+            .map(parse_time_sql)
+            .transpose()?,
+        finished_at: row
+            .get::<_, Option<String>>(9)?
+            .map(parse_time_sql)
+            .transpose()?,
+    })
+}
+
+fn reuse_matching_receipts(
+    connection: &Connection,
+    campaign_id: Uuid,
+    candidate: &ValidationCandidate,
+) -> Result<(), String> {
+    let mut statement = connection
+        .prepare(
+            "SELECT gate_id, spec_json, validation_key FROM validation_gates WHERE campaign_id=?1",
+        )
+        .map_err(db_error)?;
+    let gates = statement
+        .query_map(params![campaign_id.to_string()], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                parse_json_sql::<GateSpec>(row.get::<_, String>(1)?)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(db_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(db_error)?;
+    drop(statement);
+    for (gate_id, spec, key) in gates {
+        if !spec.reuse {
+            continue;
+        }
+        let prior = connection
+            .query_row(
+                "SELECT id, receipt_json FROM validation_receipts
+                 WHERE validation_key=?1 AND outcome='passed' AND freshness='exact_head'
+                 ORDER BY created_at DESC LIMIT 1",
+                params![key],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()
+            .map_err(db_error)?;
+        let Some((prior_id, receipt_json)) = prior else {
+            continue;
+        };
+        let mut receipt = serde_json::from_str::<ValidationReceipt>(&receipt_json)
+            .map_err(|error| error.to_string())?;
+        if receipt.candidate_id != candidate.id() {
+            continue;
+        }
+        let prior_uuid = Uuid::parse_str(&prior_id).map_err(|error| error.to_string())?;
+        receipt.id = Uuid::new_v4();
+        receipt.campaign_id = campaign_id;
+        receipt.gate_id = gate_id.clone();
+        receipt.reused_from = Some(prior_uuid);
+        let execution_key = format!("reused:{prior_uuid}");
+        connection
+            .execute(
+                "INSERT INTO validation_receipts
+                 (id, campaign_id, gate_id, execution_key, validation_key, receipt_json,
+                  outcome, freshness, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'passed', 'exact_head', ?7)",
+                params![
+                    receipt.id.to_string(),
+                    campaign_id.to_string(),
+                    gate_id,
+                    execution_key,
+                    key,
+                    json_string(&receipt)?,
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .map_err(db_error)?;
+        connection
+            .execute(
+                "UPDATE validation_gates SET status='passed', outcome='passed',
+                 freshness='exact_head', execution_json=?3, reused_receipt_id=?4,
+                 started_at=?5, finished_at=?5 WHERE campaign_id=?1 AND gate_id=?2",
+                params![
+                    campaign_id.to_string(),
+                    gate_id,
+                    json_string(&receipt.execution)?,
+                    prior_id,
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .map_err(db_error)?;
+    }
+    Ok(())
+}
+
+fn recompute_campaign(connection: &Connection, campaign_id: Uuid) -> Result<(), String> {
+    let mut statement = connection
+        .prepare("SELECT gate_id, spec_json, status FROM validation_gates WHERE campaign_id=?1")
+        .map_err(db_error)?;
+    let gates = statement
+        .query_map(params![campaign_id.to_string()], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                parse_json_sql::<GateSpec>(row.get::<_, String>(1)?)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(db_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(db_error)?;
+    drop(statement);
+    let statuses = gates
+        .iter()
+        .map(|(id, _, status)| (id.as_str(), status.as_str()))
+        .collect::<HashMap<_, _>>();
+    for (id, spec, status) in &gates {
+        if status == "pending"
+            && spec
+                .dependencies
+                .iter()
+                .all(|dependency| statuses.get(dependency.as_str()) == Some(&"passed"))
+        {
+            connection
+                .execute(
+                    "UPDATE validation_gates SET status='ready' WHERE campaign_id=?1 AND gate_id=?2",
+                    params![campaign_id.to_string(), id],
+                )
+                .map_err(db_error)?;
+        }
+    }
+    let required = gates
+        .iter()
+        .filter(|(_, spec, _)| spec.required)
+        .collect::<Vec<_>>();
+    let failed = required.iter().any(|(_, _, status)| status == "failed");
+    let blocked = required.iter().any(|(_, _, status)| status == "blocked");
+    let complete = !required.is_empty() && required.iter().all(|(_, _, status)| status == "passed");
+    let certifying = complete
+        && required
+            .iter()
+            .any(|(_, spec, status)| spec.mode == ValidationMode::Clean && status == "passed");
+    let next_status = if failed {
+        "failed"
+    } else if blocked {
+        "blocked"
+    } else if complete {
+        "completed"
+    } else {
+        "active"
+    };
+    let prior_status: String = connection
+        .query_row(
+            "SELECT status FROM validation_campaigns WHERE id=?1",
+            params![campaign_id.to_string()],
+            |row| row.get(0),
+        )
+        .map_err(db_error)?;
+    connection
+        .execute(
+            "UPDATE validation_campaigns SET status=?2, certifying=?3, updated_at=?4 WHERE id=?1",
+            params![
+                campaign_id.to_string(),
+                next_status,
+                certifying,
+                Utc::now().to_rfc3339(),
+            ],
+        )
+        .map_err(db_error)?;
+    if prior_status != next_status && matches!(next_status, "failed" | "blocked" | "completed") {
+        insert_outbox(
+            connection,
+            campaign_id,
+            "campaign_terminal",
+            next_status,
+            serde_json::json!({
+                "campaign_id": campaign_id,
+                "status": next_status,
+                "certifying": certifying,
+            }),
+        )?;
+    }
+    Ok(())
+}
+
+fn insert_outbox(
+    connection: &Connection,
+    campaign_id: Uuid,
+    event_type: &str,
+    fingerprint: &str,
+    payload: serde_json::Value,
+) -> Result<(), String> {
+    connection
+        .execute(
+            "INSERT OR IGNORE INTO validation_outbox
+             (id, campaign_id, event_type, fingerprint, payload_json, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                Uuid::new_v4().to_string(),
+                campaign_id.to_string(),
+                event_type,
+                fingerprint,
+                payload.to_string(),
+                Utc::now().to_rfc3339(),
+            ],
+        )
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn validation_key(candidate: &ValidationCandidate, gate: &GateSpec) -> String {
+    digest_json(&(candidate, gate))
+}
+
+fn digest_json(value: &impl Serialize) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn hash_text(value: &str) -> String {
+    hex::encode(Sha256::digest(value.trim().as_bytes()))
+}
+
+fn json_string(value: &impl Serialize) -> Result<String, String> {
+    serde_json::to_string(value).map_err(|error| error.to_string())
+}
+
+fn parse_json_sql<T: serde::de::DeserializeOwned>(raw: String) -> Result<T, rusqlite::Error> {
+    serde_json::from_str(&raw).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            raw.len(),
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+fn parse_uuid_sql(raw: String) -> Result<Uuid, rusqlite::Error> {
+    Uuid::parse_str(&raw).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            raw.len(),
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+fn parse_time_sql(raw: String) -> Result<DateTime<Utc>, rusqlite::Error> {
+    DateTime::parse_from_rfc3339(&raw)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                raw.len(),
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })
+}
+
+fn db_error(error: rusqlite::Error) -> String {
+    format!("validation database: {error}")
+}
+
+fn bad_request(message: String) -> ApiError {
+    (StatusCode::BAD_REQUEST, message)
+}
+
+fn not_found(message: String) -> ApiError {
+    (StatusCode::NOT_FOUND, message)
+}
+
+fn internal(error: impl std::fmt::Display) -> ApiError {
+    (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(commit: char) -> ValidationCandidate {
+        ValidationCandidate {
+            repo: "https://github.com/example/verity.git".to_string(),
+            commit: commit.to_string().repeat(40),
+            expected_head: Some(commit.to_string().repeat(40)),
+            source_bundle_digest: None,
+        }
+    }
+
+    fn matrix() -> ValidationMatrix {
+        ValidationMatrix {
+            version: 1,
+            project: "verity".to_string(),
+            profile: Some("lean-4.31".to_string()),
+            gates: vec![
+                GateSpec {
+                    id: "targeted".to_string(),
+                    description: None,
+                    command: vec![
+                        "lake".to_string(),
+                        "build".to_string(),
+                        "CodeData".to_string(),
+                    ],
+                    cwd: None,
+                    dependencies: vec![],
+                    required: true,
+                    mode: ValidationMode::Incremental,
+                    reuse: true,
+                    toolchain: Some("leanprover/lean4:v4.31.0".to_string()),
+                    timeout_secs: Some(1800),
+                    artifacts: vec![],
+                },
+                GateSpec {
+                    id: "clean-final".to_string(),
+                    description: None,
+                    command: vec!["lake".to_string(), "build".to_string()],
+                    cwd: None,
+                    dependencies: vec!["targeted".to_string()],
+                    required: true,
+                    mode: ValidationMode::Clean,
+                    reuse: true,
+                    toolchain: Some("leanprover/lean4:v4.31.0".to_string()),
+                    timeout_secs: Some(7200),
+                    artifacts: vec![],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn rejects_cycles_and_invalid_candidates() {
+        let mut cyclic = matrix();
+        cyclic.gates[0].dependencies = vec!["clean-final".to_string()];
+        assert!(cyclic.validate().unwrap_err().contains("cycle"));
+        let mut invalid = candidate('a');
+        invalid.commit = "short".to_string();
+        assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn diagnostic_clusters_ignore_location_numbers() {
+        let clusters =
+            cluster_diagnostics("Foo.lean:10:2: type mismatch\nFoo.lean:99:8: type mismatch\nbar");
+        assert_eq!(clusters[0].count, 2);
+        assert_eq!(clusters.len(), 2);
+    }
+
+    #[test]
+    fn exact_head_clean_gate_is_required_for_certification() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: candidate('a'),
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap();
+        assert_eq!(campaign.gates[0].status, "ready");
+        assert_eq!(campaign.gates[1].status, "pending");
+        assert!(!campaign.certifying);
+    }
+
+    #[test]
+    fn dependency_progression_requires_exact_pass_and_clean_gate_certifies() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: candidate('a'),
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap();
+        let connection = store.lock().unwrap();
+        connection
+            .execute(
+                "UPDATE validation_gates SET status='stale', outcome='passed', freshness='stale'
+                 WHERE campaign_id=?1 AND gate_id='targeted'",
+                params![campaign.id.to_string()],
+            )
+            .unwrap();
+        recompute_campaign(&connection, campaign.id).unwrap();
+        assert_eq!(
+            load_gate(&connection, campaign.id, "clean-final")
+                .unwrap()
+                .unwrap()
+                .status,
+            "pending"
+        );
+        connection
+            .execute(
+                "UPDATE validation_gates SET status='passed', freshness='exact_head'
+                 WHERE campaign_id=?1 AND gate_id='targeted'",
+                params![campaign.id.to_string()],
+            )
+            .unwrap();
+        recompute_campaign(&connection, campaign.id).unwrap();
+        assert_eq!(
+            load_gate(&connection, campaign.id, "clean-final")
+                .unwrap()
+                .unwrap()
+                .status,
+            "ready"
+        );
+        connection
+            .execute(
+                "UPDATE validation_gates SET status='passed', outcome='passed', freshness='exact_head'
+                 WHERE campaign_id=?1 AND gate_id='clean-final'",
+                params![campaign.id.to_string()],
+            )
+            .unwrap();
+        recompute_campaign(&connection, campaign.id).unwrap();
+        drop(connection);
+        let campaign = store.get(campaign.id).unwrap();
+        assert_eq!(campaign.status, "completed");
+        assert!(campaign.certifying);
+    }
+
+    #[test]
+    fn material_outbox_coalesces_same_fingerprint() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: candidate('a'),
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap();
+        let connection = store.lock().unwrap();
+        for _ in 0..3 {
+            insert_outbox(
+                &connection,
+                campaign.id,
+                "blocker_changed",
+                "same-blocker",
+                serde_json::json!({"reason": "same"}),
+            )
+            .unwrap();
+        }
+        let count: u32 = connection
+            .query_row(
+                "SELECT count(*) FROM validation_outbox
+                 WHERE campaign_id=?1 AND event_type='blocker_changed'",
+                params![campaign.id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn matrix_toml_is_versioned_and_uses_argv() {
+        let raw = r#"
+version = 1
+project = "verity"
+profile = "lean-4.31"
+
+[[gates]]
+id = "compiler"
+command = ["lake", "build", "Compiler"]
+mode = "clean"
+"#;
+        let matrix: ValidationMatrix = toml::from_str(raw).unwrap();
+        matrix.validate().unwrap();
+        assert_eq!(matrix.gates[0].mode, ValidationMode::Clean);
+    }
+}

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -76,6 +76,17 @@ impl ValidationCandidate {
         validate_digest("candidate.commit", &self.commit, 40)?;
         if let Some(head) = self.expected_head.as_deref() {
             validate_digest("candidate.expected_head", head, 40)?;
+            // Exact receipts certify the pinned candidate commit; an
+            // expected_head pointing at a different revision would classify
+            // evidence for that other revision as exact_head and certify the
+            // wrong commit.
+            if head != self.commit {
+                return Err(format!(
+                    "candidate.expected_head ({head}) must match candidate.commit ({}): \
+                     exact receipts certify the candidate commit",
+                    self.commit
+                ));
+            }
         }
         if let Some(digest) = self.source_bundle_digest.as_deref() {
             validate_digest("candidate.source_bundle_digest", digest, 64)?;
@@ -154,12 +165,12 @@ impl ValidationMatrix {
         if self.gates.is_empty() {
             return Err("matrix.gates must not be empty".to_string());
         }
-        let mut ids = HashSet::new();
+        let mut by_id = HashMap::new();
         for gate in &self.gates {
             if !valid_gate_id(&gate.id) {
                 return Err(format!("invalid gate id '{}'", gate.id));
             }
-            if !ids.insert(gate.id.as_str()) {
+            if by_id.insert(gate.id.as_str(), gate).is_some() {
                 return Err(format!("duplicate gate id '{}'", gate.id));
             }
             if gate.command.is_empty() || gate.command.iter().any(|arg| arg.contains('\0')) {
@@ -174,9 +185,24 @@ impl ValidationMatrix {
         }
         for gate in &self.gates {
             for dependency in &gate.dependencies {
-                if dependency == &gate.id || !ids.contains(dependency.as_str()) {
+                let Some(dependency_gate) = by_id.get(dependency.as_str()) else {
                     return Err(format!(
                         "gate '{}' has invalid dependency '{}'",
+                        gate.id, dependency
+                    ));
+                };
+                if dependency == &gate.id {
+                    return Err(format!(
+                        "gate '{}' has invalid dependency '{}'",
+                        gate.id, dependency
+                    ));
+                }
+                // An optional gate's failure does not fail the campaign, so a
+                // required gate waiting on it would stay pending forever while
+                // the campaign stays active. Reject the shape outright.
+                if gate.required && !dependency_gate.required {
+                    return Err(format!(
+                        "required gate '{}' depends on optional gate '{}'",
                         gate.id, dependency
                     ));
                 }
@@ -528,6 +554,27 @@ impl ValidationStore {
     ) -> Result<GateView, ApiError> {
         let mut connection = self.lock().map_err(internal)?;
         let transaction = connection.transaction().map_err(internal)?;
+        let campaign_status: String = transaction
+            .query_row(
+                "SELECT status FROM validation_campaigns WHERE id=?1",
+                params![campaign_id.to_string()],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(internal)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    "validation campaign not found".to_string(),
+                )
+            })?;
+        // Merged is terminal: nothing left to validate for a landed candidate.
+        if campaign_status == "merged" {
+            return Err((
+                StatusCode::CONFLICT,
+                "campaign is merged, gates are no longer claimable".to_string(),
+            ));
+        }
         let current = load_gate(&transaction, campaign_id, gate_id)
             .map_err(internal)?
             .ok_or_else(|| {
@@ -909,11 +956,14 @@ async fn get_ready_gates(
     AxumPath(id): AxumPath<Uuid>,
 ) -> Result<Json<Vec<GateView>>, ApiError> {
     let campaign = state.validation.get(id).map_err(not_found)?;
+    // Stale gates stay claimable (see `ValidationStore::claim`), so workers
+    // dispatching from this listing must see them or exact-head retries of
+    // stale evidence would never be scheduled.
     Ok(Json(
         campaign
             .gates
             .into_iter()
-            .filter(|gate| gate.status == "ready")
+            .filter(|gate| gate.status == "ready" || gate.status == "stale")
             .collect(),
     ))
 }
@@ -1378,6 +1428,19 @@ fn reuse_matching_receipts(
 }
 
 fn recompute_campaign(connection: &Connection, campaign_id: Uuid) -> Result<(), String> {
+    let prior_status: String = connection
+        .query_row(
+            "SELECT status FROM validation_campaigns WHERE id=?1",
+            params![campaign_id.to_string()],
+            |row| row.get(0),
+        )
+        .map_err(db_error)?;
+    // Merged is terminal: the candidate has already landed, so late receipts
+    // (for example from leftover optional gates) must never downgrade the
+    // campaign back to completed/active.
+    if prior_status == "merged" {
+        return Ok(());
+    }
     let mut statement = connection
         .prepare("SELECT gate_id, spec_json, status FROM validation_gates WHERE campaign_id=?1")
         .map_err(db_error)?;
@@ -1432,13 +1495,6 @@ fn recompute_campaign(connection: &Connection, campaign_id: Uuid) -> Result<(), 
     } else {
         "active"
     };
-    let prior_status: String = connection
-        .query_row(
-            "SELECT status FROM validation_campaigns WHERE id=?1",
-            params![campaign_id.to_string()],
-            |row| row.get(0),
-        )
-        .map_err(db_error)?;
     connection
         .execute(
             "UPDATE validation_campaigns SET status=?2, certifying=?3, updated_at=?4 WHERE id=?1",
@@ -1667,6 +1723,22 @@ mod tests {
             .status
     }
 
+    fn optional_gate(id: &str) -> GateSpec {
+        GateSpec {
+            id: id.to_string(),
+            description: None,
+            command: vec!["lake".to_string(), "test".to_string()],
+            cwd: None,
+            dependencies: vec![],
+            required: false,
+            mode: ValidationMode::Incremental,
+            reuse: true,
+            toolchain: None,
+            timeout_secs: None,
+            artifacts: vec![],
+        }
+    }
+
     #[test]
     fn rejects_cycles_and_invalid_candidates() {
         let mut cyclic = matrix();
@@ -1675,6 +1747,35 @@ mod tests {
         let mut invalid = candidate('a');
         invalid.commit = "short".to_string();
         assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_expected_head_that_differs_from_commit() {
+        let mut mismatched = candidate('a');
+        mismatched.expected_head = Some("b".repeat(40));
+        let error = mismatched.validate().unwrap_err();
+        assert!(error.contains("must match candidate.commit"));
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let error = store
+            .create(CreateCampaignRequest {
+                candidate: mismatched,
+                matrix: matrix(),
+                workspace_id: None,
+            })
+            .unwrap_err();
+        assert!(error.contains("expected_head"));
+    }
+
+    #[test]
+    fn required_gate_cannot_depend_on_optional_gate() {
+        let mut invalid = matrix();
+        invalid.gates[0].required = false;
+        assert_eq!(
+            invalid.validate().unwrap_err(),
+            "required gate 'clean-final' depends on optional gate 'targeted'"
+        );
     }
 
     #[test]
@@ -1952,6 +2053,78 @@ mod tests {
             .claim(campaign.id, "targeted", &execution())
             .unwrap_err();
         assert_eq!(error.0, StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn merged_campaign_stays_terminal() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ValidationStore::open(dir.path().join("validation.db")).unwrap();
+        let mut matrix = matrix();
+        matrix.gates.push(optional_gate("optional-extra"));
+        matrix.gates.push(optional_gate("optional-late"));
+        let campaign = store
+            .create(CreateCampaignRequest {
+                candidate: candidate('a'),
+                matrix,
+                workspace_id: None,
+            })
+            .unwrap();
+        let head = "a".repeat(40);
+
+        // Claim one optional gate while the campaign is still active.
+        let optional_execution = execution();
+        store
+            .claim(campaign.id, "optional-extra", &optional_execution)
+            .unwrap();
+
+        // Complete both required gates so the campaign certifies.
+        claim_and_record(
+            &store,
+            campaign.id,
+            "targeted",
+            Some(&head),
+            Some(PINNED_TOOLCHAIN),
+            None,
+        );
+        {
+            let connection = store.lock().unwrap();
+            connection
+                .execute(
+                    "UPDATE validation_gates SET status='passed', outcome='passed',
+                     freshness='exact_head' WHERE campaign_id=?1 AND gate_id='clean-final'",
+                    params![campaign.id.to_string()],
+                )
+                .unwrap();
+            recompute_campaign(&connection, campaign.id).unwrap();
+        }
+        assert_eq!(store.get(campaign.id).unwrap().status, "completed");
+        {
+            let connection = store.lock().unwrap();
+            connection
+                .execute(
+                    "UPDATE validation_campaigns SET status='merged' WHERE id=?1",
+                    params![campaign.id.to_string()],
+                )
+                .unwrap();
+        }
+
+        // A leftover optional gate recording its receipt must not downgrade
+        // the merged campaign.
+        store
+            .record(
+                campaign.id,
+                "optional-extra",
+                passing_receipt(optional_execution, Some(&head), None, None),
+            )
+            .unwrap();
+        assert_eq!(store.get(campaign.id).unwrap().status, "merged");
+
+        // Gates on a merged campaign are no longer claimable.
+        let error = store
+            .claim(campaign.id, "optional-late", &execution())
+            .unwrap_err();
+        assert_eq!(error.0, StatusCode::CONFLICT);
+        assert!(error.1.contains("merged"));
     }
 
     #[test]

--- a/src/bin/palomactl.rs
+++ b/src/bin/palomactl.rs
@@ -72,6 +72,24 @@ fn run(args: Vec<String>) -> Result<()> {
             let plan = dispatch_plan(&root, project)?;
             println!("{}", serde_json::to_string_pretty(&plan)?);
         }
+        "validation-matrix" => {
+            let path = args
+                .get(1)
+                .map(PathBuf::from)
+                .unwrap_or_else(|| root.join(".sandboxed/validation.toml"));
+            let raw = fs::read_to_string(&path)
+                .with_context(|| format!("read validation matrix {}", path.display()))?;
+            let matrix: sandboxed_sh::api::validation::ValidationMatrix =
+                toml::from_str(&raw).context("parse validation matrix")?;
+            matrix.validate().map_err(|error| anyhow!(error))?;
+            println!("{}", serde_json::to_string_pretty(&matrix)?);
+        }
+        "cluster-lean-errors" => {
+            let path = args.get(1).ok_or_else(|| anyhow!("missing log path"))?;
+            let raw = fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+            let clusters = sandboxed_sh::api::validation::cluster_diagnostics(&raw);
+            println!("{}", serde_json::to_string_pretty(&clusters)?);
+        }
         _ => {
             print_usage();
             bail!("unknown command {command}");
@@ -82,7 +100,7 @@ fn run(args: Vec<String>) -> Result<()> {
 
 fn print_usage() {
     println!(
-        "usage:\n  palomactl status\n  palomactl reconcile\n  palomactl pr-gates <owner/repo> <number> [--worker-head <sha>]\n  palomactl set-mode <project> <mode> --until <iso>\n  palomactl dispatch-plan --project <slug>"
+        "usage:\n  palomactl status\n  palomactl reconcile\n  palomactl pr-gates <owner/repo> <number> [--worker-head <sha>]\n  palomactl set-mode <project> <mode> --until <iso>\n  palomactl dispatch-plan --project <slug>\n  palomactl validation-matrix [path]\n  palomactl cluster-lean-errors <log-path>"
     );
 }
 

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -767,11 +767,11 @@ mod tests {
                 mission_id,
                 lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
                 payload: sandboxed_sh::remote_node::JobPayload::LeanBuild {
-                    source: sandboxed_sh::remote_node::JobSource {
+                    source: Box::new(sandboxed_sh::remote_node::JobSource {
                         repo: "/node/local/repo".to_string(),
                         commit: "a".repeat(40),
                         bundle: None,
-                    },
+                    }),
                     cwd_rel: None,
                     command: vec!["lake".to_string(), "build".to_string()],
                     timeout_secs: None,

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1341,9 +1341,10 @@ async fn require_real_directory_tree(
     Ok(true)
 }
 
-/// Before creating a cache destination, require every existing ancestor below
-/// the checkout root to be a real directory. Once a component is absent, all
-/// deeper components are necessarily absent too and may be created safely.
+/// Before creating or deleting a bundle destination, require every existing
+/// ancestor below the checkout root to be a real directory. Once a component is
+/// absent, all deeper components are necessarily absent too and may be created
+/// safely (or, for deletions, the target cannot exist).
 async fn require_safe_directory_creation_path(
     root: &Path,
     path: &Path,
@@ -1385,6 +1386,16 @@ async fn apply_source_bundle(
     let total_bytes = validate_source_bundle(bundle).map_err(|error| anyhow::anyhow!("{error}"))?;
     for relative in &bundle.deleted_paths {
         let destination = checkout.join(relative);
+        let parent = destination
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("bundle deletion path '{relative}' has no parent"))?;
+        if parent != checkout {
+            // A tracked symlink such as `escape -> /outside` would let
+            // `remove_file` on `escape/victim` delete outside the checkout:
+            // `symlink_metadata` refuses to follow only the final component.
+            require_safe_directory_creation_path(checkout, parent, "source bundle deletion")
+                .await?;
+        }
         match tokio::fs::symlink_metadata(&destination).await {
             Ok(metadata) if metadata.is_file() || metadata.file_type().is_symlink() => {
                 tokio::fs::remove_file(&destination).await?;
@@ -2343,6 +2354,36 @@ mod tests {
         let receipt = tokio::fs::read_to_string(log).await.unwrap();
         assert!(receipt.contains(&bundle.manifest_sha256));
         assert!(receipt.contains("files=1 deletions=1 bytes=10"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn source_bundle_deletion_rejects_symlinked_parent_directories() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let checkout = temp.path().join("checkout");
+        let log = temp.path().join("job.log");
+        tokio::fs::create_dir_all(&checkout).await.unwrap();
+        let outside = temp.path().join("outside");
+        tokio::fs::create_dir_all(&outside).await.unwrap();
+        let victim = outside.join("victim");
+        tokio::fs::write(&victim, b"keep me").await.unwrap();
+        symlink(&outside, checkout.join("escape")).unwrap();
+
+        let mut bundle = source_bundle("Beal/Proof.lean", b"new proof\n");
+        bundle.deleted_paths = vec!["escape/victim".to_string()];
+        bundle.operations_sha256 = Some(bundle_operations_sha256(&bundle));
+
+        let error = apply_source_bundle(&checkout, &bundle, &log)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("must not contain a symlink"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(tokio::fs::read(&victim).await.unwrap(), b"keep me");
     }
 
     #[tokio::test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -132,14 +132,41 @@ pub(crate) fn bundle_manifest_sha256(files: &[(String, String)]) -> String {
     hex::encode(hasher.finalize())
 }
 
-fn validate_source_bundle(bundle: &SourceBundle) -> Result<u64, String> {
-    if bundle.files.is_empty() {
-        return Err("source.bundle.files must not be empty".to_string());
+pub(crate) fn bundle_operations_sha256(bundle: &SourceBundle) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"sandboxed-source-bundle-ops-v1\n");
+    for file in &bundle.files {
+        hasher.update(b"file\0");
+        hasher.update(file.path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(if file.executable == Some(true) {
+            b"x"
+        } else {
+            b"-"
+        });
+        hasher.update(b"\n");
     }
-    if bundle.files.len() > MAX_SOURCE_BUNDLE_FILES {
+    for path in &bundle.deleted_paths {
+        hasher.update(b"delete\0");
+        hasher.update(path.as_bytes());
+        hasher.update(b"\n");
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn validate_source_bundle(bundle: &SourceBundle) -> Result<u64, String> {
+    if bundle.files.is_empty() && bundle.deleted_paths.is_empty() {
+        return Err("source bundle must contain files or deletions".to_string());
+    }
+    if bundle
+        .files
+        .len()
+        .saturating_add(bundle.deleted_paths.len())
+        > MAX_SOURCE_BUNDLE_FILES
+    {
         return Err(format!(
-            "source bundle has {} files; maximum is {MAX_SOURCE_BUNDLE_FILES}",
-            bundle.files.len()
+            "source bundle has {} operations; maximum is {MAX_SOURCE_BUNDLE_FILES}",
+            bundle.files.len() + bundle.deleted_paths.len()
         ));
     }
     let mut manifest_files = Vec::with_capacity(bundle.files.len());
@@ -182,6 +209,35 @@ fn validate_source_bundle(bundle: &SourceBundle) -> Result<u64, String> {
     let expected = bundle_manifest_sha256(&manifest_files);
     if expected != bundle.manifest_sha256 {
         return Err("source bundle manifest hash mismatch".to_string());
+    }
+    let has_extended_operations = !bundle.deleted_paths.is_empty()
+        || bundle.files.iter().any(|file| file.executable.is_some());
+    if has_extended_operations {
+        let Some(digest) = bundle.operations_sha256.as_deref() else {
+            return Err("source bundle operations_sha256 is required".to_string());
+        };
+        if digest != bundle_operations_sha256(bundle) {
+            return Err("source bundle operations hash mismatch".to_string());
+        }
+        let mut prior = None;
+        let file_paths = bundle
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        for path in &bundle.deleted_paths {
+            if !bundle_path_is_safe(path) || file_paths.contains(path.as_str()) {
+                return Err(format!(
+                    "unsafe or conflicting source bundle deletion '{path}'"
+                ));
+            }
+            if prior.is_some_and(|value| value >= path.as_str()) {
+                return Err("source bundle deleted paths must be unique and sorted".to_string());
+            }
+            prior = Some(path.as_str());
+        }
+    } else if bundle.operations_sha256.is_some() {
+        return Err("source bundle operations_sha256 has no operations".to_string());
     }
     Ok(total)
 }
@@ -948,6 +1004,20 @@ async fn apply_source_bundle(
     log_path: &Path,
 ) -> anyhow::Result<()> {
     let total_bytes = validate_source_bundle(bundle).map_err(|error| anyhow::anyhow!("{error}"))?;
+    for relative in &bundle.deleted_paths {
+        let destination = checkout.join(relative);
+        match tokio::fs::symlink_metadata(&destination).await {
+            Ok(metadata) if metadata.is_file() || metadata.file_type().is_symlink() => {
+                tokio::fs::remove_file(&destination).await?;
+            }
+            Ok(_) => anyhow::bail!(
+                "source bundle deletion must target a file: {}",
+                destination.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
     for file in &bundle.files {
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(&file.data_base64)
@@ -984,6 +1054,18 @@ async fn apply_source_bundle(
             let _ = tokio::fs::remove_file(&tmp).await;
             return Err(error.into());
         }
+        #[cfg(unix)]
+        if let Some(executable) = file.executable {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = tokio::fs::metadata(&destination).await?.permissions();
+            let mode = permissions.mode();
+            permissions.set_mode(if executable {
+                mode | 0o111
+            } else {
+                mode & !0o111
+            });
+            tokio::fs::set_permissions(&destination, permissions).await?;
+        }
     }
     let mut log = tokio::fs::OpenOptions::new()
         .create(true)
@@ -992,9 +1074,11 @@ async fn apply_source_bundle(
         .await?;
     log.write_all(
         format!(
-            "source bundle verified sha256={} files={} bytes={}\n",
+            "source bundle verified sha256={} operations_sha256={} files={} deletions={} bytes={}\n",
             bundle.manifest_sha256,
+            bundle.operations_sha256.as_deref().unwrap_or("none"),
             bundle.files.len(),
+            bundle.deleted_paths.len(),
             total_bytes
         )
         .as_bytes(),
@@ -1400,7 +1484,10 @@ mod tests {
                 path: path.to_string(),
                 sha256,
                 data_base64: base64::engine::general_purpose::STANDARD.encode(contents),
+                executable: None,
             }],
+            deleted_paths: Vec::new(),
+            operations_sha256: None,
         }
     }
 
@@ -1590,7 +1677,13 @@ mod tests {
         tokio::fs::write(checkout.join("Beal/Proof.lean"), b"old")
             .await
             .unwrap();
-        let bundle = source_bundle("Beal/Proof.lean", b"new proof\n");
+        tokio::fs::write(checkout.join("Beal/Obsolete.lean"), b"remove")
+            .await
+            .unwrap();
+        let mut bundle = source_bundle("Beal/Proof.lean", b"new proof\n");
+        bundle.files[0].executable = Some(true);
+        bundle.deleted_paths = vec!["Beal/Obsolete.lean".to_string()];
+        bundle.operations_sha256 = Some(bundle_operations_sha256(&bundle));
 
         apply_source_bundle(&checkout, &bundle, &log).await.unwrap();
 
@@ -1600,9 +1693,22 @@ mod tests {
                 .unwrap(),
             b"new proof\n"
         );
+        assert!(!checkout.join("Beal/Obsolete.lean").exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_ne!(
+                std::fs::metadata(checkout.join("Beal/Proof.lean"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o111,
+                0
+            );
+        }
         let receipt = tokio::fs::read_to_string(log).await.unwrap();
         assert!(receipt.contains(&bundle.manifest_sha256));
-        assert!(receipt.contains("files=1 bytes=10"));
+        assert!(receipt.contains("files=1 deletions=1 bytes=10"));
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1664,6 +1664,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let log = temp.path().join("job.log");
         let mut bundled_source = source(&"a".repeat(40));
+        bundled_source.repo = "https://github.com/private/lido-proof.git".to_string();
         let mut bundle = source_bundle("lean-toolchain", b"leanprover/lean4:v4.31.0\n");
         bundle.complete = true;
         bundle.manifest_sha256 = bundle_manifest_sha256_for_mode(
@@ -1690,6 +1691,7 @@ mod tests {
                 .unwrap(),
             "leanprover/lean4:v4.31.0\n"
         );
+        assert!(!checkout.join(".git").exists());
         tokio::fs::create_dir_all(checkout.join(".lake/build"))
             .await
             .unwrap();

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -777,7 +777,7 @@ mod tests {
     #[test]
     fn persisted_lean_payload_redacts_source_archive_bytes() {
         let payload = JobPayload::LeanBuild {
-            source: JobSource {
+            source: Box::new(JobSource {
                 repo: "https://example.invalid/private.git".to_string(),
                 commit: "a".repeat(40),
                 archive: Some(Box::new(SourceArchive {
@@ -786,7 +786,7 @@ mod tests {
                     data_base64: "private-source-data".to_string(),
                 })),
                 bundle: None,
-            },
+            }),
             cwd_rel: None,
             command: vec!["lake".to_string(), "build".to_string()],
             timeout_secs: None,

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -13,6 +13,8 @@ use std::sync::OnceLock;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::ArtifactEntry;
+
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum JobHandleKind {
@@ -127,6 +129,11 @@ pub struct RemoteJobReceipt {
     #[serde(default)]
     pub exit_status: Option<i32>,
     pub identity: RemoteJobIdentity,
+    /// Content digests produced by the exact terminal execution. Older
+    /// receipts deserialize empty and are not reused for artifact-bearing
+    /// validations.
+    #[serde(default)]
+    pub artifacts: Vec<ArtifactEntry>,
     /// The accepted request owned a mission continuation even if its terminal
     /// wake had not yet been armed. This lets startup recover the narrow
     /// crash window after finalization but before a synchronous result reaches
@@ -336,7 +343,7 @@ pub async fn equivalent_remote_validation(
         .into_iter()
         .filter(|receipt| {
             receipt.identity == *identity
-                && identity.artifacts.is_empty()
+                && (identity.artifacts.is_empty() || !receipt.artifacts.is_empty())
                 && receipt.state == "succeeded"
                 && receipt.exit_status == Some(0)
         })
@@ -521,6 +528,17 @@ pub async fn finalize(
     state: &str,
     exit_status: Option<i32>,
 ) -> anyhow::Result<bool> {
+    finalize_with_artifacts(working_dir, job_id, state, exit_status, Vec::new()).await
+}
+
+/// Finalize a remote build while retaining its resolved artifact evidence.
+pub async fn finalize_with_artifacts(
+    working_dir: &Path,
+    job_id: Uuid,
+    state: &str,
+    exit_status: Option<i32>,
+    artifacts: Vec<ArtifactEntry>,
+) -> anyhow::Result<bool> {
     const MAX_RECEIPTS: usize = 2_000;
 
     let _guard = lock().lock().await;
@@ -551,6 +569,7 @@ pub async fn finalize(
             state: state.to_string(),
             exit_status,
             identity,
+            artifacts,
             continuation_expected,
             wake_required: handle.kind == JobHandleKind::RemoteBuild && handle.wake_on_terminal,
             wake_delivered_at: previous_wake_delivered_at,
@@ -1014,16 +1033,26 @@ mod tests {
         )
         .await
         .unwrap();
-        finalize(dir.path(), artifact_job_id, "succeeded", Some(0))
-            .await
-            .unwrap();
-        assert!(
+        finalize_with_artifacts(
+            dir.path(),
+            artifact_job_id,
+            "succeeded",
+            Some(0),
+            vec![ArtifactEntry {
+                path: "build/report.json".to_string(),
+                sha256: "c".repeat(64),
+                size_bytes: 42,
+            }],
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
             equivalent_remote_validation(dir.path(), &artifact_identity)
                 .await
-                .unwrap()
-                .is_none(),
-            "artifact-producing validation cannot replay until receipts retain artifact digests"
-        );
+                .unwrap(),
+            Some(EquivalentRemoteValidation::Succeeded(receipt))
+                if receipt.job_id == artifact_job_id && receipt.artifacts.len() == 1
+        ));
 
         let changed_overlay = RemoteJobIdentity {
             source_bundle_digest: Some("b".repeat(64)),

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -365,6 +365,29 @@ pub async fn equivalent_remote_validation(
         .map(EquivalentRemoteValidation::Active))
 }
 
+/// Unresolved (accepted or ambiguously submitted) job handle with the same
+/// immutable validation identity, ignoring terminal receipts. In the combined
+/// lookup above a successful receipt takes precedence over an active handle,
+/// so forced runs that bypass receipt replay must use this to keep failing
+/// closed on a concurrent equivalent submission.
+pub async fn active_equivalent_remote_validation(
+    working_dir: &Path,
+    identity: &RemoteJobIdentity,
+) -> anyhow::Result<Option<JobHandle>> {
+    let _guard = lock().lock().await;
+    Ok(load_result(working_dir)
+        .await?
+        .into_iter()
+        .filter(|handle| {
+            handle.identity.as_ref() == Some(identity)
+                && matches!(
+                    handle.kind,
+                    JobHandleKind::RemoteBuild | JobHandleKind::Tentative
+                )
+        })
+        .min_by_key(|handle| handle.started_at))
+}
+
 /// Terminal remote-build receipts whose mission continuation has not yet
 /// reached a durable queue. The startup reconciler retries these after a
 /// process crash, making receipt finalization and mission wake-up effectively
@@ -1056,12 +1079,48 @@ mod tests {
 
         let changed_overlay = RemoteJobIdentity {
             source_bundle_digest: Some("b".repeat(64)),
-            ..identity
+            ..identity.clone()
         };
         assert!(equivalent_remote_validation(dir.path(), &changed_overlay)
             .await
             .unwrap()
             .is_none());
+
+        // A forced run bypasses the succeeded receipt, so it must be able to
+        // see a concurrent unresolved handle that the combined lookup hides
+        // behind receipt precedence.
+        let forced_job_id = Uuid::new_v4();
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id: Uuid::new_v4(),
+                node_id: "node-c".to_string(),
+                job_id: forced_job_id,
+                started_at: chrono::Utc::now(),
+                submission_sequence: 0,
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity.clone()),
+                wait_for_completion: None,
+                wake_on_terminal: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            equivalent_remote_validation(dir.path(), &identity)
+                .await
+                .unwrap(),
+            Some(EquivalentRemoteValidation::Succeeded(receipt)) if receipt.job_id == job_id
+        ));
+        assert!(matches!(
+            active_equivalent_remote_validation(dir.path(), &identity)
+                .await
+                .unwrap(),
+            Some(handle) if handle.job_id == forced_job_id
+        ));
     }
 
     #[tokio::test]

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -15,7 +15,7 @@ use super::RemoteNodeError;
 type HmacSha256 = Hmac<Sha256>;
 
 /// Current node protocol version reported by heartbeats.
-pub const NODE_PROTOCOL_VERSION: u32 = 3;
+pub const NODE_PROTOCOL_VERSION: u32 = 4;
 /// First protocol that reports `active_jobs` and `queued_jobs` in heartbeats.
 pub const NODE_JOB_COUNTER_PROTOCOL_VERSION: u32 = 2;
 
@@ -139,12 +139,24 @@ pub struct SourceBundleFile {
     pub path: String,
     pub sha256: String,
     pub data_base64: String,
+    /// Preserve the executable bit for local-only scripts. Absent on v1-v3
+    /// bundles, where files retain the checkout/default mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceBundle {
     pub manifest_sha256: String,
     pub files: Vec<SourceBundleFile>,
+    /// Tracked files removed by the local candidate. Renames are represented
+    /// as one deletion plus one regular file entry.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deleted_paths: Vec<String>,
+    /// Digest covering deletions and executable-mode metadata. Required when
+    /// either feature is present so an intermediary cannot strip operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operations_sha256: Option<String>,
 }
 
 /// One artifact produced by a build job, relative to the checkout root.
@@ -176,7 +188,7 @@ pub enum JobPayload {
     /// constrained `lake`/`lean`/`elan` argv, and reports artifact digests.
     /// See `src/node/lean.rs` for validation and execution.
     LeanBuild {
-        source: JobSource,
+        source: Box<JobSource>,
         /// Build cwd relative to the checkout root (validated: no traversal,
         /// no shell metacharacters). `None`/empty = checkout root.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -485,11 +497,11 @@ mod tests {
     #[test]
     fn lean_build_payload_round_trips_with_defaults() {
         let payload = JobPayload::LeanBuild {
-            source: JobSource {
+            source: Box::new(JobSource {
                 repo: "https://github.com/example/verity.git".to_string(),
                 commit: "a".repeat(40),
                 bundle: None,
-            },
+            }),
             cwd_rel: Some("morpho-verity".to_string()),
             command: vec!["lake".to_string(), "build".to_string()],
             timeout_secs: Some(3600),


### PR DESCRIPTION
# Integration rollup: remote-build certification, gzip private sources, validation campaigns

Consolidates the three open PRs into one reviewed, conflict-free branch intended for the next production deploy, with all outstanding bot-review findings fixed.

## Included PRs

- **#705 — Allow independent remote certification receipts** (`fix/remote-build-force-new`)
- **#704 — gzip complete private source requests** (`fix/remote-build-gzip-private-source`)
- **#695 — native validation campaigns** (`agent/validation-campaigns`)

## Conflict resolutions

- `src/api/remote_build.rs`: kept master's credential-placeholder test remote URL; full-source capture test now decodes the gzipped wire request **and** keeps master's assertion that complete mode never duplicates a `source_archive`.
- `src/remote_node/protocol.rs`: `SourceBundle` carries the union of both features — `complete` (master) plus `deleted_paths`/`operations_sha256` (#695).
- `src/node/lean.rs`: `validate_source_bundle` merges both sides — complete-aware file caps counted in operations (files + deletions), `bundle_manifest_sha256_for_mode` domain separation, and #695's extended-operations digest checks.
- `scripts/remote-lean-build`: full mode keeps master's semantics (complete snapshot, deletions by omission); overlay mode adopts #695's `--name-status` parsing so deletions/renames are encoded; the emitted bundle carries `complete` + `deleted_paths` + `operations_sha256`.

## Review findings fixed on top

- **#705 (codex P1)** `force_new` no longer bypasses the fail-closed `REMOTE_VALIDATION_ALREADY_ACTIVE` rejection — only the successful-receipt replay is skipped, on both the optimistic and under-lock dedup checks.
- **#705 (cursor Medium / codex P2)** `force_new` is excluded from the wrapper receipt fingerprint, so a forced result replaces the receipt of the same immutable request instead of forking the local state file (local replay was already gated on `REMOTE_BUILD_FORCE_NEW != 1`).
- **#704 (codex P2)** already resolved in the merged branch: the gzip wire copy is generated **before** the submission recovery blocker is armed.
- **Cross-PR gap found during integration**: source bundles with deletions or operation digests now require protocol v4 nodes — a v3 node would silently ignore `deleted_paths`/executable bits and build the wrong tree.
- **#695 (codex P1)** deletions through symlinked parent directories are rejected: `apply_source_bundle` now walks every ancestor with the existing `require_safe_directory_creation_path` helper before removing, failing closed; test proves an `escape -> /outside` symlink cannot delete outside the checkout.
- **#695 (codex P1)** exact-head evidence now requires the receipt to attest the candidate's `source_bundle_digest` (strict `Option` equality: clean-base or foreign-overlay runs sharing the head are `stale`; a bundle attestation cannot certify a bundle-less candidate).
- **#695 (codex P1)** when a gate pins `spec.toolchain`, an omitted or different attested toolchain classifies the receipt `stale` — it never unlocks dependants or certifies.
- **#695 (codex P2)** stale gates are claimable again, so a later exact-head execution replaces retained stale evidence instead of wedging the campaign; certification invariants unchanged.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --workspace -- -D clippy::all` clean
- `cargo test`: 1610 + auxiliary suites, 0 failures
- dashboard: `vitest` 256/256 green (pre-existing 2 `tsc` errors in `new-mission-dialog.test.tsx` exist on master, untouched by this PR)
- `bash -n scripts/remote-lean-build` + AST parse of all embedded python blocks

Supersedes #695, #704, #705 — they should be closed when this merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches remote build submission, source overlay semantics, and new certification logic that gates merges and webhooks; incorrect exact-head or v3/v4 placement could certify or build the wrong tree.
> 
> **Overview**
> This integration rollup wires **validation campaigns** end to end: a new `/api/validation-campaigns` API and SQLite store pin a candidate and a project-defined gate DAG (from `.sandboxed/validation.toml`), with claim/receipt flows, receipt reuse, **exact-head** vs **stale** classification (head, `source_bundle_digest`, pinned toolchain), stale gates reclaimable, merged campaigns terminal, and a webhook outbox. The dashboard exports matching TypeScript clients; `palomactl` can validate matrices and cluster Lean errors.
> 
> **Remote Lean builds** now accept **gzip** request bodies (large private full snapshots), and overlay source bundles encode **deletions, renames, and executable bits** via `operations_sha256`, requiring **protocol v4** nodes. The `remote-lean-build` wrapper builds those bundles, gzips the wire request, supports **`REMOTE_BUILD_FORCE_NEW`**, and excludes `force_new` from the local fingerprint. Server-side **`force_new`** skips successful-receipt replay but still conflicts on active equivalent jobs; job ledger **finalization persists artifacts** for artifact-bearing identity reuse.
> 
> Node checkout applies bundle deletions with symlink-safe path checks; remote build identity digests incorporate the extended bundle shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc0a46630a68ec326d676a85ef42df4e2277544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->