### PR TITLE
Projects board: fix white-on-white indicators in light mode

### DIFF
--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -250,7 +250,7 @@ export default function ProjectsBoard() {
           {/* ── Triage list ── */}
           <div
             className={cn(
-              "min-h-0 overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.015]",
+              "min-h-0 overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.02]",
               mobileDetail && "hidden lg:block",
             )}
           >
@@ -312,7 +312,7 @@ export default function ProjectsBoard() {
           {/* ── Detail pane ── */}
           <div
             className={cn(
-              "min-h-0 overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.015]",
+              "min-h-0 overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.02]",
               !mobileDetail && "hidden lg:block",
             )}
           >
@@ -372,7 +372,7 @@ function ProjectListRow({
           <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
             {live > 0 && (
               <span className="flex shrink-0 items-center gap-1 text-white/55">
-                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white/60" />
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[rgb(var(--text)/0.6)]" />
                 {live}
               </span>
             )}
@@ -744,7 +744,7 @@ function MissionRow({ mission }: { mission: ProjectMissionChip }) {
         <span
           className={cn(
             "h-1.5 w-1.5 shrink-0 rounded-full",
-            live ? "animate-pulse bg-white/70" : "bg-white/25",
+            live ? "animate-pulse bg-[rgb(var(--text)/0.65)]" : "bg-[rgb(var(--text)/0.25)]",
           )}
         />
       )}
@@ -848,7 +848,7 @@ function UpdateEntry({
 function BoardSkeleton() {
   return (
     <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 pb-4 lg:grid-cols-[340px_minmax(0,1fr)] xl:grid-cols-[380px_minmax(0,1fr)]">
-      <div className="animate-pulse overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.015]">
+      <div className="animate-pulse overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.02]">
         <div className="border-b border-white/[0.05] px-3 py-2">
           <div className="h-3 w-28 rounded bg-white/[0.06]" />
         </div>
@@ -862,7 +862,7 @@ function BoardSkeleton() {
           </div>
         ))}
       </div>
-      <div className="hidden animate-pulse overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.015] lg:block">
+      <div className="hidden animate-pulse overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.02] lg:block">
         <div className="space-y-3 border-b border-white/[0.06] px-5 py-4">
           <div className="flex items-center gap-3">
             <div className="h-5 w-40 rounded bg-white/[0.06]" />


### PR DESCRIPTION
The live/idle status dots (`bg-white/60|70|25`) and the two pane backgrounds (`bg-white/[0.015]`) are not covered by the globals.css light-mode remap list, so in light theme the dots were literally white on white and the panes lost their surface tint.

- Dots now use the theme token `rgb(var(--text)/…)` — dark dots in light mode, white in dark, no remap dependency.
- Panes use `bg-white/[0.02]`, which the remap covers.

Reviewed live in light mode: triage list dots, expanded mission rows, unrouted footer and timeline all render correctly; dark mode unchanged. 7/7 vitest, tsc clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind class-only UI tweaks in one component; no logic, API, or auth changes.
> 
> **Overview**
> Fixes **light-mode visibility** on the projects board where live/idle dots and pane backgrounds were effectively invisible.
> 
> **Live/idle status dots** in the triage list and mission rows no longer use fixed `bg-white/…` fills. They now use **`rgb(var(--text)/…)`** so the pulse dot follows the theme foreground (dark in light mode, light in dark) without relying on the globals light-mode utility remap.
> 
> **Triage list, detail pane, and loading skeleton** pane shells bump surface tint from **`bg-white/[0.015]`** to **`bg-white/[0.02]`**, aligning with other dashboard panels that the light-theme remap already adjusts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f96b6754092e70212f810373f053eebc132dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->