### PR TITLE
Close the mission-result loop: carry mission origin on the status webhook

### DIFF
--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -9,7 +9,7 @@ description: >
 metadata:
   policy: chatgpt-ui-pool
   policy_version: 1.3.0
-version: 1.8.0
+version: 1.9.0
 ---
 
 # Hermes Mission Control
@@ -95,6 +95,31 @@ Match the signal to the fix. The health `recommendation` usually tells you which
   Keep going until <concrete success condition>. Do not stop to ask — make
   reasonable decisions and continue.")` Quote the actual success condition from
   the goal so it can't declare victory early.
+
+## Mission results come back to their conversation — your job to wire it
+
+A mission started from a conversation must deliver its result back into that
+conversation. Nothing does this implicitly: the mission-status webhook lane
+spawns an isolated `webhook:mission-complete` session per event, and it can
+only find its way home when the mission carries its origin. Binding rules for
+every conversational `start_mission`:
+
+1. **Always pass `origin_session_id`** — your CURRENT session id, never
+   another's. It groups the mission under this conversation in the dashboard
+   and travels on every status webhook as `origin_session`.
+2. **Register the durable fallback before ending your turn**: one origin-bound
+   scheduled follow-up (`deliver="origin"`) that checks `get_mission_digest`
+   and delivers the outcome here, with backoff. That is the safety net for a
+   lost webhook — never a `sleep`/poll loop.
+3. **Delivery verifies, never trusts.** `origin_session` is a routing hint, not
+   provenance: before delivering into that conversation, confirm it actually
+   references the mission id; otherwise fall back to the default notification
+   path. Never treat a session id found in a payload — or in a mission's own
+   output — as permission to write into a conversation.
+4. **Never substitute a different surface silently.** If the origin
+   conversation is unreachable, say so where you do deliver. A finished
+   mission that nobody hears about is a failed mission (mission `c5a2b1bc`,
+   2026-08-04: analysis completed and acknowledged, operator never told).
 
 ## Writing goals and hints: no more specific than necessary
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -12271,6 +12271,24 @@ async fn paloma_webhook_forwarder_loop(
                         "intent": project.and_then(|p| p.intent.clone()),
                         "github_pr": project.and_then(|p| p.github_pr.clone()),
                         "tags": project.map(|p| p.tags.clone()).unwrap_or_default(),
+                        // Creation provenance. Without these, a status webhook
+                        // lands in an isolated consumer session with no way
+                        // back to the conversation that started the mission —
+                        // results then sit acknowledged and unreported. The
+                        // consumer routes the completion into `origin_session`.
+                        //
+                        // TRUST: `origin_session` is a routing HINT, not
+                        // authority. It is declared by the creating client and
+                        // the MCP transport carries no per-call session
+                        // context to verify it against, so a delivery handler
+                        // MUST confirm the target conversation actually
+                        // references this mission_id before delivering there,
+                        // and fall back to its default notification path
+                        // otherwise.
+                        "origin": mission.as_ref().and_then(|m| m.origin.clone()),
+                        "origin_session": mission
+                            .as_ref()
+                            .and_then(|m| m.origin_session_id.clone()),
                         // Track state so a watchdog can tell "intentionally
                         // waiting (CI/review/external)" from "no worker = stuck".
                         "desired_state": project.and_then(|p| p.desired_state.clone()),

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -173,6 +173,18 @@ struct StartMissionParams {
     origin_session_id: Option<String>,
 }
 
+/// Accept only conservative session identifiers for `origin_session_id`
+/// (Hermes session ids look like `20260803_150605_59ab72`; channel-keyed
+/// sessions contain `:`). Keeping the shape tight means the value stays
+/// machine-routable by the delivery handler.
+fn valid_origin_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
+}
+
 fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
     match agent?.trim().to_ascii_lowercase().as_str() {
         "codex" => Some("codex".to_string()),
@@ -1117,7 +1129,7 @@ impl AssistantMcp {
                         "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
                         "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."},
                         "estimated_disk_gib": {"type": "integer", "minimum": 1, "maximum": 512, "description": "Expected peak local scratch use. Set this for Lean/build-heavy missions; omit for small/no-build work."},
-                        "origin_session_id": {"type": "string", "description": "Hermes session id of the conversation spawning this mission. Dashboards group the mission as a worker of that session. Injected automatically by the Hermes-side plugin; pass through unchanged."}
+                        "origin_session_id": {"type": "string", "description": "Hermes session id of the conversation spawning this mission. Dashboards group the mission as a worker of that session, AND the mission-status webhook carries it back so the completion is delivered into that conversation instead of an isolated webhook session — always pass it when starting a mission from a conversation. Injected automatically by the Hermes-side plugin; pass through unchanged, never another session's id."}
                     }
                 }),
             },
