### PR TITLE
Add Hermes conversations to mission control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -245,3 +245,13 @@ JWT_TTL_DAYS=30
 # for the cron delivery timeline.
 # HERMES_PROJECTS_DIR=/var/lib/hermes-assistant/.hermes/projects/active
 # HERMES_STATE_DB=/srv/sandboxed-storage/staging/agent-core/hermes/state.db
+#
+# Hermes gateway WebSocket bridge (GET /api/assistant/hermes/ws). The bridge
+# dials the loopback Hermes dashboard gateway (/api/ws, JSON-RPC) and needs
+# its session token. Pin HERMES_DASHBOARD_SESSION_TOKEN on the
+# hermes-dashboard unit (otherwise Hermes rotates it every restart) and
+# mirror the same value here or in the Hermes runtime env file. PORT/WS_URL
+# only when the Hermes dashboard is not on the default 127.0.0.1:9119.
+# HERMES_DASHBOARD_SESSION_TOKEN=
+# HERMES_DASHBOARD_PORT=9119
+# HERMES_DASHBOARD_WS_URL=ws://127.0.0.1:9119/api/ws

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "tower-http 0.5.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ tokio = { version = "1", features = ["full"] }
 
 # Web framework
 axum = { version = "0.7", features = ["ws", "multipart"] }
+# WebSocket client for the Hermes gateway bridge (same version axum uses)
+tokio-tungstenite = "0.24"
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 
 # Serialization

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -127,6 +127,50 @@ Hermes gotchas:
 - When rotating the `hsk_` key, update `API_SERVER_KEY`,
   `HERMES_DASHBOARD_SESSION_TOKEN`, and the desktop's `connection.json` together.
 
