### PR TITLE
Fix: aggregate failed-mission attention reasons (missed in #711)

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -308,16 +308,30 @@ impl ProjectRowBuilder {
                 attention.push("same state on 3 consecutive updates".to_string());
             }
         }
-        for chip in &self.missions {
-            if matches!(
-                chip.status,
-                MissionStatus::Failed | MissionStatus::Interrupted
-            ) {
+        // One aggregated line instead of one per mission: the detail pane
+        // already lists every mission chip.
+        let problem_missions: Vec<&MissionChip> = self
+            .missions
+            .iter()
+            .filter(|chip| {
+                matches!(
+                    chip.status,
+                    MissionStatus::Failed | MissionStatus::Interrupted
+                )
+            })
+            .collect();
+        match problem_missions.len() {
+            0 => {}
+            1 => {
+                let chip = problem_missions[0];
                 attention.push(format!(
                     "mission {} is {:?}",
                     &chip.id[..8.min(chip.id.len())],
                     chip.status
                 ));
+            }
+            count => {
+                attention.push(format!("{count} missions failed or interrupted"));
             }
         }
         let tracker_active = self
@@ -793,6 +807,28 @@ mod tests {
     fn headline_falls_back_to_cron_tag_title() {
         let parsed = parse_delivery("s", 0.0, "[Cron delivery: Lido campaign controller]\n\n");
         assert_eq!(parsed.headline, "Lido campaign controller");
+    }
+
+    #[test]
+    fn multiple_problem_missions_aggregate_into_one_reason() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        for i in 0..3 {
+            builder.missions.push(MissionChip {
+                id: format!("0000000{i}-aaaa-bbbb-cccc-dddddddddddd"),
+                status: MissionStatus::Failed,
+                title: None,
+                updated_at: "2026-08-01T00:00:00Z".to_string(),
+                github_pr: None,
+            });
+        }
+        let row = builder.finish(&[], None);
+        let failed_lines: Vec<&String> = row
+            .attention_reasons
+            .iter()
+            .filter(|r| r.contains("ailed"))
+            .collect();
+        assert_eq!(failed_lines.len(), 1);
+        assert!(failed_lines[0].contains("3 missions failed or interrupted"));
     }
 
     #[test]


### PR DESCRIPTION
The aggregation announced in #711 silently never landed: the scripted replacement missed its anchor after rustfmt reshaped the block, and no test pinned the behavior — prod still lists one 'mission X is Failed' line per mission (verified live after deploy).

This lands the real change: >1 failed/interrupted missions collapse into a single 'N missions failed or interrupted' reason (a single one keeps its detailed line), plus a regression test asserting 3 failed missions produce exactly one aggregated reason.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation change to `attention_reasons` in the projects overview API with a targeted regression test; no auth, persistence, or mission execution paths touched.
> 
> **Overview**
> **Projects board attention reasons** for failed or interrupted missions are collapsed so the row summary stays readable when several missions are in a bad state.
> 
> In `ProjectRowBuilder::finish`, the loop that pushed one `"mission {id} is {status}"` line per problem mission is replaced with logic that keeps the detailed line for a **single** failed/interrupted mission and adds **`{N} missions failed or interrupted`** when **N > 1** (mission chips remain in the detail pane).
> 
> A unit test **`multiple_problem_missions_aggregate_into_one_reason`** asserts three failed missions produce exactly one aggregated reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407a62df214a3f2cfaa9ecf3538d9aba81d0cde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->