### PR TITLE
Projects board: /api/projects overview + kanban replacing the / chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -236,3 +236,12 @@ JWT_TTL_DAYS=30
 # must exceed the 10s background-watcher poll so AwaitingUser→WaitingBackground
 # promotions are observed by the pre-stop recheck.
 # SCOPE_TEARDOWN_GRACE_SECS=30
+#
+# Projects board (GET /api/projects/overview). Both optional: absence just
+# empties that data source on the board.
+# HERMES_PROJECTS_DIR points at Hermes project trackers (active/*.md); an
+# optional routes.json alias map there routes signature keys onto tracker
+# slugs. HERMES_STATE_DB is the Hermes gateway state.db, opened read-only,
+# for the cron delivery timeline.
+# HERMES_PROJECTS_DIR=/var/lib/hermes-assistant/.hermes/projects/active
+# HERMES_STATE_DB=/srv/sandboxed-storage/staging/agent-core/hermes/state.db

--- a/dashboard/src/app/assistant/chat/page.tsx
+++ b/dashboard/src/app/assistant/chat/page.tsx
@@ -1,0 +1,3 @@
+import HermesPage from '@/components/hermes/hermes-page';
+
+export default HermesPage;

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,3 +1,3 @@
-import HermesPage from '@/components/hermes/hermes-page';
+import ProjectsBoard from '@/components/projects/projects-board';
 
