### PR TITLE
Providers page: don't paint the reconnect button red on healthy providers

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -978,6 +978,8 @@ export default function ProvidersPage() {
                                   'p-1.5 rounded-md hover:bg-white/[0.04] transition-colors cursor-pointer disabled:opacity-50',
                                   effectiveStatus === 'needs_auth' || effectiveStatus === 'needs_reauth'
                                     ? 'text-amber-400'
+                                    : effectiveStatus === 'connected'
+                                    ? 'text-white/30 hover:text-white/70'
                                     : 'text-red-400 hover:text-red-300'
                                 )}
                                 title={


### PR DESCRIPTION
Reported: after successfully reconnecting Anthropic, the link icon on /settings/providers still 'looks red'. Debugged live: provider status is `connected` (emerald dot) and the usage probe is healthy — the red element is the permanent **Reconnect OAuth account** button, whose color ternary fell through to `text-red-400` for every status except needs_auth/needs_reauth, including `connected`.

Fix: connected providers render the reconnect affordance neutral (white/30 → white/70 on hover); amber stays for needs_auth/needs_reauth and red is reserved for genuine error states. tsc clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 36f88e56432debf07408a89af3d3834ba54d1723. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->