### PR TITLE
Projects board: minimal palette, in-session replies, pause/archive/delete

### DIFF
--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -2,13 +2,23 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { SWRConfig } from "swr";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { getProjectsOverview, getProjectUpdates } from "@/lib/api/projects";
+import {
+  getProjectsOverview,
+  getProjectUpdates,
+  postProjectAction,
+} from "@/lib/api/projects";
 import type { ProjectRow, ProjectsOverview } from "@/lib/api/projects";
+import { hermesChatStream } from "@/lib/api/hermes";
 import ProjectsBoard from "./projects-board";
 
 vi.mock("@/lib/api/projects", () => ({
   getProjectsOverview: vi.fn(),
   getProjectUpdates: vi.fn(),
+  postProjectAction: vi.fn(),
+}));
+
+vi.mock("@/lib/api/hermes", () => ({
+  hermesChatStream: vi.fn(),
 }));
 
 vi.mock("@/components/markdown-content", () => ({
@@ -17,6 +27,8 @@ vi.mock("@/components/markdown-content", () => ({
 
 const mockedOverview = vi.mocked(getProjectsOverview);
 const mockedUpdates = vi.mocked(getProjectUpdates);
+const mockedAction = vi.mocked(postProjectAction);
+const mockedChat = vi.mocked(hermesChatStream);
 
 function project(overrides: Partial<ProjectRow>): ProjectRow {
   return {
@@ -52,6 +64,8 @@ describe("ProjectsBoard", () => {
   beforeEach(() => {
     mockedOverview.mockReset();
     mockedUpdates.mockReset();
+    mockedAction.mockReset();
+    mockedChat.mockReset();
     mockedUpdates.mockResolvedValue({ slug: "verity", updates: [] });
   });
 
@@ -165,5 +179,67 @@ describe("ProjectsBoard", () => {
       screen.queryByRole("button", { name: /beal/ }),
     ).not.toBeInTheDocument();
     expect(screen.getAllByText("verity").length).toBeGreaterThan(0);
+  });
+
+  test("pause action posts and refreshes the overview", async () => {
+    mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
+    mockedAction.mockResolvedValue(undefined);
+
+    renderBoard();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Pauser/ }));
+    await waitFor(() =>
+      expect(mockedAction).toHaveBeenCalledWith("verity", "pause"),
+    );
+  });
+
+  test("delete requires a second confirming click", async () => {
+    mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
+    mockedAction.mockResolvedValue(undefined);
+
+    renderBoard();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Supprimer/ }));
+    expect(mockedAction).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Confirmer/ }));
+    await waitFor(() =>
+      expect(mockedAction).toHaveBeenCalledWith("verity", "delete"),
+    );
+  });
+
+  test("reply composer streams into the update's origin session", async () => {
+    mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
+    mockedUpdates.mockResolvedValue({
+      slug: "verity",
+      updates: [
+        {
+          headline: "Tick",
+          body: "corps",
+          session_id: "sess-cron-7",
+          at: "2026-08-01T07:11:00Z",
+          signature: "verity",
+          blocker: null,
+        },
+      ],
+    });
+    mockedChat.mockImplementation(async (_id, _msg, handlers) => {
+      handlers.onDelta("Bien re");
+      handlers.onCompleted?.("Bien reçu.");
+    });
+
+    renderBoard();
+
+    const composer = await screen.findByPlaceholderText(/sess-cron-7/);
+    fireEvent.change(composer, { target: { value: "continue le plan" } });
+    fireEvent.click(screen.getByTitle("Envoyer (⌘↵)"));
+
+    await waitFor(() =>
+      expect(mockedChat).toHaveBeenCalledWith(
+        "sess-cron-7",
+        "continue le plan",
+        expect.anything(),
+      ),
+    );
+    expect(await screen.findByText("Bien reçu.")).toBeInTheDocument();
   });
 });

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -8,35 +8,50 @@ import {
   useRef,
   useState,
 } from "react";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
+import type { LucideIcon } from "lucide-react";
 import {
+  Activity,
   AlertTriangle,
   Archive,
+  ArchiveRestore,
   ArrowLeft,
   GitPullRequest,
   Inbox,
   Loader,
-  PauseCircle,
+  Pause,
+  Play,
   Search,
+  Send,
+  Trash2,
 } from "lucide-react";
 
 import {
   getProjectsOverview,
   getProjectUpdates,
+  postProjectAction,
+  type ProjectAction,
   type ProjectBucket,
   type ProjectDeliveryUpdate,
   type ProjectMissionChip,
   type ProjectRow,
 } from "@/lib/api/projects";
+import { hermesChatStream } from "@/lib/api/hermes";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { cn } from "@/lib/utils";
 
