### PR TITLE
Weakest-spec orchestration: outcome contracts, relaxed retries, plumbing fixes

### DIFF
--- a/scripts/configure_hermes_reliability.py
+++ b/scripts/configure_hermes_reliability.py
@@ -61,7 +61,10 @@ def configure(config: dict, assistant_mcp: str) -> None:
     )
     server = config.setdefault("mcp_servers", {}).setdefault("sandboxed_assistant", {})
     server["command"] = assistant_mcp
-    server["timeout"] = 120
+    # Ask turns (ask_mission) can make multiple sequential LLM/tool calls;
+    # match the 600s timeout contract of the generated config
+    # (hermes_config_yaml in src/api/system.rs) so they aren't cut off.
+    server["timeout"] = 600
     tools = server.setdefault("tools", {})
     tools["include"] = list(ASSISTANT_TOOLS)
     tools["prompts"] = False
@@ -107,7 +110,7 @@ def main() -> None:
 
     print(
         f"Configured {path}: native Kanban disabled, "
-        f"assistant-MCP timeout=120s, tools={len(ASSISTANT_TOOLS)}, "
+        f"assistant-MCP timeout=600s, tools={len(ASSISTANT_TOOLS)}, "
         "Proton disabled"
     )
 

--- a/scripts/configure_hermes_reliability.py
+++ b/scripts/configure_hermes_reliability.py
@@ -12,24 +12,42 @@ from pathlib import Path
 from ruamel.yaml import YAML
 
 
+# Canonical assistant-mcp allowlist. Mirrors
+# src/hermes_tools.rs::HERMES_ASSISTANT_TOOL_ALLOWLIST — a Rust test pins the
+# two lists together, so update both in the same change.
 ASSISTANT_TOOLS = [
     "list_active_missions",
     "list_missions",
     "get_mission",
+    "get_mission_digest",
     "get_mission_events",
+    "get_chatgpt_ui_pool_status",
+    "list_mission_shared_files",
+    "download_shared_file",
     "start_mission",
     "send_message_to_mission",
+    "ask_mission",
     "cancel_mission",
-    "list_workspaces",
+    "acknowledge_mission",
     "get_compute_fleet",
+    "list_workspaces",
+    "get_workspace",
+    "create_workspace",
+    "update_workspace",
+    "delete_workspace",
+    "list_workspace_templates",
+    "get_workspace_template",
+    "save_workspace_template",
+    "delete_workspace_template",
+    "rebuild_workspace_from_template",
+    "workspace_bash",
+    "start_workspace_job",
+    "get_workspace_job",
+    "cancel_workspace_job",
     "get_mission_health",
     "get_mission_diagnostics",
     "update_mission_settings",
     "resume_mission",
-    "acknowledge_mission",
-    "start_workspace_job",
-    "get_workspace_job",
-    "cancel_workspace_job",
 ]
 
 

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -9,7 +9,7 @@ description: >
 metadata:
   policy: chatgpt-ui-pool
   policy_version: 1.3.0
-version: 1.7.0
+version: 1.8.0
 ---
 
 # Hermes Mission Control
@@ -95,6 +95,26 @@ Match the signal to the fix. The health `recommendation` usually tells you which
   Keep going until <concrete success condition>. Do not stop to ask — make
   reasonable decisions and continue.")` Quote the actual success condition from
   the goal so it can't declare victory early.
+
+## Writing goals and hints: no more specific than necessary
+
+A mission spec is a hypothesis about what will get the outcome you need, and
+over-specific hypotheses fail on the cases you didn't foresee. Apply one rule
+everywhere you write instructions for an agent:
+
+- **`/goal` objectives are verifiable end-states, never step lists.** Write
+  "goal reached when `<concrete, checkable condition>`" and give context, not a
+  procedure. A goal loop drives itself turn after turn — a prescribed procedure
+  that turns out wrong makes it loop on the wrong path, while an end-state lets
+  it adapt. (This is also what `resume_mission` pushes should quote.)
+- **Hints are the minimal added constraint.** When nudging a struggling
+  mission, state the one fact or counterexample it is missing ("X is already
+  handled in Y; only Z remains"), not a revised plan for the whole task. Let it
+  re-plan around the new constraint.
+- **Boss missions inherit the same rule.** When you start an orchestration
+  boss, tell it to specify board tasks by `acceptance_criteria` +
+  `verification_command` (the outcome contract) and treat prompt procedure as
+  advisory — the scheduler and the board tooling already assume this.
 
 ## Switching backends safely (between turns)
 
@@ -222,6 +242,12 @@ this section must stay in sync with it.
    continue with a concrete success condition, not a vague "keep going."
 3. **One change at a time.** Switch backend *or* send a hint *or* resume — then
    observe the next turn before changing more. Don't stack interventions.
+   Corollary — **prefer the weakest diagnosis the evidence supports**: when
+   signals are ambiguous between explanations (transport vs model vs prompt),
+   pick the intervention that is correct under *all* remaining candidates
+   (usually: gather diagnostics, or resume with no other change) rather than a
+   specific fix that damages the mission if your guess is wrong. Commit to a
+   specific intervention only once diagnostics have excluded the alternatives.
 4. **Verify, don't trust the summary.** A mission claiming "done" may not be.
    Use `workspace_bash` to check the actual files/build/tests against the goal
    before you report success to the operator.

--- a/skills/orchestrator-boss/SKILL.md
+++ b/skills/orchestrator-boss/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: orchestrator-boss
 description: >
-  Boss skill for parallel worker orchestration. Analyze, split, delegate, monitor,
-  integrate. Do not implement directly.
+  Boss skill for parallel worker orchestration. Analyze, split, delegate by
+  outcome, judge by acceptance criteria, integrate. Do not implement directly.
 ---
 
 # Orchestrator Boss
@@ -13,77 +13,107 @@ You coordinate worker missions. Prefer delegation over direct work.
 
 Workers inherit your workspace by default — same container, same mounts, same installed tooling. Pass `workspace_id` only to escape that (e.g. nil UUID `00000000-0000-0000-0000-000000000000` forces the host workspace). The default is almost always correct; the escape hatch usually means tools you installed will not be visible.
 
+## Specify Outcomes, Not Procedures
+
+A task spec has two parts with different authority:
+
+- **The contract** — `acceptance_criteria` + `verification_command`. Objective,
+  testable, and as *weak* as possible: the least specific conditions that still
+  guarantee the outcome you need. Every task should have them.
+- **The prompt** — scope, absolute paths, context, and (optionally) a suggested
+  approach. The suggested approach is advisory; workers are told so.
+
+Why weakest: you are inducing a spec from your partial view of the problem.
+Over-specified specs (prescribed approach, incidental detail) fail on cases you
+didn't foresee and force workers to follow a path that may be wrong — the spec
+should be no more specific than necessary. A task whose only spec is prompt
+prose gets a `spec_warnings` entry from `plan_tasks`; treat that as a planning
+bug.
+
+Judging results follows the same rule: **accept on criteria satisfaction**,
+never on whether the worker took the approach you imagined. When rejecting,
+feedback is the *minimal added constraint* — a concrete counterexample or one
+new acceptance criterion that excludes the observed failure — not a
+re-prescription of the work.
+
 ## Hard Rules
 
 1. Never edit implementation files or run the main fix loop yourself.
 2. If a task can be delegated, delegate it.
-3. Keep the worker pool full: `active_workers = min(max_parallel, ready_tasks)`.
-4. Use `batch_create_workers` whenever 2+ ready tasks exist.
-5. Use `wait_for_any_worker` for concurrent workers. Do not wait on one worker while others are still running.
-6. Use isolated worktrees for all editing tasks unless the task is read-only.
-7. Never trust a worker summary by itself. Verify actual files, diffs, or commits before accepting the result.
-8. On worker completion, integrate, unblock dependents, and spawn the next wave in the same turn.
-9. On `failed` or `interrupted`, inspect once, then either `resume_worker` to recover or replace the worker immediately.
-10. If you choose not to delegate something, state the blocker explicitly.
-11. Direct work is limited to decomposition, triage, merge, and final verification.
-12. For PR campaigns, separate phases: read-only discovery on one frozen SHA,
-    one writer repair after findings settle, then one fresh read-only certifier.
-    Never interleave pushes with discovery reviews.
-13. A task with `writer: false` is a capability boundary. It may inspect and
-    build, but may not edit, commit, push, comment, resolve, approve, or merge.
-14. If two certification cycles expose the same root-cause family, stop
+3. Prefer `plan_tasks` (server-owned board). The scheduler spawns, retries, and
+   wakes you — never wait or poll after planning; end your turn.
+4. Every editing task gets an isolated worktree unless it is read-only.
+5. Never trust a worker summary by itself. Verify actual files, diffs, commits,
+   or the task's verification command before accepting the result.
+6. Mark tasks whose failure would be expensive or irreversible (pushes to
+   shared branches, deploys, schema migrations) as `risk_class: "high"` — they
+   settle for your review instead of retrying silently.
+7. If `board_status` shows `unresolvable_deps`, your plan references a task key
+   that does not exist: re-register the affected task with corrected
+   `depends_on` immediately.
+8. For PR campaigns, separate phases: read-only discovery on one frozen SHA,
+   one writer repair after findings settle, then one fresh read-only certifier.
+   Never interleave pushes with discovery reviews.
+9. A task with `writer: false` is a capability boundary. It may inspect and
+   build, but may not edit, commit, push, comment, resolve, approve, or merge.
+10. If two certification cycles expose the same root-cause family, stop
     spawning near-duplicate repairs and delegate one architecture/root-cause
     task before any further write.
+11. If you choose not to delegate something, state the blocker explicitly.
+12. Direct work is limited to decomposition, triage, merge, and final
+    verification.
 
 ## Backend Guide
 
 - `codex` + `gpt-5.6-terra`: default for bounded code changes
 - `codex` + `gpt-5.6-sol`: hard blockers, formal proofs, and adversarial certification
 - `gemini` + `gemini-3.1-pro-preview` or `gemini-2.5-pro`: good for proofs and parallel analysis
-- `claudecode` + Claude models: careful broad edits
 - `opencode`: cheap redundancy
 
-Always match `backend` to `model_override`.
+Always match `backend` to `model_override`. Workers are never Claude (operator policy; enforced).
 
-## Tools
+## Required Loop (task board)
 
-- `get_workspace_layout`
-- `get_backend_auth_status`
-- `batch_create_workers`, `create_worker_mission`
-- `wait_for_any_worker`, `get_worker_status`, `list_worker_missions`
-- `resume_worker`, `retask_worker`, `send_message_to_worker`
-- `cancel_worker`, `cancel_all_workers`
-- `create_worktree`, `remove_worktree`
+1. Call `get_workspace_layout` once. Use its paths in task prompts and worktree specs.
+2. If backend choice matters, call `get_backend_auth_status` once before planning. Do not infer auth from shell env vars, CLI login status, or missing `*_API_KEY` in Bash.
+3. Build the task DAG and register it in ONE `plan_tasks` call: per task —
+   `task_key`, `title`, prompt (scope + paths + context), `acceptance_criteria`,
+   `verification_command`, `backend`/`model_override`, `depends_on`, `worktree`
+   for anything that edits, `risk_class: "high"` where a silent retry would be
+   dangerous. Fix any `spec_warnings` in the response before ending your turn.
+4. END YOUR TURN. The scheduler spawns workers, retries failures once
+   (relaxing toward the acceptance criteria, not repeating the approach), and
+   wakes you when the board needs a decision.
+5. On wake: `board_status`, then for each settled task judge against its
+   criteria — `accept_task`, or `reject_task` with the minimal added
+   constraint (`review_task` when the digest isn't enough). `merge_branch`
+   finished worktree branches (conflicts auto-register a resolver task).
+   Register follow-up work via `plan_tasks`. End your turn again.
 
-## Required Loop
+### Legacy manual fleet
 
-1. Call `get_workspace_layout` once. Use its paths in worker prompts and worktree setup.
-2. If backend choice matters, call `get_backend_auth_status` once before spawning. Do not infer auth from shell env vars, CLI login status, or missing `*_API_KEY` in Bash.
-3. Build a task graph with `ready`, `blocked`, and `depends_on`.
-4. For a PR campaign, register every read-only discovery task first. Make the
-   single repair task depend on all discovery tasks, and certification depend
-   on repair. Otherwise spawn every ready task now.
-5. Wait with `wait_for_any_worker`.
-6. React immediately:
-   - `completed`: verify the actual result, then integrate or reject and spawn newly-ready work
-   - `failed` or `interrupted`: recover with `resume_worker` or replace the worker
-   - `stalled`: cancel and replace
-7. Update `orchestrator-state.json` after every state change.
+`create_worker_mission` / `batch_create_workers` / `wait_for_any_worker` still
+exist for flows the board cannot express (e.g. a persistent advisor via
+`ask_worker`). If you must use them: keep the pool full
+(`active_workers = min(max_parallel, ready_tasks)`), use
+`wait_for_any_worker` — never wait on one worker while others run — and on
+completion integrate, unblock dependents, and spawn the next wave in the same
+turn.
 
-## Worker Prompt Checklist
+## Task Spec Checklist
 
-Every worker prompt must include:
-- exact scope and file paths
-- exact success condition
-- exact verification command
-- worktree/branch instructions
+Every task must include:
+- exact scope and absolute file paths (prompt)
+- `acceptance_criteria`: weakest testable conditions that define success
+- `verification_command`: the command that proves them
+- worktree/branch spec for anything that edits
 - "do not widen scope"
-- "report blocker immediately"
+- `risk_class: "high"` when a silent retry would be dangerous
 
 ## State File
 
-Maintain `orchestrator-state.json` as your recovery log. Record task IDs, worker IDs, branches, worktrees, attempts, and blockers.
+Maintain `orchestrator-state.json` as your recovery log. Record task keys, worker IDs, branches, worktrees, attempts, and blockers.
 
 ## Default Behavior
 
-Assume the user wants maximum safe parallelism. Do not sit on idle worker capacity.
+Assume the user wants maximum safe parallelism. Do not sit on idle worker capacity — but capacity management is the scheduler's job once the board is planned; yours is judgment.

--- a/skills/orchestrator-worker/SKILL.md
+++ b/skills/orchestrator-worker/SKILL.md
@@ -14,7 +14,11 @@ You are a worker spawned by a boss mission. You run in the same workspace as the
 1. Stay inside the assigned scope. Do not widen the task on your own.
 2. Work only in the provided working directory or branch.
 3. Do not modify files outside your scope unless the boss explicitly expands it.
-4. Verify with the command from the prompt before finishing.
+4. Verify with the command from the prompt before finishing. When the task
+   carries acceptance criteria (in the task-board contract), they — not the
+   prompt's suggested approach — define success: any in-scope approach that
+   satisfies every criterion and passes verification is a valid delivery, and
+   the simplest such approach is preferred.
 5. Do not report `DONE` unless the files on disk actually match your claimed result.
 6. If the prompt is wrong, the task is impossible, or scope is insufficient, report that immediately instead of exploring unrelated work.
 7. Be concise. Prefer changes, verification, and a short status over long explanation.

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -146,16 +146,37 @@ fn retry_disposition(task: &BoardTask, preflight: &RetryPreflight) -> RetryDispo
     }
 }
 