-export default HermesPage;
+export default ProjectsBoard;

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -1,0 +1,139 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { getProjectsOverview, getProjectUpdates } from "@/lib/api/projects";
+import type { ProjectRow, ProjectsOverview } from "@/lib/api/projects";
+import ProjectsBoard from "./projects-board";
+
+vi.mock("@/lib/api/projects", () => ({
+  getProjectsOverview: vi.fn(),
+  getProjectUpdates: vi.fn(),
+}));
+
+vi.mock("@/components/markdown-content", () => ({
+  MarkdownContent: ({ content }: { content: string }) => <pre>{content}</pre>,
+}));
+
+const mockedOverview = vi.mocked(getProjectsOverview);
+const mockedUpdates = vi.mocked(getProjectUpdates);
+
+function project(overrides: Partial<ProjectRow>): ProjectRow {
+  return {
+    slug: "verity",
+    bucket: "active",
+    tracker: null,
+    missions: [],
+    latest_update: null,
+    updates_count: 0,
+    attention_reasons: [],
+    ...overrides,
+  };
+}
+
+function overview(projects: ProjectRow[]): ProjectsOverview {
+  return {
+    projects,
+    archived: [],
+    unrouted_updates: [],
+    sources: { trackers: true, hermes_db: true },
+  };
+}
+
+function renderBoard() {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <ProjectsBoard />
+    </SWRConfig>,
+  );
+}
+
+describe("ProjectsBoard", () => {
+  beforeEach(() => {
+    mockedOverview.mockReset();
+    mockedUpdates.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("places projects in their bucket columns with attention reasons", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({ slug: "verity" }),
+        project({
+          slug: "lido-audit",
+          bucket: "attention",
+          attention_reasons: ["blocker signalé: lease writer fantôme"],
+        }),
+        project({ slug: "erc", bucket: "paused" }),
+      ]),
+    );
+
+    renderBoard();
+
+    expect(await screen.findByText("verity")).toBeInTheDocument();
+    expect(screen.getByText("lido-audit")).toBeInTheDocument();
+    expect(
+      screen.getByText(/blocker signalé: lease writer fantôme/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("erc")).toBeInTheDocument();
+  });
+
+  test("mission chips link to /control", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity",
+          missions: [
+            {
+              id: "f98e1ee2-0000-0000-0000-000000000000",
+              status: "active",
+              title: "Phase 1C slice",
+              updated_at: "2026-08-01T00:00:00Z",
+              github_pr: null,
+            },
+          ],
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    const chip = await screen.findByRole("link", { name: /Phase 1C slice/ });
+    expect(chip).toHaveAttribute(
+      "href",
+      "/control?mission=f98e1ee2-0000-0000-0000-000000000000",
+    );
+  });
+
+  test("opening a card loads the updates timeline drawer", async () => {
+    mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
+    mockedUpdates.mockResolvedValue({
+      slug: "verity",
+      updates: [
+        {
+          headline: "Phase 1C merged",
+          body: "**Changé :** slice mergée.",
+          session_id: "sess-42",
+          at: "2026-08-01T07:11:00Z",
+          signature: "verity",
+          blocker: null,
+        },
+      ],
+    });
+
+    renderBoard();
+
+    fireEvent.click(await screen.findByText("verity"));
+
+    expect(await screen.findByText("Phase 1C merged")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockedUpdates).toHaveBeenCalledWith("verity", 50),
+    );
+
+    fireEvent.click(screen.getByText("Phase 1C merged"));
+    expect(await screen.findByText(/Session d’origine : sess-42/)).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import useSWR from "swr";
+import {
+  AlertTriangle,
+  Archive,
+  CircleDot,
+  ExternalLink,
+  GitPullRequest,
+  Inbox,
+  Loader,
+  PauseCircle,
+  X,
+} from "lucide-react";
+
+import {
+  getProjectsOverview,
+  getProjectUpdates,
+  type ProjectBucket,
+  type ProjectDeliveryUpdate,
+  type ProjectMissionChip,
+  type ProjectRow,
+} from "@/lib/api/projects";
+import { MarkdownContent } from "@/components/markdown-content";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { cn } from "@/lib/utils";
+
+const COLUMNS: {
+  bucket: ProjectBucket;
+  title: string;
+  emoji: string;
+  empty: string;
+}[] = [
+  { bucket: "active", title: "Actif", emoji: "🟢", empty: "Aucun projet actif" },
+  {
+    bucket: "attention",
+    title: "Attention requise",
+    emoji: "🟠",
+    empty: "Rien à signaler",
+  },
+  { bucket: "paused", title: "Pausé", emoji: "⏸", empty: "Aucun projet en pause" },
+  { bucket: "archived", title: "Archive", emoji: "📦", empty: "Archive vide" },
+];
+
+export default function ProjectsBoard() {
+  const { data, error, isLoading } = useSWR(
+    "projects-overview",
+    getProjectsOverview,
+    { refreshInterval: 30000, revalidateOnFocus: false },
+  );
+  const [openSlug, setOpenSlug] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!openSlug) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpenSlug(null);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [openSlug]);
+
+  const close = useCallback(() => setOpenSlug(null), []);
+
+  const projects = data?.projects ?? [];
+  const unrouted = data?.unrouted_updates ?? [];
+  const openProject = projects.find((p) => p.slug === openSlug) ?? null;
+
+  return (
+    <div className="mx-auto flex h-full max-w-[1600px] flex-col gap-4 px-4 py-4 sm:px-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-semibold text-white/90">Projets</h1>
+          <p className="text-xs text-white/40">
+            Trackers Hermes · missions taguées · updates cron.{" "}
+            <Link href="/assistant/chat" className="text-indigo-300/80 hover:text-indigo-200">
+              Le chat vit sous /assistant/chat
+            </Link>
+          </p>
+        </div>
+        {data && (
+          <div className="flex items-center gap-3 text-[11px] text-white/40">
+            <SourceDot ok={data.sources.trackers} label="trackers" />
+            <SourceDot ok={data.sources.hermes_db} label="hermes db" />
+          </div>
+        )}
+      </header>
+
+      {error && (
+        <div className="rounded-lg border border-red-400/20 bg-red-500/10 px-3 py-2 text-sm text-red-300/90">
+          Impossible de charger l’aperçu des projets : {String(error)}
+        </div>
+      )}
+      {isLoading && !data && (
+        <div className="flex items-center gap-2 py-10 text-sm text-white/40">
+          <Loader className="h-4 w-4 animate-spin" /> Chargement du board…
+        </div>
+      )}
+
+      {data && (
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-y-auto sm:grid-cols-2 xl:grid-cols-4">
+          {COLUMNS.map((column) => {
+            const rows = projects.filter((p) => p.bucket === column.bucket);
+            return (
+              <section
+                key={column.bucket}
+                className="flex min-h-[120px] flex-col rounded-xl border border-white/[0.06] bg-white/[0.02]"
+              >
+                <div className="flex items-center justify-between border-b border-white/[0.05] px-3 py-2">
+                  <span className="text-sm font-medium text-white/75">
+                    {column.emoji} {column.title}
+                  </span>
+                  <span className="rounded-full bg-white/[0.06] px-2 py-0.5 text-[11px] text-white/45">
+                    {rows.length}
+                  </span>
+                </div>
+                <div className="flex flex-col gap-2 overflow-y-auto p-2">
+                  {rows.length === 0 ? (
+                    <p className="px-1 py-3 text-center text-xs text-white/30">
+                      {column.empty}
+                    </p>
+                  ) : (
+                    rows.map((project) => (
+                      <ProjectCard
+                        key={project.slug}
+                        project={project}
+                        onOpen={() => setOpenSlug(project.slug)}
+                      />
+                    ))
+                  )}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      {unrouted.length > 0 && (
+        <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+          <div className="flex items-center gap-2 text-xs font-medium text-white/60">
+            <Inbox className="h-3.5 w-3.5" /> Updates non routées ({unrouted.length})
+          </div>
+          <div className="mt-1 space-y-1">
+            {unrouted.slice(0, 5).map((update, index) => (
+              <div
+                key={`${update.session_id}-${update.at}-${index}`}
+                className="flex min-w-0 items-center gap-2 text-xs text-white/45"
+              >
+                <span className="min-w-0 flex-1 truncate">{update.headline || "(sans titre)"}</span>
+                <UpdateAge at={update.at} />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {openProject && <ProjectDrawer project={openProject} onClose={close} />}
+    </div>
+  );
+}
+
+function SourceDot({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span
+        className={cn(
+          "h-1.5 w-1.5 rounded-full",
+          ok ? "bg-emerald-400" : "bg-amber-300",
+        )}
+      />
+      {label}
+    </span>
+  );
+}
+
+function ProjectCard({
+  project,
+  onOpen,
+}: {
+  project: ProjectRow;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className={cn(
+        "group w-full rounded-lg border px-3 py-2.5 text-left transition-colors",
+        project.bucket === "attention"
+          ? "border-amber-400/25 bg-amber-500/[0.06] hover:border-amber-400/40"
+          : "border-white/[0.07] bg-white/[0.03] hover:border-indigo-400/30 hover:bg-white/[0.05]",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate text-sm font-medium text-white/85">
+          {project.slug}
+        </span>
+        <BucketIcon bucket={project.bucket} />
+      </div>
+
+      {project.tracker?.status_line && (
+        <p className="mt-1 line-clamp-2 text-xs text-white/50">
+          {project.tracker.status_line}
+        </p>
+      )}
+
+      {project.missions.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {project.missions.slice(0, 4).map((mission) => (
+            <MissionMiniChip key={mission.id} mission={mission} />
+          ))}
+          {project.missions.length > 4 && (
+            <span className="px-1 text-[10px] text-white/35">
+              +{project.missions.length - 4}
+            </span>
+          )}
+        </div>
+      )}
+
+      {project.latest_update && (
+        <div className="mt-2 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
+          <span className="min-w-0 flex-1 truncate">
+            {project.latest_update.headline || "(update sans titre)"}
+          </span>
+          <UpdateAge at={project.latest_update.at} />
+        </div>
+      )}
+
+      {project.attention_reasons.length > 0 && (
+        <div className="mt-2 flex items-start gap-1.5 text-[11px] text-amber-300/85">
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          <span className="min-w-0">
+            {project.attention_reasons.join(" · ")}
+          </span>
+        </div>
+      )}
+    </button>
+  );
+}
+
+function BucketIcon({ bucket }: { bucket: ProjectBucket }) {
+  if (bucket === "attention")
+    return <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-300/80" />;
+  if (bucket === "paused")
+    return <PauseCircle className="h-3.5 w-3.5 shrink-0 text-white/35" />;
+  if (bucket === "archived")
+    return <Archive className="h-3.5 w-3.5 shrink-0 text-white/30" />;
+  return <CircleDot className="h-3.5 w-3.5 shrink-0 text-emerald-400/70" />;
+}
+
+const LIVE_STATUSES = new Set([
+  "created",
+  "queued",
+  "active",
+  "pending",
+  "waiting_background",
+  "awaiting_user",
+  "paused",
+]);
+
+function MissionMiniChip({ mission }: { mission: ProjectMissionChip }) {
+  const live = LIVE_STATUSES.has(mission.status);
+  return (
+    <Link
+      href={`/control?mission=${mission.id}`}
+      onClick={(event) => event.stopPropagation()}
+      title={`${mission.title ?? mission.id} — ${mission.status}`}
+      className={cn(
+        "inline-flex max-w-[160px] items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] !no-underline transition-colors",
+        live
+          ? "border-sky-400/25 bg-sky-500/10 text-sky-200/90 hover:border-sky-400/50"
+          : "border-white/[0.1] bg-white/[0.04] text-white/50 hover:border-white/25",
+      )}
+    >
+      <span
+        className={cn(
+          "h-1 w-1 shrink-0 rounded-full",
+          missionDot(mission.status),
+        )}
+      />
+      <span className="truncate">
+        {mission.title || mission.id.slice(0, 8)}
+      </span>
+      {mission.github_pr && <GitPullRequest className="h-2.5 w-2.5 shrink-0" />}
+    </Link>
+  );
+}
+
+function missionDot(status: string) {
+  switch (status) {
+    case "active":
+    case "queued":
+    case "created":
+      return "bg-sky-400";
+    case "pending":
+    case "awaiting_user":
+    case "waiting_background":
+    case "paused":
+      return "bg-amber-300";
+    case "completed":
+    case "acknowledged":
+      return "bg-emerald-400";
+    case "failed":
+    case "interrupted":
+    case "blocked":
+    case "not_feasible":
+      return "bg-red-400";
+    default:
+      return "bg-white/30";
+  }
+}
+
+function UpdateAge({ at }: { at: string }) {
+  const date = new Date(at);
+  if (Number.isNaN(date.getTime())) return null;
+  return (
+    <RelativeTime date={date} className="shrink-0 text-[10px] text-white/30" />
+  );
+}
+
+function ProjectDrawer({
+  project,
+  onClose,
+}: {
+  project: ProjectRow;
+  onClose: () => void;
+}) {
+  const { data, error, isLoading } = useSWR(
+    ["project-updates", project.slug],
+    () => getProjectUpdates(project.slug, 50),
+    { revalidateOnFocus: false },
+  );
+  const updates = data?.updates ?? [];
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <button
+        type="button"
+        aria-label="Fermer"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"
+      />
+      <aside className="relative flex h-full w-full max-w-2xl flex-col border-l border-white/[0.08] bg-[rgb(var(--background))] shadow-2xl">
+        <div className="flex items-start justify-between gap-3 border-b border-white/[0.06] px-4 py-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-semibold text-white/90">
+              {project.slug}
+            </h2>
+            {project.tracker?.status_line && (
+              <p className="mt-0.5 text-xs text-white/50">
+                {project.tracker.status_line}
+              </p>
+            )}
+            {project.attention_reasons.length > 0 && (
+              <div className="mt-1.5 flex items-start gap-1.5 text-xs text-amber-300/85">
+                <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                <span>{project.attention_reasons.join(" · ")}</span>
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {project.missions.length > 0 && (
+          <div className="border-b border-white/[0.06] px-4 py-2.5">
+            <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-white/35">
+              Missions
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {project.missions.map((mission) => (
+                <MissionMiniChip key={mission.id} mission={mission} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-white/35">
+            Timeline des updates
+          </p>
+          {isLoading && (
+            <div className="flex items-center gap-2 py-6 text-sm text-white/40">
+              <Loader className="h-4 w-4 animate-spin" /> Chargement…
+            </div>
+          )}
+          {error && (
+            <p className="py-4 text-sm text-red-300/80">
+              Impossible de charger les updates.
+            </p>
+          )}
+          {!isLoading && !error && updates.length === 0 && (
+            <p className="py-4 text-sm text-white/35">
+              Aucune update routée vers ce projet.
+            </p>
+          )}
+          <div className="space-y-3">
+            {updates.map((update, index) => (
+              <UpdateEntry
+                key={`${update.session_id}-${update.at}-${index}`}
+                update={update}
+              />
+            ))}
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function UpdateEntry({ update }: { update: ProjectDeliveryUpdate }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center justify-between gap-2 text-left"
+      >
+        <span className="min-w-0 flex-1 truncate text-sm text-white/80">
+          {update.headline || "(update sans titre)"}
+        </span>
+        <UpdateAge at={update.at} />
+      </button>
+      {update.blocker && (
+        <p className="mt-1 flex items-start gap-1.5 text-xs text-amber-300/85">
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          Bloqué par : {update.blocker}
+        </p>
+      )}
+      {expanded && update.body && (
+        <div className="mt-2 border-t border-white/[0.05] pt-2 text-sm">
+          <MarkdownContent content={update.body} />
+          <div className="mt-2 text-[11px] text-white/30">
+            <span className="inline-flex items-center gap-1">
+              <ExternalLink className="h-3 w-3" />
+              Session d’origine : {update.session_id}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Archive,
   ChatCircleText,
   ChatsCircle,
+  Kanban,
   CheckCircle,
   CirclesFour,
   CircleNotch,
@@ -47,12 +48,17 @@ type NavItem = {
 };
 
 const navigation: NavItem[] = [
-  { name: 'Hermes', href: '/', icon: ChatsCircle },
+  { name: 'Projets', href: '/', icon: Kanban },
   { name: 'Overview', href: '/overview', icon: Layout },
   { name: 'Mission', href: '/control', icon: ChatCircleText },
   { name: 'Workspaces', href: '/workspaces', icon: SidebarSimple },
   { name: 'Console', href: '/console', icon: TerminalWindow },
-  { name: 'Assistant', href: '/assistant', icon: Robot },
+  {
+    name: 'Assistant',
+    href: '/assistant',
+    icon: Robot,
+    children: [{ name: 'Chat Hermes', href: '/assistant/chat', icon: ChatsCircle }],
+  },
   { name: 'Routing', href: '/model-routing', icon: GitBranch },
   {
     name: 'Library',

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -20,6 +20,7 @@ export * from "./api/automations";
 export * from "./api/telegram";
 export * from "./api/assistant";
 export * from "./api/hermes";
+export * from "./api/projects";
 
 // Import core utilities for use in this file (remaining APIs not yet split)
 import {

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -1,0 +1,67 @@
+/**
+ * Projects board API — read-only overview joining Hermes project trackers,
+ * project-tagged missions, and cron delivery updates.
+ */
+
+import { apiGet } from "./core";
+
+export interface ProjectTracker {
+  slug: string;
+  status_line: string | null;
+  updated_at: string | null;
+}
+
+export interface ProjectMissionChip {
+  id: string;
+  status: string;
+  title: string | null;
+  updated_at: string;
+  github_pr: string | null;
+}
+
+export interface ProjectDeliveryUpdate {
+  headline: string;
+  body: string | null;
+  session_id: string;
+  at: string;
+  signature: string | null;
+  blocker: string | null;
+}
+
+export type ProjectBucket = "attention" | "active" | "paused" | "archived";
+
+export interface ProjectRow {
+  slug: string;
+  bucket: ProjectBucket;
+  tracker: ProjectTracker | null;
+  missions: ProjectMissionChip[];
+  latest_update: ProjectDeliveryUpdate | null;
+  updates_count: number;
+  attention_reasons: string[];
+}
+
+export interface ProjectsOverview {
+  projects: ProjectRow[];
+  archived: string[];
+  unrouted_updates: ProjectDeliveryUpdate[];
+  sources: { trackers: boolean; hermes_db: boolean };
+}
+
+export interface ProjectUpdatesResponse {
+  slug: string;
+  updates: ProjectDeliveryUpdate[];
+}
+
+export function getProjectsOverview(): Promise<ProjectsOverview> {
+  return apiGet("/api/projects/overview", "Failed to load projects overview");
+}
+
+export function getProjectUpdates(
+  slug: string,
+  limit = 50,
+): Promise<ProjectUpdatesResponse> {
+  return apiGet(
+    `/api/projects/${encodeURIComponent(slug)}/updates?limit=${limit}`,
+    "Failed to load project updates",
+  );
+}

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3723,6 +3723,69 @@ impl ControlHub {
 
     /// Inventory every live and persisted mission store without opening
     /// offline SQLite stores in read-write migration mode.
+
+    /// Collect every mission that carries a `project` tag across all mission
+    /// stores (live, offline file, offline sqlite). Read-only; used by the
+    /// projects-overview board. Terminal missions older than `terminal_horizon`
+    /// are skipped so the scan stays bounded on long-lived stores.
+    pub(crate) async fn collect_project_missions(
+        &self,
+        terminal_horizon: chrono::Duration,
+    ) -> Result<Vec<Mission>, String> {
+        const PAGE_SIZE: usize = 200;
+        let cutoff = chrono::Utc::now() - terminal_horizon;
+        let keep = |mission: &Mission| -> bool {
+            if mission.project.project.is_none() {
+                return false;
+            }
+            if mission.status.is_terminal() || mission.status == MissionStatus::Acknowledged {
+                return chrono::DateTime::parse_from_rfc3339(&mission.updated_at)
+                    .map(|t| t.with_timezone(&chrono::Utc) >= cutoff)
+                    .unwrap_or(false);
+            }
+            true
+        };
+        let mut collected: Vec<Mission> = Vec::new();
+        let mut seen: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+        let inventory = self.mission_store_inventory().await?;
+        let mut stores: Vec<Arc<dyn MissionStore>> = inventory.live;
+        for user in inventory.offline_file_users {
+            stores.push(Arc::new(
+                mission_store::FileMissionStore::new(inventory.base_dir.clone(), &user).await?,
+            ));
+        }
+        for store in stores {
+            let mut offset = 0;
+            loop {
+                let page = store.list_missions(PAGE_SIZE, offset).await?;
+                let page_len = page.len();
+                for mission in page {
+                    if keep(&mission) && seen.insert(mission.id) {
+                        collected.push(mission);
+                    }
+                }
+                if page_len < PAGE_SIZE {
+                    break;
+                }
+                offset += page_len;
+            }
+        }
+        for path in inventory.offline_sqlite {
+            let cutoff_str = cutoff.to_rfc3339();
+            let rows = tokio::task::spawn_blocking(move || {
+                collect_project_missions_from_sqlite(&path, &cutoff_str)
+            })
+            .await
+            .map_err(|error| error.to_string())??;
+            for mission in rows {
+                if seen.insert(mission.id) {
+                    collected.push(mission);
+                }
+            }
+        }
+        Ok(collected)
+    }
+
     async fn mission_store_inventory(&self) -> Result<MissionStoreInventory, String> {
         let sessions = self.sessions.read().await;
         let live: Vec<Arc<dyn MissionStore>> = sessions
@@ -5654,6 +5717,98 @@ fn cross_tenant_mission_projection(
         "read_only": true,
         "note": "mission belongs to another mission store; transcript and control operations are not exposed here",
     })
+}
+
+/// Read-only scan of an offline sqlite store for project-tagged missions.
+/// Returns lightweight Mission values (no history) — enough for board rows.
+fn collect_project_missions_from_sqlite(
+    path: &std::path::Path,
+    terminal_cutoff_rfc3339: &str,
+) -> Result<Vec<Mission>, String> {
+    let connection =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|error| format!("open {} read-only: {error}", path.display()))?;
+    let columns: std::collections::HashSet<String> = connection
+        .prepare("SELECT name FROM pragma_table_info('missions')")
+        .and_then(|mut st| {
+            st.query_map([], |row| row.get::<_, String>(0))
+                .map(|rows| rows.filter_map(Result::ok).collect())
+        })
+        .map_err(|error| error.to_string())?;
+    if !columns.contains("project") {
+        return Ok(Vec::new());
+    }
+    let mut statement = connection
+        .prepare(
+            "SELECT id, status, title, workspace_id, backend, created_at, updated_at, \
+             project, track, intent, github_pr \
+             FROM missions WHERE project IS NOT NULL",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, Option<String>>(9)?,
+                row.get::<_, Option<String>>(10)?,
+            ))
+        })
+        .map_err(|error| error.to_string())?;
+    let mut collected = Vec::new();
+    for row in rows {
+        let (
+            id,
+            status,
+            title,
+            workspace_id,
+            backend,
+            created_at,
+            updated_at,
+            project,
+            track,
+            intent,
+            github_pr,
+        ) = row.map_err(|error| error.to_string())?;
+        let Ok(id) = Uuid::parse_str(&id) else {
+            continue;
+        };
+        let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status))
+            .unwrap_or(MissionStatus::Active);
+        let updated_at = updated_at.unwrap_or_default();
+        if (status.is_terminal() || status == MissionStatus::Acknowledged)
+            && updated_at.as_str() < terminal_cutoff_rfc3339
+        {
+            continue;
+        }
+        let mut mission: Mission = serde_json::from_value(serde_json::json!({
+            "id": id,
+            "status": status,
+            "workspace_id": workspace_id
+                .as_deref()
+                .and_then(|raw| Uuid::parse_str(raw).ok())
+                .unwrap_or_else(Uuid::nil),
+            "backend": backend.unwrap_or_default(),
+            "history": [],
+            "created_at": created_at.unwrap_or_default(),
+            "updated_at": updated_at,
+        }))
+        .map_err(|error| error.to_string())?;
+        mission.title = title;
+        mission.project.project = project;
+        mission.project.track = track;
+        mission.project.intent = intent;
+        mission.project.github_pr = github_pr;
+        collected.push(mission);
+    }
+    Ok(collected)
 }
 
 /// Minimal read-only projection load from an offline sqlite store. Missing

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3721,9 +3721,6 @@ impl ControlHub {
         self.sessions.read().await.values().cloned().collect()
     }
 
-    /// Inventory every live and persisted mission store without opening
-    /// offline SQLite stores in read-write migration mode.
-
     /// Collect every mission that carries a `project` tag across all mission
     /// stores (live, offline file, offline sqlite). Read-only; used by the
     /// projects-overview board. Terminal missions older than `terminal_horizon`

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,6 +48,7 @@ mod native_loop_observer;
 pub mod oauth_reconcile;
 pub mod opencode;
 pub mod paloma;
+pub mod projects_overview;
 mod provider_usage_cache;
 pub(crate) mod providers;
 pub(crate) mod proxy;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1,0 +1,705 @@
+//! Projects board backend: one read-only endpoint that joins the three
+//! sources of project truth on this host into board-ready rows.
+//!
+//! Sources (each optional — absence degrades the row, never the endpoint):
+//! 1. Hermes project trackers (`HERMES_PROJECTS_DIR`, markdown files with a
+//!    `**Status**:` line) — the operator-curated project list.
+//! 2. sandboxed.sh missions across every mission store, joined by their
+//!    `project` tag (live executions per project).
+//! 3. Hermes cron deliveries (`HERMES_STATE_DB`, read-only sqlite) — the same
+//!    `[Cron delivery: …]` updates the operator receives in sessions, routed
+//!    to projects via their `[STATE_SIGNATURE: <key>|…]` trailer.
+//!
+//! Routing keys and tracker slugs don't always coincide; an optional
+//! `routes.json` alias map in the trackers directory bridges them, and
+//! anything still unmatched surfaces in an explicit `unrouted` bucket rather
+//! than being dropped.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use super::control::events::MissionStatus;
+use super::mission_store::Mission;
+use super::routes::AppState;
+
+/// Terminal missions younger than this stay on the board (recent history).
+const TERMINAL_MISSION_HORIZON_HOURS: i64 = 48;
+/// Hard cap of deliveries scanned per request (newest first).
+const DELIVERY_SCAN_LIMIT: usize = 600;
+/// A tracker marked active with no live mission and no update for this long
+/// is flagged stale-active.
+const STALE_ACTIVE_HOURS: i64 = 24;
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/overview", get(projects_overview))
+        .route("/:slug/updates", get(project_updates))
+}
+
+fn hermes_projects_dir() -> Option<PathBuf> {
+    std::env::var("HERMES_PROJECTS_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|path| path.is_dir())
+}
+
+fn hermes_state_db() -> Option<PathBuf> {
+    std::env::var("HERMES_STATE_DB")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TrackerInfo {
+    slug: String,
+    status_line: Option<String>,
+    updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MissionChip {
+    id: String,
+    status: MissionStatus,
+    title: Option<String>,
+    updated_at: String,
+    github_pr: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DeliveryUpdate {
+    headline: String,
+    body: Option<String>,
+    session_id: String,
+    at: String,
+    signature: Option<String>,
+    blocker: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProjectRow {
+    slug: String,
+    bucket: &'static str,
+    tracker: Option<TrackerInfo>,
+    missions: Vec<MissionChip>,
+    latest_update: Option<DeliveryUpdate>,
+    updates_count: usize,
+    attention_reasons: Vec<String>,
+}
+
+pub async fn projects_overview(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let trackers_dir = hermes_projects_dir();
+    let state_db = hermes_state_db();
+
+    let trackers = trackers_dir
+        .as_deref()
+        .map(read_trackers)
+        .unwrap_or_default();
+    let archived = trackers_dir
+        .as_deref()
+        .and_then(|dir| dir.parent().map(|p| p.join("archive")))
+        .filter(|dir| dir.is_dir())
+        .map(|dir| list_markdown_slugs(&dir))
+        .unwrap_or_default();
+    let aliases = trackers_dir
+        .as_deref()
+        .map(read_alias_map)
+        .unwrap_or_default();
+
+    let missions = state
+        .control
+        .collect_project_missions(chrono::Duration::hours(TERMINAL_MISSION_HORIZON_HOURS))
+        .await
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+
+    let deliveries = match state_db.as_deref() {
+        Some(path) => {
+            let path = path.to_path_buf();
+            tokio::task::spawn_blocking(move || read_deliveries(&path, DELIVERY_SCAN_LIMIT, None))
+                .await
+                .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?
+                .unwrap_or_else(|error| {
+                    tracing::warn!("hermes deliveries unavailable: {error}");
+                    Vec::new()
+                })
+        }
+        None => Vec::new(),
+    };
+
+    // ── Assemble rows: union of tracker slugs, mission project tags, and
+    //    routed delivery keys. Every source can create a row; every source
+    //    can only enrich, never hide, another.
+    let mut rows: HashMap<String, ProjectRowBuilder> = HashMap::new();
+
+    for tracker in trackers {
+        let slug = tracker.slug.clone();
+        rows.entry(slug.clone())
+            .or_insert_with(|| ProjectRowBuilder::new(slug))
+            .tracker = Some(tracker);
+    }
+    for mission in &missions {
+        let Some(project) = mission.project.project.as_deref() else {
+            continue;
+        };
+        let key = resolve_alias(&aliases, project);
+        rows.entry(key.clone())
+            .or_insert_with(|| ProjectRowBuilder::new(key))
+            .missions
+            .push(mission_chip(mission));
+    }
+    let mut unrouted: Vec<DeliveryUpdate> = Vec::new();
+    for delivery in deliveries {
+        let Some(signature_key) = delivery.signature.as_deref().map(str::to_string) else {
+            unrouted.push(delivery);
+            continue;
+        };
+        let key = resolve_alias(&aliases, &signature_key);
+        rows.entry(key.clone())
+            .or_insert_with(|| ProjectRowBuilder::new(key))
+            .push_delivery(delivery);
+    }
+
+    let mut projects: Vec<ProjectRow> = rows
+        .into_values()
+        .map(|builder| builder.finish(&archived))
+        .collect();
+    projects.sort_by(|a, b| {
+        bucket_rank(a.bucket)
+            .cmp(&bucket_rank(b.bucket))
+            .then_with(|| a.slug.cmp(&b.slug))
+    });
+
+    Ok(Json(serde_json::json!({
+        "projects": projects,
+        "archived": archived,
+        "unrouted_updates": unrouted.into_iter().take(20).collect::<Vec<_>>(),
+        "sources": {
+            "trackers": trackers_dir.is_some(),
+            "hermes_db": state_db.is_some(),
+        },
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatesQuery {
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+pub async fn project_updates(
+    AxumPath(slug): AxumPath<String>,
+    Query(query): Query<UpdatesQuery>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let Some(db) = hermes_state_db() else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "HERMES_STATE_DB is not configured".to_string(),
+        ));
+    };
+    let aliases = hermes_projects_dir()
+        .as_deref()
+        .map(read_alias_map)
+        .unwrap_or_default();
+    // Accept either the routing key or a tracker slug that aliases route TO.
+    let mut keys: Vec<String> = vec![slug.clone()];
+    for (from, to) in &aliases {
+        if to == &slug {
+            keys.push(from.clone());
+        }
+    }
+    let limit = query.limit.unwrap_or(50).min(200);
+    let updates =
+        tokio::task::spawn_blocking(move || read_deliveries(&db, DELIVERY_SCAN_LIMIT, Some(&keys)))
+            .await
+            .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?
+            .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+
+    Ok(Json(serde_json::json!({
+        "slug": slug,
+        "updates": updates.into_iter().take(limit).collect::<Vec<_>>(),
+    })))
+}
+
+struct ProjectRowBuilder {
+    slug: String,
+    tracker: Option<TrackerInfo>,
+    missions: Vec<MissionChip>,
+    latest_update: Option<DeliveryUpdate>,
+    recent_signatures: Vec<Option<String>>,
+    updates_count: usize,
+}
+
+impl ProjectRowBuilder {
+    fn new(slug: String) -> Self {
+        Self {
+            slug,
+            tracker: None,
+            missions: Vec::new(),
+            latest_update: None,
+            recent_signatures: Vec::new(),
+            updates_count: 0,
+        }
+    }
+
+    /// Deliveries arrive newest-first; keep the first as latest and remember
+    /// the three most recent signatures for the repeated-state stall signal.
+    fn push_delivery(&mut self, delivery: DeliveryUpdate) {
+        self.updates_count += 1;
+        if self.recent_signatures.len() < 3 {
+            self.recent_signatures.push(delivery.signature.clone());
+        }
+        if self.latest_update.is_none() {
+            self.latest_update = Some(delivery);
+        }
+    }
+
+    fn finish(mut self, archived: &[String]) -> ProjectRow {
+        self.missions
+            .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        self.missions.truncate(8);
+
+        let mut attention: Vec<String> = Vec::new();
+
+        if let Some(latest) = &self.latest_update {
+            if let Some(blocker) = latest.blocker.as_deref() {
+                attention.push(format!("blocker signalé: {blocker}"));
+            }
+            // Same non-silent state three ticks in a row: the controller
+            // keeps reporting an unchanged world — the phantom-lease shape.
+            if latest.signature.is_some()
+                && self.recent_signatures.len() >= 3
+                && self
+                    .recent_signatures
+                    .iter()
+                    .all(|signature| signature == &latest.signature)
+            {
+                attention.push("état identique sur 3 updates consécutives".to_string());
+            }
+        }
+        for chip in &self.missions {
+            if matches!(
+                chip.status,
+                MissionStatus::Failed | MissionStatus::Interrupted
+            ) {
+                attention.push(format!(
+                    "mission {} en état {:?}",
+                    &chip.id[..8.min(chip.id.len())],
+                    chip.status
+                ));
+            }
+        }
+        let tracker_active = self
+            .tracker
+            .as_ref()
+            .and_then(|t| t.status_line.as_deref())
+            .map(|line| {
+                let lower = line.to_lowercase();
+                lower.contains("active") || lower.contains("running")
+            })
+            .unwrap_or(false);
+        let tracker_paused = self
+            .tracker
+            .as_ref()
+            .and_then(|t| t.status_line.as_deref())
+            .map(|line| line.to_lowercase().contains("paused"))
+            .unwrap_or(false);
+        let has_live_mission = self
+            .missions
+            .iter()
+            .any(|chip| !chip.status.is_terminal() && chip.status != MissionStatus::Acknowledged);
+        if tracker_active && !has_live_mission {
+            let last_signal = self
+                .latest_update
+                .as_ref()
+                .map(|u| u.at.clone())
+                .or_else(|| self.tracker.as_ref().and_then(|t| t.updated_at.clone()));
+            let stale = last_signal
+                .and_then(|at| chrono::DateTime::parse_from_rfc3339(&at).ok())
+                .map(|at| {
+                    chrono::Utc::now().signed_duration_since(at.with_timezone(&chrono::Utc))
+                        > chrono::Duration::hours(STALE_ACTIVE_HOURS)
+                })
+                .unwrap_or(false);
+            if stale {
+                attention.push("tracker actif sans mission live ni update récente".to_string());
+            }
+        }
+
+        let bucket: &'static str = if archived.contains(&self.slug) {
+            "archived"
+        } else if !attention.is_empty() {
+            "attention"
+        } else if tracker_paused {
+            "paused"
+        } else {
+            "active"
+        };
+
+        ProjectRow {
+            slug: self.slug,
+            bucket,
+            tracker: self.tracker,
+            missions: self.missions,
+            latest_update: self.latest_update,
+            updates_count: self.updates_count,
+            attention_reasons: attention,
+        }
+    }
+}
+
+fn bucket_rank(bucket: &str) -> u8 {
+    match bucket {
+        "attention" => 0,
+        "active" => 1,
+        "paused" => 2,
+        _ => 3,
+    }
+}
+
+fn mission_chip(mission: &Mission) -> MissionChip {
+    MissionChip {
+        id: mission.id.to_string(),
+        status: mission.status,
+        title: mission.title.clone(),
+        updated_at: mission.updated_at.clone(),
+        github_pr: mission.project.github_pr.clone(),
+    }
+}
+
+fn read_trackers(dir: &Path) -> Vec<TrackerInfo> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut trackers = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let Some(slug) = path.file_stem().and_then(|s| s.to_str()).map(String::from) else {
+            continue;
+        };
+        let status_line = std::fs::read_to_string(&path).ok().and_then(|content| {
+            content
+                .lines()
+                .find_map(|line| {
+                    let trimmed = line.trim();
+                    trimmed
+                        .strip_prefix("**Status**:")
+                        .or_else(|| trimmed.strip_prefix("**Status** :"))
+                        .map(|rest| rest.trim().to_string())
+                })
+                .or_else(|| {
+                    // Fallback: yaml-ish `status: …` near the top of the file.
+                    content.lines().take(20).find_map(|line| {
+                        let trimmed = line.trim();
+                        let rest = trimmed
+                            .strip_prefix("status:")
+                            .or_else(|| trimmed.strip_prefix("Status:"))?;
+                        let value = rest.trim();
+                        (!value.is_empty()).then(|| value.to_string())
+                    })
+                })
+        });
+        let updated_at = entry
+            .metadata()
+            .ok()
+            .and_then(|meta| meta.modified().ok())
+            .map(|time| chrono::DateTime::<chrono::Utc>::from(time).to_rfc3339());
+        trackers.push(TrackerInfo {
+            slug,
+            status_line,
+            updated_at,
+        });
+    }
+    trackers
+}
+
+fn list_markdown_slugs(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut slugs: Vec<String> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                return None;
+            }
+            path.file_stem().and_then(|s| s.to_str()).map(String::from)
+        })
+        .collect();
+    slugs.sort();
+    slugs
+}
+
+/// Optional `routes.json` in the trackers dir: `{ "verity": "verity-roadmap" }`
+/// maps a controller routing key (STATE_SIGNATURE prefix or mission project
+/// tag) onto the tracker slug that should own its row.
+fn read_alias_map(dir: &Path) -> HashMap<String, String> {
+    std::fs::read_to_string(dir.join("routes.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<HashMap<String, String>>(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn resolve_alias(aliases: &HashMap<String, String>, key: &str) -> String {
+    aliases.get(key).cloned().unwrap_or_else(|| key.to_string())
+}
+
+/// Read `[Cron delivery: …]` updates from the Hermes SessionDB, newest first.
+/// `filter_keys`, when set, keeps only deliveries whose signature key matches.
+pub fn read_deliveries(
+    db_path: &Path,
+    scan_limit: usize,
+    filter_keys: Option<&[String]>,
+) -> Result<Vec<DeliveryUpdate>, String> {
+    let connection =
+        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|error| format!("open {} read-only: {error}", db_path.display()))?;
+    // Two shapes coexist in the Hermes DB: the canonical cron-session report
+    // (assistant message ending in a real `[STATE_SIGNATURE: …]` trailer) and
+    // its `[Cron delivery: …]` copy in target sessions, which has the
+    // signature stripped. We read both and drop copies whose body duplicates
+    // a signature-bearing report.
+    let mut statement = connection
+        .prepare(
+            "SELECT session_id, timestamp, content FROM messages \
+             WHERE role = 'assistant' AND (content LIKE '[Cron delivery:%' \
+                OR content LIKE '%[STATE_SIGNATURE:%') \
+             ORDER BY timestamp DESC LIMIT ?1",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = statement
+        .query_map([scan_limit as i64], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, f64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|error| error.to_string())?;
+    let mut deliveries = Vec::new();
+    let mut routed_fingerprints: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    for row in rows {
+        let (session_id, timestamp, content) = row.map_err(|error| error.to_string())?;
+        let parsed = parse_delivery(&session_id, timestamp, &content);
+        if parsed.signature.is_some() {
+            routed_fingerprints.insert(delivery_fingerprint(&content));
+        }
+        if let Some(keys) = filter_keys {
+            let matches = parsed
+                .signature
+                .as_deref()
+                .is_some_and(|signature| keys.iter().any(|key| key == signature));
+            if !matches {
+                continue;
+            }
+        }
+        deliveries.push(parsed);
+    }
+    // Second pass: signature-less delivery copies of a routed report are
+    // duplicates, not unrouted updates.
+    deliveries.retain(|delivery| {
+        delivery.signature.is_some()
+            || delivery
+                .body
+                .as_deref()
+                .map(|body| !routed_fingerprints.contains(&delivery_fingerprint(body)))
+                .unwrap_or(true)
+    });
+    Ok(deliveries)
+}
+
+/// Whitespace-normalized prefix of the report body (tag and signature lines
+/// stripped) — enough to identify a delivery copy of a routed report.
+fn delivery_fingerprint(content: &str) -> String {
+    content
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty()
+                && !trimmed.starts_with("[Cron delivery:")
+                && !trimmed.starts_with("[STATE_SIGNATURE:")
+        })
+        .flat_map(|line| line.split_whitespace())
+        .flat_map(|word| word.chars())
+        .take(160)
+        .collect()
+}
+
+fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUpdate {
+    let at = chrono::DateTime::<chrono::Utc>::from_timestamp(
+        timestamp as i64,
+        ((timestamp.fract()) * 1e9) as u32,
+    )
+    .map(|t| t.to_rfc3339())
+    .unwrap_or_default();
+
+    // Headline: the first non-empty line after the `[Cron delivery: …]` tag,
+    // falling back to the tag's own title (the cron job name).
+    let tag_title = content.lines().next().and_then(|line| {
+        line.trim()
+            .strip_prefix("[Cron delivery:")
+            .map(|rest| rest.trim_end_matches(']').trim().to_string())
+    });
+    let mut headline = String::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with("[Cron delivery:")
+            || trimmed.starts_with("[STATE_SIGNATURE:")
+        {
+            continue;
+        }
+        headline = trimmed.trim_start_matches('#').trim().to_string();
+        break;
+    }
+    if headline.is_empty() {
+        headline = tag_title.unwrap_or_default();
+    }
+
+    let signature = content
+        .lines()
+        .rev()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            trimmed
+                .strip_prefix("[STATE_SIGNATURE:")
+                .and_then(|rest| rest.strip_suffix(']'))
+        })
+        .and_then(|inner| inner.split('|').next())
+        .map(|key| key.trim().to_string())
+        // Reject template placeholders like `<project>` and anything that
+        // isn't a plain routing key.
+        .filter(|key| {
+            !key.is_empty()
+                && key
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        });
+
+    // "Bloqué par:" / "Blocked by:" field, when it names a real blocker.
+    let blocker = content.lines().find_map(|line| {
+        let lower = line.to_lowercase();
+        let rest = if let Some(idx) = lower.find("bloqué par") {
+            &line[idx + "bloqué par".len()..]
+        } else if let Some(idx) = lower.find("blocked by") {
+            &line[idx + "blocked by".len()..]
+        } else {
+            return None;
+        };
+        let value = rest
+            .trim_start_matches(['*', ':', ' ', '\u{a0}'])
+            .trim_end_matches("**")
+            .trim();
+        let normalized = value.to_lowercase();
+        if value.is_empty()
+            || normalized.starts_with("aucun")
+            || normalized.starts_with("rien")
+            || normalized.starts_with("none")
+            || normalized.starts_with('—')
+            || normalized.starts_with('-')
+        {
+            None
+        } else {
+            Some(value.chars().take(200).collect::<String>())
+        }
+    });
+
+    DeliveryUpdate {
+        headline,
+        body: Some(content.chars().take(8000).collect()),
+        session_id: session_id.to_string(),
+        at,
+        signature,
+        blocker,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "[Cron delivery: Verity two-phase Fable/Codex progression]\n\
+        Verity — BLOQUÉE PAR LE CONTROL PLANE\n\n\
+        **Changé :** l'audit est terminé.\n\
+        **Bloqué par :** lease writer fantôme sur #2219.\n\n\
+        [STATE_SIGNATURE: verity|phase-1b|abc123|blocked|lease|next]";
+
+    #[test]
+    fn parses_delivery_headline_signature_and_blocker() {
+        let parsed = parse_delivery("sess-1", 1_754_000_000.5, SAMPLE);
+        assert_eq!(parsed.headline, "Verity — BLOQUÉE PAR LE CONTROL PLANE");
+        assert_eq!(parsed.signature.as_deref(), Some("verity"));
+        assert!(parsed
+            .blocker
+            .as_deref()
+            .is_some_and(|b| b.contains("lease writer fantôme")));
+        assert!(!parsed.at.is_empty());
+    }
+
+    #[test]
+    fn empty_blockers_are_not_blockers() {
+        let content = "[Cron delivery: x]\nTitre\n**Bloqué par :** aucun pour l'instant.\n";
+        let parsed = parse_delivery("s", 0.0, content);
+        assert!(parsed.blocker.is_none());
+    }
+
+    #[test]
+    fn repeated_signature_and_blocker_raise_attention() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder.push_delivery(parse_delivery("s", 3.0, SAMPLE));
+        builder.push_delivery(parse_delivery("s", 2.0, SAMPLE));
+        builder.push_delivery(parse_delivery("s", 1.0, SAMPLE));
+        let row = builder.finish(&[]);
+        assert_eq!(row.bucket, "attention");
+        assert!(row.attention_reasons.iter().any(|r| r.contains("blocker")));
+        assert!(row
+            .attention_reasons
+            .iter()
+            .any(|r| r.contains("état identique")));
+    }
+
+    #[test]
+    fn template_placeholder_signatures_are_rejected() {
+        let content = "Rapport\n[STATE_SIGNATURE: <project>|<item>|x]";
+        let parsed = parse_delivery("s", 0.0, content);
+        assert!(parsed.signature.is_none());
+    }
+
+    #[test]
+    fn delivery_copy_shares_fingerprint_with_routed_report() {
+        let routed = "Verity — état stable.\n\nDétails du tick.\n\n[STATE_SIGNATURE: verity|a|b]";
+        let copy = "[Cron delivery: Verity two-phase]\nVerity — état stable.\n\nDétails du tick.";
+        assert_eq!(delivery_fingerprint(routed), delivery_fingerprint(copy));
+    }
+
+    #[test]
+    fn headline_falls_back_to_cron_tag_title() {
+        let parsed = parse_delivery("s", 0.0, "[Cron delivery: Lido campaign controller]\n\n");
+        assert_eq!(parsed.headline, "Lido campaign controller");
+    }
+
+    #[test]
+    fn paused_tracker_without_signals_lands_in_paused_bucket() {
+        let mut builder = ProjectRowBuilder::new("erc".to_string());
+        builder.tracker = Some(TrackerInfo {
+            slug: "erc".to_string(),
+            status_line: Some("paused (drained)".to_string()),
+            updated_at: None,
+        });
+        let row = builder.finish(&[]);
+        assert_eq!(row.bucket, "paused");
+    }
+}

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -592,13 +592,10 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
     // "Bloqué par:" / "Blocked by:" field, when it names a real blocker.
     let blocker = content.lines().find_map(|line| {
         let lower = line.to_lowercase();
-        let rest = if let Some(idx) = lower.find("bloqué par") {
-            &line[idx + "bloqué par".len()..]
-        } else if let Some(idx) = lower.find("blocked by") {
-            &line[idx + "blocked by".len()..]
-        } else {
-            return None;
-        };
+        let (idx, marker_len) = ["bloqué par", "blocked by"]
+            .iter()
+            .find_map(|marker| lower.find(marker).map(|idx| (idx, marker.len())))?;
+        let rest = &line[idx + marker_len..];
         let value = rest
             .trim_start_matches(['*', ':', ' ', '\u{a0}'])
             .trim_end_matches("**")

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1211,6 +1211,9 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .nest("/api/desktop", desktop::routes())
         // Durable background jobs launched outside ephemeral agent-turn shells
         .nest("/api/durable-jobs", durable_jobs::routes())
+        // Projects board: read-only join of Hermes trackers, project-tagged
+        // missions, and cron deliveries.
+        .nest("/api/projects", super::projects_overview::routes())
         // Project-native validation campaigns and structured receipts.
         .nest("/api/validation-campaigns", super::validation::routes())
         // System component management endpoints


### PR DESCRIPTION
Replaces the Hermes chat at `/` with a projects kanban wired to real data, per the active goal.

## Backend (phase 1)
- `GET /api/projects/overview` (auth-protected): joins three optional sources —
  - **Trackers**: `HERMES_PROJECTS_DIR` (`.hermes/projects/active/*.md`) — slug, `**Status**:`/`status:` line, mtime; `../archive/*.md` feeds the Archive column; optional `routes.json` alias map (signature key → tracker slug).
  - **Missions**: `ControlHub::collect_project_missions` scans live stores, offline file users and offline sqlite stores for project-tagged missions (terminal ones kept 48h).
  - **Updates**: read-only sqlite on `HERMES_STATE_DB`; canonical source = assistant messages carrying a real `[STATE_SIGNATURE: key|…]` trailer; `[Cron delivery:…]` copies are fingerprint-deduped; leftovers land in an explicit **unrouted** bucket.
- `GET /api/projects/:slug/updates` for the drawer timeline (accepts routing keys aliased to the slug).

## Attention requise (phase 3)
Automatic when: latest delivery has a non-empty `Bloqué par`/`Blocked by`; same STATE_SIGNATURE on ≥3 consecutive updates; a project mission is failed/interrupted; or an active tracker has no live mission nor update for 24h.

## Dashboard (phase 2)
- `/` = 4-column kanban 🟢 Actif · 🟠 Attention requise · ⏸ Pausé · 📦 Archive; cards show tracker status, clickable mission chips (→ /control), latest update + age, attention badge; click opens a drawer with the full markdown update timeline + origin session.
- Hermes chat preserved at `/assistant/chat` (page + sidebar child link); sidebar `/` entry renamed **Projets**.

## Tests
- Rust: 7 unit tests (delivery parsing, signature sanitization vs template placeholders, fingerprint dedup, bucket rules) — pass.
- Dashboard: 3 new vitest tests (bucket columns + attention reasons, chip links, drawer timeline); full suite 259/259 pass; `tsc` clean on touched files (2 pre-existing errors in new-mission-dialog.test.tsx untouched).

Verified against prod data shapes (messages schema, real signature trailers, tracker files) before writing the readers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cross-store mission scan and read-only SQLite access on each overview request could add load on busy hosts; endpoints are read-only and degrade when env paths are missing.
> 
> **Overview**
> **Replaces the Hermes chat on `/` with a four-column projects kanban** (Actif, Attention requise, Pausé, Archive). Hermes chat moves to `/assistant/chat`; the sidebar home link becomes **Projets** with **Chat Hermes** under Assistant.
> 
> **New read-only backend** under `/api/projects`: `GET /overview` joins optional Hermes markdown trackers (`HERMES_PROJECTS_DIR`), project-tagged missions from all mission stores via `ControlHub::collect_project_missions` (48h terminal horizon), and cron deliveries from read-only `HERMES_STATE_DB` with `routes.json` aliasing and an **unrouted** bucket for unmatched updates. `GET /:slug/updates` powers the drawer timeline. Rows get automatic **attention** signals (blockers, repeated signatures, failed missions, stale active trackers).
> 
> **Dashboard**: `ProjectsBoard` polls overview every 30s, shows mission chips linking to `/control`, unrouted updates, and a drawer with markdown update history. Client API in `dashboard/src/lib/api/projects.ts`. Env docs added for `HERMES_PROJECTS_DIR` and `HERMES_STATE_DB`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1a245fe6de94de1b58b596077cd3a6d8e12da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->