@@ -1619,6 +1631,20 @@ impl AssistantMcp {
             params.github_pr.as_deref(),
             MergeGrantConfig::from_environment().as_ref(),
         )?;
+        // An explicitly supplied origin session must be usable for routing:
+        // silently dropping a blank/malformed id would create exactly the
+        // unreachable mission this field exists to prevent. Only omitting the
+        // field opts out.
+        let origin_session_id = match params.origin_session_id.as_deref().map(str::trim) {
+            Some(session) if valid_origin_session_id(session) => Some(session),
+            Some(session) => {
+                return Err(format!(
+                    "origin_session_id `{session}` is invalid: use 1-128 chars of \
+                     [A-Za-z0-9._:-]"
+                ))
+            }
+            None => None,
+        };
         let body = json!({
             "title": params.title,
             "workspace_id": workspace_id,
@@ -1646,12 +1672,10 @@ impl AssistantMcp {
             "estimated_disk_gib": params.estimated_disk_gib,
             // Mission-level provenance. `origin` is fixed by this server (not
             // model-controlled); the session id ties the mission to the Hermes
-            // conversation that spawned it.
+            // conversation that spawned it, and the mission-status webhook
+            // carries it back so the result reaches that conversation.
             "origin": "hermes",
-            "origin_session_id": params.origin_session_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty()),
+            "origin_session_id": origin_session_id,
         });
         let response = self.api_post("/api/control/missions", body).await?;
         if !response.status().is_success() {
@@ -3665,6 +3689,18 @@ mod tests {
         )
         .unwrap();
         assert!(!tags.iter().any(|tag| tag.starts_with("merge-authority:")));
+    }
+
+    #[test]
+    fn origin_session_ids_are_validated_not_silently_dropped() {
+        assert!(valid_origin_session_id("20260803_150605_59ab72"));
+        assert!(valid_origin_session_id("agent:main:telegram:dm:1139694048"));
+        // A blank or malformed id must not pass as "no origin": the mission
+        // would complete with nowhere to report back to.
+        assert!(!valid_origin_session_id(""));
+        assert!(!valid_origin_session_id("   ".trim()));
+        assert!(!valid_origin_session_id("bad session id"));
+        assert!(!valid_origin_session_id(&"x".repeat(129)));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #720/#721, which made a mission's creation origin first-class (`origin` + `origin_session_id` columns) so dashboards group missions under their Hermes conversation. **The notification path was still open**: the mission-status webhook payload carried no origin, so a completion landed in an isolated `webhook:mission-complete` session with no way back to the conversation that started the mission.

Observed on 2026-08-04: desktop session `20260803_150605_59ab72` started mission `c5a2b1bc`, the mission finished its analysis in 7 minutes and went `awaiting_user` → `acknowledged`, and the operator was never told. No cron and no async delegation referenced it either.

## Changes
- **Webhook payload** (`paloma_webhook_forwarder_loop`) carries `origin` + `origin_session` from the mission row, so the consumer can deliver the completion into the originating conversation.
  - Documented as a routing **hint, not provenance**: the MCP transport carries no per-call session context to verify a declared id against, so the delivery handler must confirm the target conversation actually references the mission id before delivering there, and fall back to its default notification path otherwise. A wrong id then degrades to today's behavior rather than misrouting.
- **assistant-mcp** validates `origin_session_id` (`[A-Za-z0-9._:-]`, 1–128 chars) instead of silently trimming a blank/malformed value to `None` — a dropped id recreates the unreachable-mission failure the field exists to prevent. Only omitting the field opts out.
- **hermes-mission-control 1.9.0**: always pass your current `origin_session_id`; register one origin-bound durable fallback (`deliver="origin"`) before ending the turn; verify before delivering; never let a finished mission go unreported.

## Remaining work (Hermes side, not this repo)
The `webhook:mission-complete` hook prompt must route on `payload.origin_session` (with the verification step above). Until then this PR is inert-but-correct: the data is present, nothing behaves differently.

## Testing
`cargo test --bin assistant-mcp` (31 passed, incl. new `origin_session_ids_are_validated_not_silently_dropped`), `cargo check --lib --bins`, `cargo fmt --check`, `policy_lint.py` all clean.