-const SECTIONS: { bucket: ProjectBucket; title: string; emoji: string }[] = [
-  { bucket: "attention", title: "Attention requise", emoji: "🟠" },
-  { bucket: "active", title: "Actif", emoji: "🟢" },
-  { bucket: "paused", title: "Pausé", emoji: "⏸" },
-  { bucket: "archived", title: "Archive", emoji: "📦" },
+// Palette discipline: neutrals for structure, indigo for the current
+// selection, amber for problems. Nothing else carries color.
+const SECTIONS: {
+  bucket: ProjectBucket;
+  title: string;
+  icon: LucideIcon;
+}[] = [
+  { bucket: "attention", title: "Attention requise", icon: AlertTriangle },
+  { bucket: "active", title: "Actif", icon: Activity },
+  { bucket: "paused", title: "Pausé", icon: Pause },
+  { bucket: "archived", title: "Archive", icon: Archive },
 ];
 
 const LIVE_STATUSES = new Set([
@@ -47,6 +62,13 @@ const LIVE_STATUSES = new Set([
   "waiting_background",
   "awaiting_user",
   "paused",
+]);
+
+const PROBLEM_STATUSES = new Set([
+  "failed",
+  "interrupted",
+  "blocked",
+  "not_feasible",
 ]);
 
 function liveMissionCount(project: ProjectRow): number {
@@ -148,6 +170,12 @@ export default function ProjectsBoard() {
   const liveTotal =
     data?.projects.reduce((sum, p) => sum + liveMissionCount(p), 0) ?? 0;
   const unrouted = data?.unrouted_updates ?? [];
+  const degradedSources = data
+    ? [
+        !data.sources.trackers && "trackers",
+        !data.sources.hermes_db && "hermes",
+      ].filter(Boolean)
+    : [];
 
   return (
     <div className="mx-auto flex h-[calc(100vh-1px)] max-w-[1500px] flex-col px-3 pt-3 sm:px-5">
@@ -169,16 +197,27 @@ export default function ProjectsBoard() {
         <div className="ml-auto flex items-center gap-2.5">
           {data && (
             <>
-              <StatPill
-                tone={attentionCount > 0 ? "amber" : "neutral"}
-                label="attention"
-                value={attentionCount}
-              />
-              <StatPill tone="sky" label="missions live" value={liveTotal} />
-              <span className="hidden items-center gap-2.5 text-[11px] text-white/35 sm:flex">
-                <SourceDot ok={data.sources.trackers} label="trackers" />
-                <SourceDot ok={data.sources.hermes_db} label="hermes" />
+              {attentionCount > 0 && (
+                <span className="flex items-center gap-1.5 rounded-full border border-amber-400/25 bg-amber-500/10 px-2.5 py-1 text-[11px] text-amber-300">
+                  <AlertTriangle className="h-3 w-3" />
+                  <span className="font-semibold tabular-nums">
+                    {attentionCount}
+                  </span>
+                </span>
+              )}
+              <span className="flex items-center gap-1.5 rounded-full border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-[11px] text-white/50">
+                <Activity className="h-3 w-3" />
+                <span className="font-semibold tabular-nums text-white/70">
+                  {liveTotal}
+                </span>
+                live
               </span>
+              {degradedSources.length > 0 && (
+                <span className="hidden items-center gap-1.5 text-[11px] text-amber-300 sm:flex">
+                  <AlertTriangle className="h-3 w-3" />
+                  source {degradedSources.join(" + ")} indisponible
+                </span>
+              )}
             </>
           )}
           <div className="relative">
@@ -194,7 +233,8 @@ export default function ProjectsBoard() {
       </header>
 
       {error && (
-        <div className="mb-3 rounded-lg border border-red-400/20 bg-red-500/10 px-3 py-2 text-sm text-red-300/90">
+        <div className="mb-3 flex items-center gap-2 rounded-lg border border-amber-400/20 bg-amber-500/[0.06] px-3 py-2 text-sm text-amber-200/90">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
           Impossible de charger l’aperçu des projets : {String(error)}
         </div>
       )}
@@ -217,8 +257,16 @@ export default function ProjectsBoard() {
             {sections.map((section) => (
               <div key={section.bucket}>
                 <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-white/[0.05] bg-[rgb(var(--background))]/95 px-3 py-1.5 backdrop-blur">
+                  <section.icon
+                    className={cn(
+                      "h-3 w-3",
+                      section.bucket === "attention"
+                        ? "text-amber-300/90"
+                        : "text-white/30",
+                    )}
+                  />
                   <span className="text-[11px] font-semibold uppercase tracking-wider text-white/45">
-                    {section.emoji} {section.title}
+                    {section.title}
                   </span>
                   <span className="text-[11px] text-white/25">
                     {section.projects.length}
@@ -283,51 +331,6 @@ export default function ProjectsBoard() {
   );
 }
 
-function StatPill({
-  tone,
-  label,
-  value,
-}: {
-  tone: "amber" | "sky" | "neutral";
-  label: string;
-  value: number;
-}) {
-  return (
-    <span
-      className={cn(
-        "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px]",
-        tone === "amber" && "border-amber-400/25 bg-amber-500/10 text-amber-200/90",
-        tone === "sky" && "border-sky-400/25 bg-sky-500/[0.07] text-sky-300",
-        tone === "neutral" && "border-white/[0.08] bg-white/[0.03] text-white/50",
-      )}
-    >
-      <span className="font-semibold tabular-nums">{value}</span> {label}
-    </span>
-  );
-}
-
-function SourceDot({ ok, label }: { ok: boolean; label: string }) {
-  return (
-    <span className="flex items-center gap-1.5">
-      <span
-        className={cn(
-          "h-1.5 w-1.5 rounded-full",
-          ok ? "bg-emerald-400" : "bg-amber-300",
-        )}
-      />
-      {label}
-    </span>
-  );
-}
-
-function railColor(project: ProjectRow): string {
-  if (project.bucket === "attention") return "bg-amber-400/80";
-  if (project.bucket === "paused") return "bg-white/20";
-  if (project.bucket === "archived") return "bg-white/10";
-  if (liveMissionCount(project) > 0) return "bg-emerald-400/80";
-  return "bg-emerald-400/30";
-}
-
 function ProjectListRow({
   project,
   selected,
@@ -339,6 +342,7 @@ function ProjectListRow({
 }) {
   const live = liveMissionCount(project);
   const quiet = isQuiet(project);
+  const attention = project.bucket === "attention";
   return (
     <button
       type="button"
@@ -346,15 +350,17 @@ function ProjectListRow({
       onClick={onSelect}
       className={cn(
         "group relative flex w-full items-stretch gap-2.5 px-3 py-2 text-left transition-colors",
-        selected
-          ? "bg-indigo-500/[0.09]"
-          : "hover:bg-white/[0.03]",
+        selected ? "bg-indigo-500/[0.09]" : "hover:bg-white/[0.03]",
       )}
     >
       <span
         className={cn(
           "w-[3px] shrink-0 self-stretch rounded-full",
-          selected ? "bg-indigo-400" : railColor(project),
+          selected
+            ? "bg-indigo-400"
+            : attention
+              ? "bg-amber-400/70"
+              : "bg-transparent",
         )}
       />
       <span className="min-w-0 flex-1">
@@ -367,16 +373,19 @@ function ProjectListRow({
           >
             {project.slug}
           </span>
-          {project.latest_update && (
-            <UpdateAge at={project.latest_update.at} />
-          )}
+          {project.latest_update && <UpdateAge at={project.latest_update.at} />}
         </span>
         {!quiet && (
-          <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
+          <span
+            className={cn(
+              "mt-0.5 flex min-w-0 items-center gap-2 text-[11px]",
+              attention ? "text-amber-300/80" : "text-white/40",
+            )}
+          >
             {live > 0 && (
-              <span className="flex shrink-0 items-center gap-1 text-sky-300">
-                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-400" />
-                {live} live
+              <span className="flex shrink-0 items-center gap-1 text-white/55">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white/60" />
+                {live}
               </span>
             )}
             <span className="min-w-0 truncate">
@@ -388,46 +397,213 @@ function ProjectListRow({
           </span>
         )}
       </span>
-      {project.bucket === "attention" && (
-        <AlertTriangle className="mt-1 h-3.5 w-3.5 shrink-0 text-amber-300/80" />
-      )}
-      {project.bucket === "paused" && (
-        <PauseCircle className="mt-1 h-3.5 w-3.5 shrink-0 text-white/25" />
-      )}
-      {project.bucket === "archived" && (
-        <Archive className="mt-1 h-3.5 w-3.5 shrink-0 text-white/20" />
-      )}
     </button>
   );
 }
 
-function bucketPill(bucket: ProjectBucket) {
-  switch (bucket) {
-    case "attention":
-      return (
-        <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-200/90">
-          🟠 attention requise
-        </span>
-      );
-    case "paused":
-      return (
-        <span className="rounded-full border border-white/[0.1] bg-white/[0.04] px-2 py-0.5 text-[10px] font-medium text-white/50">
-          ⏸ pausé
-        </span>
-      );
-    case "archived":
-      return (
-        <span className="rounded-full border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[10px] font-medium text-white/40">
-          📦 archivé
-        </span>
-      );
-    default:
-      return (
-        <span className="rounded-full border border-emerald-400/25 bg-emerald-500/[0.08] px-2 py-0.5 text-[10px] font-medium text-emerald-200/80">
-          🟢 actif
-        </span>
-      );
-  }
+/** Icon button for the detail-pane action bar. */
+function ActionButton({
+  icon: Icon,
+  label,
+  onClick,
+  busy,
+  danger,
+}: {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  busy?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      title={label}
+      className={cn(
+        "flex items-center gap-1.5 rounded-lg border px-2 py-1 text-[11px] transition-colors disabled:opacity-50",
+        danger
+          ? "border-amber-400/25 bg-amber-500/10 text-amber-300 hover:border-amber-400/50"
+          : "border-white/[0.08] bg-white/[0.03] text-white/50 hover:border-white/20 hover:text-white/80",
+      )}
+    >
+      {busy ? (
+        <Loader className="h-3 w-3 animate-spin" />
+      ) : (
+        <Icon className="h-3 w-3" />
+      )}
+      {label}
+    </button>
+  );
+}
+
+function ProjectActions({ project }: { project: ProjectRow }) {
+  const { mutate } = useSWRConfig();
+  const [busy, setBusy] = useState<ProjectAction | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (action: ProjectAction) => {
+      setBusy(action);
+      setActionError(null);
+      try {
+        await postProjectAction(project.slug, action);
+        await mutate("projects-overview");
+      } catch (err) {
+        setActionError(String(err instanceof Error ? err.message : err));
+      } finally {
+        setBusy(null);
+        setConfirmDelete(false);
+      }
+    },
+    [project.slug, mutate],
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {project.bucket === "paused" ? (
+        <ActionButton
+          icon={Play}
+          label="Reprendre"
+          busy={busy === "resume"}
+          onClick={() => run("resume")}
+        />
+      ) : (
+        <ActionButton
+          icon={Pause}
+          label="Pauser"
+          busy={busy === "pause"}
+          onClick={() => run("pause")}
+        />
+      )}
+      {project.bucket === "archived" ? (
+        <ActionButton
+          icon={ArchiveRestore}
+          label="Désarchiver"
+          busy={busy === "unarchive"}
+          onClick={() => run("unarchive")}
+        />
+      ) : (
+        <ActionButton
+          icon={Archive}
+          label="Archiver"
+          busy={busy === "archive"}
+          onClick={() => run("archive")}
+        />
+      )}
+      <ActionButton
+        icon={Trash2}
+        label={confirmDelete ? "Confirmer ?" : "Supprimer"}
+        danger={confirmDelete}
+        busy={busy === "delete"}
+        onClick={() => {
+          if (confirmDelete) {
+            void run("delete");
+          } else {
+            setConfirmDelete(true);
+            window.setTimeout(() => setConfirmDelete(false), 4000);
+          }
+        }}
+      />
+      {actionError && (
+        <span className="text-[11px] text-amber-300">{actionError}</span>
+      )}
+    </div>
+  );
+}
+
+/** Inline reply into the Hermes session an update came from. */
+function ReplyComposer({ sessionId }: { sessionId: string }) {
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [reply, setReply] = useState<string | null>(null);
+  const [replyDone, setReplyDone] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  const send = useCallback(async () => {
+    const text = message.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setSendError(null);
+    setReply("");
+    setReplyDone(false);
+    try {
+      let streamed = "";
+      await hermesChatStream(sessionId, text, {
+        onDelta: (delta) => {
+          streamed += delta;
+          setReply(streamed);
+        },
+        onCompleted: (content) => {
+          setReply(content);
+          setReplyDone(true);
+        },
+        onError: (errorMessage) => setSendError(errorMessage),
+      });
+      setMessage("");
+    } catch (err) {
+      setSendError(String(err instanceof Error ? err.message : err));
+    } finally {
+      setSending(false);
+      setReplyDone(true);
+    }
+  }, [message, sending, sessionId]);
+
+  return (
+    <div className="mt-2 border-t border-white/[0.05] pt-2">
+      <div className="flex items-end gap-2">
+        <textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault();
+              void send();
+            }
+          }}
+          placeholder={`Répondre dans la session ${sessionId.slice(0, 14)}…`}
+          rows={message.includes("\n") ? 3 : 1}
+          className="min-h-[32px] flex-1 resize-none rounded-lg border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/80 placeholder:text-white/25 focus:border-indigo-400/40 focus:outline-none"
+        />
+        <button
+          type="button"
+          onClick={() => void send()}
+          disabled={sending || message.trim().length === 0}
+          title="Envoyer (⌘↵)"
+          className="flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-lg border border-white/[0.08] bg-white/[0.03] text-white/50 transition-colors hover:border-indigo-400/40 hover:text-white/85 disabled:opacity-40"
+        >
+          {sending ? (
+            <Loader className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Send className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+      {sendError && (
+        <p className="mt-1.5 flex items-center gap-1.5 text-[11px] text-amber-300">
+          <AlertTriangle className="h-3 w-3 shrink-0" /> {sendError}
+        </p>
+      )}
+      {reply !== null && !sendError && (
+        <div className="mt-2 rounded-lg border border-indigo-400/15 bg-indigo-500/[0.04] px-3 py-2 text-sm">
+          {reply === "" ? (
+            <p className="flex items-center gap-2 text-xs text-white/40">
+              <Loader className="h-3 w-3 animate-spin" /> Hermes répond…
+            </p>
+          ) : (
+            <MarkdownContent content={reply} />
+          )}
+          {replyDone && reply !== "" && (
+            <p className="mt-1.5 text-[10px] text-white/30">
+              Réponse de la session {sessionId.slice(0, 14)}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function ProjectDetail({
@@ -443,6 +619,7 @@ function ProjectDetail({
     { revalidateOnFocus: false },
   );
   const updates = data?.updates ?? [];
+  const section = SECTIONS.find((s) => s.bucket === project.bucket);
 
   return (
     <div className="flex min-h-full flex-col">
@@ -459,12 +636,22 @@ function ProjectDetail({
           <h2 className="min-w-0 truncate text-base font-semibold text-white/90">
             {project.slug}
           </h2>
-          {bucketPill(project.bucket)}
-          {project.tracker?.updated_at && (
-            <span className="ml-auto hidden shrink-0 text-[11px] text-white/30 sm:block">
-              tracker <UpdateAge at={project.tracker.updated_at} />
+          {section && (
+            <span
+              className={cn(
+                "flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-medium",
+                project.bucket === "attention"
+                  ? "border-amber-400/25 bg-amber-500/10 text-amber-300"
+                  : "border-white/[0.08] bg-white/[0.03] text-white/45",
+              )}
+            >
+              <section.icon className="h-3 w-3" />
+              {section.title.toLowerCase()}
             </span>
           )}
+          <span className="ml-auto">
+            <ProjectActions project={project} />
+          </span>
         </div>
         {project.tracker?.status_line && (
           <p className="mt-1.5 text-xs leading-relaxed text-white/55">
@@ -503,7 +690,8 @@ function ProjectDetail({
           </div>
         )}
         {error && (
-          <p className="py-4 text-sm text-red-300/80">
+          <p className="flex items-center gap-2 py-4 text-sm text-amber-200/90">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
             Impossible de charger les updates.
           </p>
         )}
@@ -526,24 +714,9 @@ function ProjectDetail({
   );
 }
 
-const LIVE_DOT: Record<string, string> = {
-  active: "bg-sky-400",
-  queued: "bg-sky-400",
-  created: "bg-sky-400",
-  pending: "bg-amber-300",
-  awaiting_user: "bg-amber-300",
-  waiting_background: "bg-amber-300",
-  paused: "bg-amber-300",
-  completed: "bg-emerald-400",
-  acknowledged: "bg-emerald-400",
-  failed: "bg-red-400",
-  interrupted: "bg-red-400",
-  blocked: "bg-red-400",
-  not_feasible: "bg-red-400",
-};
-
 function MissionMiniChip({ mission }: { mission: ProjectMissionChip }) {
   const live = LIVE_STATUSES.has(mission.status);
+  const problem = PROBLEM_STATUSES.has(mission.status);
   return (
     <Link
       href={`/control?mission=${mission.id}`}
@@ -551,22 +724,27 @@ function MissionMiniChip({ mission }: { mission: ProjectMissionChip }) {
       title={`${mission.title ?? mission.id} — ${mission.status}`}
       className={cn(
         "inline-flex max-w-[200px] items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] !no-underline transition-colors",
-        live
-          ? "border-sky-400/25 bg-sky-500/10 text-sky-300 hover:border-sky-400/50"
-          : "border-white/[0.1] bg-white/[0.04] text-white/50 hover:border-white/25",
+        problem
+          ? "border-amber-400/20 bg-amber-500/[0.05] text-amber-200/80 hover:border-amber-400/40"
+          : "border-white/[0.09] bg-white/[0.03] hover:border-white/25",
+        !problem && (live ? "text-white/75" : "text-white/45"),
       )}
     >
-      <span
-        className={cn(
-          "h-1.5 w-1.5 shrink-0 rounded-full",
-          LIVE_DOT[mission.status] ?? "bg-white/30",
-        )}
-      />
+      {problem ? (
+        <AlertTriangle className="h-3 w-3 shrink-0" />
+      ) : (
+        <span
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full",
+            live ? "animate-pulse bg-white/70" : "bg-white/25",
+          )}
+        />
+      )}
       <span className="truncate">
         {mission.title || mission.id.slice(0, 8)}
       </span>
       {mission.github_pr && (
-        <GitPullRequest className="h-3 w-3 shrink-0 opacity-70" />
+        <GitPullRequest className="h-3 w-3 shrink-0 opacity-60" />
       )}
     </Link>
   );
@@ -601,7 +779,10 @@ function bodyWithoutHeadline(body: string, headline: string): string {
   }
   return lines
     .slice(index)
-    .filter((line) => line.trim() !== "[SILENT]")
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed !== "[SILENT]" && !trimmed.startsWith("[STATE_SIGNATURE:");
+    })
     .join("\n");
 }
 
@@ -655,6 +836,7 @@ function UpdateEntry({
             </p>
           </div>
         )}
+        {expanded && <ReplyComposer sessionId={update.session_id} />}
       </div>
     </div>
   );

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -3,7 +3,7 @@
  * project-tagged missions, and cron delivery updates.
  */
 
-import { apiGet } from "./core";
+import { apiGet, apiPost } from "./core";
 
 export interface ProjectTracker {
   slug: string;
@@ -63,5 +63,24 @@ export function getProjectUpdates(
   return apiGet(
     `/api/projects/${encodeURIComponent(slug)}/updates?limit=${limit}`,
     "Failed to load project updates",
+  );
+}
+
+export type ProjectAction =
+  | "pause"
+  | "resume"
+  | "archive"
+  | "unarchive"
+  | "delete"
+  | "restore";
+
+export async function postProjectAction(
+  slug: string,
+  action: ProjectAction,
+): Promise<void> {
+  await apiPost(
+    `/api/projects/${encodeURIComponent(slug)}/action`,
+    { action },
+    "Failed to apply project action",
   );
 }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -41,6 +41,7 @@ pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/overview", get(projects_overview))
         .route("/:slug/updates", get(project_updates))
+        .route("/:slug/action", axum::routing::post(project_action))
 }
 
 fn hermes_projects_dir() -> Option<PathBuf> {
@@ -114,6 +115,10 @@ pub async fn projects_overview(
         .as_deref()
         .map(read_alias_map)
         .unwrap_or_default();
+    let overrides = trackers_dir
+        .as_deref()
+        .map(read_overrides)
+        .unwrap_or_default();
 
     let missions = state
         .control
@@ -140,7 +145,11 @@ pub async fn projects_overview(
     //    can only enrich, never hide, another.
     let mut rows: HashMap<String, ProjectRowBuilder> = HashMap::new();
 
+    let deleted = |slug: &str| overrides.get(slug).map(String::as_str) == Some("deleted");
     for tracker in trackers {
+        if deleted(&tracker.slug) {
+            continue;
+        }
         let slug = tracker.slug.clone();
         rows.entry(slug.clone())
             .or_insert_with(|| ProjectRowBuilder::new(slug))
@@ -150,7 +159,15 @@ pub async fn projects_overview(
         let Some(project) = mission.project.project.as_deref() else {
             continue;
         };
+        // Some missions carry malformed project tags (raw JSON blobs); only
+        // plain slugs may create or join a row.
+        if !is_plain_key(project) {
+            continue;
+        }
         let key = resolve_alias(&aliases, project);
+        if deleted(&key) {
+            continue;
+        }
         rows.entry(key.clone())
             .or_insert_with(|| ProjectRowBuilder::new(key))
             .missions
@@ -163,6 +180,9 @@ pub async fn projects_overview(
             continue;
         };
         let key = resolve_alias(&aliases, &signature_key);
+        if deleted(&key) {
+            continue;
+        }
         rows.entry(key.clone())
             .or_insert_with(|| ProjectRowBuilder::new(key))
             .push_delivery(delivery);
@@ -170,7 +190,10 @@ pub async fn projects_overview(
 
     let mut projects: Vec<ProjectRow> = rows
         .into_values()
-        .map(|builder| builder.finish(&archived))
+        .map(|builder| {
+            let forced = overrides.get(&builder.slug).cloned();
+            builder.finish(&archived, forced.as_deref())
+        })
         .collect();
     projects.sort_by(|a, b| {
         bucket_rank(a.bucket)
@@ -262,7 +285,7 @@ impl ProjectRowBuilder {
         }
     }
 
-    fn finish(mut self, archived: &[String]) -> ProjectRow {
+    fn finish(mut self, archived: &[String], forced: Option<&str>) -> ProjectRow {
         self.missions
             .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
         self.missions.truncate(8);
@@ -334,14 +357,22 @@ impl ProjectRowBuilder {
             }
         }
 
-        let bucket: &'static str = if archived.contains(&self.slug) {
-            "archived"
-        } else if !attention.is_empty() {
-            "attention"
-        } else if tracker_paused {
-            "paused"
-        } else {
-            "active"
+        // A board override silences the automatic rules: pausing a project is
+        // an explicit "stop flagging this" from the operator.
+        let bucket: &'static str = match forced {
+            Some("paused") => "paused",
+            Some("archived") => "archived",
+            _ => {
+                if archived.contains(&self.slug) {
+                    "archived"
+                } else if !attention.is_empty() {
+                    "attention"
+                } else if tracker_paused {
+                    "paused"
+                } else {
+                    "active"
+                }
+            }
         };
 
         ProjectRow {
@@ -454,6 +485,87 @@ fn read_alias_map(dir: &Path) -> HashMap<String, String> {
 
 fn resolve_alias(aliases: &HashMap<String, String>, key: &str) -> String {
     aliases.get(key).cloned().unwrap_or_else(|| key.to_string())
+}
+
+/// A routing key / project tag must be a plain slug.
+fn is_plain_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= 100
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+/// Board-level state overrides (`board-overrides.json` in the trackers dir):
+/// `{ "slug": "paused" | "archived" | "deleted" }`. An overlay owned by the
+/// dashboard — tracker files stay untouched because Hermes controllers own
+/// them. `deleted` hides the row (and drops its deliveries); the two others
+/// force the bucket.
+fn overrides_path(dir: &Path) -> PathBuf {
+    dir.join("board-overrides.json")
+}
+
+fn read_overrides(dir: &Path) -> HashMap<String, String> {
+    std::fs::read_to_string(overrides_path(dir))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<HashMap<String, String>>(&raw).ok())
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProjectActionRequest {
+    action: String,
+}
+
+/// Apply a board action to a project: `pause` / `archive` / `delete` set the
+/// override, `resume` / `unarchive` / `restore` clear it.
+pub async fn project_action(
+    AxumPath(slug): AxumPath<String>,
+    Json(request): Json<ProjectActionRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let Some(dir) = hermes_projects_dir() else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "HERMES_PROJECTS_DIR is not configured".to_string(),
+        ));
+    };
+    if slug.is_empty() || slug.len() > 200 {
+        return Err((StatusCode::BAD_REQUEST, "invalid slug".to_string()));
+    }
+    let mut overrides = read_overrides(&dir);
+    match request.action.as_str() {
+        "pause" => {
+            overrides.insert(slug.clone(), "paused".to_string());
+        }
+        "archive" => {
+            overrides.insert(slug.clone(), "archived".to_string());
+        }
+        "delete" => {
+            overrides.insert(slug.clone(), "deleted".to_string());
+        }
+        "resume" | "unarchive" | "restore" => {
+            overrides.remove(&slug);
+        }
+        other => {
+            return Err((StatusCode::BAD_REQUEST, format!("unknown action '{other}'")));
+        }
+    }
+    let serialized = serde_json::to_string_pretty(&overrides)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+    let path = overrides_path(&dir);
+    let tmp = dir.join(".board-overrides.json.tmp");
+    std::fs::write(&tmp, serialized)
+        .and_then(|_| std::fs::rename(&tmp, &path))
+        .map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("write {}: {error}", path.display()),
+            )
+        })?;
+    Ok(Json(serde_json::json!({
+        "slug": slug,
+        "override": overrides.get(&slug),
+    })))
 }
 
 /// Read `[Cron delivery: …]` updates from the Hermes SessionDB, newest first.
@@ -582,12 +694,7 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
         .map(|key| key.trim().to_string())
         // Reject template placeholders like `<project>` and anything that
         // isn't a plain routing key.
-        .filter(|key| {
-            !key.is_empty()
-                && key
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
-        });
+        .filter(|key| is_plain_key(key));
 
     // "Bloqué par:" / "Blocked by:" field, when it names a real blocker.
     let blocker = content.lines().find_map(|line| {
@@ -659,7 +766,7 @@ mod tests {
         builder.push_delivery(parse_delivery("s", 3.0, SAMPLE));
         builder.push_delivery(parse_delivery("s", 2.0, SAMPLE));
         builder.push_delivery(parse_delivery("s", 1.0, SAMPLE));
-        let row = builder.finish(&[]);
+        let row = builder.finish(&[], None);
         assert_eq!(row.bucket, "attention");
         assert!(row.attention_reasons.iter().any(|r| r.contains("blocker")));
         assert!(row
@@ -689,6 +796,18 @@ mod tests {
     }
 
     #[test]
+    fn forced_override_silences_attention() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder.push_delivery(parse_delivery("s", 3.0, SAMPLE));
+        builder.push_delivery(parse_delivery("s", 2.0, SAMPLE));
+        builder.push_delivery(parse_delivery("s", 1.0, SAMPLE));
+        let row = builder.finish(&[], Some("paused"));
+        assert_eq!(row.bucket, "paused");
+        // Reasons stay visible in the detail pane even when silenced.
+        assert!(!row.attention_reasons.is_empty());
+    }
+
+    #[test]
     fn paused_tracker_without_signals_lands_in_paused_bucket() {
         let mut builder = ProjectRowBuilder::new("erc".to_string());
         builder.tracker = Some(TrackerInfo {
@@ -696,7 +815,7 @@ mod tests {
             status_line: Some("paused (drained)".to_string()),
             updated_at: None,
         });
-        let row = builder.finish(&[]);
+        let row = builder.finish(&[], None);
         assert_eq!(row.bucket, "paused");
     }
 }


### PR DESCRIPTION
Follow-up to #709, reviewed live in the browser against prod data (dark + light).

## Simplification visuelle
Palette réduite à trois rôles: **neutres** (structure), **indigo** (sélection), **ambre** (problèmes). Suppression des accents sky/emerald/rouge et des emojis de sections au profit d'icônes lucide monochromes. Les chips missions sont neutres (pulse blanc = live, ambre + icône warning = failed/interrupted). Le vert « tout va bien » disparaît: la couleur n'apparaît que là où une décision est attendue.

## Répondre dans la session d'origine
Chaque update dépliée expose un composer qui envoie dans la session Hermes d'où vient l'update (`hermesChatStream` via le proxy authentifié `/api/assistant/hermes`, déjà en prod) et affiche la réponse streamée en markdown inline. ⌘↵ pour envoyer.

## Actions projet
`POST /api/projects/:slug/action` (`pause`/`resume`/`archive`/`unarchive`/`delete`/`restore`) écrit un overlay `board-overrides.json` à côté des trackers — les fichiers trackers ne sont jamais modifiés (ils appartiennent aux contrôleurs Hermes). `deleted` masque la ligne et ses deliveries; `paused`/`archived` forcent la colonne et font taire l'attention automatique (les raisons restent visibles dans le détail). UI: Pauser/Reprendre, Archiver/Désarchiver, Supprimer avec confirmation en deux clics (pas de dialog bloquant).

## Durcissement
- Les tags `project` malformés (blobs JSON) ne créent plus de ligne (même sanitization que les clés de signature).
- Les lignes brutes `[STATE_SIGNATURE:…]` sont masquées des corps d'updates.

Tests: Rust 8 (dont override qui force le bucket en silençant l'attention), vitest 7 (actions, confirm deux-clics, reply streamé dans la bonne session).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated project actions write filesystem state and Hermes chat from the board; mistakes could hide projects or send messages to production sessions, though trackers themselves are untouched.
> 
> **Overview**
> Extends the projects board with **operator actions**, **Hermes replies on updates**, a **tighter visual system**, and **overview hardening**.
> 
> **UI** shifts to a three-role palette (neutrals / indigo selection / amber problems): Lucide section icons replace emojis, mission chips and list rails drop sky/emerald/red “healthy” cues, and degraded sources surface as an amber header warning instead of per-source dots.
> 
> **Detail pane** adds `ProjectActions` (pause/resume, archive/unarchive, delete with a two-click confirm) wired to `postProjectAction` and SWR `mutate("projects-overview")`. Expanded timeline entries get a `ReplyComposer` that streams via `hermesChatStream` into the update’s `session_id` (⌘↵ send, markdown inline).
> 
> **API** adds `POST /api/projects/:slug/action` and dashboard `postProjectAction`. The Rust handler persists `board-overrides.json` beside trackers (`paused` / `archived` / `deleted`; resume/unarchive/restore clear). `deleted` drops rows and deliveries; `paused`/`archived` force bucket and silence auto-attention while keeping reasons in detail. Overview also ignores malformed mission `project` tags via `is_plain_key`, and the UI strips `[STATE_SIGNATURE:…]` from rendered update bodies.
> 
> **Tests**: Vitest covers pause, delete confirm, and streamed reply; Rust adds forced-override bucket behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62425d4ff3ad4072c2ea212e80c2b3e599c55def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->