+### CLIProxyAPI inference sidecar
+
+Production subscription-backed OpenAI-compatible inference uses a loopback-only
+CLIProxyAPI sidecar. Sandboxed.sh translates `/v1/chat/completions` requests for
+Codex, xAI, and Anthropic OAuth accounts through this service.
+
+| Item | Production value |
+| --- | --- |
+| Unit | `cli-proxy-api.service` |
+| Listener | `127.0.0.1:8317` |
+| Binary | `/usr/local/bin/cli-proxy-api` |
+| Config | `/etc/cli-proxy-api/config.yaml` |
+| Auth directory | `/var/lib/cli-proxy-api/auth` |
+
+The Sandboxed.sh environment must define `CLI_PROXY_API_BASE_URL`,
+`CLI_PROXY_API_KEY`, and `CLI_PROXY_AUTH_DIR`. The API key must match one of the
+sidecar's configured `api-keys`; never print either value while debugging.
+The systemd unit must set `UMask=0077`, and every OAuth JSON file in the auth
+directory must remain mode `0600` because those files contain refresh tokens.
+
+During a zero-downtime migration, CLIProxyAPI can temporarily run without
+`api-keys` so an already-running Sandboxed.sh process can use the loopback
+default without a restart. This is acceptable only while the listener is bound
+to `127.0.0.1`; restore key enforcement after the next safe backend restart.
+
+Safe health checks:
+
+```bash
+systemctl is-active cli-proxy-api
+ss -ltn | grep -F '127.0.0.1:8317'
+find /var/lib/cli-proxy-api/auth -maxdepth 1 -type f -name '*.json' \
+  -printf '%f\n' | sed -E 's/^([^-]+)-.*/auth_type=\1/' | sort
+```
+
+Expected auth types are `codex`, `xai`, and `claude`. Create them with the
+sidecar's own OAuth login commands under the `cli-proxy-api` system account.
+Do not copy refresh tokens out of Sandboxed.sh's provider store: two independent
+refreshers can rotate the same token and trigger `refresh_token_reused`.
+
+After changing the three `CLI_PROXY_*` environment variables, restart
+`sandboxed-sh-prod` only when no mission harness is active, then validate both
+`/v1/models` and real streaming/non-streaming inference. Direct provider IDs use
+the `openai/<model>` form unless a short model-routing chain is configured.
+
 ```bash
 # Production inspection. Deploy/restart through the guarded endpoint below.
 systemctl status sandboxed-sh-prod

--- a/dashboard/src/app/control/components/HermesConversation.tsx
+++ b/dashboard/src/app/control/components/HermesConversation.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Link from "next/link";
+import { Loader, Plus, Sparkles, Square } from "lucide-react";
+
+import {
+  getHermesSessionMessages,
+  hermesChatStream,
+  listHermesSessions,
+  listMissions,
+  type HermesMessage,
+  type HermesSession,
+  type Mission,
+} from "@/lib/api";
+import { getMissionTitle, STATUS_DOT_COLORS } from "@/lib/mission-status";
+import {
+  HermesGatewayClient,
+  type HermesGatewayEvent,
+} from "@/lib/hermes-gateway";
+import { EnhancedInput } from "@/components/enhanced-input";
+import { cn } from "@/lib/utils";
+
+import { ChatItemRow, deriveItemViews, getGroupedItemKey } from "../control-client";
+import type { ChatItem } from "../events-reducer";
+import {
+  HermesLiveTranscript,
+  hermesHistoryToItems,
+} from "../hermes-session-adapter";
+
+let nextLocalId = 0;
+function localId(prefix: string): string {
+  nextLocalId += 1;
+  return `${prefix}-${nextLocalId}`;
+}
+
+interface ResumeResult {
+  session_id?: string;
+  messages?: HermesMessage[];
+  running?: boolean;
+  info?: { model?: string };
+}
+
+type Transport = "connecting" | "ws" | "rest" | "offline";
+
+/**
+ * A Hermes session rendered through the control-page transcript pipeline
+ * (ChatItem → deriveItemViews → ChatItemRow), so sessions and missions share
+ * one visual grammar. Transport is WS-first (the Hermes gateway JSON-RPC
+ * bridge, live events for turns started from any platform) with a REST+SSE
+ * fallback (history poll + per-turn chat stream) when the bridge is not
+ * provisioned.
+ */
+export function HermesConversation({ sessionId }: { sessionId: string }) {
+  const [items, setItems] = useState<ChatItem[]>([]);
+  const [running, setRunning] = useState(false);
+  const [transport, setTransport] = useState<Transport>("connecting");
+  const [error, setError] = useState<string | null>(null);
+  const [historyLoaded, setHistoryLoaded] = useState(false);
+  const [session, setSession] = useState<HermesSession | null>(null);
+  const [workerMissions, setWorkerMissions] = useState<Mission[]>([]);
+  const [input, setInput] = useState("");
+  const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const clientRef = useRef<HermesGatewayClient | null>(null);
+  const transcriptRef = useRef(new HermesLiveTranscript());
+  // The live RPC handle for this session (session.resume may return an
+  // ephemeral id distinct from the stored one).
+  const handleRef = useRef<string>(sessionId);
+  const restAbortRef = useRef<AbortController | null>(null);
+  // Open REST tool rows by name (REST tool events carry no tool_id).
+  const restToolIdsByName = useRef(new Map<string, string[]>());
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const generationRef = useRef(0);
+
+  const syncFromTranscript = useCallback(() => {
+    setItems([...transcriptRef.current.items]);
+    setRunning(transcriptRef.current.running);
+  }, []);
+
+  // ── Connection lifecycle ──────────────────────────────────────────────────
+  useEffect(() => {
+    const generation = ++generationRef.current;
+    const transcript = transcriptRef.current;
+    handleRef.current = sessionId;
+
+    const client = new HermesGatewayClient();
+    clientRef.current = client;
+    let disposed = false;
+
+    const applyEvent = (event: HermesGatewayEvent) => {
+      if (disposed || generationRef.current !== generation) return;
+      if (event.session_id && event.session_id !== handleRef.current) return;
+      if (transcript.apply(event)) syncFromTranscript();
+    };
+
+    const loadRestHistory = async () => {
+      const messages = await getHermesSessionMessages(sessionId);
+      if (disposed || generationRef.current !== generation) return;
+      transcript.reset(hermesHistoryToItems(messages));
+      syncFromTranscript();
+      setHistoryLoaded(true);
+    };
+
+    void (async () => {
+      try {
+        await client.connect();
+        const unsubscribe = client.onEvent(applyEvent);
+        void unsubscribe;
+        const result = await client.request<ResumeResult>("session.resume", {
+          session_id: sessionId,
+        });
+        if (disposed || generationRef.current !== generation) return;
+        if (result?.session_id) handleRef.current = result.session_id;
+        if (Array.isArray(result?.messages)) {
+          transcript.reset(hermesHistoryToItems(result.messages));
+        } else {
+          transcript.reset(
+            hermesHistoryToItems(await getHermesSessionMessages(sessionId)),
+          );
+        }
+        transcript.running = Boolean(result?.running);
+        syncFromTranscript();
+        setHistoryLoaded(true);
+        setTransport("ws");
+      } catch {
+        if (disposed || generationRef.current !== generation) return;
+        client.close();
+        try {
+          await loadRestHistory();
+          setTransport("rest");
+        } catch (restErr) {
+          if (disposed || generationRef.current !== generation) return;
+          setTransport("offline");
+          setError(
+            restErr instanceof Error
+              ? restErr.message
+              : "Hermes is unreachable",
+          );
+        }
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      client.close();
+      restAbortRef.current?.abort();
+      restAbortRef.current = null;
+    };
+  }, [sessionId, syncFromTranscript]);
+
+  // Session metadata (title) + worker missions spawned by this session.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const sessions = await listHermesSessions(200);
+        if (cancelled) return;
+        setSession(sessions.find((s) => s.id === sessionId) ?? null);
+      } catch {
+        // Title stays generic; not fatal.
+      }
+      try {
+        const missions = await listMissions();
+        if (cancelled) return;
+        setWorkerMissions(
+          missions.filter((m) => m.origin_session_id === sessionId),
+        );
+      } catch {
+        // Worker strip stays empty; not fatal.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, running]);
+  // REST transport: re-poll the transcript while idle so turns driven from
+  // other platforms (Telegram, cron) eventually appear.
+  useEffect(() => {
+    if (transport !== "rest" || running) return;
+    const timer = setInterval(() => {
+      void (async () => {
+        try {
+          const messages = await getHermesSessionMessages(sessionId);
+          const fresh = hermesHistoryToItems(messages);
+          const transcript = transcriptRef.current;
+          if (!transcript.running && fresh.length !== transcript.items.length) {
+            transcript.reset(fresh);
+            syncFromTranscript();
+          }
+        } catch {
+          // Transient poll failure; next tick retries.
+        }
+      })();
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [transport, running, sessionId, syncFromTranscript]);
+
+  // Pin to bottom as content streams in.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [items]);
+
+  const pushUserItem = useCallback(
+    (content: string) => {
+      const transcript = transcriptRef.current;
+      transcript.items = [
+        ...transcript.items,
+        {
+          kind: "user",
+          id: localId("hs-user"),
+          content,
+          timestamp: Date.now(),
+          sendStatus: "sent",
+        },
+      ];
+      transcript.running = true;
+      syncFromTranscript();
+    },
+    [syncFromTranscript],
+  );
+
+  const sendViaRest = useCallback(
+    (content: string) => {
+      const transcript = transcriptRef.current;
+      const abort = new AbortController();
+      restAbortRef.current = abort;
+      const synthesize = (event: HermesGatewayEvent) => {
+        if (transcript.apply(event)) syncFromTranscript();
+      };
+      const openRestTool = (name: string, args: unknown) => {
+        const toolId = localId("rest-tool");
+        const stack = restToolIdsByName.current.get(name) ?? [];
+        stack.push(toolId);
+        restToolIdsByName.current.set(name, stack);
+        synthesize({
+          type: "tool.start",
+          payload: { tool_id: toolId, name, args },
+        });
+      };
+      const closeRestTool = (name: string, result: unknown) => {
+        const stack = restToolIdsByName.current.get(name);
+        const toolId = stack?.shift();
+        if (toolId) {
+          synthesize({
+            type: "tool.complete",
+            payload: { tool_id: toolId, result },
+          });
+        }
+      };
+      void hermesChatStream(
+        sessionId,
+        content,
+        {
+          onDelta: (text) =>
+            synthesize({ type: "message.delta", payload: { text } }),
+          onThinking: (text) =>
+            synthesize({ type: "thinking.delta", payload: { text } }),
+          onToolStart: (t) => openRestTool(t.tool_name ?? "tool", t.args),
+          onToolComplete: (t) =>
+            closeRestTool(t.tool_name ?? "tool", t.preview),
+          onToolFailed: (t) =>
+            closeRestTool(t.tool_name ?? "tool", t.preview ?? "failed"),
+          onCompleted: (text) =>
+            synthesize({ type: "message.complete", payload: { text } }),
+          onError: (message) =>
+            synthesize({ type: "error", payload: { message } }),
+        },
+        abort.signal,
+      )
+        .catch((err: unknown) => {
+          if (abort.signal.aborted) return;
+          synthesize({
+            type: "error",
+            payload: {
+              message: err instanceof Error ? err.message : "Send failed",
+            },
+          });
+        })
+        .finally(() => {
+          if (restAbortRef.current === abort) restAbortRef.current = null;
+          synthesize({ type: "turn.end" });
+        });
+    },
+    [sessionId, syncFromTranscript],
+  );
+
+  const handleSubmit = useCallback(
+    ({ content }: { content: string }) => {
+      const text = content.trim();
+      if (!text || running) return;
+      setInput("");
+      setError(null);
+      pushUserItem(text);
+      if (transport === "ws" && clientRef.current) {
+        clientRef.current
+          .request("prompt.submit", {
+            session_id: handleRef.current,
+            text,
+          })
+          .catch((err: unknown) => {
+            const transcript = transcriptRef.current;
+            transcript.apply({
+              type: "error",
+              payload: {
+                message: err instanceof Error ? err.message : "Send failed",
+              },
+            });
+            syncFromTranscript();
+          });
+      } else {
+        sendViaRest(text);
+      }
+    },
+    [pushUserItem, running, sendViaRest, syncFromTranscript, transport],
+  );
+
+  const handleStop = useCallback(() => {
+    if (transport === "ws" && clientRef.current) {
+      clientRef.current
+        .request("session.interrupt", { session_id: handleRef.current })
+        .catch(() => {
+          // Interrupt is best-effort; the turn may already be over.
+        });
+    } else {
+      restAbortRef.current?.abort();
+      restAbortRef.current = null;
+      const transcript = transcriptRef.current;
+      transcript.apply({ type: "turn.end" });
+      syncFromTranscript();
+    }
+  }, [syncFromTranscript, transport]);
+
+  const toggleToolGroup = useCallback((groupId: string) => {
+    setExpandedToolGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }, []);
+
+  const views = useMemo(
+    () => deriveItemViews(items, false, running),
+    [items, running],
+  );
+  const rows = views.groupedItems;
+
+  const title =
+    session?.title?.trim() ||
+    session?.preview?.trim() ||
+    `Session ${sessionId.slice(0, 8)}`;
+
+  const noopToolResult = useCallback(
+    async () => ({ ok: false, delivered: false }),
+    [],
+  );
+  const noop = useCallback(() => {}, []);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-white/5 px-4 py-2.5">
+        <Sparkles className="h-4 w-4 shrink-0 text-indigo-400" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-zinc-100">
+            {title}
+          </div>
+          <div className="text-[11px] text-zinc-500">
+            Hermes session
+            {transport === "rest" && " · live events unavailable (polling)"}
+            {transport === "connecting" && " · connecting…"}
+          </div>
+        </div>
+        {running && (
+          <span className="flex items-center gap-1.5 text-[11px] text-zinc-400">
+            <Loader className="h-3 w-3 animate-spin" />
+            working
+          </span>
+        )}
+      </div>
+
+      {/* Worker missions spawned by this session */}
+      {workerMissions.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5 border-b border-white/5 px-4 py-1.5">
+          <span className="text-[11px] text-zinc-500">Workers</span>
+          {workerMissions.map((mission) => (
+            <Link
+              key={mission.id}
+              href={`/control?mission=${mission.id}`}
+              className="flex items-center gap-1.5 rounded-full border border-white/10 px-2 py-0.5 text-[11px] text-zinc-300 transition-colors hover:border-white/25 hover:text-zinc-100"
+            >
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full",
+                  STATUS_DOT_COLORS[mission.status] ?? "bg-zinc-500",
+                )}
+              />
+              <span className="max-w-48 truncate">
+                {getMissionTitle(mission)}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Transcript */}
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        {!historyLoaded && transport === "connecting" && (
+          <div className="flex items-center justify-center gap-2 py-12 text-sm text-zinc-500">
+            <Loader className="h-4 w-4 animate-spin" />
+            Connecting to Hermes…
+          </div>
+        )}
+        {transport === "offline" && (
+          <div className="mx-auto max-w-md py-12 text-center text-sm text-zinc-500">
+            <p className="text-zinc-300">Hermes is unreachable.</p>
+            {error && <p className="mt-2 text-xs">{error}</p>}
+          </div>
+        )}
+        {historyLoaded && rows.length === 0 && transport !== "offline" && (
+          <div className="flex flex-col items-center gap-2 py-12 text-sm text-zinc-500">
+            <Plus className="h-4 w-4" />
+            Send the first message to start this session.
+          </div>
+        )}
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-1">
+          {rows.map((item, index) => (
+            <ChatItemRow
+              key={getGroupedItemKey(item)}
+              item={item}
+              highlighted={false}
+              workspaceId={undefined}
+              missionId={undefined}
+              basePath={undefined}
+              isLast={index === rows.length - 1}
+              isToolGroupExpanded={expandedToolGroups.has(
+                getGroupedItemKey(item),
+              )}
+              onToggleToolGroup={toggleToolGroup}
+              onResume={noop}
+              onToolResult={noopToolResult}
+              onOptimisticToolResult={noop}
+              onRetryUserMessage={noop}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Composer */}
+      <div className="border-t border-white/5 px-4 py-3">
+        <div className="mx-auto w-full max-w-3xl">
+          {running && (
+            <div className="mb-2 flex justify-end">
+              <button
+                type="button"
+                onClick={handleStop}
+                className="flex items-center gap-1.5 rounded-md border border-white/10 px-2.5 py-1 text-xs text-zinc-300 transition-colors hover:border-white/25 hover:text-zinc-100"
+              >
+                <Square className="h-3 w-3" />
+                Stop
+              </button>
+            </div>
+          )}
+          <EnhancedInput
+            value={input}
+            onChange={setInput}
+            onSubmit={handleSubmit}
+            placeholder="Message Hermes…"
+            disabled={transport === "offline" || transport === "connecting"}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -736,9 +736,9 @@ type ThinkingGroup = {
   groupId: string;
   thoughts: SidePanelItem[];
 };
-type GroupedItem = ChatItem | ToolGroup | ThinkingGroup;
+export type GroupedItem = ChatItem | ToolGroup | ThinkingGroup;
 
-function getGroupedItemKey(item: GroupedItem): string {
+export function getGroupedItemKey(item: GroupedItem): string {
   if (item.kind === "tool_group" || item.kind === "thinking_group") {
     return item.groupId;
   }
@@ -2633,7 +2633,7 @@ type ChatItemRowProps = {
  * plain boolean per row so toggling one group doesn't invalidate any
  * of the others.
  */
-const ChatItemRow = memo(function ChatItemRow({
+export const ChatItemRow = memo(function ChatItemRow({
   item,
   highlighted,
   workspaceId,

--- a/dashboard/src/app/control/conversation-router.tsx
+++ b/dashboard/src/app/control/conversation-router.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+import ControlClient from "./control-client";
+import { HermesConversation } from "./components/HermesConversation";
+
+/**
+ * `/control` hosts two conversation kinds behind one route:
+ *  - `?mission=<uuid>`  → native sandboxed.sh mission (ControlClient)
+ *  - `?session=<id>`    → Hermes session (HermesConversation)
+ *
+ * The branch happens here, above ControlClient, so the mission monolith
+ * (its stores, SSE stream, and ~60 hooks) never mounts for a Hermes view.
+ */
+export default function ConversationRouter() {
+  const searchParams = useSearchParams();
+  const hermesSessionId = searchParams.get("session");
+  if (hermesSessionId) {
+    return (
+      <div className="flex h-[calc(100vh-3rem)] flex-col lg:h-screen">
+        <HermesConversation
+          key={hermesSessionId}
+          sessionId={hermesSessionId}
+        />
+      </div>
+    );
+  }
+  return <ControlClient />;
+}

--- a/dashboard/src/app/control/hermes-session-adapter.ts
+++ b/dashboard/src/app/control/hermes-session-adapter.ts
@@ -1,0 +1,437 @@
+import type { HermesMessage } from "@/lib/api";
+import type { HermesGatewayEvent } from "@/lib/hermes-gateway";
+import type { ChatItem } from "./events-reducer";
+
+/**
+ * Adapter from the Hermes session protocol to the control-page `ChatItem`
+ * union, so Hermes conversations render through the exact same transcript
+ * pipeline as missions (deriveItemViews + ChatItemRow).
+ *
+ * Two sources feed it:
+ *  - persisted history (`HermesMessage[]` from session.resume / REST)
+ *  - live gateway events (message.delta / thinking.delta / tool.* / …)
+ */
+
+let nextLocalId = 0;
+function localId(prefix: string): string {
+  nextLocalId += 1;
+  return `${prefix}-${nextLocalId}`;
+}
+
+function parseTimestamp(raw: unknown): number {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    // Hermes timestamps are seconds; anything past ~2001 in ms is already ms.
+    return raw > 1e12 ? raw : raw * 1000;
+  }
+  if (typeof raw === "string") {
+    const parsed = Date.parse(raw);
+    if (Number.isFinite(parsed)) return parsed;
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric)) return numeric > 1e12 ? numeric : numeric * 1000;
+  }
+  return Date.now();
+}
+
+function parseToolCallArguments(raw: unknown): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+interface RawToolCall {
+  id?: unknown;
+  function?: { name?: unknown; arguments?: unknown };
+  name?: unknown;
+  arguments?: unknown;
+}
+
+/** Map persisted Hermes messages onto ChatItems. Tool results (role "tool")
+ * are folded into the tool item created by the assistant's tool_calls. */
+export function hermesHistoryToItems(messages: HermesMessage[]): ChatItem[] {
+  const items: ChatItem[] = [];
+  const toolItemIndexByCallId = new Map<string, number>();
+
+  for (const message of messages) {
+    const id =
+      message.id == null ? localId("hh") : `hermes-msg-${String(message.id)}`;
+    const timestamp = parseTimestamp(message.timestamp);
+    const content = (message.content ?? "").trim();
+
+    if (message.role === "user") {
+      if (content) {
+        items.push({ kind: "user", id, content, timestamp });
+      }
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const reasoning = (
+        message.reasoning_content ??
+        message.reasoning ??
+        ""
+      ).trim();
+      if (reasoning) {
+        items.push({
+          kind: "thinking",
+          id: `${id}-thinking`,
+          content: reasoning,
+          done: true,
+          startTime: timestamp,
+          endTime: timestamp,
+        });
+      }
+      if (content) {
+        items.push({
+          kind: "assistant",
+          id,
+          content,
+          success: true,
+          costCents: 0,
+          costSource: "unknown",
+          model: null,
+          timestamp,
+        });
+      }
+      const toolCalls = Array.isArray(message.tool_calls)
+        ? (message.tool_calls as RawToolCall[])
+        : [];
+      for (const call of toolCalls) {
+        const callId =
+          typeof call.id === "string" && call.id
+            ? call.id
+            : localId("hh-call");
+        const name =
+          (typeof call.function?.name === "string" && call.function.name) ||
+          (typeof call.name === "string" && call.name) ||
+          "tool";
+        toolItemIndexByCallId.set(callId, items.length);
+        items.push({
+          kind: "tool",
+          id: `hermes-tool-${callId}`,
+          toolCallId: callId,
+          name,
+          args: parseToolCallArguments(
+            call.function?.arguments ?? call.arguments,
+          ),
+          isUiTool: false,
+          startTime: timestamp,
+          endTime: timestamp,
+          hasResult: false,
+        });
+      }
+      continue;
+    }
+
+    if (message.role === "tool") {
+      const callId = message.tool_call_id ?? undefined;
+      const index =
+        callId != null ? toolItemIndexByCallId.get(callId) : undefined;
+      if (index !== undefined) {
+        const existing = items[index];
+        if (existing.kind === "tool") {
+          items[index] = {
+            ...existing,
+            result: content,
+            hasResult: true,
+            endTime: timestamp,
+          };
+        }
+      } else if (content) {
+        items.push({
+          kind: "tool",
+          id,
+          toolCallId: callId ?? id,
+          name: message.tool_name ?? "tool",
+          args: undefined,
+          result: content,
+          isUiTool: false,
+          startTime: timestamp,
+          endTime: timestamp,
+          hasResult: true,
+        });
+      }
+    }
+  }
+  return items;
+}
+
+function payloadString(payload: unknown, key: string): string | undefined {
+  if (typeof payload !== "object" || payload === null) return undefined;
+  const value = (payload as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function payloadValue(payload: unknown, key: string): unknown {
+  if (typeof payload !== "object" || payload === null) return undefined;
+  return (payload as Record<string, unknown>)[key];
+}
+
+/**
+ * Streaming state machine for one live Hermes session. `apply` folds a
+ * gateway event into the item list and returns true when the list changed.
+ * The caller owns re-rendering (typically by cloning `items` into state).
+ */
+export class HermesLiveTranscript {
+  items: ChatItem[] = [];
+  running = false;
+
+  private streamItemId: string | null = null;
+  private thinkingItemId: string | null = null;
+  private streamText = "";
+  private toolItemIdByToolId = new Map<string, string>();
+
+  reset(items: ChatItem[]) {
+    this.items = items;
+    this.streamItemId = null;
+    this.thinkingItemId = null;
+    this.streamText = "";
+    this.toolItemIdByToolId.clear();
+  }
+
+  private updateItem(id: string, update: (item: ChatItem) => ChatItem) {
+    const index = this.items.findIndex((item) => item.id === id);
+    if (index >= 0) {
+      this.items = [
+        ...this.items.slice(0, index),
+        update(this.items[index]),
+        ...this.items.slice(index + 1),
+      ];
+    }
+  }
+
+  private appendStreamText(text: string) {
+    if (!text) return;
+    this.streamText += text;
+    if (this.streamItemId == null) {
+      this.streamItemId = localId("hs-stream");
+      this.items = [
+        ...this.items,
+        {
+          kind: "stream",
+          id: this.streamItemId,
+          content: this.streamText,
+          done: false,
+          startTime: Date.now(),
+        },
+      ];
+    } else {
+      const id = this.streamItemId;
+      const content = this.streamText;
+      this.updateItem(id, (item) =>
+        item.kind === "stream" ? { ...item, content } : item,
+      );
+    }
+  }
+
+  private appendThinkingText(text: string) {
+    if (!text) return;
+    if (this.thinkingItemId == null) {
+      this.thinkingItemId = localId("hs-think");
+      this.items = [
+        ...this.items,
+        {
+          kind: "thinking",
+          id: this.thinkingItemId,
+          content: text,
+          done: false,
+          startTime: Date.now(),
+        },
+      ];
+    } else {
+      const id = this.thinkingItemId;
+      this.updateItem(id, (item) =>
+        item.kind === "thinking"
+          ? { ...item, content: item.content + text }
+          : item,
+      );
+    }
+  }
+
+  private finalizeThinking() {
+    if (this.thinkingItemId == null) return;
+    const id = this.thinkingItemId;
+    this.thinkingItemId = null;
+    this.updateItem(id, (item) =>
+      item.kind === "thinking"
+        ? { ...item, done: true, endTime: Date.now() }
+        : item,
+    );
+  }
+
+  private finalizeAssistant(finalText?: string) {
+    this.finalizeThinking();
+    const text = (finalText ?? this.streamText).trim();
+    const streamId = this.streamItemId;
+    this.streamItemId = null;
+    this.streamText = "";
+    if (streamId != null) {
+      this.items = this.items.filter((item) => item.id !== streamId);
+    }
+    if (text) {
+      this.items = [
+        ...this.items,
+        {
+          kind: "assistant",
+          id: localId("hs-assistant"),
+          content: text,
+          success: true,
+          costCents: 0,
+          costSource: "unknown",
+          model: null,
+          timestamp: Date.now(),
+        },
+      ];
+    }
+  }
+
+  private startTool(toolId: string, name: string, args: unknown) {
+    const itemId = `hs-tool-${toolId}`;
+    this.toolItemIdByToolId.set(toolId, itemId);
+    this.items = [
+      ...this.items,
+      {
+        kind: "tool",
+        id: itemId,
+        toolCallId: toolId,
+        name,
+        args,
+        isUiTool: false,
+        startTime: Date.now(),
+        hasResult: false,
+      },
+    ];
+  }
+
+  private completeTool(toolId: string, result: unknown) {
+    const itemId = this.toolItemIdByToolId.get(toolId);
+    if (itemId == null) return;
+    this.toolItemIdByToolId.delete(toolId);
+    this.updateItem(itemId, (item) =>
+      item.kind === "tool"
+        ? { ...item, result, hasResult: true, endTime: Date.now() }
+        : item,
+    );
+  }
+
+  apply(event: HermesGatewayEvent): boolean {
+    const before = this.items;
+    const runningBefore = this.running;
+    const payload = event.payload;
+
+    switch (event.type) {
+      case "turn.start":
+      case "turn.started":
+        this.running = true;
+        break;
+      case "message.start":
+        this.running = true;
+        break;
+      case "message.delta":
+        this.appendStreamText(payloadString(payload, "text") ?? "");
+        break;
+      case "message.interim":
+        // A full interim assistant message: flush it as its own bubble.
+        this.finalizeAssistant(payloadString(payload, "text"));
+        break;
+      case "message.complete":
+        this.finalizeAssistant(payloadString(payload, "text"));
+        break;
+      case "thinking.delta":
+      case "reasoning.delta":
+        this.appendThinkingText(payloadString(payload, "text") ?? "");
+        break;
+      case "reasoning.available": {
+        this.appendThinkingText(payloadString(payload, "text") ?? "");
+        this.finalizeThinking();
+        break;
+      }
+      case "tool.start": {
+        const toolId =
+          payloadString(payload, "tool_id") ?? localId("hs-toolid");
+        const name = payloadString(payload, "name") ?? "tool";
+        this.startTool(
+          toolId,
+          name,
+          payloadValue(payload, "args") ??
+            payloadString(payload, "args_text"),
+        );
+        break;
+      }
+      case "tool.complete": {
+        const toolId = payloadString(payload, "tool_id");
+        if (toolId != null) {
+          this.completeTool(
+            toolId,
+            payloadValue(payload, "result") ??
+              payloadString(payload, "summary"),
+          );
+        }
+        break;
+      }
+      case "subagent.start": {
+        const subagentId =
+          payloadString(payload, "subagent_id") ?? localId("hs-subagent");
+        this.startTool(`subagent:${subagentId}`, "subagent", {
+          goal: payloadString(payload, "goal"),
+          model: payloadString(payload, "model"),
+          child_session_id: payloadString(payload, "child_session_id"),
+        });
+        break;
+      }
+      case "subagent.complete": {
+        const subagentId = payloadString(payload, "subagent_id");
+        if (subagentId != null) {
+          this.completeTool(
+            `subagent:${subagentId}`,
+            payloadString(payload, "summary") ??
+              payloadValue(payload, "status"),
+          );
+        }
+        break;
+      }
+      case "approval.request": {
+        const command = payloadString(payload, "command");
+        this.items = [
+          ...this.items,
+          {
+            kind: "system",
+            id: localId("hs-approval"),
+            content: command
+              ? `Hermes is asking for approval:\n\`\`\`\n${command}\n\`\`\`\nRespond from a connected Hermes client.`
+              : "Hermes is asking for an approval. Respond from a connected Hermes client.",
+            timestamp: Date.now(),
+          },
+        ];
+        break;
+      }
+      case "error":
+      case "turn.error": {
+        const message =
+          payloadString(payload, "message") ?? "Hermes reported an error.";
+        this.finalizeAssistant();
+        this.items = [
+          ...this.items,
+          {
+            kind: "system",
+            id: localId("hs-error"),
+            content: message,
+            timestamp: Date.now(),
+          },
+        ];
+        this.running = false;
+        break;
+      }
+      case "turn.end":
+        this.finalizeAssistant();
+        this.running = false;
+        break;
+      default:
+        break;
+    }
+
+    return this.items !== before || this.running !== runningBefore;
+  }
+}

