### PR TITLE
Persist /goal mode at mission creation (fixes MCP goal_mode=false)

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7622,6 +7622,20 @@ pub async fn create_mission(
             .set_deferred_goal(mission.id, Some(prompt.clone()))
             .await
             .map_err(internal_error)?;
+        // A `/goal …` prompt is a goal-mode mandate from the very first turn.
+        // Persist it here, synchronously on the same store that created the
+        // mission — the event-loop hook that also does this only sees events
+        // while a control session is pumping, so MCP/API creations could
+        // otherwise stay goal_mode=false forever.
+        if let Some(objective) = parse_goal_objective(&prompt) {
+            control
+                .mission_store
+                .update_mission_goal(mission.id, true, Some(&objective))
+                .await
+                .map_err(internal_error)?;
+            mission.goal_mode = true;
+            mission.goal_objective = Some(objective);
+        }
         // Surface the queued goal so UIs show it as pending until dispatch.
         let _ = control.events_tx.send(AgentEvent::UserMessage {
             id: Uuid::new_v4(),
@@ -13709,12 +13723,14 @@ fn mission_status_summary_for_terminal_reason(reason: TerminalReason) -> Option<
 }
 
 fn parse_goal_objective(message: &str) -> Option<String> {
-    message
-        .trim_start()
-        .strip_prefix("/goal ")
-        .map(str::trim)
-        .filter(|objective| !objective.is_empty())
-        .map(ToString::to_string)
+    // Accept any whitespace after the command ("/goal x", "/goal\nx"), but
+    // not other slash commands sharing the prefix ("/goals").
+    let rest = message.trim_start().strip_prefix("/goal")?;
+    if !rest.starts_with(char::is_whitespace) {
+        return None;
+    }
+    let objective = rest.trim();
+    (!objective.is_empty()).then(|| objective.to_string())
 }
 
 /// If the turn ended with `LlmError` or `AuthError` but the agent produced
@@ -23226,6 +23242,26 @@ pub async fn telegram_webhook_receiver(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn parse_goal_objective_tolerates_whitespace_variants() {
+        assert_eq!(
+            parse_goal_objective("/goal write the docs").as_deref(),
+            Some("write the docs")
+        );
+        assert_eq!(
+            parse_goal_objective("/goal\nMulti-line objective\nwith details").as_deref(),
+            Some("Multi-line objective\nwith details")
+        );
+        assert_eq!(
+            parse_goal_objective("  /goal   spaced   ").as_deref(),
+            Some("spaced")
+        );
+        assert!(parse_goal_objective("/goal").is_none());
+        assert!(parse_goal_objective("/goal   ").is_none());
+        assert!(parse_goal_objective("/goals are nice").is_none());
+        assert!(parse_goal_objective("plain message").is_none());
+    }
+
     #[test]
     fn awaiting_writer_lease_grace_policy() {
         use super::awaiting_pr_writer_lease_expired;


### PR DESCRIPTION
Hermes reported: mission launched via the MCP route with a `/goal …` prompt runs the right model but the control plane keeps `goal_mode=false`.

**Root cause**: the only place goal metadata was persisted from a prompt was the control-session event pump (`AgentEvent::UserMessage` hook). The MCP/REST atomic create+start path stashes the prompt as a deferred goal and emits a queued UserMessage on the broadcast channel — persistence then depends on a control loop happening to pump that event, which is not guaranteed at creation time.

**Fix**:
- The create handler now persists `goal_mode=true` + objective synchronously on the same store when the prompt parses as `/goal …`, and reflects it in the returned mission JSON (so the MCP caller sees it immediately).
- `parse_goal_objective` accepts any whitespace after `/goal` (e.g. `/goal\nObjective…`) while still rejecting `/goals…` prefixes — a newline after the command previously silently disabled goal mode everywhere.

Tests: new unit test covering the whitespace variants; clippy/fmt clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission creation and goal metadata persistence on a core control-plane path; behavior change is narrow but affects how MCP/API missions are stored and returned.
> 
> **Overview**
> Fixes missions created via MCP/REST with a **`/goal …`** prompt staying **`goal_mode=false`** even when the agent runs correctly.
> 
> The atomic create+start path now **persists `goal_mode` and the objective on the mission store immediately** when the initial prompt parses as `/goal`, and updates the in-memory mission returned to callers. Previously that metadata only stuck when a control session event loop handled the queued `UserMessage`, which MCP/API creation does not guarantee.
> 
> **`parse_goal_objective`** now treats any whitespace after `/goal` as valid (including newlines for multi-line objectives) and still rejects **`/goals`** and empty objectives. Unit tests cover those parsing cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb6832b43b16663509ec5c05e581aba6db71770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->