### PR TITLE
Projects board v2: triage master-detail view replacing the kanban

### DIFF
--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -52,13 +52,14 @@ describe("ProjectsBoard", () => {
   beforeEach(() => {
     mockedOverview.mockReset();
     mockedUpdates.mockReset();
+    mockedUpdates.mockResolvedValue({ slug: "verity", updates: [] });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  test("places projects in their bucket columns with attention reasons", async () => {
+  test("groups projects into sections, attention first with its reasons", async () => {
     mockedOverview.mockResolvedValue(
       overview([
         project({ slug: "verity" }),
@@ -74,14 +75,18 @@ describe("ProjectsBoard", () => {
     renderBoard();
 
     expect(await screen.findByText("verity")).toBeInTheDocument();
-    expect(screen.getByText("lido-audit")).toBeInTheDocument();
-    expect(
-      screen.getByText(/blocker signalé: lease writer fantôme/),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText("lido-audit").length).toBeGreaterThan(0);
     expect(screen.getByText("erc")).toBeInTheDocument();
+    // Attention project is auto-selected (first in triage order) and its
+    // reasons render in the detail pane banner.
+    expect(
+      await screen.findAllByText(/blocker signalé: lease writer fantôme/),
+    ).not.toHaveLength(0);
+    const sections = screen.getAllByText(/Attention requise|Actif|Pausé/);
+    expect(sections.length).toBeGreaterThanOrEqual(3);
   });
 
-  test("mission chips link to /control", async () => {
+  test("mission chips in the detail pane link to /control", async () => {
     mockedOverview.mockResolvedValue(
       overview([
         project({
@@ -108,32 +113,57 @@ describe("ProjectsBoard", () => {
     );
   });
 
-  test("opening a card loads the updates timeline drawer", async () => {
-    mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
-    mockedUpdates.mockResolvedValue({
-      slug: "verity",
-      updates: [
-        {
-          headline: "Phase 1C merged",
-          body: "**Changé :** slice mergée.",
-          session_id: "sess-42",
-          at: "2026-08-01T07:11:00Z",
-          signature: "verity",
-          blocker: null,
-        },
-      ],
-    });
+  test("selecting a project loads its updates timeline in the detail pane", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({ slug: "verity" }),
+        project({ slug: "beal" }),
+      ]),
+    );
+    mockedUpdates.mockImplementation(async (slug: string) => ({
+      slug,
+      updates:
+        slug === "beal"
+          ? [
+              {
+                headline: "P_Cl promoted to proved",
+                body: "**Changé :** promotion vérifiée.",
+                session_id: "sess-42",
+                at: "2026-08-01T07:11:00Z",
+                signature: "beal",
+                blocker: null,
+              },
+            ]
+          : [],
+    }));
 
     renderBoard();
 
-    fireEvent.click(await screen.findByText("verity"));
+    fireEvent.click(await screen.findByRole("button", { name: /beal/ }));
 
-    expect(await screen.findByText("Phase 1C merged")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mockedUpdates).toHaveBeenCalledWith("verity", 50),
+    expect(await screen.findByText("P_Cl promoted to proved")).toBeInTheDocument();
+    await waitFor(() => expect(mockedUpdates).toHaveBeenCalledWith("beal", 50));
+    // First update is expanded by default: body + origin session visible.
+    expect(
+      await screen.findByText(/Session d’origine : sess-42/),
+    ).toBeInTheDocument();
+  });
+
+  test("search filter narrows the triage list", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([project({ slug: "verity" }), project({ slug: "beal" })]),
     );
 
-    fireEvent.click(screen.getByText("Phase 1C merged"));
-    expect(await screen.findByText(/Session d’origine : sess-42/)).toBeInTheDocument();
+    renderBoard();
+    await screen.findByRole("button", { name: /beal/ });
+
+    fireEvent.change(screen.getByPlaceholderText("Filtrer…"), {
+      target: { value: "ver" },
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /beal/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("verity").length).toBeGreaterThan(0);
   });
 });

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -1,18 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import useSWR from "swr";
 import {
   AlertTriangle,
   Archive,
-  CircleDot,
-  ExternalLink,
+  ArrowLeft,
   GitPullRequest,
   Inbox,
   Loader,
   PauseCircle,
-  X,
+  Search,
 } from "lucide-react";
 
 import {
@@ -27,22 +32,45 @@ import { MarkdownContent } from "@/components/markdown-content";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { cn } from "@/lib/utils";
 
-const COLUMNS: {
-  bucket: ProjectBucket;
-  title: string;
-  emoji: string;
-  empty: string;
-}[] = [
-  { bucket: "active", title: "Actif", emoji: "🟢", empty: "Aucun projet actif" },
-  {
-    bucket: "attention",
-    title: "Attention requise",
-    emoji: "🟠",
-    empty: "Rien à signaler",
-  },
-  { bucket: "paused", title: "Pausé", emoji: "⏸", empty: "Aucun projet en pause" },
-  { bucket: "archived", title: "Archive", emoji: "📦", empty: "Archive vide" },
+const SECTIONS: { bucket: ProjectBucket; title: string; emoji: string }[] = [
+  { bucket: "attention", title: "Attention requise", emoji: "🟠" },
+  { bucket: "active", title: "Actif", emoji: "🟢" },
+  { bucket: "paused", title: "Pausé", emoji: "⏸" },
+  { bucket: "archived", title: "Archive", emoji: "📦" },
 ];
+
+const LIVE_STATUSES = new Set([
+  "created",
+  "queued",
+  "active",
+  "pending",
+  "waiting_background",
+  "awaiting_user",
+  "paused",
+]);
+
+function liveMissionCount(project: ProjectRow): number {
+  return project.missions.filter((m) => LIVE_STATUSES.has(m.status)).length;
+}
+
+/** Latest signal timestamp for sorting: update, mission activity, or tracker mtime. */
+function lastSignalMs(project: ProjectRow): number {
+  const candidates = [
+    project.latest_update?.at,
+    project.missions[0]?.updated_at,
+    project.tracker?.updated_at,
+  ];
+  return candidates.reduce((max, at) => {
+    if (!at) return max;
+    const ms = new Date(at).getTime();
+    return Number.isNaN(ms) ? max : Math.max(max, ms);
+  }, 0);
+}
+
+/** A project with no missions and no updates is a quiet tracker file. */
+function isQuiet(project: ProjectRow): boolean {
+  return project.missions.length === 0 && project.updates_count === 0;
+}
 
 export default function ProjectsBoard() {
   const { data, error, isLoading } = useSWR(
@@ -50,113 +78,231 @@ export default function ProjectsBoard() {
     getProjectsOverview,
     { refreshInterval: 30000, revalidateOnFocus: false },
   );
-  const [openSlug, setOpenSlug] = useState<string | null>(null);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+  const [mobileDetail, setMobileDetail] = useState(false);
+  const listRef = useRef<HTMLDivElement | null>(null);
 
+  const sections = useMemo(() => {
+    const projects = data?.projects ?? [];
+    const query = filter.trim().toLowerCase();
+    const filtered = query
+      ? projects.filter((p) => p.slug.toLowerCase().includes(query))
+      : projects;
+    return SECTIONS.map((section) => ({
+      ...section,
+      projects: filtered
+        .filter((p) => p.bucket === section.bucket)
+        .sort((a, b) => {
+          const quiet = Number(isQuiet(a)) - Number(isQuiet(b));
+          if (quiet !== 0) return quiet;
+          return lastSignalMs(b) - lastSignalMs(a) || a.slug.localeCompare(b.slug);
+        }),
+    })).filter((section) => section.projects.length > 0);
+  }, [data, filter]);
+
+  const flatList = useMemo(
+    () => sections.flatMap((section) => section.projects),
+    [sections],
+  );
+
+  const selected =
+    flatList.find((p) => p.slug === selectedSlug) ?? flatList[0] ?? null;
+
+  const select = useCallback((slug: string, viaPointer = false) => {
+    setSelectedSlug(slug);
+    if (viaPointer) setMobileDetail(true);
+  }, []);
+
+  // Keyboard triage: ↑/↓ move the selection through the flattened list.
   useEffect(() => {
-    if (!openSlug) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpenSlug(null);
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      const target = event.target as HTMLElement | null;
+      if (target && ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName)) {
+        return;
+      }
+      if (flatList.length === 0) return;
+      event.preventDefault();
+      const currentIndex = selected
+        ? flatList.findIndex((p) => p.slug === selected.slug)
+        : -1;
+      const nextIndex =
+        event.key === "ArrowDown"
+          ? Math.min(currentIndex + 1, flatList.length - 1)
+          : Math.max(currentIndex - 1, 0);
+      const next = flatList[nextIndex];
+      if (next) {
+        setSelectedSlug(next.slug);
+        listRef.current
+          ?.querySelector(`[data-slug="${CSS.escape(next.slug)}"]`)
+          ?.scrollIntoView({ block: "nearest" });
+      }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [openSlug]);
+  }, [flatList, selected]);
 
-  const close = useCallback(() => setOpenSlug(null), []);
-
-  const projects = data?.projects ?? [];
+  const attentionCount =
+    data?.projects.filter((p) => p.bucket === "attention").length ?? 0;
+  const liveTotal =
+    data?.projects.reduce((sum, p) => sum + liveMissionCount(p), 0) ?? 0;
   const unrouted = data?.unrouted_updates ?? [];
-  const openProject = projects.find((p) => p.slug === openSlug) ?? null;
 
   return (
-    <div className="mx-auto flex h-full max-w-[1600px] flex-col gap-4 px-4 py-4 sm:px-6">
-      <header className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-lg font-semibold text-white/90">Projets</h1>
-          <p className="text-xs text-white/40">
-            Trackers Hermes · missions taguées · updates cron.{" "}
-            <Link href="/assistant/chat" className="text-indigo-300/80 hover:text-indigo-200">
-              Le chat vit sous /assistant/chat
+    <div className="mx-auto flex h-[calc(100vh-1px)] max-w-[1500px] flex-col px-3 pt-3 sm:px-5">
+      <header className="flex flex-wrap items-center gap-x-4 gap-y-2 pb-3">
+        <div className="min-w-0">
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">
+            Projets
+          </h1>
+          <p className="text-[11px] text-white/35">
+            <Link
+              href="/assistant/chat"
+              className="transition-colors hover:text-white/60"
+            >
+              Le chat vit sous /assistant/chat →
             </Link>
           </p>
         </div>
-        {data && (
-          <div className="flex items-center gap-3 text-[11px] text-white/40">
-            <SourceDot ok={data.sources.trackers} label="trackers" />
-            <SourceDot ok={data.sources.hermes_db} label="hermes db" />
+
+        <div className="ml-auto flex items-center gap-2.5">
+          {data && (
+            <>
+              <StatPill
+                tone={attentionCount > 0 ? "amber" : "neutral"}
+                label="attention"
+                value={attentionCount}
+              />
+              <StatPill tone="sky" label="missions live" value={liveTotal} />
+              <span className="hidden items-center gap-2.5 text-[11px] text-white/35 sm:flex">
+                <SourceDot ok={data.sources.trackers} label="trackers" />
+                <SourceDot ok={data.sources.hermes_db} label="hermes" />
+              </span>
+            </>
+          )}
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-white/30" />
+            <input
+              value={filter}
+              onChange={(event) => setFilter(event.target.value)}
+              placeholder="Filtrer…"
+              className="w-36 rounded-lg border border-white/[0.08] bg-white/[0.03] py-1.5 pl-8 pr-3 text-xs text-white/80 placeholder:text-white/25 focus:border-indigo-400/40 focus:outline-none sm:w-48"
+            />
           </div>
-        )}
+        </div>
       </header>
 
       {error && (
-        <div className="rounded-lg border border-red-400/20 bg-red-500/10 px-3 py-2 text-sm text-red-300/90">
+        <div className="mb-3 rounded-lg border border-red-400/20 bg-red-500/10 px-3 py-2 text-sm text-red-300/90">
           Impossible de charger l’aperçu des projets : {String(error)}
         </div>
       )}
       {isLoading && !data && (
         <div className="flex items-center gap-2 py-10 text-sm text-white/40">
-          <Loader className="h-4 w-4 animate-spin" /> Chargement du board…
+          <Loader className="h-4 w-4 animate-spin" /> Chargement des projets…
         </div>
       )}
 
       {data && (
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-y-auto sm:grid-cols-2 xl:grid-cols-4">
-          {COLUMNS.map((column) => {
-            const rows = projects.filter((p) => p.bucket === column.bucket);
-            return (
-              <section
-                key={column.bucket}
-                className="flex min-h-[120px] flex-col rounded-xl border border-white/[0.06] bg-white/[0.02]"
-              >
-                <div className="flex items-center justify-between border-b border-white/[0.05] px-3 py-2">
-                  <span className="text-sm font-medium text-white/75">
-                    {column.emoji} {column.title}
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 pb-4 lg:grid-cols-[340px_minmax(0,1fr)] xl:grid-cols-[380px_minmax(0,1fr)]">
+          {/* ── Triage list ── */}
+          <div
+            ref={listRef}
+            className={cn(
+              "min-h-0 overflow-y-auto rounded-xl border border-white/[0.06] bg-white/[0.015]",
+              mobileDetail && "hidden lg:block",
+            )}
+          >
+            {sections.map((section) => (
+              <div key={section.bucket}>
+                <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-white/[0.05] bg-[rgb(var(--background))]/95 px-3 py-1.5 backdrop-blur">
+                  <span className="text-[11px] font-semibold uppercase tracking-wider text-white/45">
+                    {section.emoji} {section.title}
                   </span>
-                  <span className="rounded-full bg-white/[0.06] px-2 py-0.5 text-[11px] text-white/45">
-                    {rows.length}
+                  <span className="text-[11px] text-white/25">
+                    {section.projects.length}
                   </span>
                 </div>
-                <div className="flex flex-col gap-2 overflow-y-auto p-2">
-                  {rows.length === 0 ? (
-                    <p className="px-1 py-3 text-center text-xs text-white/30">
-                      {column.empty}
-                    </p>
-                  ) : (
-                    rows.map((project) => (
-                      <ProjectCard
-                        key={project.slug}
-                        project={project}
-                        onOpen={() => setOpenSlug(project.slug)}
-                      />
-                    ))
-                  )}
-                </div>
-              </section>
-            );
-          })}
-        </div>
-      )}
-
-      {unrouted.length > 0 && (
-        <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-3 py-2">
-          <div className="flex items-center gap-2 text-xs font-medium text-white/60">
-            <Inbox className="h-3.5 w-3.5" /> Updates non routées ({unrouted.length})
-          </div>
-          <div className="mt-1 space-y-1">
-            {unrouted.slice(0, 5).map((update, index) => (
-              <div
-                key={`${update.session_id}-${update.at}-${index}`}
-                className="flex min-w-0 items-center gap-2 text-xs text-white/45"
-              >
-                <span className="min-w-0 flex-1 truncate">{update.headline || "(sans titre)"}</span>
-                <UpdateAge at={update.at} />
+                {section.projects.map((project) => (
+                  <ProjectListRow
+                    key={project.slug}
+                    project={project}
+                    selected={selected?.slug === project.slug}
+                    onSelect={() => select(project.slug, true)}
+                  />
+                ))}
               </div>
             ))}
+            {flatList.length === 0 && (
+              <p className="px-4 py-8 text-center text-sm text-white/30">
+                Aucun projet ne correspond.
+              </p>
+            )}
+            {unrouted.length > 0 && (
+              <div className="border-t border-white/[0.05] px-3 py-2.5">
+                <p className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-white/35">
+                  <Inbox className="h-3 w-3" /> Non routées ({unrouted.length})
+                </p>
+                {unrouted.slice(0, 4).map((update, index) => (
+                  <div
+                    key={`${update.session_id}-${update.at}-${index}`}
+                    className="flex min-w-0 items-center gap-2 py-0.5 text-[11px] text-white/40"
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {update.headline || "(sans titre)"}
+                    </span>
+                    <UpdateAge at={update.at} />
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
-        </section>
-      )}
 
-      {openProject && <ProjectDrawer project={openProject} onClose={close} />}
+          {/* ── Detail pane ── */}
+          <div
+            className={cn(
+              "min-h-0 overflow-y-auto rounded-xl border border-white/[0.06] bg-white/[0.015]",
+              !mobileDetail && "hidden lg:block",
+            )}
+          >
+            {selected ? (
+              <ProjectDetail
+                project={selected}
+                onBack={() => setMobileDetail(false)}
+              />
+            ) : (
+              <p className="px-4 py-10 text-center text-sm text-white/30">
+                Sélectionne un projet pour voir sa timeline.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </div>
+  );
+}
+
+function StatPill({
+  tone,
+  label,
+  value,
+}: {
+  tone: "amber" | "sky" | "neutral";
+  label: string;
+  value: number;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px]",
+        tone === "amber" && "border-amber-400/25 bg-amber-500/10 text-amber-200/90",
+        tone === "sky" && "border-sky-400/25 bg-sky-500/[0.07] text-sky-300",
+        tone === "neutral" && "border-white/[0.08] bg-white/[0.03] text-white/50",
+      )}
+    >
+      <span className="font-semibold tabular-nums">{value}</span> {label}
+    </span>
   );
 }
 
@@ -174,157 +320,122 @@ function SourceDot({ ok, label }: { ok: boolean; label: string }) {
   );
 }
 
-function ProjectCard({
+function railColor(project: ProjectRow): string {
+  if (project.bucket === "attention") return "bg-amber-400/80";
+  if (project.bucket === "paused") return "bg-white/20";
+  if (project.bucket === "archived") return "bg-white/10";
+  if (liveMissionCount(project) > 0) return "bg-emerald-400/80";
+  return "bg-emerald-400/30";
+}
+
+function ProjectListRow({
   project,
-  onOpen,
+  selected,
+  onSelect,
 }: {
   project: ProjectRow;
-  onOpen: () => void;
+  selected: boolean;
+  onSelect: () => void;
 }) {
+  const live = liveMissionCount(project);
+  const quiet = isQuiet(project);
   return (
     <button
       type="button"
-      onClick={onOpen}
+      data-slug={project.slug}
+      onClick={onSelect}
       className={cn(
-        "group w-full rounded-lg border px-3 py-2.5 text-left transition-colors",
-        project.bucket === "attention"
-          ? "border-amber-400/25 bg-amber-500/[0.06] hover:border-amber-400/40"
-          : "border-white/[0.07] bg-white/[0.03] hover:border-indigo-400/30 hover:bg-white/[0.05]",
+        "group relative flex w-full items-stretch gap-2.5 px-3 py-2 text-left transition-colors",
+        selected
+          ? "bg-indigo-500/[0.09]"
+          : "hover:bg-white/[0.03]",
       )}
     >
-      <div className="flex items-center justify-between gap-2">
-        <span className="truncate text-sm font-medium text-white/85">
-          {project.slug}
-        </span>
-        <BucketIcon bucket={project.bucket} />
-      </div>
-
-      {project.tracker?.status_line && (
-        <p className="mt-1 line-clamp-2 text-xs text-white/50">
-          {project.tracker.status_line}
-        </p>
-      )}
-
-      {project.missions.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1">
-          {project.missions.slice(0, 4).map((mission) => (
-            <MissionMiniChip key={mission.id} mission={mission} />
-          ))}
-          {project.missions.length > 4 && (
-            <span className="px-1 text-[10px] text-white/35">
-              +{project.missions.length - 4}
-            </span>
+      <span
+        className={cn(
+          "w-[3px] shrink-0 self-stretch rounded-full",
+          selected ? "bg-indigo-400" : railColor(project),
+        )}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-baseline justify-between gap-2">
+          <span
+            className={cn(
+              "truncate text-[13px] font-medium",
+              quiet ? "text-white/45" : "text-white/85",
+            )}
+          >
+            {project.slug}
+          </span>
+          {project.latest_update && (
+            <UpdateAge at={project.latest_update.at} />
           )}
-        </div>
-      )}
-
-      {project.latest_update && (
-        <div className="mt-2 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
-          <span className="min-w-0 flex-1 truncate">
-            {project.latest_update.headline || "(update sans titre)"}
+        </span>
+        {!quiet && (
+          <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
+            {live > 0 && (
+              <span className="flex shrink-0 items-center gap-1 text-sky-300">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-400" />
+                {live} live
+              </span>
+            )}
+            <span className="min-w-0 truncate">
+              {project.attention_reasons[0] ??
+                project.latest_update?.headline ??
+                project.tracker?.status_line ??
+                ""}
+            </span>
           </span>
-          <UpdateAge at={project.latest_update.at} />
-        </div>
+        )}
+      </span>
+      {project.bucket === "attention" && (
+        <AlertTriangle className="mt-1 h-3.5 w-3.5 shrink-0 text-amber-300/80" />
       )}
-
-      {project.attention_reasons.length > 0 && (
-        <div className="mt-2 flex items-start gap-1.5 text-[11px] text-amber-300/85">
-          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
-          <span className="min-w-0">
-            {project.attention_reasons.join(" · ")}
-          </span>
-        </div>
+      {project.bucket === "paused" && (
+        <PauseCircle className="mt-1 h-3.5 w-3.5 shrink-0 text-white/25" />
+      )}
+      {project.bucket === "archived" && (
+        <Archive className="mt-1 h-3.5 w-3.5 shrink-0 text-white/20" />
       )}
     </button>
   );
 }
 
-function BucketIcon({ bucket }: { bucket: ProjectBucket }) {
-  if (bucket === "attention")
-    return <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-300/80" />;
-  if (bucket === "paused")
-    return <PauseCircle className="h-3.5 w-3.5 shrink-0 text-white/35" />;
-  if (bucket === "archived")
-    return <Archive className="h-3.5 w-3.5 shrink-0 text-white/30" />;
-  return <CircleDot className="h-3.5 w-3.5 shrink-0 text-emerald-400/70" />;
-}
-
-const LIVE_STATUSES = new Set([
-  "created",
-  "queued",
-  "active",
-  "pending",
-  "waiting_background",
-  "awaiting_user",
-  "paused",
-]);
-
-function MissionMiniChip({ mission }: { mission: ProjectMissionChip }) {
-  const live = LIVE_STATUSES.has(mission.status);
-  return (
-    <Link
-      href={`/control?mission=${mission.id}`}
-      onClick={(event) => event.stopPropagation()}
-      title={`${mission.title ?? mission.id} — ${mission.status}`}
-      className={cn(
-        "inline-flex max-w-[160px] items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] !no-underline transition-colors",
-        live
-          ? "border-sky-400/25 bg-sky-500/10 text-sky-200/90 hover:border-sky-400/50"
-          : "border-white/[0.1] bg-white/[0.04] text-white/50 hover:border-white/25",
-      )}
-    >
-      <span
-        className={cn(
-          "h-1 w-1 shrink-0 rounded-full",
-          missionDot(mission.status),
-        )}
-      />
-      <span className="truncate">
-        {mission.title || mission.id.slice(0, 8)}
-      </span>
-      {mission.github_pr && <GitPullRequest className="h-2.5 w-2.5 shrink-0" />}
-    </Link>
-  );
-}
-
-function missionDot(status: string) {
-  switch (status) {
-    case "active":
-    case "queued":
-    case "created":
-      return "bg-sky-400";
-    case "pending":
-    case "awaiting_user":
-    case "waiting_background":
+function bucketPill(bucket: ProjectBucket) {
+  switch (bucket) {
+    case "attention":
+      return (
+        <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-200/90">
+          🟠 attention requise
+        </span>
+      );
     case "paused":
-      return "bg-amber-300";
-    case "completed":
-    case "acknowledged":
-      return "bg-emerald-400";
-    case "failed":
-    case "interrupted":
-    case "blocked":
-    case "not_feasible":
-      return "bg-red-400";
+      return (
+        <span className="rounded-full border border-white/[0.1] bg-white/[0.04] px-2 py-0.5 text-[10px] font-medium text-white/50">
+          ⏸ pausé
+        </span>
+      );
+    case "archived":
+      return (
+        <span className="rounded-full border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[10px] font-medium text-white/40">
+          📦 archivé
+        </span>
+      );
     default:
-      return "bg-white/30";
+      return (
+        <span className="rounded-full border border-emerald-400/25 bg-emerald-500/[0.08] px-2 py-0.5 text-[10px] font-medium text-emerald-200/80">
+          🟢 actif
+        </span>
+      );
   }
 }
 
-function UpdateAge({ at }: { at: string }) {
-  const date = new Date(at);
-  if (Number.isNaN(date.getTime())) return null;
-  return (
-    <RelativeTime date={date} className="shrink-0 text-[10px] text-white/30" />
-  );
-}
-
-function ProjectDrawer({
+function ProjectDetail({
   project,
-  onClose,
+  onBack,
 }: {
   project: ProjectRow;
-  onClose: () => void;
+  onBack: () => void;
 }) {
   const { data, error, isLoading } = useSWR(
     ["project-updates", project.slug],
@@ -334,117 +445,217 @@ function ProjectDrawer({
   const updates = data?.updates ?? [];
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-end">
-      <button
-        type="button"
-        aria-label="Fermer"
-        onClick={onClose}
-        className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"
-      />
-      <aside className="relative flex h-full w-full max-w-2xl flex-col border-l border-white/[0.08] bg-[rgb(var(--background))] shadow-2xl">
-        <div className="flex items-start justify-between gap-3 border-b border-white/[0.06] px-4 py-3">
-          <div className="min-w-0">
-            <h2 className="truncate text-base font-semibold text-white/90">
-              {project.slug}
-            </h2>
-            {project.tracker?.status_line && (
-              <p className="mt-0.5 text-xs text-white/50">
-                {project.tracker.status_line}
-              </p>
-            )}
-            {project.attention_reasons.length > 0 && (
-              <div className="mt-1.5 flex items-start gap-1.5 text-xs text-amber-300/85">
-                <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
-                <span>{project.attention_reasons.join(" · ")}</span>
-              </div>
-            )}
-          </div>
+    <div className="flex min-h-full flex-col">
+      <div className="border-b border-white/[0.06] px-4 py-3 sm:px-5">
+        <div className="flex items-center gap-2.5">
           <button
             type="button"
-            onClick={onClose}
-            className="rounded-md p-1.5 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+            onClick={onBack}
+            className="rounded-md p-1 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/80 lg:hidden"
+            aria-label="Retour à la liste"
           >
-            <X className="h-4 w-4" />
+            <ArrowLeft className="h-4 w-4" />
           </button>
+          <h2 className="min-w-0 truncate text-base font-semibold text-white/90">
+            {project.slug}
+          </h2>
+          {bucketPill(project.bucket)}
+          {project.tracker?.updated_at && (
+            <span className="ml-auto hidden shrink-0 text-[11px] text-white/30 sm:block">
+              tracker <UpdateAge at={project.tracker.updated_at} />
+            </span>
+          )}
         </div>
-
-        {project.missions.length > 0 && (
-          <div className="border-b border-white/[0.06] px-4 py-2.5">
-            <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-white/35">
-              Missions
-            </p>
-            <div className="flex flex-wrap gap-1.5">
-              {project.missions.map((mission) => (
-                <MissionMiniChip key={mission.id} mission={mission} />
-              ))}
-            </div>
-          </div>
-        )}
-
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-          <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-white/35">
-            Timeline des updates
+        {project.tracker?.status_line && (
+          <p className="mt-1.5 text-xs leading-relaxed text-white/55">
+            {project.tracker.status_line}
           </p>
-          {isLoading && (
-            <div className="flex items-center gap-2 py-6 text-sm text-white/40">
-              <Loader className="h-4 w-4 animate-spin" /> Chargement…
-            </div>
-          )}
-          {error && (
-            <p className="py-4 text-sm text-red-300/80">
-              Impossible de charger les updates.
-            </p>
-          )}
-          {!isLoading && !error && updates.length === 0 && (
-            <p className="py-4 text-sm text-white/35">
-              Aucune update routée vers ce projet.
-            </p>
-          )}
-          <div className="space-y-3">
-            {updates.map((update, index) => (
-              <UpdateEntry
-                key={`${update.session_id}-${update.at}-${index}`}
-                update={update}
-              />
+        )}
+        {project.attention_reasons.length > 0 && (
+          <div className="mt-2 space-y-1 rounded-lg border border-amber-400/20 bg-amber-500/[0.06] px-3 py-2">
+            {project.attention_reasons.map((reason) => (
+              <p
+                key={reason}
+                className="flex items-start gap-1.5 text-xs text-amber-200/90"
+              >
+                <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                {reason}
+              </p>
             ))}
           </div>
+        )}
+        {project.missions.length > 0 && (
+          <div className="mt-2.5 flex flex-wrap gap-1.5">
+            {project.missions.map((mission) => (
+              <MissionMiniChip key={mission.id} mission={mission} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 px-4 py-3 sm:px-5">
+        <p className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-white/35">
+          Timeline des updates
+        </p>
+        {isLoading && (
+          <div className="flex items-center gap-2 py-6 text-sm text-white/40">
+            <Loader className="h-4 w-4 animate-spin" /> Chargement…
+          </div>
+        )}
+        {error && (
+          <p className="py-4 text-sm text-red-300/80">
+            Impossible de charger les updates.
+          </p>
+        )}
+        {!isLoading && !error && updates.length === 0 && (
+          <p className="py-4 text-sm text-white/35">
+            Aucune update routée vers ce projet.
+          </p>
+        )}
+        <div className="relative space-y-2.5 before:absolute before:bottom-2 before:left-[5px] before:top-2 before:w-px before:bg-white/[0.07]">
+          {updates.map((update, index) => (
+            <UpdateEntry
+              key={`${update.session_id}-${update.at}-${index}`}
+              update={update}
+              defaultExpanded={index === 0}
+            />
+          ))}
         </div>
-      </aside>
+      </div>
     </div>
   );
 }
 
-function UpdateEntry({ update }: { update: ProjectDeliveryUpdate }) {
-  const [expanded, setExpanded] = useState(false);
+const LIVE_DOT: Record<string, string> = {
+  active: "bg-sky-400",
+  queued: "bg-sky-400",
+  created: "bg-sky-400",
+  pending: "bg-amber-300",
+  awaiting_user: "bg-amber-300",
+  waiting_background: "bg-amber-300",
+  paused: "bg-amber-300",
+  completed: "bg-emerald-400",
+  acknowledged: "bg-emerald-400",
+  failed: "bg-red-400",
+  interrupted: "bg-red-400",
+  blocked: "bg-red-400",
+  not_feasible: "bg-red-400",
+};
+
+function MissionMiniChip({ mission }: { mission: ProjectMissionChip }) {
+  const live = LIVE_STATUSES.has(mission.status);
   return (
-    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
-      <button
-        type="button"
-        onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center justify-between gap-2 text-left"
+    <Link
+      href={`/control?mission=${mission.id}`}
+      onClick={(event) => event.stopPropagation()}
+      title={`${mission.title ?? mission.id} — ${mission.status}`}
+      className={cn(
+        "inline-flex max-w-[200px] items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] !no-underline transition-colors",
+        live
+          ? "border-sky-400/25 bg-sky-500/10 text-sky-300 hover:border-sky-400/50"
+          : "border-white/[0.1] bg-white/[0.04] text-white/50 hover:border-white/25",
+      )}
+    >
+      <span
+        className={cn(
+          "h-1.5 w-1.5 shrink-0 rounded-full",
+          LIVE_DOT[mission.status] ?? "bg-white/30",
+        )}
+      />
+      <span className="truncate">
+        {mission.title || mission.id.slice(0, 8)}
+      </span>
+      {mission.github_pr && (
+        <GitPullRequest className="h-3 w-3 shrink-0 opacity-70" />
+      )}
+    </Link>
+  );
+}
+
+function UpdateAge({ at }: { at: string }) {
+  const date = new Date(at);
+  if (Number.isNaN(date.getTime())) return null;
+  return (
+    <RelativeTime
+      date={date}
+      className="shrink-0 text-[10px] tabular-nums text-white/30"
+    />
+  );
+}
+
+/** Body without the `[Cron delivery:…]` tag line and the headline it repeats. */
+function bodyWithoutHeadline(body: string, headline: string): string {
+  const lines = body.split("\n");
+  let index = 0;
+  while (index < lines.length) {
+    const trimmed = lines[index].trim();
+    if (
+      trimmed.length === 0 ||
+      trimmed.startsWith("[Cron delivery:") ||
+      trimmed.replace(/^#+\s*/, "") === headline
+    ) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return lines
+    .slice(index)
+    .filter((line) => line.trim() !== "[SILENT]")
+    .join("\n");
+}
+
+function UpdateEntry({
+  update,
+  defaultExpanded,
+}: {
+  update: ProjectDeliveryUpdate;
+  defaultExpanded: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  return (
+    <div className="relative pl-6">
+      <span
+        className={cn(
+          "absolute left-0 top-[13px] h-[11px] w-[11px] rounded-full border-2 border-[rgb(var(--background))]",
+          update.blocker ? "bg-amber-400" : "bg-white/25",
+        )}
+      />
+      <div
+        className={cn(
+          "rounded-lg border px-3 py-2 transition-colors",
+          update.blocker
+            ? "border-amber-400/20 bg-amber-500/[0.04]"
+            : "border-white/[0.06] bg-white/[0.02]",
+        )}
       >
-        <span className="min-w-0 flex-1 truncate text-sm text-white/80">
-          {update.headline || "(update sans titre)"}
-        </span>
-        <UpdateAge at={update.at} />
-      </button>
-      {update.blocker && (
-        <p className="mt-1 flex items-start gap-1.5 text-xs text-amber-300/85">
-          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
-          Bloqué par : {update.blocker}
-        </p>
-      )}
-      {expanded && update.body && (
-        <div className="mt-2 border-t border-white/[0.05] pt-2 text-sm">
-          <MarkdownContent content={update.body} />
-          <div className="mt-2 text-[11px] text-white/30">
-            <span className="inline-flex items-center gap-1">
-              <ExternalLink className="h-3 w-3" />
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="flex w-full items-center justify-between gap-2 text-left"
+        >
+          <span className="min-w-0 flex-1 truncate text-[13px] text-white/80">
+            {update.headline || "(update sans titre)"}
+          </span>
+          <UpdateAge at={update.at} />
+        </button>
+        {update.blocker && (
+          <p className="mt-1 flex items-start gap-1.5 text-xs text-amber-300/90">
+            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+            Bloqué par : {update.blocker}
+          </p>
+        )}
+        {expanded && update.body && (
+          <div className="mt-2 border-t border-white/[0.05] pt-2 text-sm">
+            <MarkdownContent
+              content={bodyWithoutHeadline(update.body, update.headline)}
+            />
+            <p className="mt-2 text-[11px] text-white/30">
               Session d’origine : {update.session_id}
-            </span>
+            </p>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Reworks the `/` projects board (from #708) into an inbox-style triage view — reviewed live in the browser against prod data.

## Why not a kanban
Four columns wasted width (two mostly empty), cards were too small to surface updates, and the modal drawer broke navigation flow. The new layout is a master-detail triage list (mail-client pattern):

- **Left — triage list**: Attention requise first, then Actif / Pausé / Archive; sorted by latest signal (update, mission activity, tracker mtime); quiet tracker files (no missions, no updates) sink to the bottom; colored status rail, live-mission pulse, latest headline/attention reason, sticky section headers; unrouted updates footer.
- **Right — permanent detail pane**: bucket pill, tracker status, attention banner, clickable mission chips (→ /control), full markdown update timeline (first entry expanded, blocker entries amber on the rail, origin session shown).
- **Header**: attention/live-missions stat pills, source health dots, slug filter.
- **Navigation**: ↑/↓ keyboard triage, search filter, mobile list→detail with back button.

## Live review fixes
- Light-mode contrast: globals.css only remaps exact `text-sky-300/400`, so all sky accents use those classes now.
- Expanded update bodies no longer repeat the headline or show Hermes `[SILENT]` markers.

Tests: 4 vitest cases (sections + auto-selected attention reasons, chip links, timeline load on selection, search filter); tsc clean on touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UI and test changes; same SWR APIs (`getProjectsOverview`, `getProjectUpdates`) with no backend or auth impact.
> 
> **Overview**
> Replaces the four-column **Projets** kanban with an inbox-style **master-detail** layout: a left triage list and a persistent right detail pane (no modal drawer).
> 
> The list groups projects by bucket (**Attention requise** first, then Actif / Pausé / Archive), applies slug **Filtrer…** search, sorts by latest signal with quiet trackers sunk, and supports **↑/↓** keyboard selection. The header adds attention and live-mission stat pills plus source health dots. The detail pane shows bucket status, tracker line, attention banner, mission chips to `/control`, and a markdown update timeline (first entry expanded; bodies strip repeated headlines and `[SILENT]` / cron delivery noise).
> 
> Tests are updated for sections, detail-pane behavior, and a new search-filter case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913361a35d3b23272b6466fdab308cfb4dc1862d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->