### PR TITLE
Kimi OAuth refresh margin, empty-blocker false positives, board visibility polish

### DIFF
--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -230,11 +230,7 @@ export default function ProjectsBoard() {
           Failed to load the projects overview: {String(error)}
         </div>
       )}
-      {isLoading && !data && (
-        <div className="flex items-center gap-2 py-10 text-sm text-white/40">
-          <Loader className="h-4 w-4 animate-spin" /> Loading projects…
-        </div>
-      )}
+      {isLoading && !data && <BoardSkeleton />}
 
       {data && (
         <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 pb-4 lg:grid-cols-[340px_minmax(0,1fr)] xl:grid-cols-[380px_minmax(0,1fr)]">
@@ -334,7 +330,6 @@ function ProjectListRow({
 }) {
   const live = liveMissionCount(project);
   const quiet = isQuiet(project);
-  const attention = project.bucket === "attention";
   return (
     <button
       type="button"
@@ -358,12 +353,7 @@ function ProjectListRow({
           {project.latest_update && <UpdateAge at={project.latest_update.at} />}
         </span>
         {!quiet && (
-          <span
-            className={cn(
-              "mt-0.5 flex min-w-0 items-center gap-2 text-[11px]",
-              attention ? "text-amber-300/80" : "text-white/40",
-            )}
-          >
+          <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
             {live > 0 && (
               <span className="flex shrink-0 items-center gap-1 text-white/55">
                 <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white/60" />
@@ -619,15 +609,13 @@ function ProjectDetail({
             {project.slug}
           </h2>
           {section && (
-            <span
-              className={cn(
-                "flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-medium",
-                project.bucket === "attention"
-                  ? "border-amber-400/25 bg-amber-500/10 text-amber-300"
-                  : "border-white/[0.08] bg-white/[0.03] text-white/45",
-              )}
-            >
-              <section.icon className="h-3 w-3" />
+            <span className="flex shrink-0 items-center gap-1.5 rounded-full border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[10px] font-medium text-white/45">
+              <section.icon
+                className={cn(
+                  "h-3 w-3",
+                  project.bucket === "attention" && "text-amber-300/90",
+                )}
+              />
               {section.title.toLowerCase()}
             </span>
           )}
@@ -641,13 +629,13 @@ function ProjectDetail({
           </p>
         )}
         {project.attention_reasons.length > 0 && (
-          <div className="mt-2 space-y-1 rounded-lg border border-amber-400/20 bg-amber-500/[0.06] px-3 py-2">
+          <div className="mt-2 space-y-1 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2">
             {project.attention_reasons.map((reason) => (
               <p
                 key={reason}
-                className="flex items-start gap-1.5 text-xs text-amber-200/90"
+                className="flex items-start gap-1.5 text-xs text-white/60"
               >
-                <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-300/80" />
                 {reason}
               </p>
             ))}
@@ -705,15 +693,12 @@ function MissionMiniChip({ mission }: { mission: ProjectMissionChip }) {
       onClick={(event) => event.stopPropagation()}
       title={`${mission.title ?? mission.id} — ${mission.status}`}
       className={cn(
-        "inline-flex max-w-[200px] items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] !no-underline transition-colors",
-        problem
-          ? "border-amber-400/20 bg-amber-500/[0.05] text-amber-200/80 hover:border-amber-400/40"
-          : "border-white/[0.09] bg-white/[0.03] hover:border-white/25",
-        !problem && (live ? "text-white/75" : "text-white/45"),
+        "inline-flex max-w-[200px] items-center gap-1.5 rounded-full border border-white/[0.09] bg-white/[0.03] px-2 py-0.5 text-[11px] !no-underline transition-colors hover:border-white/25",
+        live ? "text-white/75" : "text-white/45",
       )}
     >
       {problem ? (
-        <AlertTriangle className="h-3 w-3 shrink-0" />
+        <AlertTriangle className="h-3 w-3 shrink-0 text-amber-300/80" />
       ) : (
         <span
           className={cn(
@@ -778,14 +763,7 @@ function UpdateEntry({
   const [expanded, setExpanded] = useState(defaultExpanded);
   return (
     <div>
-      <div
-        className={cn(
-          "rounded-lg border px-3 py-2 transition-colors",
-          update.blocker
-            ? "border-amber-400/20 bg-amber-500/[0.04]"
-            : "border-white/[0.06] bg-white/[0.02]",
-        )}
-      >
+      <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 transition-colors">
         <button
           type="button"
           onClick={() => setExpanded((value) => !value)}
@@ -797,8 +775,8 @@ function UpdateEntry({
           <UpdateAge at={update.at} />
         </button>
         {update.blocker && (
-          <p className="mt-1 flex items-start gap-1.5 text-xs text-amber-300/90">
-            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          <p className="mt-1 flex items-start gap-1.5 text-xs text-white/60">
+            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-300/80" />
             Blocked by: {update.blocker}
           </p>
         )}
@@ -813,6 +791,48 @@ function UpdateEntry({
           </div>
         )}
         {expanded && <ReplyComposer sessionId={update.session_id} />}
+      </div>
+    </div>
+  );
+}
+
+/** Pulse skeleton mirroring the two-pane layout while the overview loads. */
+function BoardSkeleton() {
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 pb-4 lg:grid-cols-[340px_minmax(0,1fr)] xl:grid-cols-[380px_minmax(0,1fr)]">
+      <div className="animate-pulse overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.015]">
+        <div className="border-b border-white/[0.05] px-3 py-2">
+          <div className="h-3 w-28 rounded bg-white/[0.06]" />
+        </div>
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="space-y-1.5 px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="h-3.5 w-32 rounded bg-white/[0.06]" />
+              <div className="h-2.5 w-10 rounded bg-white/[0.04]" />
+            </div>
+            <div className="h-2.5 w-48 rounded bg-white/[0.04]" />
+          </div>
+        ))}
+      </div>
+      <div className="hidden animate-pulse overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.015] lg:block">
+        <div className="space-y-3 border-b border-white/[0.06] px-5 py-4">
+          <div className="flex items-center gap-3">
+            <div className="h-5 w-40 rounded bg-white/[0.06]" />
+            <div className="h-4 w-20 rounded-full bg-white/[0.04]" />
+          </div>
+          <div className="h-3 w-3/4 rounded bg-white/[0.04]" />
+          <div className="flex gap-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-5 w-28 rounded-full bg-white/[0.04]" />
+            ))}
+          </div>
+        </div>
+        <div className="space-y-3 px-5 py-4">
+          <div className="h-3 w-16 rounded bg-white/[0.05]" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-16 rounded-lg border border-white/[0.05] bg-white/[0.02]" />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -9036,15 +9036,19 @@ async fn upsert_kimi_oauth_provider(
 pub fn spawn_kimi_oauth_refresh_loop(state: Arc<super::routes::AppState>) {
     tokio::spawn(async move {
         loop {
-            // Run immediately at startup, then every five minutes. Reuse the
-            // same serialized store refresh path as catalog discovery so
-            // rotating refresh tokens cannot race.
+            // Run immediately at startup, then every four minutes. Kimi
+            // access tokens only live 300s, so a 300s sleep left a ~1s hole
+            // between expiry and the next refresh each cycle — requests
+            // landing in it got upstream 403s (about one per hour under
+            // steady builtin/smart traffic). A 240s cadence keeps a 60s
+            // validity margin. Reuse the same serialized store refresh path
+            // as catalog discovery so rotating refresh tokens cannot race.
             let (_, refreshed) =
                 refresh_due_store_oauth(&state.ai_providers, ProviderType::Kimi, 600_000).await;
             if refreshed > 0 {
                 tracing::info!(refreshed, "Refreshed Kimi OAuth credentials");
             }
-            tokio::time::sleep(Duration::from_secs(300)).await;
+            tokio::time::sleep(Duration::from_secs(240)).await;
         }
     });
 }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -722,10 +722,21 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
             .trim_end_matches("**")
             .trim();
         let normalized = value.to_lowercase();
+        // Controllers routinely write "Blocked by: nothing currently; …" —
+        // any negation opener means "not blocked", however long the tail.
+        const EMPTY_OPENERS: [&str; 7] = [
+            "aucun",
+            "rien",
+            "none",
+            "nothing",
+            "n/a",
+            "no blocker",
+            "not blocked",
+        ];
         if value.is_empty()
-            || normalized.starts_with("aucun")
-            || normalized.starts_with("rien")
-            || normalized.starts_with("none")
+            || EMPTY_OPENERS
+                .iter()
+                .any(|opener| normalized.starts_with(opener))
             || normalized.starts_with('—')
             || normalized.starts_with('-')
         {
@@ -769,9 +780,17 @@ mod tests {
 
     #[test]
     fn empty_blockers_are_not_blockers() {
-        let content = "[Cron delivery: x]\nTitre\n**Bloqué par :** aucun pour l'instant.\n";
-        let parsed = parse_delivery("s", 0.0, content);
-        assert!(parsed.blocker.is_none());
+        for line in [
+            "**Bloqué par :** aucun pour l'instant.",
+            "**Blocked by:** nothing currently; the four v33 lanes are healthy.",
+            "**Blocked by:** none — waiting on CI.",
+            "**Blocked by:** n/a",
+            "**Blocked by:** not blocked, just slow.",
+        ] {
+            let content = format!("[Cron delivery: x]\nTitre\n{line}\n");
+            let parsed = parse_delivery("s", 0.0, &content);
+            assert!(parsed.blocker.is_none(), "should be empty: {line}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Debugging the 'auth errors with kimi and glm' reports plus board readability follow-up.

## Kimi 403s — root cause
Kimi OAuth access tokens live **300s** and the refresh loop slept exactly **300s**: each cycle had a ~1s hole between token expiry and the next refresh. Requests landing in it got upstream **403 Forbidden** (logged 'Upstream auth error, trying next entry', ~1/hour under builtin/smart traffic, hourly-periodic in the journal). Fix: refresh every **240s** → permanent 60s validity margin. (The chain fallback already masked user impact — MiniMax served those requests.)

## GLM — no bug
Z.AI 429s are genuine: the **weekly quota window is at 100%** (projected 166%, resets 2026-08-06 02:01 UTC). Health cooldown + fallback behave as designed; GLM re-enters the chain at reset. Kimi's own sporadic 429s are short burst limits (Retry-After: 5s), also handled by fallback.

## Board visibility (review feedback: too much yellow, inelegant loading)
- Amber reduced to **icons only**: list rows, attention banner, problem chips and blocker lines now use neutral text with a small amber triangle; amber blocks/borders/text are gone.
- **Skeleton loading** replacing the plain 'Loading projects…' text: pulse placeholders mirroring the two-pane layout, same idiom as the assistant page.
- Backend: 'Blocked by: nothing currently…' style updates no longer count as blockers (negation openers: nothing/none/n\/a/no blocker/not blocked/aucun/rien) — this was inflating the Needs-attention column with false positives.

Tests: Rust 9 (empty-blocker matrix extended), vitest 7, clippy/fmt clean. Reviewed live in the browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Kimi OAuth timing affects all builtin/smart Kimi traffic; backend blocker parsing changes attention bucketing; UI-only board changes are low risk.
> 
> **Overview**
> Tightens **Kimi OAuth** reliability by running the background refresh loop every **240s** instead of 300s, keeping a ~60s margin before 300s access tokens expire and avoiding intermittent upstream **403**s in the gap.
> 
> On the **projects overview** backend, delivery updates whose “Blocked by” line is a negation (e.g. “nothing currently”, “none”, “n/a”, “not blocked”, plus existing French empty openers) are no longer treated as real blockers, with tests extended for that matrix.
> 
> The **projects board** UI swaps the spinner for a **two-pane pulse skeleton** while loading, and tones down amber styling so warning color is mostly on **icons** (attention rows, banners, problem chips, blocker lines) instead of amber borders/backgrounds/text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71037cc3999fe85c77fc79db83efeefdcc4415a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->