-/// Guidance prepended to automatic-retry prompts. A failed attempt often
-/// means the prompt over-specified the approach, not just that the worker
-/// slipped: the retry is told explicitly that only the task's acceptance
-/// criteria / verification are binding, so it can pick a simpler approach
-/// instead of mechanically re-running the one that just failed.
+/// Guidance prepended to automatic-retry prompts when the task declares an
+/// outcome contract. A failed attempt often means the prompt over-specified
+/// the approach, not just that the worker slipped: the retry is told
+/// explicitly that only the task's acceptance criteria / verification are
+/// binding, so it can pick a simpler approach instead of mechanically
+/// re-running the one that just failed.
 const RETRY_RELAXATION_GUIDANCE: &str = "[Retry guidance] The prior attempt failed. Do not \
     mechanically repeat it. The task's success condition — its acceptance criteria and \
     verification command (see the task-board contract below) — is the only hard requirement; \
     any suggested approach in the prompt is advisory. Choose the simplest approach that \
     satisfies the success condition and addresses the prior failure.";
+
+/// Retry guidance for tasks WITHOUT an outcome contract. The prompt is then
+/// the task's only specification, so it must stay binding — declaring it
+/// advisory here would leave the retry with no success condition at all and
+/// let a worker simplify away required behavior.
+const RETRY_PROMPT_BINDING_GUIDANCE: &str = "[Retry guidance] The prior attempt failed. Do \
+    not mechanically repeat it. The prompt's stated scope and success condition remain \
+    binding; what is open is the approach — try a different or simpler way to satisfy them, \
+    addressing the prior failure.";
+
+/// Whether the task declares an objective success condition beyond its
+/// prompt: non-empty acceptance criteria or a non-blank verification command.
+fn has_outcome_contract(task: &BoardTask) -> bool {
+    !task.acceptance_criteria.is_empty()
+        || task
+            .verification_command
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|command| !command.is_empty())
+}
 
 fn retry_prompt(task: &BoardTask, preflight: &RetryPreflight) -> String {
     let mut sections: Vec<String> = Vec::new();
@@ -209,7 +230,12 @@ fn retry_prompt(task: &BoardTask, preflight: &RetryPreflight) -> String {
     }
 
     if task.attempts > 1 {
-        sections.push(RETRY_RELAXATION_GUIDANCE.to_string());
+        let guidance = if has_outcome_contract(task) {
+            RETRY_RELAXATION_GUIDANCE
+        } else {
+            RETRY_PROMPT_BINDING_GUIDANCE
+        };
+        sections.push(guidance.to_string());
     }
 
     sections.push(task.prompt.clone());
@@ -729,7 +755,7 @@ fn worker_contract(task: &BoardTask) -> String {
         contract.push_str(command);
         contract.push('`');
     }
-    if !task.acceptance_criteria.is_empty() || verification.is_some() {
+    if has_outcome_contract(task) {
         contract.push_str(
             "\n- The criteria/verification above define success. Any approach that satisfies \
              them is acceptable — the prompt's suggested approach is advisory; prefer the \
@@ -2335,13 +2361,32 @@ mod tests {
     fn automatic_retry_relaxes_the_spec_instead_of_repeating_it() {
         let mut task = mk("relaxed-retry", &[], BoardTaskStatus::Pending, None);
         task.attempts = 2; // spawn_task_worker increments before building the prompt
+        task.acceptance_criteria = vec!["tests pass".to_string()];
         task.prior_outcome = Some(BoardTaskOutcome::Failed);
         task.prior_result_digest = Some("build failed: missing import".into());
 
         let prompt = retry_prompt(&task, &RetryPreflight::NothingFound);
 
         assert!(prompt.contains("[Retry guidance]"));
+        assert!(prompt.contains("advisory"));
         assert!(prompt.contains("build failed: missing import"));
+        assert!(prompt.ends_with(&task.prompt));
+    }
+
+    #[test]
+    fn retry_without_outcome_contract_keeps_the_prompt_binding() {
+        // No acceptance criteria / verification command: the prompt is the
+        // task's only spec, so the retry must NOT be told it is advisory.
+        let mut task = mk("prompt-only-retry", &[], BoardTaskStatus::Pending, None);
+        task.attempts = 2;
+        task.prior_outcome = Some(BoardTaskOutcome::Failed);
+        task.prior_result_digest = Some("worker gave up".into());
+
+        let prompt = retry_prompt(&task, &RetryPreflight::NothingFound);
+
+        assert!(prompt.contains("[Retry guidance]"));
+        assert!(prompt.contains("remain\n    binding") || prompt.contains("remain binding"));
+        assert!(!prompt.contains("advisory"));
         assert!(prompt.ends_with(&task.prompt));
     }
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -146,12 +146,25 @@ fn retry_disposition(task: &BoardTask, preflight: &RetryPreflight) -> RetryDispo
     }
 }
 
+/// Guidance prepended to automatic-retry prompts. A failed attempt often
+/// means the prompt over-specified the approach, not just that the worker
+/// slipped: the retry is told explicitly that only the task's acceptance
+/// criteria / verification are binding, so it can pick a simpler approach
+/// instead of mechanically re-running the one that just failed.
+const RETRY_RELAXATION_GUIDANCE: &str = "[Retry guidance] The prior attempt failed. Do not \
+    mechanically repeat it. The task's success condition — its acceptance criteria and \
+    verification command (see the task-board contract below) — is the only hard requirement; \
+    any suggested approach in the prompt is advisory. Choose the simplest approach that \
+    satisfies the success condition and addresses the prior failure.";
+
 fn retry_prompt(task: &BoardTask, preflight: &RetryPreflight) -> String {
-    let (branch_state, pr_number) = match preflight {
+    let mut sections: Vec<String> = Vec::new();
+
+    let branch_guard = match preflight {
         RetryPreflight::Surviving {
             branch_state,
             pr_number,
-        } => (branch_state.as_str(), *pr_number),
+        } => Some((branch_state.as_str(), *pr_number)),
         // A spawn message can be dropped after the live preflight result was
         // computed. The zombie re-kick only has persisted task metadata, so
         // retain the same conservative branch guard for every declared retry
@@ -161,26 +174,46 @@ fn retry_prompt(task: &BoardTask, preflight: &RetryPreflight) -> String {
                 && task.prior_worker_mission_id.is_some()
                 && task.branch.is_some() =>
         {
-            ("declared retry branch; re-check before editing", None)
+            Some(("declared retry branch; re-check before editing", None))
         }
-        _ => return task.prompt.clone(),
+        _ => None,
     };
-    let pr = pr_number
-        .map(|number| format!("#{number}"))
-        .unwrap_or_else(|| "none".to_string());
-    format!(
-        "[Prior-attempt digest]\nPrior worker: {}\nPrior outcome: {}\nPrior result: {}\nBranch: {} ({branch_state})\nPR: {pr}\n\
-         Continue the prior attempt: checkout the existing branch, never recreate from master, never force-push.\n\n{}",
-        task.prior_worker_mission_id
-            .map(|id| id.to_string())
-            .unwrap_or_else(|| "unknown".into()),
-        task.prior_outcome
-            .map(|outcome| outcome.to_string())
-            .unwrap_or_else(|| "unknown".into()),
-        task.prior_result_digest.as_deref().unwrap_or("unavailable"),
-        task.branch.as_deref().unwrap_or("unknown"),
-        task.prompt,
-    )
+    if let Some((branch_state, pr_number)) = branch_guard {
+        let pr = pr_number
+            .map(|number| format!("#{number}"))
+            .unwrap_or_else(|| "none".to_string());
+        sections.push(format!(
+            "[Prior-attempt digest]\nPrior worker: {}\nPrior outcome: {}\nPrior result: {}\nBranch: {} ({branch_state})\nPR: {pr}\n\
+             Continue the prior attempt: checkout the existing branch, never recreate from master, never force-push.",
+            task.prior_worker_mission_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "unknown".into()),
+            task.prior_outcome
+                .map(|outcome| outcome.to_string())
+                .unwrap_or_else(|| "unknown".into()),
+            task.prior_result_digest.as_deref().unwrap_or("unavailable"),
+            task.branch.as_deref().unwrap_or("unknown"),
+        ));
+    } else if task.attempts > 1 {
+        // No branch to guard, but this is still an automatic retry: surface
+        // what the prior attempt produced so the retry reacts to the failure
+        // instead of rediscovering it.
+        if let Some(digest) = task.prior_result_digest.as_deref() {
+            sections.push(format!(
+                "[Prior-attempt digest]\nPrior outcome: {}\nPrior result: {digest}",
+                task.prior_outcome
+                    .map(|outcome| outcome.to_string())
+                    .unwrap_or_else(|| "unknown".into()),
+            ));
+        }
+    }
+
+    if task.attempts > 1 {
+        sections.push(RETRY_RELAXATION_GUIDANCE.to_string());
+    }
+
+    sections.push(task.prompt.clone());
+    sections.join("\n\n")
 }
 
 fn repository_identity(repository: &str) -> Option<String> {
@@ -656,9 +689,14 @@ pub fn digest_excerpt(output: &str) -> String {
     format!("{head}\n[… truncated …]\n{tail}")
 }
 
-/// The standing contract appended to every worker prompt.
+/// The standing contract appended to every worker prompt. When the task
+/// declares acceptance criteria / a verification command, they are delivered
+/// here as the authoritative success condition: acceptance is judged on
+/// whether the result satisfies them, not on whether the worker followed the
+/// prompt's suggested approach — so the weakest spec that passes verification
+/// is always an acceptable delivery.
 fn worker_contract(task: &BoardTask) -> String {
-    format!(
+    let mut contract = format!(
         "\n\n---\n[task-board contract] You are the worker for task `{key}` (\"{title}\") \
          of boss mission {boss}.\n\
          - Work autonomously until the success condition in the task is met and verified.\n\
@@ -672,16 +710,63 @@ fn worker_contract(task: &BoardTask) -> String {
         key = task.task_key,
         title = task.title,
         boss = task.boss_mission_id,
-    )
+    );
+    let verification = task
+        .verification_command
+        .as_deref()
+        .map(str::trim)
+        .filter(|c| !c.is_empty());
+    if !task.acceptance_criteria.is_empty() {
+        contract
+            .push_str("\n- Acceptance criteria (ALL must hold; this is the success condition):");
+        for criterion in &task.acceptance_criteria {
+            contract.push_str("\n  * ");
+            contract.push_str(criterion);
+        }
+    }
+    if let Some(command) = verification {
+        contract.push_str("\n- Verification command (must pass before DELIVERED): `");
+        contract.push_str(command);
+        contract.push('`');
+    }
+    if !task.acceptance_criteria.is_empty() || verification.is_some() {
+        contract.push_str(
+            "\n- The criteria/verification above define success. Any approach that satisfies \
+             them is acceptable — the prompt's suggested approach is advisory; prefer the \
+             simplest solution that passes.",
+        );
+    }
+    contract
+}
+
+/// Dependency keys referenced by pending tasks that do not exist on the
+/// board. `ready_tasks` blocks such tasks forever by design (a typo'd key
+/// must never silently pass), but that parking must be *visible*: these feed
+/// `board_needs_attention` so the boss is woken to fix its plan instead of
+/// the board sitting idle until someone notices in the UI.
+pub fn unresolvable_dependencies(tasks: &[BoardTask]) -> Vec<(String, String)> {
+    let known: HashSet<&str> = tasks.iter().map(|t| t.task_key.as_str()).collect();
+    tasks
+        .iter()
+        .filter(|t| t.status == BoardTaskStatus::Pending)
+        .flat_map(|t| {
+            t.depends_on
+                .iter()
+                .filter(|dep| !known.contains(dep.as_str()))
+                .map(|dep| (t.task_key.clone(), dep.clone()))
+        })
+        .collect()
 }
 
 /// True when a board has at least one task needing a boss decision — a
-/// settled task awaiting a verdict, or a task that exhausted its retries and
-/// failed. This is the wake trigger.
+/// settled task awaiting a verdict, a task that exhausted its retries and
+/// failed, or a pending task parked forever on a dependency key that doesn't
+/// exist on the board. This is the wake trigger.
 fn board_needs_attention(tasks: &[BoardTask]) -> bool {
     tasks
         .iter()
         .any(|t| matches!(t.status, BoardTaskStatus::Settled | BoardTaskStatus::Failed))
+        || !unresolvable_dependencies(tasks).is_empty()
 }
 
 /// Stable revision for a controller wake. Board state alone is insufficient:
@@ -718,11 +803,13 @@ fn board_wake_revision(tasks: &[BoardTask], history: &[MissionHistoryEntry]) -> 
 /// finds nothing to act on and simply ends its turn, so a misroute can't leak
 /// one board's work into another mission.
 const BOARD_WAKE_PROMPT: &str = "[task-board] Your task board changed — one or more tasks \
-    settled, failed, or need a decision. Call board_status now and act on YOUR board only: \
-    judge each settled task with accept_task / reject_task (review_task for detail), \
-    merge_branch finished worktree branches, and plan_tasks for newly-unblocked or follow-up \
-    work. Scheduling, retries, and worker dispatch are automatic — never wait or poll. If \
-    board_status shows nothing needing action, just end your turn.";
+    settled, failed, need a decision, or are parked on an unresolvable depends_on key. Call \
+    board_status now and act on YOUR board only: judge each settled task with accept_task / \
+    reject_task (review_task for detail), merge_branch finished worktree branches, fix any \
+    task listed under unresolvable_deps by re-registering it via plan_tasks with corrected \
+    depends_on, and plan_tasks for newly-unblocked or follow-up work. Scheduling, retries, \
+    and worker dispatch are automatic — never wait or poll. If board_status shows nothing \
+    needing action, just end your turn.";
 
 pub type BoardOutboxInflight = Arc<std::sync::Mutex<HashSet<Uuid>>>;
 
@@ -1583,6 +1670,20 @@ async fn spawn_task_worker(
     Ok(mission.id)
 }
 
+/// Whether a failed settle re-queues silently for its one automatic retry.
+/// High-risk tasks never retry silently: a failed high-risk attempt is a boss
+/// decision, not a scheduler decision — the board wake surfaces it instead.
+fn eligible_for_automatic_retry(
+    task: &BoardTask,
+    outcome: BoardTaskOutcome,
+    retry: AutomaticRetry,
+) -> bool {
+    outcome == BoardTaskOutcome::Failed
+        && task.attempts < MAX_ATTEMPTS
+        && retry != AutomaticRetry::Suppressed
+        && !task.risk_class.eq_ignore_ascii_case("high")
+}
+
 /// Settle a task: persist outcome + result digest, and retry failures once.
 /// Does NOT notify the boss — the scheduler pass wakes the boss from board
 /// state (pull model), so a settle never pushes per-task content into any
@@ -1623,10 +1724,8 @@ async fn settle_task(
     {
         tracing::warn!(task = %task.task_key, "board: failed to close task attempt: {error}");
     }
-    if outcome == BoardTaskOutcome::Failed
-        && task.attempts < MAX_ATTEMPTS
-        && retry != AutomaticRetry::Suppressed
-    {
+    let high_risk = task.risk_class.eq_ignore_ascii_case("high");
+    if eligible_for_automatic_retry(&task, outcome, retry) {
         // Silent automatic retry: back to pending, next pass respawns fresh.
         task.status = BoardTaskStatus::Pending;
         task.notes = append_note(
@@ -1660,6 +1759,11 @@ async fn settle_task(
             _ => "policy suppressed automatic retry",
         };
         task.notes = append_note(&task.notes, reason);
+    } else if outcome == BoardTaskOutcome::Failed && high_risk && task.attempts < MAX_ATTEMPTS {
+        task.notes = append_note(
+            &task.notes,
+            "risk_class=high: automatic retry suppressed; boss review required",
+        );
     }
     task.status = if outcome == BoardTaskOutcome::Failed {
         BoardTaskStatus::Failed
@@ -1765,6 +1869,70 @@ mod tests {
         .await
         .expect("outbox acknowledgement persisted");
         assert!(inflight.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unresolvable_dependencies_are_visible_and_trigger_attention() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = store
+            .create_mission_with_parent(
+                Some("boss"),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create boss");
+        store
+            .upsert_board_tasks(
+                boss.id,
+                vec![
+                    NewBoardTask {
+                        task_key: "a".into(),
+                        title: "a".into(),
+                        prompt: "p".into(),
+                        backend: "codex".into(),
+                        ..Default::default()
+                    },
+                    NewBoardTask {
+                        task_key: "b".into(),
+                        title: "b".into(),
+                        prompt: "p".into(),
+                        backend: "codex".into(),
+                        depends_on: vec!["a".into(), "typo-key".into()],
+                        ..Default::default()
+                    },
+                ],
+            )
+            .await
+            .expect("create tasks");
+        let tasks = store.list_board_tasks(boss.id).await.expect("list tasks");
+
+        // `b` is parked forever (ready_tasks never returns it) …
+        assert!(ready_tasks(&tasks).iter().all(|t| t.task_key != "b"));
+        // … so the parking must be visible and wake the boss.
+        assert_eq!(
+            unresolvable_dependencies(&tasks),
+            vec![("b".to_string(), "typo-key".to_string())]
+        );
+        assert!(board_needs_attention(&tasks));
+
+        // A board whose deps all resolve raises no attention.
+        let resolved: Vec<BoardTask> = tasks
+            .into_iter()
+            .map(|mut t| {
+                t.depends_on.retain(|d| d != "typo-key");
+                t
+            })
+            .collect();
+        assert!(unresolvable_dependencies(&resolved).is_empty());
+        assert!(!board_needs_attention(&resolved));
     }
 
     #[tokio::test]
@@ -2161,6 +2329,83 @@ mod tests {
             retry_prompt(&task, &RetryPreflight::NothingFound),
             task.prompt
         );
+    }
+
+    #[test]
+    fn automatic_retry_relaxes_the_spec_instead_of_repeating_it() {
+        let mut task = mk("relaxed-retry", &[], BoardTaskStatus::Pending, None);
+        task.attempts = 2; // spawn_task_worker increments before building the prompt
+        task.prior_outcome = Some(BoardTaskOutcome::Failed);
+        task.prior_result_digest = Some("build failed: missing import".into());
+
+        let prompt = retry_prompt(&task, &RetryPreflight::NothingFound);
+
+        assert!(prompt.contains("[Retry guidance]"));
+        assert!(prompt.contains("build failed: missing import"));
+        assert!(prompt.ends_with(&task.prompt));
+    }
+
+    #[test]
+    fn first_spawn_prompt_carries_no_retry_guidance() {
+        let mut task = mk("first", &[], BoardTaskStatus::Pending, None);
+        task.attempts = 1;
+        assert_eq!(
+            retry_prompt(&task, &RetryPreflight::NothingFound),
+            task.prompt
+        );
+    }
+
+    #[test]
+    fn worker_contract_delivers_acceptance_criteria_as_the_success_condition() {
+        let mut task = mk("criteria", &[], BoardTaskStatus::Pending, None);
+        task.acceptance_criteria = vec![
+            "cargo test passes".to_string(),
+            "no new clippy warnings".to_string(),
+        ];
+        task.verification_command = Some("cargo test -p sandboxed_sh".to_string());
+
+        let contract = worker_contract(&task);
+        assert!(contract.contains("Acceptance criteria"));
+        assert!(contract.contains("* cargo test passes"));
+        assert!(contract.contains("* no new clippy warnings"));
+        assert!(contract.contains("`cargo test -p sandboxed_sh`"));
+        assert!(contract.contains("suggested approach is advisory"));
+
+        // A task without declared criteria makes no claim that the prompt is
+        // advisory — the prompt is then the only spec.
+        let bare = worker_contract(&mk("bare", &[], BoardTaskStatus::Pending, None));
+        assert!(!bare.contains("Acceptance criteria"));
+        assert!(!bare.contains("advisory"));
+    }
+
+    #[test]
+    fn high_risk_tasks_never_retry_silently() {
+        let mut task = mk("risky", &[], BoardTaskStatus::Running, None);
+        task.attempts = 1;
+        task.risk_class = "high".into();
+        assert!(!eligible_for_automatic_retry(
+            &task,
+            BoardTaskOutcome::Failed,
+            AutomaticRetry::Allowed
+        ));
+
+        task.risk_class = "normal".into();
+        assert!(eligible_for_automatic_retry(
+            &task,
+            BoardTaskOutcome::Failed,
+            AutomaticRetry::Allowed
+        ));
+        assert!(!eligible_for_automatic_retry(
+            &task,
+            BoardTaskOutcome::Failed,
+            AutomaticRetry::Suppressed
+        ));
+        task.attempts = MAX_ATTEMPTS;
+        assert!(!eligible_for_automatic_retry(
+            &task,
+            BoardTaskOutcome::Failed,
+            AutomaticRetry::Allowed
+        ));
     }
 
     #[test]

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -1974,6 +1974,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn running_task_outcome_contract_can_still_be_corrected() {
+        // spec_warnings arrive after registration and the scheduler can spawn
+        // within one pass — so re-registering the same task_key must land the
+        // corrected contract on a RUNNING task (contract fields only; the
+        // in-flight prompt stays frozen).
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = store
+            .create_mission_with_parent(
+                Some("boss"),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create boss");
+        store
+            .upsert_board_tasks(
+                boss.id,
+                vec![NewBoardTask {
+                    task_key: "t".into(),
+                    title: "t".into(),
+                    prompt: "original prompt".into(),
+                    backend: "codex".into(),
+                    ..Default::default()
+                }],
+            )
+            .await
+            .expect("register");
+        let mut task = store
+            .list_board_tasks(boss.id)
+            .await
+            .expect("list")
+            .remove(0);
+        task.status = BoardTaskStatus::Running;
+        store.save_board_task(&task).await.expect("mark running");
+
+        store
+            .upsert_board_tasks(
+                boss.id,
+                vec![NewBoardTask {
+                    task_key: "t".into(),
+                    title: "ignored".into(),
+                    prompt: "ignored".into(),
+                    backend: "codex".into(),
+                    acceptance_criteria: vec!["tests pass".into()],
+                    verification_command: Some("cargo test".into()),
+                    risk_class: "high".into(),
+                    ..Default::default()
+                }],
+            )
+            .await
+            .expect("correct contract");
+
+        let corrected = store
+            .list_board_tasks(boss.id)
+            .await
+            .expect("list")
+            .remove(0);
+        assert_eq!(corrected.status, BoardTaskStatus::Running);
+        assert_eq!(corrected.prompt, "original prompt");
+        assert_eq!(
+            corrected.acceptance_criteria,
+            vec!["tests pass".to_string()]
+        );
+        assert_eq!(
+            corrected.verification_command.as_deref(),
+            Some("cargo test")
+        );
+        assert_eq!(corrected.risk_class, "high");
+    }
+
+    #[tokio::test]
     async fn dropped_delivery_is_released_for_pending_replay() {
         let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
         let (cmd_tx, mut cmd_rx) = mpsc::channel(1);

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -168,9 +168,15 @@ const RETRY_PROMPT_BINDING_GUIDANCE: &str = "[Retry guidance] The prior attempt 
     addressing the prior failure.";
 
 /// Whether the task declares an objective success condition beyond its
-/// prompt: non-empty acceptance criteria or a non-blank verification command.
+/// prompt: at least one non-blank acceptance criterion or a non-blank
+/// verification command. Registration normalizes blanks away
+/// (`validate_and_normalize_board_tasks`), but tasks persisted before that —
+/// or written through another path — must not have `[" "]` count as a
+/// contract and get the prompt declared advisory.
 fn has_outcome_contract(task: &BoardTask) -> bool {
-    !task.acceptance_criteria.is_empty()
+    task.acceptance_criteria
+        .iter()
+        .any(|criterion| !criterion.trim().is_empty())
         || task
             .verification_command
             .as_deref()
@@ -742,10 +748,16 @@ fn worker_contract(task: &BoardTask) -> String {
         .as_deref()
         .map(str::trim)
         .filter(|c| !c.is_empty());
-    if !task.acceptance_criteria.is_empty() {
+    let criteria: Vec<&str> = task
+        .acceptance_criteria
+        .iter()
+        .map(|criterion| criterion.trim())
+        .filter(|criterion| !criterion.is_empty())
+        .collect();
+    if !criteria.is_empty() {
         contract
             .push_str("\n- Acceptance criteria (ALL must hold; this is the success condition):");
-        for criterion in &task.acceptance_criteria {
+        for criterion in criteria {
             contract.push_str("\n  * ");
             contract.push_str(criterion);
         }
@@ -2388,6 +2400,16 @@ mod tests {
         assert!(prompt.contains("remain\n    binding") || prompt.contains("remain binding"));
         assert!(!prompt.contains("advisory"));
         assert!(prompt.ends_with(&task.prompt));
+
+        // Blank-only criteria (possible for tasks persisted before
+        // registration normalization) must not count as a contract either:
+        // no advisory retry guidance, no advisory line in the contract.
+        task.acceptance_criteria = vec!["  ".to_string()];
+        assert!(!has_outcome_contract(&task));
+        assert!(!retry_prompt(&task, &RetryPreflight::NothingFound).contains("advisory"));
+        let contract = worker_contract(&task);
+        assert!(!contract.contains("Acceptance criteria"));
+        assert!(!contract.contains("advisory"));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4063,9 +4063,30 @@ pub struct BoardUtilization {
 }
 
 #[derive(Debug, serde::Serialize)]
+pub struct UnresolvableDep {
+    pub task_key: String,
+    pub missing_dep: String,
+}
+
+#[derive(Debug, serde::Serialize)]
 pub struct BoardResponse {
     pub tasks: Vec<BoardTask>,
     pub utilization: BoardUtilization,
+    /// Pending tasks parked forever on a `depends_on` key that doesn't exist
+    /// on this board (typo'd or never-registered dependency). The scheduler
+    /// wakes the boss when this is non-empty; fix by re-registering the task
+    /// with corrected depends_on via plan_tasks.
+    pub unresolvable_deps: Vec<UnresolvableDep>,
+}
+
+fn board_unresolvable_deps(tasks: &[BoardTask]) -> Vec<UnresolvableDep> {
+    board::unresolvable_dependencies(tasks)
+        .into_iter()
+        .map(|(task_key, missing_dep)| UnresolvableDep {
+            task_key,
+            missing_dep,
+        })
+        .collect()
 }
 
 fn validate_and_normalize_board_tasks(
@@ -4115,6 +4136,19 @@ fn validate_and_normalize_board_tasks(
             .model_override
             .as_deref()
             .and_then(|model| normalize_model_override_for_backend(Some(&t.backend), model));
+        // `risk_class` now gates scheduler behavior (high = no silent retry),
+        // so an unrecognized value must fail loudly instead of silently acting
+        // like "normal".
+        t.risk_class = t.risk_class.trim().to_ascii_lowercase();
+        if !matches!(t.risk_class.as_str(), "low" | "normal" | "high") {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "task `{}`: unknown risk_class `{}` (use low|normal|high)",
+                    t.task_key, t.risk_class
+                ),
+            ));
+        }
     }
     Ok(())
 }
@@ -4148,6 +4182,7 @@ pub async fn get_mission_board(
     let max_parallel = crate::settings::max_parallel_missions_cached_or(control.max_parallel);
     Ok(Json(BoardResponse {
         utilization: board_utilization(&tasks, max_parallel),
+        unresolvable_deps: board_unresolvable_deps(&tasks),
         tasks,
     }))
 }
@@ -4189,6 +4224,7 @@ pub async fn upsert_mission_board_tasks(
     let max_parallel = crate::settings::max_parallel_missions_cached_or(control.max_parallel);
     Ok(Json(BoardResponse {
         utilization: board_utilization(&tasks, max_parallel),
+        unresolvable_deps: board_unresolvable_deps(&tasks),
         tasks,
     }))
 }
@@ -7617,6 +7653,10 @@ pub async fn create_mission(
     // when set. Unlike the old create-then-message pattern, this cannot be
     // dropped at capacity.
     if let Some(prompt) = nonblank(&req.prompt) {
+        // Canonicalise `/goal\n…` to the space form before storing: the
+        // deferred goal is later re-injected verbatim, and the backend goal
+        // drivers only recognise `/goal <objective>` with a space.
+        let prompt = canonical_goal_message(&prompt).unwrap_or(prompt);
         control
             .mission_store
             .set_deferred_goal(mission.id, Some(prompt.clone()))
@@ -13731,6 +13771,16 @@ fn parse_goal_objective(message: &str) -> Option<String> {
     }
     let objective = rest.trim();
     (!objective.is_empty()).then(|| objective.to_string())
+}
+
+/// Canonical `/goal <objective>` form for a goal message, or `None` when the
+/// message is not a goal command. The backend goal drivers (codex
+/// `parse_goal_prefix`, grok, opencode) only recognise the space-separated
+/// form, while `parse_goal_objective` accepts any whitespace after the
+/// command — normalising at the choke points keeps every downstream parser in
+/// agreement without teaching each one about `/goal\n`.
+fn canonical_goal_message(message: &str) -> Option<String> {
+    parse_goal_objective(message).map(|objective| format!("/goal {objective}"))
 }
 
 /// If the turn ended with `LlmError` or `AuthError` but the agent produced
@@ -20179,10 +20229,9 @@ async fn run_single_control_turn(
             };
             let is_continuation =
                 force_session_resume || history.iter().any(|(role, _)| role == "assistant");
-            let grok_message_owned: String = if user_message.trim_start().starts_with("/goal ") {
-                user_message.clone()
-            } else {
-                convo.clone()
+            let grok_message_owned: String = match canonical_goal_message(&user_message) {
+                Some(goal) => goal,
+                None => convo.clone(),
             };
             use crate::api::runners::HarnessRunner as _;
             Box::pin(
@@ -20219,10 +20268,9 @@ async fn run_single_control_turn(
             // reach the codex backend; the wrapped `convo` buries the prefix
             // and breaks `parse_goal_prefix`. Mirror the same routing the
             // mission_runner dispatch uses.
-            let codex_message_owned: String = if user_message.trim_start().starts_with("/goal ") {
-                user_message.clone()
-            } else {
-                convo.clone()
+            let codex_message_owned: String = match canonical_goal_message(&user_message) {
+                Some(goal) => goal,
+                None => convo.clone(),
             };
             let codex_message: &str = codex_message_owned.as_str();
             // Shared rotation wrapper: identical account rotation + usage-cap
@@ -20353,13 +20401,14 @@ async fn run_single_control_turn(
             // mission that only has the Claude-Code UUID placeholder),
             // keep using `convo` so the model still gets a history-aware
             // prompt.
-            let is_goal_mode = user_message.trim_start().starts_with("/goal ");
-            let opencode_message_owned: String =
-                if is_goal_mode || (opencode_is_continuation && has_opencode_session) {
-                    user_message.clone()
-                } else {
-                    convo.clone()
-                };
+            let canonical_goal = canonical_goal_message(&user_message);
+            let opencode_message_owned: String = if let Some(goal) = canonical_goal {
+                goal
+            } else if opencode_is_continuation && has_opencode_session {
+                user_message.clone()
+            } else {
+                convo.clone()
+            };
             use crate::api::runners::HarnessRunner as _;
             Box::pin(crate::api::runners::OpenCodeRunner.run_turn(
                 crate::api::runners::TurnContext {
@@ -23260,6 +23309,22 @@ mod tests {
         assert!(parse_goal_objective("/goal   ").is_none());
         assert!(parse_goal_objective("/goals are nice").is_none());
         assert!(parse_goal_objective("plain message").is_none());
+    }
+
+    #[test]
+    fn canonical_goal_message_normalises_to_space_form() {
+        // Backend goal drivers only recognise "/goal <objective>"; every
+        // whitespace variant must canonicalise to that form.
+        assert_eq!(
+            canonical_goal_message("/goal ship it").as_deref(),
+            Some("/goal ship it")
+        );
+        assert_eq!(
+            canonical_goal_message("/goal\nMulti-line objective\nwith details").as_deref(),
+            Some("/goal Multi-line objective\nwith details")
+        );
+        assert!(canonical_goal_message("/goals are nice").is_none());
+        assert!(canonical_goal_message("plain message").is_none());
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4136,6 +4136,21 @@ fn validate_and_normalize_board_tasks(
             .model_override
             .as_deref()
             .and_then(|model| normalize_model_override_for_backend(Some(&t.backend), model));
+        // Blank acceptance criteria must not count as an outcome contract:
+        // `[" "]` would otherwise suppress spec_warnings, emit a blank bullet
+        // in the worker contract, and declare the prompt advisory on retry.
+        t.acceptance_criteria = t
+            .acceptance_criteria
+            .iter()
+            .map(|criterion| criterion.trim().to_string())
+            .filter(|criterion| !criterion.is_empty())
+            .collect();
+        t.verification_command = t
+            .verification_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .map(String::from);
         // `risk_class` now gates scheduler behavior (high = no silent retry),
         // so an unrecognized value must fail loudly instead of silently acting
         // like "normal".
@@ -15233,6 +15248,17 @@ async fn control_actor_loop(
                         // through unchanged. See `api/grok_goal.rs`.
                         let goal_target_mission = effective_target.or(main_mission_id);
                         let mut content = content;
+                        // Canonicalise `/goal\n…` to the space form at the single
+                        // entry point, so every downstream space-only parser (the
+                        // grok kickoff below, the mission_runner dispatch paths,
+                        // the codex/opencode goal drivers) sees the same goal
+                        // command. Strict (control-plane) messages are never goal
+                        // commands and stay byte-exact.
+                        if !strict {
+                            if let Some(canonical) = canonical_goal_message(&content) {
+                                content = canonical;
+                            }
+                        }
                         // Strict (control-plane) messages are system-generated and must
                         // never be reinterpreted as a `/goal` kickoff — skip the rewrite.
                         if !strict {

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -835,6 +835,15 @@ impl MissionStore for InMemoryMissionStore {
                         bt.cost_budget_cents = t.cost_budget_cents;
                         bt.depends_on = t.depends_on;
                         bt.updated_at = now.clone();
+                    } else if bt.status == BoardTaskStatus::Running {
+                        // Mirror the sqlite store: a running task's prompt is
+                        // frozen but its outcome contract may still be
+                        // corrected (spec_warnings arrive after registration,
+                        // and the scheduler can spawn within one pass).
+                        bt.acceptance_criteria = t.acceptance_criteria;
+                        bt.verification_command = t.verification_command;
+                        bt.risk_class = t.risk_class;
+                        bt.updated_at = now.clone();
                     }
                     out.push(bt.clone());
                 }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -10570,7 +10570,34 @@ impl MissionStore for SqliteMissionStore {
                         .map_err(|e| format!("Failed to update board task: {e}"))?;
                         id
                     }
-                    Some((id, _)) => id, // non-pending: leave untouched
+                    Some((id, status)) if status == "running" => {
+                        // A worker is already executing this task, so its
+                        // prompt/backend/deps are frozen — but the OUTCOME
+                        // CONTRACT may still be corrected. `plan_tasks` warns
+                        // about missing acceptance criteria only after
+                        // registration, and the scheduler can spawn the task
+                        // within one pass (~3s), before the boss reads the
+                        // warning. Letting the contract fields through means
+                        // that correction still lands: verdict guidance and
+                        // the retry prompt read them live, and a retry's
+                        // worker contract delivers them.
+                        conn.execute(
+                            "UPDATE board_tasks SET acceptance_criteria = ?1, \
+                             verification_command = ?2, risk_class = ?3, updated_at = ?4 \
+                             WHERE id = ?5",
+                            params![
+                                serde_json::to_string(&t.acceptance_criteria)
+                                    .unwrap_or_else(|_| "[]".into()),
+                                t.verification_command,
+                                t.risk_class,
+                                now,
+                                id,
+                            ],
+                        )
+                        .map_err(|e| format!("Failed to update running task contract: {e}"))?;
+                        id
+                    }
+                    Some((id, _)) => id, // settled/terminal: leave untouched
                     None => {
                         let id = Uuid::new_v4().to_string();
                         conn.execute(

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1489,10 +1489,28 @@ async fn list_remote_nodes(
             cached.as_ref(),
         ));
     }
+    // The Spark offload lane is separate from the remote-node fleet; expose
+    // it alongside so `get_compute_fleet` consumers (Hermes, controllers) see
+    // all capacity lanes, not just `nodes`.
+    let spark_configured = state.config.spark_arbiter_url.is_some()
+        && state.config.spark_arbiter_token.is_some()
+        && state.config.spark_ssh_target.is_some();
+    let spark_workspaces: Vec<String> = state
+        .workspaces
+        .list()
+        .await
+        .into_iter()
+        .filter(|w| w.spark_offload_enabled())
+        .map(|w| w.name)
+        .collect();
     Json(crate::remote_node::RemoteNodesResponse {
         enabled: settings.enabled,
         nodes,
         recent_jobs: state.fleet.recent_outcomes(10),
+        spark_offload: crate::remote_node::SparkOffloadStatus {
+            configured: spark_configured,
+            enabled_workspaces: spark_workspaces,
+        },
     })
 }
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1491,10 +1491,14 @@ async fn list_remote_nodes(
     }
     // The Spark offload lane is separate from the remote-node fleet; expose
     // it alongside so `get_compute_fleet` consumers (Hermes, controllers) see
-    // all capacity lanes, not just `nodes`.
+    // all capacity lanes, not just `nodes`. `configured` requires the
+    // capability-token signing secret too: without it no workspace can mint a
+    // token for the endpoint, so advertising the lane would direct work at
+    // unusable capacity.
     let spark_configured = state.config.spark_arbiter_url.is_some()
         && state.config.spark_arbiter_token.is_some()
-        && state.config.spark_ssh_target.is_some();
+        && state.config.spark_ssh_target.is_some()
+        && crate::api::spark::spark_offload_signing_available();
     let spark_workspaces: Vec<String> = state
         .workspaces
         .list()

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -44,6 +44,14 @@ fn spark_offload_secret() -> Option<String> {
         })
 }
 
+/// Whether a signing secret for spark-offload capability tokens is available.
+/// Without it, `build_spark_offload_token` returns `None` and no workspace can
+/// actually reach the offload endpoint — so availability reporting must treat
+/// the lane as unconfigured.
+pub fn spark_offload_signing_available() -> bool {
+    spark_offload_secret().is_some()
+}
+
 /// Mint a per-mission, scope-bound capability token for spark offload. Unlike
 /// the master `SANDBOXED_PROXY_SECRET`, a leaked token only authorizes spark
 /// builds for THIS mission — it can't be replayed against the LLM proxy or any

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1217,31 +1217,7 @@ mcp_servers:
     connect_timeout: 15
     tools:
       include:
-        - list_active_missions
-        - list_missions
-        - get_mission
-        - get_mission_digest
-        - get_mission_events
-        - get_mission_health
-        - get_mission_diagnostics
-        - get_compute_fleet
-        - start_mission
-        - send_message_to_mission
-        - ask_mission
-        - update_mission_settings
-        - resume_mission
-        - cancel_mission
-        - list_workspaces
-        - get_workspace
-        - create_workspace
-        - update_workspace
-        - delete_workspace
-        - list_workspace_templates
-        - get_workspace_template
-        - save_workspace_template
-        - delete_workspace_template
-        - rebuild_workspace_from_template
-        - workspace_bash
+{tools_include}
       prompts: false
       resources: false
 
@@ -1259,6 +1235,7 @@ display:
         jwt_secret = yaml_squote(jwt_secret),
         user_id = yaml_squote(user_id),
         default_workspace_id = yaml_squote(default_workspace_id),
+        tools_include = crate::hermes_tools::yaml_include_items("        "),
     )
 }
 
@@ -5428,19 +5405,10 @@ mod tests {
 
         assert!(yaml.contains("    timeout: 600\n"));
         assert!(!yaml.contains("    timeout: 120\n"));
-        assert!(yaml.contains("        - ask_mission\n"));
-        for tool in [
-            "get_workspace",
-            "create_workspace",
-            "update_workspace",
-            "delete_workspace",
-            "list_workspace_templates",
-            "get_workspace_template",
-            "save_workspace_template",
-            "delete_workspace_template",
-            "rebuild_workspace_from_template",
-            "workspace_bash",
-        ] {
+        // The generated allowlist is the canonical one — every assistant-mcp
+        // tool, including the ones that had drifted out of it
+        // (get_chatgpt_ui_pool_status, acknowledge_mission, workspace jobs).
+        for tool in crate::hermes_tools::HERMES_ASSISTANT_TOOL_ALLOWLIST {
             assert!(
                 yaml.contains(&format!("        - {tool}\n")),
                 "generated Hermes config missing {tool}"

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -2610,9 +2610,11 @@ fn compact_compute_fleet(fleet: &Value) -> Value {
             "ordinary_cpu_work": "prefer online non-GPU nodes with immediate capacity, then lowest normalized utilization",
             "gpu_work": "request the gpu label explicitly",
             "parallel_clean_builds": "use distinct missions and verify distinct node/job/head receipts",
+            "lean_builds": "workspaces listed under spark_offload.enabled_workspaces can also offload Lean builds to the DGX Spark lane (separate from these nodes)",
         },
         "nodes": compact_nodes,
         "recent_jobs": fleet.get("recent_jobs").cloned().unwrap_or_else(|| json!([])),
+        "spark_offload": fleet.get("spark_offload").cloned().unwrap_or(Value::Null),
     })
 }
 
@@ -3070,6 +3072,24 @@ mod tests {
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// The binary's tool table IS the curated Hermes surface; the generated
+    /// config allowlists are pinned to `HERMES_ASSISTANT_TOOL_ALLOWLIST`.
+    /// Adding/removing a tool here must go through the canonical list.
+    #[test]
+    fn tool_table_matches_canonical_allowlist() {
+        let names: Vec<String> = AssistantMcp::tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        let names: Vec<&str> = names.iter().map(String::as_str).collect();
+        assert_eq!(
+            names,
+            sandboxed_sh::hermes_tools::HERMES_ASSISTANT_TOOL_ALLOWLIST,
+            "assistant-mcp tool table diverged from \
+             src/hermes_tools.rs::HERMES_ASSISTANT_TOOL_ALLOWLIST — update both together"
+        );
+    }
 
     const ENV_KEYS: &[&str] = &[
         "HERMES_SANDBOXED_API_URL",

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -909,10 +909,27 @@ impl AssistantMcp {
     }
 
     async fn api_post(&self, path: &str, body: Value) -> Result<reqwest::Response, String> {
+        self.api_post_with_timeout(path, body, None).await
+    }
+
+    /// POST with an optional per-request timeout override. The shared client's
+    /// default is 120s; synchronous long-running endpoints (`/ask`) need more
+    /// headroom than that but must still resolve before the Hermes-side MCP
+    /// request timeout (600s in the generated config) so the caller gets a
+    /// clean error instead of a severed stdio call.
+    async fn api_post_with_timeout(
+        &self,
+        path: &str,
+        body: Value,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<reqwest::Response, String> {
         let mut req = self
             .client
             .post(format!("{}{}", self.api_url, path))
             .json(&body);
+        if let Some(timeout) = timeout {
+            req = req.timeout(timeout);
+        }
         if let Some((name, value)) = self.auth_header() {
             req = req.header(name, value);
         }
@@ -1764,8 +1781,15 @@ impl AssistantMcp {
             let tid = parse_uuid(tid)?;
             body["thread_id"] = json!(tid.to_string());
         }
+        // Ask turns make multiple sequential LLM/tool calls; give the
+        // synchronous /ask request most of the Hermes-side 600s MCP budget
+        // (the shared client default of 120s would abort long asks).
         let response = self
-            .api_post(&format!("/api/control/missions/{id}/ask"), body)
+            .api_post_with_timeout(
+                &format!("/api/control/missions/{id}/ask"),
+                body,
+                Some(std::time::Duration::from_secs(570)),
+            )
             .await?;
         if !response.status().is_success() {
             let status = response.status();

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -283,6 +283,19 @@ struct PlanTaskSpec {
     /// worktree spec is given.
     #[serde(default)]
     working_directory: Option<String>,
+    /// Objective, testable conditions that define success. Delivered to the
+    /// worker as the authoritative success condition; any approach satisfying
+    /// them is an acceptable delivery.
+    #[serde(default)]
+    acceptance_criteria: Vec<String>,
+    /// Command whose success verifies the task (run by the worker before
+    /// `DELIVERED:`).
+    #[serde(default)]
+    verification_command: Option<String>,
+    /// low | normal (default) | high. High-risk tasks are never retried
+    /// silently — a failed attempt settles for boss review instead.
+    #[serde(default)]
+    risk_class: Option<String>,
     /// Task keys (this board) that must settle successfully or be accepted first
     #[serde(default)]
     depends_on: Vec<String>,
@@ -605,7 +618,7 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "plan_tasks".to_string(),
-                description: "PREFERRED orchestration tool. Register tasks on this mission's task board. The server-side scheduler then owns everything mechanical: it spawns a worker mission for every dependency-satisfied task while capacity allows, retries failures once, and MESSAGES YOU A DIGEST as each task settles. You never create workers, wait, or poll. Each task needs: task_key (stable, unique), title, full prompt (scope, absolute paths, success condition, verification command — the done/BLOCKED turn contract is appended automatically), backend (codex/opencode/grok — never claudecode), and optionally model_override/model_effort, depends_on (keys of tasks that must settle successfully first), and worktree {path, branch, base} for an isolated checkout (created here, before registration). Re-calling with an existing key updates the task while it is still pending. After planning: END YOUR TURN — digests will wake you.".to_string(),
+                description: "PREFERRED orchestration tool. Register tasks on this mission's task board. The server-side scheduler then owns everything mechanical: it spawns a worker mission for every dependency-satisfied task while capacity allows, retries failures once, and MESSAGES YOU A DIGEST as each task settles. You never create workers, wait, or poll. Specify each task by its OUTCOME, not its procedure: acceptance_criteria + verification_command are the contract (the weakest testable conditions that define success — any approach satisfying them is an acceptable delivery); the prompt supplies scope, absolute paths, and context, and its suggested approach is advisory. Each task needs: task_key (stable, unique), title, prompt, backend (codex/opencode/grok — never claudecode), acceptance_criteria + verification_command (strongly recommended; tasks without either get a spec_warnings entry), and optionally risk_class (high = never retried silently), model_override/model_effort, depends_on (keys of tasks that must settle successfully first — unknown keys park the task and raise unresolvable_deps), and worktree {path, branch, base} for an isolated checkout (created here, before registration). Re-calling with an existing key updates the task while it is still pending. After planning: END YOUR TURN — digests will wake you.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["tasks"],
@@ -618,8 +631,11 @@ impl OrchestratorMcp {
                                 "properties": {
                                     "task_key": { "type": "string", "description": "Stable unique key on this board (e.g. 'p3-nonce')" },
                                     "title": { "type": "string" },
-                                    "prompt": { "type": "string", "description": "Full worker prompt: exact scope, absolute paths, success condition, verification command" },
+                                    "prompt": { "type": "string", "description": "Worker prompt: exact scope, absolute paths, context. Suggested approach is advisory — the acceptance criteria define success" },
                                     "backend": { "type": "string", "description": "codex | opencode | grok (never claudecode)" },
+                                    "acceptance_criteria": { "type": "array", "items": { "type": "string" }, "description": "Objective, testable conditions that define success — the weakest set that still guarantees the outcome. Delivered to the worker as the authoritative contract" },
+                                    "verification_command": { "type": "string", "description": "Command whose success verifies the task; the worker must run it before DELIVERED" },
+                                    "risk_class": { "type": "string", "description": "low | normal (default) | high. high = a failed attempt is never retried silently; it settles for your review" },
                                     "model_override": { "type": "string", "description": "Exact account-supported model ID. For Codex Terra use gpt-5.6-terra with medium effort. Never invent variants such as gpt-5.5-sol." },
                                     "model_effort": { "type": "string", "description": "low | medium | high | xhigh | max (codex)" },
                                     "working_directory": { "type": "string", "description": "Worker cwd; superseded by worktree.path if a worktree is given" },
@@ -642,7 +658,7 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "board_status".to_string(),
-                description: "Current task board: every task with status (pending/running/settled/accepted/failed/cancelled), outcome, worker mission id, digest, plus utilization counters. Cheap snapshot — use instead of list_worker_missions/get_worker_status for board work.".to_string(),
+                description: "Current task board: every task with status (pending/running/settled/accepted/failed/cancelled), outcome, worker mission id, digest, plus utilization counters and unresolvable_deps (tasks parked forever on a depends_on key that doesn't exist — fix by re-registering via plan_tasks). Cheap snapshot — use instead of list_worker_missions/get_worker_status for board work.".to_string(),
                 input_schema: json!({ "type": "object", "properties": {} }),
             },
             ToolDefinition {
@@ -670,7 +686,7 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "reject_task".to_string(),
-                description: "Reject a settled (or failed) task with feedback. The worker mission is resumed with your feedback so it keeps its context; if the worker is gone the task is re-queued with the feedback appended to its prompt. You'll get a fresh digest when it settles again.".to_string(),
+                description: "Reject a settled (or failed) task with feedback. The worker mission is resumed with your feedback so it keeps its context; if the worker is gone the task is re-queued with the feedback appended to its prompt. Feedback should be the MINIMAL added constraint: a concrete counterexample or a new acceptance criterion that excludes the observed failure — not a prescription of how to redo the work. Judge results on whether they satisfy the acceptance criteria/verification, never on whether the worker followed the approach you imagined. You'll get a fresh digest when it settles again.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["feedback"],
@@ -1835,7 +1851,7 @@ impl OrchestratorMcp {
                 validate_working_directory_visible_to_worker(wd)?;
             }
 
-            registered.push(json!({
+            let mut registered_task = json!({
                 "task_key": spec.task_key,
                 "title": spec.title,
                 "prompt": spec.prompt,
@@ -1845,9 +1861,50 @@ impl OrchestratorMcp {
                 "working_directory": working_directory,
                 "repository": repository,
                 "branch": branch,
+                "acceptance_criteria": spec.acceptance_criteria,
+                "verification_command": spec.verification_command,
                 "depends_on": spec.depends_on,
-            }));
+            });
+            // `risk_class` is a non-optional String server-side (defaulted to
+            // "normal"); only send the key when the boss set one.
+            if let Some(risk) = spec
+                .risk_class
+                .as_deref()
+                .map(str::trim)
+                .filter(|r| !r.is_empty())
+            {
+                registered_task["risk_class"] = json!(risk);
+            }
+            registered.push(registered_task);
         }
+
+        // Spec-weakness lint (advisory, never blocking): a task with neither
+        // acceptance criteria nor a verification command has no objective
+        // success condition — the worker, the settle classifier, and the boss
+        // verdict all fall back to judging prompt prose, which over-anchors
+        // on the prompt's suggested approach instead of the outcome.
+        let spec_warnings: Vec<String> = registered
+            .iter()
+            .filter_map(|task| {
+                let key = task["task_key"].as_str().unwrap_or_default();
+                let no_criteria = task["acceptance_criteria"]
+                    .as_array()
+                    .map(|criteria| criteria.is_empty())
+                    .unwrap_or(true);
+                let no_verification = task["verification_command"]
+                    .as_str()
+                    .map(str::trim)
+                    .filter(|command| !command.is_empty())
+                    .is_none();
+                (no_criteria && no_verification).then(|| {
+                    format!(
+                        "task `{key}`: no acceptance_criteria or verification_command — \
+                         declare the weakest testable success condition so any approach \
+                         that satisfies it counts as delivered"
+                    )
+                })
+            })
+            .collect();
 
         let response = self
             .api_post(
@@ -1865,6 +1922,9 @@ impl OrchestratorMcp {
             .map_err(|e| format!("Failed to parse board response: {}", e))?;
         if let Some(obj) = board.as_object_mut() {
             obj.insert("worktrees_created".to_string(), json!(worktrees_created));
+            if !spec_warnings.is_empty() {
+                obj.insert("spec_warnings".to_string(), json!(spec_warnings));
+            }
             obj.insert(
                 "hint".to_string(),
                 json!(
@@ -2094,6 +2154,15 @@ impl OrchestratorMcp {
                     ),
                     model_effort: Some("high".to_string()),
                     working_directory: Some(repo_dir.clone()),
+                    acceptance_criteria: vec![
+                        format!("a merge commit of `{source}` exists on `{target}`"),
+                        "no conflict markers remain in the tree".to_string(),
+                        "both branches' intent is preserved in the resolution".to_string(),
+                    ],
+                    verification_command: Some(format!(
+                        "git -C {repo_dir} merge-base --is-ancestor {source} {target}"
+                    )),
+                    risk_class: None,
                     depends_on: vec![],
                     worktree: None,
                 }],

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1889,7 +1889,11 @@ impl OrchestratorMcp {
                 let key = task["task_key"].as_str().unwrap_or_default();
                 let no_criteria = task["acceptance_criteria"]
                     .as_array()
-                    .map(|criteria| criteria.is_empty())
+                    .map(|criteria| {
+                        criteria.iter().all(|criterion| {
+                            criterion.as_str().map(str::trim).is_none_or(str::is_empty)
+                        })
+                    })
                     .unwrap_or(true);
                 let no_verification = task["verification_command"]
                     .as_str()

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1904,7 +1904,9 @@ impl OrchestratorMcp {
                     format!(
                         "task `{key}`: no acceptance_criteria or verification_command — \
                          declare the weakest testable success condition so any approach \
-                         that satisfies it counts as delivered"
+                         that satisfies it counts as delivered. Re-calling plan_tasks \
+                         with the same task_key applies the contract even if the task \
+                         already started (verdicts and retries read it live)."
                     )
                 })
             })

--- a/src/hermes_tools.rs
+++ b/src/hermes_tools.rs
@@ -1,0 +1,105 @@
+//! Canonical Hermes assistant tool allowlist.
+//!
+//! Single source of truth for the `assistant-mcp` tools a Hermes gateway is
+//! configured to see. Three places used to carry their own copy — the
+//! `assistant-mcp` binary's tool table, the generated Hermes `config.yaml`
+//! (`hermes_config_yaml` in `src/api/system.rs`), and
+//! `scripts/configure_hermes_reliability.py` — and they drifted apart:
+//! `get_chatgpt_ui_pool_status` is mandated by the mission-control skill's
+//! ChatGPT-UI pool policy yet was absent from both generated allowlists, and
+//! `acknowledge_mission` / the durable workspace-job tools were only in one.
+//!
+//! The `assistant-mcp` binary is itself the curated Hermes surface (it
+//! deliberately omits deployment, board, and host-durable-job tools), so the
+//! allowlist is simply "every tool the binary exposes". Tests here and in
+//! `src/bin/assistant_mcp.rs` pin the other copies to this list; add or
+//! remove tools HERE first.
+
+pub const HERMES_ASSISTANT_TOOL_ALLOWLIST: &[&str] = &[
+    "list_active_missions",
+    "list_missions",
+    "get_mission",
+    "get_mission_digest",
+    "get_mission_events",
+    "get_chatgpt_ui_pool_status",
+    "list_mission_shared_files",
+    "download_shared_file",
+    "start_mission",
+    "send_message_to_mission",
+    "ask_mission",
+    "cancel_mission",
+    "acknowledge_mission",
+    "get_compute_fleet",
+    "list_workspaces",
+    "get_workspace",
+    "create_workspace",
+    "update_workspace",
+    "delete_workspace",
+    "list_workspace_templates",
+    "get_workspace_template",
+    "save_workspace_template",
+    "delete_workspace_template",
+    "rebuild_workspace_from_template",
+    "workspace_bash",
+    "start_workspace_job",
+    "get_workspace_job",
+    "cancel_workspace_job",
+    "get_mission_health",
+    "get_mission_diagnostics",
+    "update_mission_settings",
+    "resume_mission",
+];
+
+/// Render the allowlist as the YAML items of a `tools.include` block, one
+/// `{indent}- {tool}` line per tool.
+pub fn yaml_include_items(indent: &str) -> String {
+    HERMES_ASSISTANT_TOOL_ALLOWLIST
+        .iter()
+        .map(|tool| format!("{indent}- {tool}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowlist_has_no_duplicates() {
+        let mut seen = std::collections::HashSet::new();
+        for tool in HERMES_ASSISTANT_TOOL_ALLOWLIST {
+            assert!(seen.insert(*tool), "duplicate tool in allowlist: {tool}");
+        }
+    }
+
+    /// `scripts/configure_hermes_reliability.py` runs on Hermes hosts without
+    /// the Rust source, so it carries its own copy of the allowlist. Pin that
+    /// copy to the canonical one so the two can never drift again.
+    #[test]
+    fn reliability_script_allowlist_matches_canonical() {
+        let script_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/scripts/configure_hermes_reliability.py"
+        );
+        let script =
+            std::fs::read_to_string(script_path).expect("read configure_hermes_reliability.py");
+        let body = script
+            .split_once("ASSISTANT_TOOLS = [")
+            .expect("ASSISTANT_TOOLS list in script")
+            .1
+            .split_once(']')
+            .expect("ASSISTANT_TOOLS list terminator")
+            .0;
+        let script_tools: Vec<&str> = body
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(|entry| entry.trim_matches(|c| c == '"' || c == '\''))
+            .collect();
+        assert_eq!(
+            script_tools, HERMES_ASSISTANT_TOOL_ALLOWLIST,
+            "scripts/configure_hermes_reliability.py ASSISTANT_TOOLS diverged from \
+             src/hermes_tools.rs::HERMES_ASSISTANT_TOOL_ALLOWLIST — update both together"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod backend_config;
 pub mod config;
 pub mod cost;
 pub mod github_connection;
+pub mod hermes_tools;
 pub mod library;
 pub mod mcp;
 pub mod node;

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -610,6 +610,20 @@ pub struct RemoteNodesResponse {
     pub nodes: Vec<RemoteNodeView>,
     /// Last dispatch outcomes across the fleet, newest first (max 10).
     pub recent_jobs: Vec<DispatchOutcome>,
+    /// DGX Spark build-offload lane. A separate capacity lane from the
+    /// remote-node fleet (per-workspace opt-in + HMAC env, see
+    /// `src/api/spark.rs`); surfaced here so placement decisions can see the
+    /// whole picture instead of only `nodes`.
+    pub spark_offload: SparkOffloadStatus,
+}
+
+/// Status of the Spark offload lane for fleet/placement consumers.
+#[derive(Debug, Clone, Serialize)]
+pub struct SparkOffloadStatus {
+    /// Arbiter URL, token, and SSH target are all configured on the host.
+    pub configured: bool,
+    /// Names of workspaces with `spark_offload.enabled == true`.
+    pub enabled_workspaces: Vec<String>,
 }
 
 /// Probe one node and record the result into the monitor cache.

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -620,7 +620,9 @@ pub struct RemoteNodesResponse {
 /// Status of the Spark offload lane for fleet/placement consumers.
 #[derive(Debug, Clone, Serialize)]
 pub struct SparkOffloadStatus {
-    /// Arbiter URL, token, and SSH target are all configured on the host.
+    /// Arbiter URL, token, SSH target, AND the capability-token signing
+    /// secret are all configured on the host — i.e. the lane is actually
+    /// reachable by opted-in workspaces, not merely credentialed.
     pub configured: bool,
     /// Names of workspaces with `spark_offload.enabled == true`.
     pub enabled_workspaces: Vec<String>,


### PR DESCRIPTION
Applies "explanations should be no more specific than necessary" (Bennett, arXiv:2301.12987 — the weakest hypothesis consistent with the evidence generalises best) to how Hermes and boss missions specify, retry, and judge delegated work, plus plumbing fixes surfaced by the integration review.

## Task contracts (board)
- `plan_tasks` now passes `acceptance_criteria` / `verification_command` / `risk_class` through to the board (fields existed on `BoardTask` but were unsettable via MCP), and returns advisory `spec_warnings` for tasks with no objective success condition.
- `worker_contract` delivers the criteria + verification command as the authoritative success condition: any approach satisfying them is an acceptable delivery; the prompt's suggested approach is advisory.
- Automatic retries relax instead of repeating: attempt 2 gets the prior failure digest plus guidance that only the criteria are binding.
- `risk_class=high` tasks never retry silently — a failed attempt settles for boss review; unknown risk_class is rejected at registration instead of silently acting like `normal`.
- `reject_task` guidance: feedback is the minimal added constraint (a counterexample or one new criterion), never a re-prescription.

## Board visibility
- Pending tasks parked on an unknown `depends_on` key now raise attention: `unresolvable_deps` in board responses, included in `board_needs_attention` so the boss is woken instead of the board idling forever on a typo.

## Hermes allowlist unification
- New `src/hermes_tools.rs` is the single source of truth for the assistant-mcp tool surface. `hermes_config_yaml` generates its include list from it; tests pin the binary tool table and `scripts/configure_hermes_reliability.py` to the same list. Restores `get_chatgpt_ui_pool_status` (mandated by the pool policy but missing from both generated configs), `acknowledge_mission`, and the workspace-job tools.

## /goal parsing unification
- `canonical_goal_message` normalises `/goal\n…` to the space form at mission creation (`deferred_goal`) and at the grok/codex/opencode turn dispatch sites, so backend goal drivers (space-only parsers) agree with `parse_goal_objective`.

## Compute visibility
- `/api/remote-nodes` (and `get_compute_fleet`) now reports the Spark offload lane: configured + spark-enabled workspaces.

## Skills
- `orchestrator-boss` rewritten board-first with outcome-based delegation and minimal-constraint verdicts; `orchestrator-worker` told the criteria define success; `hermes-mission-control` 1.8.0 adds goal-as-end-state phrasing and weakest-consistent-diagnosis guidance (pool-policy section untouched, `policy_lint.py` passes).

## Testing
- `cargo test --lib` (1632 passed) and `cargo test --bins` (91 passed), `cargo fmt --all --check`, `python3 scripts/policy_lint.py` all green; 9 new tests cover the behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission control scheduling, retries, and goal routing plus Hermes tool exposure; behavior changes are well-tested but affect long-running orchestration and assistant integrations.
> 
> **Overview**
> **Board orchestration** shifts boss/worker delegation toward **outcome contracts**: `plan_tasks` / MCP now set `acceptance_criteria`, `verification_command`, and `risk_class`; workers get criteria in the task-board contract (prompt approach advisory); automatic retries add prior-failure digests plus relaxation guidance when a contract exists, or keep the prompt binding when it does not. **`risk_class=high`** suppresses silent retries; registration rejects unknown risk classes and strips blank criteria. **`unresolvable_deps`** on `board_status` and board wake logic surfaces tasks parked on typo'd `depends_on` keys; running tasks can still receive contract-field corrections via re-`plan_tasks`.
> 
> **Hermes / assistant-mcp**: new `hermes_tools.rs` canonical tool allowlist (generated YAML + Python reliability script pinned by tests); assistant MCP timeout **600s** and longer `/ask` HTTP timeout; `get_compute_fleet` now includes **Spark offload** status when signing is configured.
> 
> **Goal mode**: `canonical_goal_message` normalizes `/goal\n…` to `/goal …` at deferred-goal storage and codex/grok/opencode dispatch so space-only backend parsers agree.
> 
> **Skills** (`orchestrator-boss` board-first, worker criteria-first, `hermes-mission-control` 1.8.0) document weakest-spec goals, hints, and verdicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65274cea41376f8d0dc102da769941d5591bf257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->