--- a/dashboard/src/app/control/page.tsx
+++ b/dashboard/src/app/control/page.tsx
@@ -1,14 +1,14 @@
-import { Suspense } from 'react';
-import ControlClient from './control-client';
+import { Suspense } from "react";
+import ConversationRouter from "./conversation-router";
 
 export default function ControlPage() {
   // No visible Suspense fallback: AuthGate's full-screen ring covers the cold
-  // load, and ControlClient renders its own skeleton inside the chat area
-  // while mission data fetches. A centered icon here only flashes for a few
+  // load, and the conversation body renders its own skeleton inside the chat
+  // area while data fetches. A centered icon here only flashes for a few
   // hundred ms between the two and reads as an extra unrelated spinner.
   return (
     <Suspense fallback={null}>
-      <ControlClient />
+      <ConversationRouter />
     </Suspense>
   );
 }

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import useSWR from 'swr';
 import {
   Search,
   XCircle,
@@ -14,9 +16,10 @@ import {
   ChevronDown,
   Pin,
   Pencil,
+  Sparkles,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { searchMissions, type AwaitingKind, type Mission, type RunningMissionInfo } from '@/lib/api';
+import { searchMissions, listHermesSessions, type AwaitingKind, type HermesSession, type Mission, type RunningMissionInfo } from '@/lib/api';
 import { getMissionShortName } from '@/lib/mission-display';
 import { statusLabel, getMissionDotColor, getMissionTitle } from '@/lib/mission-status';
 import { AsyncButton } from '@/components/ui/async-button';
@@ -40,13 +43,19 @@ interface MissionSwitcherProps {
 }
 
 type MissionSwitcherItem = {
-  type: 'running' | 'current' | 'recent';
+  type: 'running' | 'current' | 'recent' | 'session';
   mission?: Mission;
   runningInfo?: RunningMissionInfo;
+  /** Hermes session backing this row when `type === 'session'`. */
+  session?: HermesSession;
   id: string;
   isWorkerOf?: string;
   isBoss?: boolean;
 };
+
+/** Row id prefix for Hermes sessions, so they can't collide with mission
+ * UUIDs anywhere ids are compared (pins, selection, loading state). */
+const SESSION_ITEM_PREFIX = 'session:';
 
 type MissionSwitcherRow =
   | { kind: 'section'; id: string; label: string }
@@ -722,6 +731,7 @@ export function MissionSwitcher({
   onRenameMission,
   onRefresh,
 }: MissionSwitcherProps) {
+  const router = useRouter();
   const dialogRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -805,7 +815,15 @@ export function MissionSwitcher({
   const handleSelect = useCallback(async (missionId: string) => {
     // Don't allow selecting while already loading
     if (loadingMissionId) return;
-    
+
+    // Hermes sessions are a navigation target, not a mission load.
+    if (missionId.startsWith(SESSION_ITEM_PREFIX)) {
+      const sessionId = missionId.slice(SESSION_ITEM_PREFIX.length);
+      router.push(`/control?session=${encodeURIComponent(sessionId)}`);
+      onClose();
+      return;
+    }
+
     setLoadingMissionId(missionId);
     try {
       await onSelectMission(missionId);
@@ -815,7 +833,7 @@ export function MissionSwitcher({
       // Clear loading state on error so user can try again
       setLoadingMissionId(null);
     }
-  }, [loadingMissionId, onSelectMission, onClose]);
+  }, [loadingMissionId, onSelectMission, onClose, router]);
 
   // Compute filtered missions
   const runningMissionIds = useMemo(
@@ -840,6 +858,28 @@ export function MissionSwitcher({
           map.set(m.parent_mission_id, set);
         }
         set.add(m.id);
+      }
+    }
+    return map;
+  }, [missions]);
+
+  // Hermes sessions (conversations). The request itself doubles as the
+  // availability probe: when Hermes is not adopted/running it fails and the
+  // section simply doesn't render.
+  const { data: hermesSessions } = useSWR<HermesSession[]>(
+    open ? 'switcher-hermes-sessions' : null,
+    () => listHermesSessions(30),
+    { revalidateOnFocus: false, dedupingInterval: 15000, shouldRetryOnError: false }
+  );
+
+  // Missions spawned by a Hermes session, grouped as that session's workers.
+  const missionsBySessionId = useMemo(() => {
+    const map = new Map<string, Mission[]>();
+    for (const m of missions) {
+      if (m.origin_session_id) {
+        const list = map.get(m.origin_session_id) ?? [];
+        list.push(m);
+        map.set(m.origin_session_id, list);
       }
     }
     return map;
@@ -929,6 +969,26 @@ export function MissionSwitcher({
       });
     }
 
+    // Hermes sessions, each with the missions it spawned grouped as workers.
+    for (const session of hermesSessions ?? []) {
+      const sessionItemId = `${SESSION_ITEM_PREFIX}${session.id}`;
+      if (addedIds.has(sessionItemId)) continue;
+      addedIds.add(sessionItemId);
+      items.push({ type: 'session', id: sessionItemId, session });
+      for (const worker of missionsBySessionId.get(session.id) ?? []) {
+        if (addedIds.has(worker.id)) continue;
+        addedIds.add(worker.id);
+        const workerRunningInfo = runningByMissionId.get(worker.id);
+        items.push({
+          type: workerRunningInfo ? 'running' : 'recent',
+          mission: worker,
+          runningInfo: workerRunningInfo,
+          id: worker.id,
+          isWorkerOf: sessionItemId,
+        });
+      }
+    }
+
     // Recent missions
     recentMissions.forEach((m) => {
       if (addedIds.has(m.id)) return;
@@ -937,7 +997,7 @@ export function MissionSwitcher({
     });
 
     return items;
-  }, [currentMissionId, runningMissions, runningMissionIds, recentMissions, bossMissionWorkerIds, missionById]);
+  }, [currentMissionId, runningMissions, runningMissionIds, recentMissions, bossMissionWorkerIds, missionById, hermesSessions, missionsBySessionId]);
 
   // Bosses that have at least one worker row grouped under them in this
   // session's items list. These are the rows that get a chevron toggle.
@@ -1016,6 +1076,14 @@ export function MissionSwitcher({
 
     const cache = searchScoreCacheRef.current;
     const scored = visibleItems.flatMap((item) => {
+      if (item.type === 'session') {
+        const haystack = normalizeMetadataText(
+          `${item.session?.title ?? ''} ${item.session?.preview ?? ''} hermes session`
+        );
+        const terms = normalizedSearchQuery.split(/\s+/).filter(Boolean);
+        const matches = terms.every((term) => haystack.includes(term));
+        return matches ? [{ item, score: 0.5 }] : [];
+      }
       if (!item.mission) {
         if (!item.runningInfo) {
           return [];
@@ -1082,12 +1150,18 @@ export function MissionSwitcher({
         ) {
           rows.push({ kind: 'section', id: 'section-running', label: 'Running' });
         }
+        if (!isPinned && item.type === 'session' && previousType !== 'session') {
+          rows.push({ kind: 'section', id: 'section-sessions', label: 'Hermes sessions' });
+        }
         if (!isPinned && item.type === 'recent' && !isWorkerItem && previousType !== 'recent') {
           rows.push({ kind: 'section', id: 'section-recent', label: 'Recent' });
         }
       }
       rows.push({ kind: 'item', id: item.id, item, itemIndex });
-      previousType = isPinned ? previousType : item.type;
+      // Worker rows inherit their parent's section: letting them advance
+      // `previousType` would re-emit a section header (with a duplicate row
+      // id) as soon as the next top-level row of the same type appears.
+      previousType = isPinned || isWorkerItem ? previousType : item.type;
       previousPinned = isPinned;
     });
 
@@ -1440,6 +1514,72 @@ export function MissionSwitcher({
                 const isBossExpanded = bossesShowingWorkers.has(item.id);
                 const workerCount = workerCountByBossId.get(item.id) ?? 0;
 
+                if (item.type === 'session') {
+                  const sessionTitle =
+                    item.session?.title?.trim() ||
+                    item.session?.preview?.trim() ||
+                    `Session ${item.session?.id.slice(0, 8) ?? ''}`;
+                  const sessionHasWorkers = bossesWithGroupedWorkers.has(item.id);
+                  const sessionExpanded = bossesShowingWorkers.has(item.id);
+                  return (
+                    <div
+                      key={item.id}
+                      data-index={virtualRow.index}
+                      ref={rowVirtualizer.measureElement}
+                      className="absolute left-0 top-0 w-full"
+                      style={{ transform: `translateY(${virtualRow.start}px)` }}
+                    >
+                      <a
+                        href={`/control?session=${encodeURIComponent(item.session?.id ?? '')}`}
+                        data-selected={isSelected}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleSelect(item.id);
+                        }}
+                        className={cn(
+                          'mission-switcher-row group flex items-center gap-3 py-2 mx-2 rounded-lg px-3 cursor-pointer transition-colors no-underline',
+                          isSelected
+                            ? 'mission-switcher-row-selected bg-indigo-500/15 text-white'
+                            : 'text-white/70 hover:bg-white/[0.04]'
+                        )}
+                      >
+                        {sessionHasWorkers && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              toggleBossExpansion(item.id);
+                            }}
+                            aria-label={sessionExpanded ? 'Collapse workers' : 'Expand workers'}
+                            aria-expanded={sessionExpanded}
+                            className="-ml-0.5 p-0.5 rounded text-white/40 hover:text-white/80 hover:bg-white/[0.06] transition-colors shrink-0"
+                          >
+                            {sessionExpanded ? (
+                              <ChevronDown className="h-3.5 w-3.5" />
+                            ) : (
+                              <ChevronRight className="h-3.5 w-3.5" />
+                            )}
+                          </button>
+                        )}
+                        <Sparkles className="h-3.5 w-3.5 shrink-0 text-indigo-400" />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-sm">{sessionTitle}</div>
+                          <div className="truncate text-xs text-white/40">
+                            Hermes session
+                            {typeof item.session?.message_count === 'number'
+                              ? ` · ${item.session.message_count} messages`
+                              : ''}
+                            {workerCount > 0
+                              ? ` · ${workerCount} worker${workerCount === 1 ? '' : 's'}`
+                              : ''}
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                  );
+                }
+
                 return (
                   <div
                     key={item.id}
@@ -1631,6 +1771,14 @@ export function MissionSwitcher({
                           {mission?.mission_mode === 'assistant' && (
                             <span className="inline-flex items-center rounded bg-indigo-500/10 border border-indigo-500/20 px-1 py-0.5 text-[8px] font-medium text-indigo-400 shrink-0">
                               Assistant
+                            </span>
+                          )}
+                          {mission?.origin === 'hermes' && (
+                            <span
+                              className="shrink-0 text-indigo-400/70"
+                              title="Spawned by a Hermes session"
+                            >
+                              <Sparkles className="h-3 w-3" />
                             </span>
                           )}
                           {item.isBoss && (

--- a/dashboard/src/components/new-mission-dialog.test.tsx
+++ b/dashboard/src/components/new-mission-dialog.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getBackendConfig,
   getClaudeCodeConfig,
+  getHermesAssistantStatus,
   getSandboxedConfig,
   getVisibleAgents,
   listBackendAgents,
@@ -24,11 +25,31 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('@/lib/api', () => ({
   getVisibleAgents: vi.fn().mockResolvedValue([]),
-  getSandboxedConfig: vi.fn().mockResolvedValue({ hidden_agents: [] }),
+  getSandboxedConfig: vi.fn().mockResolvedValue({ hidden_agents: [], default_agent: null }),
   listBackends: vi.fn().mockResolvedValue([{ id: 'codex', name: 'Codex' }]),
   listBackendAgents: vi.fn().mockResolvedValue([{ id: 'default', name: 'Default' }]),
   getBackendConfig: vi.fn().mockResolvedValue({ enabled: true, cli_available: true }),
-  getClaudeCodeConfig: vi.fn().mockResolvedValue({ hidden_agents: [] }),
+  getClaudeCodeConfig: vi.fn().mockResolvedValue({
+    hidden_agents: [],
+    default_model: null,
+    default_agent: null,
+  }),
+  getHermesAssistantStatus: vi.fn().mockResolvedValue({
+    service_name: 'hermes',
+    service_active: false,
+    model: null,
+    env_path: '',
+    config_path: '',
+    env_present: false,
+    config_present: false,
+    token_present: false,
+    telegram_ok: null,
+    telegram_bot_username: null,
+    telegram_webhook_configured: null,
+    telegram_pending_update_count: null,
+    telegram_last_error: null,
+    notes: [],
+  }),
   listBackendModelOptions: vi.fn().mockResolvedValue({ backends: {} }),
   listProviders: vi.fn().mockResolvedValue({ providers: [] }),
 }));
@@ -47,7 +68,10 @@ function renderDialog(
 describe('NewMissionDialog', () => {
   beforeEach(() => {
     vi.mocked(getVisibleAgents).mockResolvedValue([]);
-    vi.mocked(getSandboxedConfig).mockResolvedValue({ hidden_agents: [] });
+    vi.mocked(getSandboxedConfig).mockResolvedValue({
+      hidden_agents: [],
+      default_agent: null,
+    });
     vi.mocked(listBackends).mockResolvedValue([{ id: 'codex', name: 'Codex' }]);
     vi.mocked(listBackendAgents).mockResolvedValue([{ id: 'default', name: 'Default' }]);
     vi.mocked(getBackendConfig).mockResolvedValue({
@@ -57,7 +81,27 @@ describe('NewMissionDialog', () => {
       settings: {},
       cli_available: true,
     });
-    vi.mocked(getClaudeCodeConfig).mockResolvedValue({ hidden_agents: [] });
+    vi.mocked(getClaudeCodeConfig).mockResolvedValue({
+      hidden_agents: [],
+      default_model: null,
+      default_agent: null,
+    });
+    vi.mocked(getHermesAssistantStatus).mockResolvedValue({
+      service_name: 'hermes',
+      service_active: false,
+      model: null,
+      env_path: '',
+      config_path: '',
+      env_present: false,
+      config_present: false,
+      token_present: false,
+      telegram_ok: null,
+      telegram_bot_username: null,
+      telegram_webhook_configured: null,
+      telegram_pending_update_count: null,
+      telegram_last_error: null,
+      notes: [],
+    });
     vi.mocked(listBackendModelOptions).mockResolvedValue({ backends: {} });
     vi.mocked(listProviders).mockResolvedValue({ providers: [] });
   });

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -6,13 +6,15 @@ import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
 import { Plus, X, ExternalLink, RefreshCw, SlidersHorizontal } from 'lucide-react';
 import useSWR from 'swr';
-import { getVisibleAgents, getSandboxedConfig, listBackends, listBackendAgents, getClaudeCodeConfig, listBackendModelOptions, listProviders, type Backend, type BackendAgent, type BackendModelOption, type ModelEffort, type Provider } from '@/lib/api';
+import { getVisibleAgents, getSandboxedConfig, listBackends, listBackendAgents, getClaudeCodeConfig, listBackendModelOptions, listProviders, createHermesSession, getHermesAssistantStatus, type Backend, type BackendAgent, type BackendModelOption, type ModelEffort, type Provider } from '@/lib/api';
 import type { Workspace } from '@/lib/api';
 import { isBackendAvailable, useBackendConfigs } from '@/lib/use-backend-configs';
 import { toast } from '@/components/toast';
 
 const KNOWN_BACKEND_IDS = ['opencode', 'claudecode', 'codex', 'gemini', 'grok', 'chatgpt_ui'] as const;
 const CHATGPT_UI_BACKEND_ID = 'chatgpt_ui';
+/** Pseudo-backend: selecting it starts a Hermes session, not a mission. */
+const HERMES_BACKEND_ID = 'hermes';
 const CHATGPT_UI_CANONICAL_MODEL = 'gpt-5.6-pro';
 const CLAUDE_CODE_DEFAULT_MODEL = 'claude-opus-5';
 
@@ -181,6 +183,15 @@ export function NewMissionDialog({
     return backends?.filter((b) => isBackendAvailable(backendConfigs[b.id])) || [];
   }, [backends, backendConfigs]);
 
+  // Hermes availability: selecting "Hermes" starts a session instead of a
+  // mission, so it only appears in create mode and when the runtime is live.
+  const { data: hermesStatus } = useSWR(
+    open && !isEditMode ? 'hermes-assistant-status' : null,
+    getHermesAssistantStatus,
+    { revalidateOnFocus: false, dedupingInterval: 30000 }
+  );
+  const hermesAvailable = !isEditMode && hermesStatus?.service_active === true;
+
   const workspaceProfile = useMemo(() => {
     const targetWorkspace = newMissionWorkspace
       ? workspaces.find((workspace) => workspace.id === newMissionWorkspace)
@@ -348,6 +359,7 @@ export function NewMissionDialog({
     return parseSelectedValue(selectedAgentValue)?.backend || 'claudecode';
   }, [selectedAgentValue]);
   const isChatGptUi = selectedBackend === CHATGPT_UI_BACKEND_ID;
+  const isHermes = selectedBackend === HERMES_BACKEND_ID;
   const chatGptUiModel = useMemo(() => {
     const configuredModel = backendConfigs[CHATGPT_UI_BACKEND_ID]?.settings?.model;
     return typeof configuredModel === 'string' && configuredModel.trim()
@@ -656,6 +668,42 @@ export function NewMissionDialog({
 
   const handleCreate = async (openInNewTab: boolean) => {
     if (disabled || submitting) return;
+    // Hermes is a conversation, not a mission: create the session through the
+    // chat proxy and navigate to the session view of the control page.
+    if (isHermes && !isEditMode) {
+      const pendingTab = openInNewTab ? window.open('about:blank', '_blank') : null;
+      if (pendingTab) pendingTab.opener = null;
+      setSubmitting(true);
+      try {
+        const session = await createHermesSession();
+        const url = `${controlPath}?session=${encodeURIComponent(session.id)}`;
+        setOpen(false);
+        resetForm();
+        if (openInNewTab) {
+          let opened = false;
+          if (pendingTab && !pendingTab.closed) {
+            try {
+              pendingTab.location.href = url;
+              opened = true;
+            } catch {
+              opened = false;
+            }
+          }
+          if (!opened && !window.open(url, '_blank')) {
+            router.push(url);
+          }
+          onClose?.();
+        } else {
+          router.push(url);
+        }
+      } catch (err) {
+        if (pendingTab && !pendingTab.closed) pendingTab.close();
+        toast.error(err instanceof Error ? err.message : 'Could not start a Hermes session');
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
     if (!isChatGptUi && newMissionWorkspace) {
       const ws = workspaces.find(w => w.id === newMissionWorkspace);
       if (ws && ws.status !== 'ready') {
@@ -761,6 +809,7 @@ export function NewMissionDialog({
 
           <div className="space-y-3">
             {/* Workspace selection */}
+            {!isHermes && (
             <div>
               <label className="block text-xs text-white/50 mb-1.5">Workspace</label>
               <select
@@ -809,6 +858,7 @@ export function NewMissionDialog({
                 <p className="text-xs text-white/30 mt-1.5">Where the mission will run</p>
               )}
             </div>
+            )}
 
             {/* Agent selection (includes backend) */}
             <div>
@@ -842,6 +892,13 @@ export function NewMissionDialog({
                     </option>
                   </optgroup>
                 )}
+                {hermesAvailable && (
+                  <optgroup key={HERMES_BACKEND_ID} label="Hermes" className="bg-[#1a1a1a]">
+                    <option value={`${HERMES_BACKEND_ID}:`} className="bg-[#1a1a1a]">
+                      Hermes assistant session
+                    </option>
+                  </optgroup>
+                )}
                 {enabledBackends.map((backend) => {
                   const backendAgentsList = agentsByBackend[backend.id] || [];
                   if (backendAgentsList.length === 0) return null;
@@ -870,14 +927,16 @@ export function NewMissionDialog({
                 })}
               </select>
               <p className="text-xs text-white/30 mt-1.5">
-                {isChatGptUi
-                  ? 'Uses the authenticated ChatGPT web harness on the control plane.'
-                  : 'Select an agent and backend to power this mission'}
+                {isHermes
+                  ? 'Starts a Hermes conversation. Hermes plans, chats across platforms, and can spawn missions as workers.'
+                  : isChatGptUi
+                    ? 'Uses the authenticated ChatGPT web harness on the control plane.'
+                    : 'Select an agent and backend to power this mission'}
               </p>
             </div>
 
             {/* Model selection */}
-            {isChatGptUi ? (
+            {isHermes ? null : isChatGptUi ? (
               <div>
                 <label className="block text-xs text-white/50 mb-1.5">Model</label>
                 <div className="flex items-center justify-between rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5 text-sm">

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -50,7 +50,7 @@ type NavItem = {
 const navigation: NavItem[] = [
   { name: 'Projects', href: '/', icon: Kanban },
   { name: 'Overview', href: '/overview', icon: Layout },
-  { name: 'Mission', href: '/control', icon: ChatCircleText },
+  { name: 'Conversations', href: '/control', icon: ChatCircleText },
   { name: 'Workspaces', href: '/workspaces', icon: SidebarSimple },
   { name: 'Console', href: '/console', icon: TerminalWindow },
   {

--- a/dashboard/src/contexts/mission-switcher-context.tsx
+++ b/dashboard/src/contexts/mission-switcher-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
+import { createContext, useContext, useState, useEffect, useCallback, useMemo, Suspense } from 'react';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import useSWR from 'swr';
 import { toast } from '@/components/toast';
 import { MissionSwitcher } from '@/components/mission-switcher';
@@ -27,6 +27,20 @@ interface MissionSwitcherContextValue {
 
 const MissionSwitcherContext = createContext<MissionSwitcherContextValue | null>(null);
 
+/**
+ * Reports whether the URL carries a `?session=` (Hermes conversation) param.
+ * Isolated in a Suspense-wrapped child because `useSearchParams` in the
+ * provider itself would opt every statically-rendered page out of prerender.
+ */
+function HermesSessionParamProbe({ onChange }: { onChange: (has: boolean) => void }) {
+  const searchParams = useSearchParams();
+  const hasSession = searchParams.get('session') != null;
+  useEffect(() => {
+    onChange(hasSession);
+  }, [hasSession, onChange]);
+  return null;
+}
+
 export function useMissionSwitcher() {
   const ctx = useContext(MissionSwitcherContext);
   if (!ctx) {
@@ -39,9 +53,13 @@ export function MissionSwitcherProvider({ children }: { children: React.ReactNod
   const router = useRouter();
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
+  const [hasHermesSession, setHasHermesSession] = useState(false);
 
-  // Control page has its own mission switcher with more context (currentMissionId, viewingMissionId)
-  const isControlPage = pathname === '/control';
+  // Control page has its own mission switcher with more context
+  // (currentMissionId, viewingMissionId) — but only for missions. The Hermes
+  // session view (`/control?session=`) does not mount ControlClient, so the
+  // global palette stays active there.
+  const isControlPage = pathname === '/control' && !hasHermesSession;
 
   // The data here only feeds the Cmd+K MissionSwitcher dialog (rendered below
   // when `!isControlPage`) and the follow-up handler. Polling it constantly
@@ -183,6 +201,9 @@ export function MissionSwitcherProvider({ children }: { children: React.ReactNod
   return (
     <MissionSwitcherContext.Provider value={contextValue}>
       {children}
+      <Suspense fallback={null}>
+        <HermesSessionParamProbe onChange={setHasHermesSession} />
+      </Suspense>
       {/* Don't render on control page - it has its own mission switcher with more context */}
       {!isControlPage && (
         <MissionSwitcher

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -71,6 +71,13 @@ export interface Mission {
   resumable?: boolean;
   session_id?: string | null;
   parent_mission_id?: string;
+  /** Which system created this mission (e.g. "hermes" for the assistant MCP). */
+  origin?: string | null;
+  /**
+   * External conversation that spawned this mission — the Hermes session id
+   * when `origin` is "hermes". Groups the mission as a worker of that session.
+   */
+  origin_session_id?: string | null;
   working_directory?: string;
   mission_mode?: "task" | "assistant";
   goal_mode?: boolean;

--- a/dashboard/src/lib/hermes-gateway.ts
+++ b/dashboard/src/lib/hermes-gateway.ts
@@ -80,13 +80,16 @@ export class HermesGatewayClient {
     }
     this.closedByUser = false;
     const jwt = getValidJwt();
-    const base = apiUrl("/api/assistant/hermes/ws").replace(/^http/, "ws");
-    const url = jwt ? `${base}?token=${encodeURIComponent(jwt.token)}` : base;
+    const url = apiUrl("/api/assistant/hermes/ws").replace(/^http/, "ws");
+    // The JWT travels in the subprotocol list (never the URL, so it can't
+    // land in access logs); the server echoes back "sandboxed". Same
+    // convention as /api/monitoring/ws.
+    const protocols = jwt ? ["sandboxed", `jwt.${jwt.token}`] : ["sandboxed"];
 
     return new Promise<void>((resolve, reject) => {
       this.setState("connecting");
       let settled = false;
-      const ws = new WebSocket(url);
+      const ws = new WebSocket(url, protocols);
       this.ws = ws;
       const connectTimer = setTimeout(() => {
         if (!settled) {

--- a/dashboard/src/lib/hermes-gateway.ts
+++ b/dashboard/src/lib/hermes-gateway.ts
@@ -1,0 +1,207 @@
+"use client";
+
+/**
+ * JSON-RPC 2.0 client for the Hermes gateway WebSocket, reached through the
+ * backend bridge at `/api/assistant/hermes/ws` (which verifies the dashboard
+ * JWT, then pumps frames to the loopback Hermes dashboard gateway `/api/ws`).
+ *
+ * Wire protocol (both directions, one JSON document per message):
+ *   request:  { jsonrpc: "2.0", id, method, params }
+ *   response: { jsonrpc: "2.0", id, result } | { jsonrpc: "2.0", id, error }
+ *   event:    { jsonrpc: "2.0", method: "event",
+ *               params: { type, session_id?, payload? } }
+ *
+ * Modeled on Hermes' own canonical TS client (apps/shared json-rpc-gateway).
+ */
+
+import { apiUrl } from "@/lib/api/core";
+import { getValidJwt } from "@/lib/auth";
+
+export type HermesGatewayState = "idle" | "connecting" | "open" | "closed" | "error";
+
+export interface HermesGatewayEvent<P = unknown> {
+  type: string;
+  session_id?: string;
+  payload?: P;
+  profile?: string;
+}
+
+interface JsonRpcFrame {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: HermesGatewayEvent;
+  result?: unknown;
+  error?: { code?: number; message?: string };
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const REQUEST_TIMEOUT_MS = 120_000;
+const CONNECT_TIMEOUT_MS = 15_000;
+
+export class HermesGatewayClient {
+  private ws: WebSocket | null = null;
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private eventHandlers = new Set<(event: HermesGatewayEvent) => void>();
+  private stateHandlers = new Set<(state: HermesGatewayState) => void>();
+  private state: HermesGatewayState = "idle";
+  private closedByUser = false;
+
+  getState(): HermesGatewayState {
+    return this.state;
+  }
+
+  onEvent(handler: (event: HermesGatewayEvent) => void): () => void {
+    this.eventHandlers.add(handler);
+    return () => this.eventHandlers.delete(handler);
+  }
+
+  onState(handler: (state: HermesGatewayState) => void): () => void {
+    this.stateHandlers.add(handler);
+    return () => this.stateHandlers.delete(handler);
+  }
+
+  private setState(state: HermesGatewayState) {
+    this.state = state;
+    for (const handler of this.stateHandlers) handler(state);
+  }
+
+  /** Connect and resolve once the socket is open (the server then emits a
+   * `gateway.ready` event through `onEvent`). */
+  connect(): Promise<void> {
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      return Promise.resolve();
+    }
+    this.closedByUser = false;
+    const jwt = getValidJwt();
+    const base = apiUrl("/api/assistant/hermes/ws").replace(/^http/, "ws");
+    const url = jwt ? `${base}?token=${encodeURIComponent(jwt.token)}` : base;
+
+    return new Promise<void>((resolve, reject) => {
+      this.setState("connecting");
+      let settled = false;
+      const ws = new WebSocket(url);
+      this.ws = ws;
+      const connectTimer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error("Hermes gateway connect timeout"));
+          ws.close();
+        }
+      }, CONNECT_TIMEOUT_MS);
+
+      ws.onopen = () => {
+        clearTimeout(connectTimer);
+        this.setState("open");
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+      };
+      ws.onmessage = (message) => {
+        if (typeof message.data !== "string") return;
+        // Frames may arrive newline-delimited; parse each line separately.
+        for (const line of message.data.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          let frame: JsonRpcFrame;
+          try {
+            frame = JSON.parse(trimmed) as JsonRpcFrame;
+          } catch {
+            continue;
+          }
+          this.handleFrame(frame);
+        }
+      };
+      ws.onerror = () => {
+        clearTimeout(connectTimer);
+        this.setState("error");
+        if (!settled) {
+          settled = true;
+          reject(new Error("Hermes gateway connection failed"));
+        }
+      };
+      ws.onclose = () => {
+        clearTimeout(connectTimer);
+        this.failAllPending(new Error("Hermes gateway connection closed"));
+        this.setState(this.closedByUser ? "closed" : "error");
+        if (!settled) {
+          settled = true;
+          reject(new Error("Hermes gateway connection closed"));
+        }
+      };
+    });
+  }
+
+  private handleFrame(frame: JsonRpcFrame) {
+    if (frame.method === "event" && frame.params) {
+      for (const handler of this.eventHandlers) handler(frame.params);
+      return;
+    }
+    if (frame.id == null) return;
+    const id = typeof frame.id === "string" ? Number(frame.id) : frame.id;
+    if (!Number.isFinite(id)) return;
+    const pending = this.pending.get(id as number);
+    if (!pending) return;
+    this.pending.delete(id as number);
+    clearTimeout(pending.timer);
+    if (frame.error) {
+      pending.reject(new Error(frame.error.message ?? "Hermes gateway error"));
+    } else {
+      pending.resolve(frame.result);
+    }
+  }
+
+  private failAllPending(error: Error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  request<T = unknown>(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs = REQUEST_TIMEOUT_MS,
+  ): Promise<T> {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("Hermes gateway is not connected"));
+    }
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Hermes gateway request timed out: ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+      ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    });
+  }
+
+  close() {
+    this.closedByUser = true;
+    this.failAllPending(new Error("Hermes gateway connection closed"));
+    const ws = this.ws;
+    this.ws = null;
+    if (ws && ws.readyState !== WebSocket.CLOSED) {
+      try {
+        ws.close();
+      } catch {
+        // Already closing; nothing to release.
+      }
+    }
+    this.setState("closed");
+  }
+}

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -299,30 +299,43 @@ pub async fn login(
     Ok(Json(LoginResponse { token, exp }))
 }
 
+/// Resolve an [`AuthUser`] from a bare JWT, mirroring `require_auth` exactly
+/// (dev-mode bypass included). Exists for handlers that receive the token
+/// outside the `Authorization` header — browser WebSocket clients cannot set
+/// request headers, so they pass the JWT as a query parameter instead.
+pub fn authenticate_token(
+    config: &crate::config::Config,
+    token: &str,
+) -> Result<AuthUser, (StatusCode, &'static str)> {
+    if config.dev_mode {
+        return Ok(implicit_single_tenant_user(config));
+    }
+    let secret = config.auth.jwt_secret.as_deref().ok_or((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "JWT_SECRET not configured",
+    ))?;
+    if token.is_empty() {
+        return Err((StatusCode::UNAUTHORIZED, "Missing Authorization header"));
+    }
+    let claims = verify_jwt(token, secret)
+        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid or expired token"))?;
+    match config.auth.auth_mode(config.dev_mode) {
+        AuthMode::MultiUser => user_for_claims(&claims, &config.auth.users)
+            .or_else(|| github_user_for_claims(&claims, config))
+            .ok_or((StatusCode::UNAUTHORIZED, "Invalid user")),
+        AuthMode::SingleTenant => Ok(AuthUser {
+            id: claims.sub,
+            username: claims.usr,
+        }),
+        AuthMode::Disabled => Ok(implicit_single_tenant_user(config)),
+    }
+}
+
 pub async fn require_auth(
     State(state): State<std::sync::Arc<AppState>>,
     mut req: Request<Body>,
     next: Next,
 ) -> Response {
-    // Dev mode => no auth checks.
-    if state.config.dev_mode {
-        req.extensions_mut()
-            .insert(implicit_single_tenant_user(&state.config));
-        return next.run(req).await;
-    }
-
-    // If auth isn't configured, fail closed in non-dev mode.
-    let secret = match state.config.auth.jwt_secret.as_deref() {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "JWT_SECRET not configured",
-            )
-                .into_response();
-        }
-    };
-
     let auth_header = req
         .headers()
         .get(axum::http::header::AUTHORIZATION)
@@ -334,33 +347,12 @@ pub async fn require_auth(
         .or_else(|| auth_header.strip_prefix("bearer "))
         .unwrap_or("");
 
-    if token.is_empty() {
-        return (StatusCode::UNAUTHORIZED, "Missing Authorization header").into_response();
-    }
-
-    match verify_jwt(token, secret) {
-        Ok(claims) => {
-            let user = match state.config.auth.auth_mode(state.config.dev_mode) {
-                AuthMode::MultiUser => {
-                    match user_for_claims(&claims, &state.config.auth.users)
-                        .or_else(|| github_user_for_claims(&claims, &state.config))
-                    {
-                        Some(u) => u,
-                        None => {
-                            return (StatusCode::UNAUTHORIZED, "Invalid user").into_response();
-                        }
-                    }
-                }
-                AuthMode::SingleTenant => AuthUser {
-                    id: claims.sub,
-                    username: claims.usr,
-                },
-                AuthMode::Disabled => implicit_single_tenant_user(&state.config),
-            };
+    match authenticate_token(&state.config, token) {
+        Ok(user) => {
             req.extensions_mut().insert(user);
             next.run(req).await
         }
-        Err(_) => (StatusCode::UNAUTHORIZED, "Invalid or expired token").into_response(),
+        Err((status, message)) => (status, message).into_response(),
     }
 }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -6170,6 +6170,13 @@ pub struct CreateMissionRequest {
     /// can continue without admitting work that would cross the emergency
     /// reserve.
     pub estimated_disk_gib: Option<u64>,
+    /// Which system created this mission (e.g. "hermes" for the assistant
+    /// MCP). Clients group foreign-origin missions as workers of their owning
+    /// conversation instead of standalone rows.
+    pub origin: Option<String>,
+    /// External conversation that spawned this mission — the Hermes session id
+    /// when `origin` is "hermes". Only stored when `origin` is set.
+    pub origin_session_id: Option<String>,
     /// Catch-all for unrecognized request fields. Serde ignores unknown fields
     /// by default, which has repeatedly hidden client bugs (a `prompt` sent
     /// before the field existed, a mistyped `target_mission_id`). Captured
@@ -7170,6 +7177,8 @@ pub async fn create_mission(
         remote_command: None,
         remote_async: None,
         estimated_disk_gib: None,
+        origin: None,
+        origin_session_id: None,
         extra: Default::default(),
     });
 
@@ -7661,6 +7670,28 @@ pub async fn create_mission(
         }
     }
     drop(pr_writer_guard);
+
+    // Creation origin ("hermes" + owning session id). Written once here so
+    // clients can group foreign-origin missions under their conversation.
+    if let Some(origin) = req
+        .origin
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let origin_session_id = req
+            .origin_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        control
+            .mission_store
+            .set_mission_origin(mission.id, origin, origin_session_id)
+            .await
+            .map_err(internal_error)?;
+        mission.origin = Some(origin.to_string());
+        mission.origin_session_id = origin_session_id.map(str::to_string);
+    }
 
     // Atomic create+start: stash the initial prompt as the deferred goal. The
     // FLEET-001 scheduler pass (every ~5s) dispatches pending missions with a
@@ -10948,6 +10979,8 @@ pub async fn clone_mission(
         remote_command: None,
         remote_async: None,
         estimated_disk_gib: None,
+        origin: None,
+        origin_session_id: None,
         extra: Default::default(),
     };
 
@@ -27583,6 +27616,8 @@ And the report:
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
         let weak = Mission {
             id: Uuid::new_v4(),
@@ -27620,6 +27655,8 @@ And the report:
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
 
         let strong_score = mission_search_relevance_score(
@@ -27672,6 +27709,8 @@ And the report:
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
 
         let score = mission_search_relevance_score(
@@ -27721,6 +27760,8 @@ And the report:
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
 
         let score = mission_search_relevance_score(
@@ -27770,6 +27811,8 @@ And the report:
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
 
         let score = mission_search_relevance_score(
@@ -27819,6 +27862,8 @@ And the report:
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
 
         let score = mission_search_relevance_score(
@@ -27952,6 +27997,8 @@ And the report:
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
         let before = mission_search_freshness_key(
             &[MissionSearchCandidate {

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -327,6 +327,8 @@ impl MissionStore for FileMissionStore {
                 ..Default::default()
             },
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
         self.missions
             .write()
@@ -662,6 +664,22 @@ impl MissionStore for FileMissionStore {
             .get_mut(&id)
             .ok_or_else(|| format!("Mission {} not found", id))?;
         mission.awaiting_kind = kind;
+        drop(missions);
+        self.persist().await
+    }
+
+    async fn set_mission_origin(
+        &self,
+        id: Uuid,
+        origin: &str,
+        origin_session_id: Option<&str>,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        mission.origin = Some(origin.to_string());
+        mission.origin_session_id = origin_session_id.map(ToString::to_string);
         drop(missions);
         self.persist().await
     }

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -329,6 +329,8 @@ impl MissionStore for InMemoryMissionStore {
                 ..Default::default()
             },
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
         self.missions
             .write()
@@ -647,6 +649,21 @@ impl MissionStore for InMemoryMissionStore {
             .get_mut(&id)
             .ok_or_else(|| format!("Mission {} not found", id))?;
         mission.awaiting_kind = kind;
+        Ok(())
+    }
+
+    async fn set_mission_origin(
+        &self,
+        id: Uuid,
+        origin: &str,
+        origin_session_id: Option<&str>,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        mission.origin = Some(origin.to_string());
+        mission.origin_session_id = origin_session_id.map(ToString::to_string);
         Ok(())
     }
 

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -396,6 +396,15 @@ pub struct Mission {
     /// decision or just an acknowledgement. `None` for every other status.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub awaiting_kind: Option<AwaitingKind>,
+    /// Which system created this mission (e.g. "hermes" for the assistant
+    /// MCP). `None` for missions created directly from the dashboard/API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
+    /// External conversation that spawned this mission — the Hermes session id
+    /// when `origin == "hermes"`. Lets clients group missions as workers under
+    /// their owning session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_session_id: Option<String>,
 }
 
 /// Aggregate mission counts by status.
@@ -1990,6 +1999,19 @@ pub trait MissionStore: Send + Sync {
     ) -> Result<std::collections::HashMap<Uuid, MissionSummary>, String> {
         let _ = ids;
         Ok(std::collections::HashMap::new())
+    }
+
+    /// Record which system created a mission (`origin`, e.g. "hermes") and,
+    /// when known, the external session that spawned it. Written once right
+    /// after creation. Default no-op for stores that do not persist it.
+    async fn set_mission_origin(
+        &self,
+        id: Uuid,
+        origin: &str,
+        origin_session_id: Option<&str>,
+    ) -> Result<(), String> {
+        let _ = (id, origin, origin_session_id);
+        Ok(())
     }
 
     /// Set (or clear) the `awaiting_kind` classification for a mission. Only
@@ -3845,6 +3867,8 @@ mod tests {
             project: MissionProject::default(),
             activity: MissionActivity::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         }
     }
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -508,7 +508,9 @@ CREATE TABLE IF NOT EXISTS missions (
     desired_state TEXT,
     next_check_at TEXT,
     awaiting_kind TEXT,
-    last_status_change_at TEXT
+    last_status_change_at TEXT,
+    origin TEXT,
+    origin_session_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
@@ -2295,6 +2297,8 @@ impl SqliteMissionStore {
             ("next_check_at", "TEXT"),
             ("awaiting_kind", "TEXT"),
             ("last_status_change_at", "TEXT"),
+            ("origin", "TEXT"),
+            ("origin_session_id", "TEXT"),
         ] {
             // `github_pr` shipped briefly as INTEGER; it now holds a free-form
             // PR reference string (e.g. "owner/repo#123"). The column is freshly
@@ -2352,6 +2356,17 @@ impl SqliteMissionStore {
                     );
                 }
             }
+        }
+
+        // Backfill `origin` for missions created by the Hermes assistant MCP
+        // before the dedicated column existed (the marker was only a tag).
+        // Non-fatal for the same concurrent-init reason as the ALTERs above.
+        if let Err(e) = conn.execute(
+            "UPDATE missions SET origin = 'hermes' \
+             WHERE origin IS NULL AND tags LIKE '%\"origin:hermes-assistant\"%'",
+            [],
+        ) {
+            tracing::warn!("origin backfill from tags skipped: {}", e);
         }
 
         Ok(())
@@ -2744,7 +2759,7 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
                             COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
                             project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at,
-                            COALESCE(fast_mode, 0) as fast_mode
+                            COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id
                      FROM missions
                      ORDER BY updated_at DESC
                      LIMIT ?1 OFFSET ?2",
@@ -2812,6 +2827,8 @@ impl MissionStore for SqliteMissionStore {
                                 ..Default::default()
                             },
                             awaiting_kind,
+                            origin: row.get(42).ok().flatten(),
+                            origin_session_id: row.get(43).ok().flatten(),
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2874,7 +2891,7 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
                             COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
                             project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at,
-                            COALESCE(fast_mode, 0) as fast_mode FROM missions WHERE id = ?1",
+                            COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id FROM missions WHERE id = ?1",
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -2939,6 +2956,8 @@ impl MissionStore for SqliteMissionStore {
                                 ..Default::default()
                             },
                             awaiting_kind,
+                            origin: row.get(42).ok().flatten(),
+                            origin_session_id: row.get(43).ok().flatten(),
                     })
                 })
                 .optional()
@@ -3373,6 +3392,8 @@ impl MissionStore for SqliteMissionStore {
             project: MissionProject::default(),
             activity: MissionActivity::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         };
 
         let m = mission.clone();
@@ -3470,6 +3491,8 @@ impl MissionStore for SqliteMissionStore {
                             project: MissionProject::default(),
                             activity: MissionActivity::default(),
                             awaiting_kind: None,
+                            origin: None,
+                            origin_session_id: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -4033,6 +4056,28 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn set_mission_origin(
+        &self,
+        id: Uuid,
+        origin: &str,
+        origin_session_id: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let origin = origin.to_string();
+        let origin_session_id = origin_session_id.map(|s| s.to_string());
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions SET origin = ?1, origin_session_id = ?2 WHERE id = ?3",
+                params![origin, origin_session_id, id.to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn get_mission_activity(
         &self,
         ids: &[Uuid],
@@ -4383,6 +4428,8 @@ impl MissionStore for SqliteMissionStore {
                         project: MissionProject::default(),
                         activity: MissionActivity::default(),
                         awaiting_kind: None,
+                        origin: None,
+                        origin_session_id: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -4463,6 +4510,8 @@ impl MissionStore for SqliteMissionStore {
                         project: MissionProject::default(),
                         activity: MissionActivity::default(),
                         awaiting_kind: None,
+                        origin: None,
+                        origin_session_id: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -4604,6 +4653,8 @@ impl MissionStore for SqliteMissionStore {
                         project: MissionProject::default(),
                         activity: MissionActivity::default(),
                         awaiting_kind: None,
+                        origin: None,
+                        origin_session_id: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -7113,6 +7164,8 @@ impl MissionStore for SqliteMissionStore {
                         project: MissionProject::default(),
                         activity: MissionActivity::default(),
                         awaiting_kind: None,
+                        origin: None,
+                        origin_session_id: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -12976,6 +13029,69 @@ mod tests {
         assert_eq!(
             fetched.awaiting_kind, None,
             "awaiting_kind must clear when leaving AwaitingUser"
+        );
+    }
+
+    #[tokio::test]
+    async fn mission_origin_roundtrip_and_tag_backfill() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("Spawned"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+        assert_eq!(mission.origin, None);
+        assert_eq!(mission.origin_session_id, None);
+
+        store
+            .set_mission_origin(mission.id, "hermes", Some("20260804_101500_ab12cd34"))
+            .await
+            .expect("set origin");
+        let fetched = store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(fetched.origin.as_deref(), Some("hermes"));
+        assert_eq!(
+            fetched.origin_session_id.as_deref(),
+            Some("20260804_101500_ab12cd34")
+        );
+        let listed = store.list_missions(10, 0).await.expect("list");
+        let listed = listed.iter().find(|m| m.id == mission.id).expect("listed");
+        assert_eq!(listed.origin.as_deref(), Some("hermes"));
+
+        // Legacy hermes missions (tag only, no origin column) get backfilled by
+        // the migration pass.
+        let legacy = store
+            .create_mission(Some("Legacy"), None, None, None, None, None, None)
+            .await
+            .expect("legacy mission");
+        store
+            .update_mission_project(
+                legacy.id,
+                MissionProjectPatch {
+                    tags: Some(vec!["origin:hermes-assistant".to_string()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag legacy");
+        {
+            let conn = store.conn.lock().await;
+            SqliteMissionStore::run_migrations(&conn).expect("re-run migration");
+        }
+        let fetched = store
+            .get_mission(legacy.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(
+            fetched.origin.as_deref(),
+            Some("hermes"),
+            "tag-only hermes mission must be backfilled to origin='hermes'"
         );
     }
 

--- a/src/api/paloma/mission_card.rs
+++ b/src/api/paloma/mission_card.rs
@@ -299,6 +299,8 @@ mod tests {
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         }
     }
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -701,6 +701,13 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             axum::routing::any(system_api::hermes_remote_proxy)
                 .layer(DefaultBodyLimit::max(50 * 1024 * 1024)),
         )
+        // Hermes gateway JSON-RPC WebSocket bridge. On public_routes because
+        // browser WebSockets cannot carry an Authorization header; the handler
+        // verifies the dashboard JWT (header or ?token=) before upgrading.
+        .route(
+            system_api::HERMES_GATEWAY_WS_PATH,
+            get(system_api::hermes_gateway_ws),
+        )
         // OpenAI-compatible proxy endpoint (bearer token auth via SANDBOXED_PROXY_SECRET).
         // LLM payloads with tool outputs and long contexts can exceed the default 2MB
         // body limit, so set a generous 50MB limit for proxy routes.

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -703,7 +703,8 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         )
         // Hermes gateway JSON-RPC WebSocket bridge. On public_routes because
         // browser WebSockets cannot carry an Authorization header; the handler
-        // verifies the dashboard JWT (header or ?token=) before upgrading.
+        // verifies the dashboard JWT (Bearer header or `jwt.<token>`
+        // subprotocol, as on /api/monitoring/ws) before upgrading.
         .route(
             system_api::HERMES_GATEWAY_WS_PATH,
             get(system_api::hermes_gateway_ws),

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2046,12 +2046,22 @@ pub async fn hermes_chat_proxy(
 /// Dashboard-JWT path under which the Hermes gateway WS is bridged.
 pub const HERMES_GATEWAY_WS_PATH: &str = "/api/assistant/hermes/ws";
 
-#[derive(Debug, serde::Deserialize)]
-pub struct HermesGatewayWsQuery {
-    /// Dashboard JWT. Browsers cannot set an Authorization header on a
-    /// WebSocket connect, so the token arrives as a query parameter instead.
-    #[serde(default)]
-    token: Option<String>,
+/// Extract the dashboard JWT from the WebSocket subprotocol list. Browsers
+/// cannot set an Authorization header on a WebSocket connect, so clients send
+/// `Sec-WebSocket-Protocol: sandboxed, jwt.<token>` instead (same convention
+/// as `/api/monitoring/ws`) — keeping the token out of URLs and access logs.
+fn extract_jwt_from_ws_protocols(headers: &axum::http::HeaderMap) -> Option<String> {
+    let raw = headers
+        .get("sec-websocket-protocol")
+        .and_then(|v| v.to_str().ok())?;
+    for part in raw.split(',').map(str::trim) {
+        if let Some(rest) = part.strip_prefix("jwt.") {
+            if !rest.is_empty() {
+                return Some(rest.to_string());
+            }
+        }
+    }
+    None
 }
 
 /// Resolve the loopback Hermes gateway WS URL, session token included.
@@ -2103,11 +2113,12 @@ async fn resolve_hermes_gateway_ws_target(
 }
 
 /// `GET /api/assistant/hermes/ws` — full pass-through bridge to the Hermes
-/// gateway JSON-RPC WebSocket. Registered on public_routes because the JWT
-/// arrives via query param; authentication happens here, before upgrade.
+/// gateway JSON-RPC WebSocket. Registered on public_routes because browser
+/// WebSockets cannot carry an Authorization header; the JWT arrives via the
+/// `jwt.<token>` subprotocol (or a Bearer header for native clients) and is
+/// verified here, before upgrade.
 pub async fn hermes_gateway_ws(
     State(state): State<Arc<AppState>>,
-    axum::extract::Query(query): axum::extract::Query<HermesGatewayWsQuery>,
     headers: axum::http::HeaderMap,
     ws: axum::extract::WebSocketUpgrade,
 ) -> axum::response::Response {
@@ -2119,9 +2130,12 @@ pub async fn hermes_gateway_ws(
         .and_then(|h| {
             h.strip_prefix("Bearer ")
                 .or_else(|| h.strip_prefix("bearer "))
-        });
-    let token = header_token.or(query.token.as_deref()).unwrap_or("");
-    if let Err((status, message)) = crate::api::auth::authenticate_token(&state.config, token) {
+        })
+        .map(str::to_string);
+    let token = header_token
+        .or_else(|| extract_jwt_from_ws_protocols(&headers))
+        .unwrap_or_default();
+    if let Err((status, message)) = crate::api::auth::authenticate_token(&state.config, &token) {
         return (status, message).into_response();
     }
 
@@ -2130,11 +2144,15 @@ pub async fn hermes_gateway_ws(
         Err(message) => return (StatusCode::SERVICE_UNAVAILABLE, message).into_response(),
     };
 
-    ws.on_upgrade(move |socket| async move {
-        if let Err(error) = bridge_hermes_gateway_ws(socket, target).await {
-            tracing::debug!("hermes gateway ws bridge closed: {error}");
-        }
-    })
+    // Echo back the stable subprotocol; the jwt.* entry never appears in the
+    // response (a browser rejects the handshake if the selected protocol was
+    // not offered, so "sandboxed" is always offered alongside the token).
+    ws.protocols(["sandboxed"])
+        .on_upgrade(move |socket| async move {
+            if let Err(error) = bridge_hermes_gateway_ws(socket, target).await {
+                tracing::debug!("hermes gateway ws bridge closed: {error}");
+            }
+        })
 }
 
 /// Pump frames between the browser socket and the loopback Hermes gateway

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2032,6 +2032,169 @@ pub async fn hermes_chat_proxy(
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Hermes gateway WebSocket bridge
+//
+// The rich Hermes client protocol (session.create / prompt.submit / streamed
+// message.delta / tool.* / subagent.* events) is the JSON-RPC WebSocket served
+// by the Hermes *dashboard* process at `/api/ws`, loopback-only. This bridge
+// re-exposes it to sandboxed.sh clients behind the dashboard JWT: the browser
+// connects here, the server dials the loopback gateway with the Hermes session
+// token, and frames are pumped verbatim in both directions.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Dashboard-JWT path under which the Hermes gateway WS is bridged.
+pub const HERMES_GATEWAY_WS_PATH: &str = "/api/assistant/hermes/ws";
+
+#[derive(Debug, serde::Deserialize)]
+pub struct HermesGatewayWsQuery {
+    /// Dashboard JWT. Browsers cannot set an Authorization header on a
+    /// WebSocket connect, so the token arrives as a query parameter instead.
+    #[serde(default)]
+    token: Option<String>,
+}
+
+/// Resolve the loopback Hermes gateway WS URL, session token included.
+///
+/// The token is Hermes' `HERMES_DASHBOARD_SESSION_TOKEN` (which pins the
+/// otherwise per-restart `_SESSION_TOKEN` of the hermes-dashboard process).
+/// Deployers set it on the hermes-dashboard unit and mirror it into the
+/// sandboxed.sh service env or the Hermes runtime env file, whichever is
+/// found first here.
+async fn resolve_hermes_gateway_ws_target(
+    config: &crate::config::Config,
+) -> Result<String, &'static str> {
+    let mut token = std::env::var("HERMES_DASHBOARD_SESSION_TOKEN")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    if token.is_none() {
+        for path in hermes_env_paths(assistant_runtime_name(config)) {
+            if let Ok(contents) = tokio::fs::read_to_string(&path).await {
+                if let Some(value) = parse_env_value(&contents, "HERMES_DASHBOARD_SESSION_TOKEN")
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty())
+                {
+                    token = Some(value);
+                    break;
+                }
+            }
+        }
+    }
+    let Some(token) = token else {
+        return Err(
+            "HERMES_DASHBOARD_SESSION_TOKEN not provisioned: pin it on the hermes-dashboard \
+             unit and mirror it into the sandboxed.sh or Hermes runtime env",
+        );
+    };
+    let base = std::env::var("HERMES_DASHBOARD_WS_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| {
+            let port = std::env::var("HERMES_DASHBOARD_PORT")
+                .ok()
+                .and_then(|v| v.trim().parse::<u16>().ok())
+                .unwrap_or(9119);
+            format!("ws://127.0.0.1:{port}/api/ws")
+        });
+    let separator = if base.contains('?') { '&' } else { '?' };
+    Ok(format!("{base}{separator}token={token}"))
+}
+
+/// `GET /api/assistant/hermes/ws` — full pass-through bridge to the Hermes
+/// gateway JSON-RPC WebSocket. Registered on public_routes because the JWT
+/// arrives via query param; authentication happens here, before upgrade.
+pub async fn hermes_gateway_ws(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(query): axum::extract::Query<HermesGatewayWsQuery>,
+    headers: axum::http::HeaderMap,
+    ws: axum::extract::WebSocketUpgrade,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let header_token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|h| {
+            h.strip_prefix("Bearer ")
+                .or_else(|| h.strip_prefix("bearer "))
+        });
+    let token = header_token.or(query.token.as_deref()).unwrap_or("");
+    if let Err((status, message)) = crate::api::auth::authenticate_token(&state.config, token) {
+        return (status, message).into_response();
+    }
+
+    let target = match resolve_hermes_gateway_ws_target(&state.config).await {
+        Ok(target) => target,
+        Err(message) => return (StatusCode::SERVICE_UNAVAILABLE, message).into_response(),
+    };
+
+    ws.on_upgrade(move |socket| async move {
+        if let Err(error) = bridge_hermes_gateway_ws(socket, target).await {
+            tracing::debug!("hermes gateway ws bridge closed: {error}");
+        }
+    })
+}
+
+/// Pump frames between the browser socket and the loopback Hermes gateway
+/// until either side closes. Frames are forwarded verbatim (newline-delimited
+/// JSON-RPC text); either side closing tears down both.
+async fn bridge_hermes_gateway_ws(
+    client: axum::extract::ws::WebSocket,
+    target: String,
+) -> Result<(), String> {
+    use axum::extract::ws::Message as ClientMessage;
+    use futures::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message as UpstreamMessage;
+
+    let (upstream, _response) = tokio_tungstenite::connect_async(&target)
+        .await
+        .map_err(|e| format!("hermes gateway unreachable: {e}"))?;
+    let (mut upstream_tx, mut upstream_rx) = upstream.split();
+    let (mut client_tx, mut client_rx) = client.split();
+
+    let client_to_upstream = async {
+        while let Some(message) = client_rx.next().await {
+            let forwarded = match message {
+                Ok(ClientMessage::Text(text)) => UpstreamMessage::Text(text),
+                Ok(ClientMessage::Binary(bytes)) => UpstreamMessage::Binary(bytes),
+                Ok(ClientMessage::Ping(payload)) => UpstreamMessage::Ping(payload),
+                Ok(ClientMessage::Pong(payload)) => UpstreamMessage::Pong(payload),
+                Ok(ClientMessage::Close(_)) | Err(_) => break,
+            };
+            if upstream_tx.send(forwarded).await.is_err() {
+                break;
+            }
+        }
+        let _ = upstream_tx.send(UpstreamMessage::Close(None)).await;
+    };
+
+    let upstream_to_client = async {
+        while let Some(message) = upstream_rx.next().await {
+            let forwarded = match message {
+                Ok(UpstreamMessage::Text(text)) => ClientMessage::Text(text),
+                Ok(UpstreamMessage::Binary(bytes)) => ClientMessage::Binary(bytes),
+                Ok(UpstreamMessage::Ping(payload)) => ClientMessage::Ping(payload),
+                Ok(UpstreamMessage::Pong(payload)) => ClientMessage::Pong(payload),
+                Ok(UpstreamMessage::Close(_)) | Err(_) => break,
+                // Raw frames never surface from a read; skip defensively.
+                Ok(UpstreamMessage::Frame(_)) => continue,
+            };
+            if client_tx.send(forwarded).await.is_err() {
+                break;
+            }
+        }
+        let _ = client_tx.send(ClientMessage::Close(None)).await;
+    };
+
+    tokio::select! {
+        _ = client_to_upstream => {}
+        _ = upstream_to_client => {}
+    }
+    Ok(())
+}
+
 /// Get the proxy API key for the Hermes gateway, reusing the key already
 /// wired into the gateway env when it is still registered; otherwise mint a
 /// fresh one. Either way, revoke any other "Hermes Assistant" keys so

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -6847,6 +6847,8 @@ mod tests {
             project: Default::default(),
             activity: Default::default(),
             awaiting_kind: None,
+            origin: None,
+            origin_session_id: None,
         }
     }
 

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -167,6 +167,10 @@ struct StartMissionParams {
     next_check_at: Option<String>,
     #[serde(default)]
     estimated_disk_gib: Option<u64>,
+    /// Hermes session that spawned this mission. Forwarded as the mission's
+    /// `origin_session_id` so clients group it as a worker of that session.
+    #[serde(default)]
+    origin_session_id: Option<String>,
 }
 
 fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
@@ -1112,7 +1116,8 @@ impl AssistantMcp {
                         "tags": {"type": "array", "items": {"type": "string"}},
                         "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
                         "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."},
-                        "estimated_disk_gib": {"type": "integer", "minimum": 1, "maximum": 512, "description": "Expected peak local scratch use. Set this for Lean/build-heavy missions; omit for small/no-build work."}
+                        "estimated_disk_gib": {"type": "integer", "minimum": 1, "maximum": 512, "description": "Expected peak local scratch use. Set this for Lean/build-heavy missions; omit for small/no-build work."},
+                        "origin_session_id": {"type": "string", "description": "Hermes session id of the conversation spawning this mission. Dashboards group the mission as a worker of that session. Injected automatically by the Hermes-side plugin; pass through unchanged."}
                     }
                 }),
             },
@@ -1639,6 +1644,14 @@ impl AssistantMcp {
             "desired_state": params.desired_state,
             "next_check_at": params.next_check_at,
             "estimated_disk_gib": params.estimated_disk_gib,
+            // Mission-level provenance. `origin` is fixed by this server (not
+            // model-controlled); the session id ties the mission to the Hermes
+            // conversation that spawned it.
+            "origin": "hermes",
+            "origin_session_id": params.origin_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty()),
         });
         let response = self.api_post("/api/control/missions", body).await?;
         if !response.status().is_success() {


### PR DESCRIPTION
## Summary

- add mission origin/session persistence and a dashboard-authenticated Hermes gateway WebSocket bridge
- render Hermes sessions through the mission-control transcript UI with live WebSocket events and REST fallback
- surface Hermes sessions in the conversation palette and new-mission flow, including spawned worker missions
- route subscription-backed inference through the CLIProxyAPI sidecar and document production operations
- keep dashboard JWTs out of WebSocket URLs by using the established subprotocol transport

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace` (1,726 tests across targets; 0 failures)
- `bunx next typegen && bunx tsc --noEmit`
- ESLint on all affected dashboard files (0 errors)
- `bunx vitest run src/components/new-mission-dialog.test.tsx src/components/lazy-json-highlighter.test.tsx` (6 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an authenticated WebSocket proxy to loopback Hermes and new mission DB columns/migrations; misconfigured `HERMES_DASHBOARD_SESSION_TOKEN` or JWT handling would break live Hermes chat but missions remain on the existing REST paths.
> 
> **Overview**
> **Hermes conversations now live on `/control?session=`** alongside missions, without mounting the full mission `ControlClient` stack. A new `HermesConversation` view reuses the same transcript pipeline (`ChatItem` → `ChatItemRow`) via a history/event adapter and a browser JSON-RPC client to **`GET /api/assistant/hermes/ws`**.
> 
> The backend adds a **loopback Hermes dashboard gateway bridge** (`tokio-tungstenite`): dashboard JWT via Bearer or `jwt.<token>` WebSocket subprotocol (shared `authenticate_token` helper), then verbatim frame relay to Hermes `/api/ws` using `HERMES_DASHBOARD_SESSION_TOKEN` (documented in `.env.example`). Live turns use `session.resume` / `prompt.submit`; if the bridge is down, the UI falls back to REST history + SSE chat and idle polling.
> 
> **Mission provenance** is persisted: `origin` and `origin_session_id` on create (API + SQLite migration/backfill from `origin:hermes-assistant` tags). `assistant-mcp` sets `origin: "hermes"` and forwards `origin_session_id` so spawned missions show as **workers** under their session in the switcher and Hermes header.
> 
> Dashboard UX: mission switcher lists Hermes sessions (with nested workers), new-mission dialog can start a Hermes session when the service is active, sidebar label becomes **Conversations**, and the global Cmd+K switcher stays enabled on Hermes session URLs.
> 
> **Docs:** `DEBUGGING.md` adds CLIProxyAPI sidecar operations (inference path); not wired in this diff’s application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1204e6f1ecbbac8699004b70da31490e9e3ad078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->