### PR TITLE
Fix Hermes desktop prompt delivery across reconnects

### DIFF
--- a/dashboard/src/app/control/components/HermesConversation.tsx
+++ b/dashboard/src/app/control/components/HermesConversation.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { Loader, Plus, Sparkles, Square } from "lucide-react";
 
@@ -24,10 +18,22 @@ import {
   HermesGatewayClient,
   type HermesGatewayEvent,
 } from "@/lib/hermes-gateway";
+import {
+  createHermesDeliveryId,
+  getHermesOutbox,
+  hermesDeliveryObserved,
+  putHermesOutbox,
+  removeHermesOutbox,
+  type HermesOutboxEntry,
+} from "@/lib/hermes-outbox";
 import { EnhancedInput } from "@/components/enhanced-input";
 import { cn } from "@/lib/utils";
 
-import { ChatItemRow, deriveItemViews, getGroupedItemKey } from "../control-client";
+import {
+  ChatItemRow,
+  deriveItemViews,
+  getGroupedItemKey,
+} from "../control-client";
 import type { ChatItem } from "../events-reducer";
 import {
   HermesLiveTranscript,
@@ -44,6 +50,7 @@ interface ResumeResult {
   session_id?: string;
   messages?: HermesMessage[];
   running?: boolean;
+  inflight?: { user?: string | null } | null;
   info?: { model?: string };
 }
 
@@ -80,11 +87,49 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
   const restToolIdsByName = useRef(new Map<string, string[]>());
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const generationRef = useRef(0);
+  const reconnectingRef = useRef(false);
+  const deliverRef = useRef<
+    ((entry: HermesOutboxEntry) => Promise<void>) | null
+  >(null);
 
   const syncFromTranscript = useCallback(() => {
     setItems([...transcriptRef.current.items]);
     setRunning(transcriptRef.current.running);
   }, []);
+
+  const markDelivery = useCallback(
+    (
+      entry: HermesOutboxEntry,
+      status: "sending" | "sent" | "failed",
+      reason?: "network" | "rejected",
+    ) => {
+      const transcript = transcriptRef.current;
+      const index = transcript.items.findIndex(
+        (item) => item.kind === "user" && item.id === entry.id,
+      );
+      if (index >= 0) {
+        transcript.items = transcript.items.map((item, itemIndex) =>
+          itemIndex === index && item.kind === "user"
+            ? { ...item, sendStatus: status, failedReason: reason }
+            : item,
+        );
+      } else {
+        transcript.items = [
+          ...transcript.items,
+          {
+            kind: "user",
+            id: entry.id,
+            content: entry.content,
+            timestamp: entry.createdAt,
+            sendStatus: status,
+            failedReason: reason,
+          },
+        ];
+      }
+      syncFromTranscript();
+    },
+    [syncFromTranscript],
+  );
 
   // ── Connection lifecycle ──────────────────────────────────────────────────
   useEffect(() => {
@@ -95,6 +140,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
     const client = new HermesGatewayClient();
     clientRef.current = client;
     let disposed = false;
+    let hasConnected = false;
 
     const applyEvent = (event: HermesGatewayEvent) => {
       if (disposed || generationRef.current !== generation) return;
@@ -110,27 +156,110 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
       setHistoryLoaded(true);
     };
 
+    const deliver = async (
+      entry: HermesOutboxEntry,
+      activeClient: HermesGatewayClient,
+    ) => {
+      markDelivery(entry, "sending");
+      try {
+        await activeClient.request("prompt.submit", {
+          session_id: handleRef.current,
+          text: entry.content,
+          // Current Hermes ignores unknown prompt fields. The bridge/client
+          // retain this stable id for observability and future server dedupe.
+          client_message_id: entry.id,
+        });
+        removeHermesOutbox(entry.id);
+        markDelivery(entry, "sent");
+      } catch (sendError) {
+        const disconnected = activeClient.getState() !== "open";
+        if (!disconnected) removeHermesOutbox(entry.id);
+        transcript.running = false;
+        markDelivery(entry, "failed", disconnected ? "network" : "rejected");
+        throw sendError;
+      }
+    };
+    deliverRef.current = (entry) => deliver(entry, client);
+
+    const resume = async () => {
+      await client.connect();
+      const result = await client.request<ResumeResult>("session.resume", {
+        session_id: sessionId,
+      });
+      if (disposed || generationRef.current !== generation) return;
+      if (result?.session_id) handleRef.current = result.session_id;
+      const messages = Array.isArray(result?.messages)
+        ? result.messages
+        : await getHermesSessionMessages(sessionId);
+      if (disposed || generationRef.current !== generation) return;
+      transcript.reset(hermesHistoryToItems(messages));
+      transcript.running = Boolean(result?.running);
+
+      const pending = getHermesOutbox(sessionId);
+      for (const entry of pending) {
+        if (
+          hermesDeliveryObserved(entry, { messages, inflight: result.inflight })
+        ) {
+          removeHermesOutbox(entry.id);
+          if (!hermesDeliveryObserved(entry, { messages })) {
+            markDelivery(entry, "sent");
+          }
+          continue;
+        }
+        markDelivery(entry, "failed", "network");
+      }
+
+      syncFromTranscript();
+      setHistoryLoaded(true);
+      setTransport("ws");
+      hasConnected = true;
+
+      // Only redeliver after the authoritative resume snapshot proved that
+      // Hermes neither persisted nor started this prompt.
+      if (!result?.running) {
+        for (const entry of getHermesOutbox(sessionId)) {
+          if (disposed || generationRef.current !== generation) return;
+          try {
+            await deliver(entry, client);
+          } catch {
+            break;
+          }
+        }
+      }
+    };
+
+    const reconnect = async () => {
+      if (reconnectingRef.current || disposed) return;
+      reconnectingRef.current = true;
+      setTransport("connecting");
+      let delay = 500;
+      try {
+        while (!disposed && generationRef.current === generation) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          try {
+            await resume();
+            return;
+          } catch {
+            delay = Math.min(delay * 2, 5_000);
+          }
+        }
+      } finally {
+        reconnectingRef.current = false;
+      }
+    };
+
+    const unsubscribeState = client.onState((state) => {
+      if (disposed || generationRef.current !== generation) return;
+      if (state === "error" && hasConnected) void reconnect();
+    });
+
+    const unsubscribeEvent = client.onEvent(applyEvent);
+    setHistoryLoaded(false);
+    setTransport("connecting");
+    setError(null);
     void (async () => {
       try {
-        await client.connect();
-        const unsubscribe = client.onEvent(applyEvent);
-        void unsubscribe;
-        const result = await client.request<ResumeResult>("session.resume", {
-          session_id: sessionId,
-        });
-        if (disposed || generationRef.current !== generation) return;
-        if (result?.session_id) handleRef.current = result.session_id;
-        if (Array.isArray(result?.messages)) {
-          transcript.reset(hermesHistoryToItems(result.messages));
-        } else {
-          transcript.reset(
-            hermesHistoryToItems(await getHermesSessionMessages(sessionId)),
-          );
-        }
-        transcript.running = Boolean(result?.running);
-        syncFromTranscript();
-        setHistoryLoaded(true);
-        setTransport("ws");
+        await resume();
       } catch {
         if (disposed || generationRef.current !== generation) return;
         client.close();
@@ -151,11 +280,17 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
 
     return () => {
       disposed = true;
+      unsubscribeState();
+      unsubscribeEvent();
+      if (clientRef.current === client) {
+        clientRef.current = null;
+        deliverRef.current = null;
+      }
       client.close();
       restAbortRef.current?.abort();
       restAbortRef.current = null;
     };
-  }, [sessionId, syncFromTranscript]);
+  }, [markDelivery, sessionId, syncFromTranscript]);
 
   // Session metadata (title) + worker missions spawned by this session.
   useEffect(() => {
@@ -211,16 +346,16 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
   }, [items]);
 
   const pushUserItem = useCallback(
-    (content: string) => {
+    (entry: HermesOutboxEntry) => {
       const transcript = transcriptRef.current;
       transcript.items = [
         ...transcript.items,
         {
           kind: "user",
-          id: localId("hs-user"),
-          content,
-          timestamp: Date.now(),
-          sendStatus: "sent",
+          id: entry.id,
+          content: entry.content,
+          timestamp: entry.createdAt,
+          sendStatus: "sending",
         },
       ];
       transcript.running = true;
@@ -230,7 +365,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
   );
 
   const sendViaRest = useCallback(
-    (content: string) => {
+    (entry: HermesOutboxEntry) => {
       const transcript = transcriptRef.current;
       const abort = new AbortController();
       restAbortRef.current = abort;
@@ -257,71 +392,114 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
           });
         }
       };
-      void hermesChatStream(
-        sessionId,
-        content,
-        {
-          onDelta: (text) =>
-            synthesize({ type: "message.delta", payload: { text } }),
-          onThinking: (text) =>
-            synthesize({ type: "thinking.delta", payload: { text } }),
-          onToolStart: (t) => openRestTool(t.tool_name ?? "tool", t.args),
-          onToolComplete: (t) =>
-            closeRestTool(t.tool_name ?? "tool", t.preview),
-          onToolFailed: (t) =>
-            closeRestTool(t.tool_name ?? "tool", t.preview ?? "failed"),
-          onCompleted: (text) =>
-            synthesize({ type: "message.complete", payload: { text } }),
-          onError: (message) =>
-            synthesize({ type: "error", payload: { message } }),
-        },
-        abort.signal,
-      )
-        .catch((err: unknown) => {
+      void (async () => {
+        let streamFailure: string | null = null;
+        try {
+          await hermesChatStream(
+            sessionId,
+            entry.content,
+            {
+              onDelta: (text) =>
+                synthesize({ type: "message.delta", payload: { text } }),
+              onThinking: (text) =>
+                synthesize({ type: "thinking.delta", payload: { text } }),
+              onToolStart: (t) => openRestTool(t.tool_name ?? "tool", t.args),
+              onToolComplete: (t) =>
+                closeRestTool(t.tool_name ?? "tool", t.preview),
+              onToolFailed: (t) =>
+                closeRestTool(t.tool_name ?? "tool", t.preview ?? "failed"),
+              onCompleted: (text) =>
+                synthesize({ type: "message.complete", payload: { text } }),
+              onError: (message) => {
+                streamFailure = message;
+                synthesize({ type: "error", payload: { message } });
+              },
+            },
+            abort.signal,
+          );
+          if (streamFailure) throw new Error(streamFailure);
+          removeHermesOutbox(entry.id);
+          markDelivery(entry, "sent");
+        } catch (err: unknown) {
           if (abort.signal.aborted) return;
+          markDelivery(entry, "failed", "network");
           synthesize({
             type: "error",
             payload: {
               message: err instanceof Error ? err.message : "Send failed",
             },
           });
-        })
-        .finally(() => {
+        } finally {
           if (restAbortRef.current === abort) restAbortRef.current = null;
           synthesize({ type: "turn.end" });
-        });
+        }
+      })();
     },
-    [sessionId, syncFromTranscript],
+    [markDelivery, sessionId, syncFromTranscript],
   );
 
   const handleSubmit = useCallback(
     ({ content }: { content: string }) => {
       const text = content.trim();
       if (!text || running) return;
+      const entry: HermesOutboxEntry = {
+        id: createHermesDeliveryId(),
+        sessionId,
+        content: text,
+        createdAt: Date.now(),
+        userOrdinal: transcriptRef.current.items.filter(
+          (item) => item.kind === "user",
+        ).length,
+      };
+      putHermesOutbox(entry);
       setInput("");
       setError(null);
-      pushUserItem(text);
-      if (transport === "ws" && clientRef.current) {
-        clientRef.current
-          .request("prompt.submit", {
-            session_id: handleRef.current,
-            text,
-          })
-          .catch((err: unknown) => {
-            const transcript = transcriptRef.current;
-            transcript.apply({
-              type: "error",
-              payload: {
-                message: err instanceof Error ? err.message : "Send failed",
-              },
-            });
-            syncFromTranscript();
-          });
+      pushUserItem(entry);
+      if (transport === "ws" && deliverRef.current) {
+        deliverRef.current(entry).catch((err: unknown) => {
+          setError(
+            err instanceof Error ? err.message : "Message not delivered",
+          );
+        });
       } else {
-        sendViaRest(text);
+        sendViaRest(entry);
       }
     },
-    [pushUserItem, running, sendViaRest, syncFromTranscript, transport],
+    [pushUserItem, running, sendViaRest, sessionId, transport],
+  );
+
+  const retryUserMessage = useCallback(
+    (message: { id: string; content: string }) => {
+      if (running) return;
+      const existing = getHermesOutbox(sessionId).find(
+        (entry) => entry.id === message.id,
+      );
+      const entry: HermesOutboxEntry = existing ?? {
+        id: message.id,
+        sessionId,
+        content: message.content,
+        createdAt: Date.now(),
+        userOrdinal: Math.max(
+          0,
+          transcriptRef.current.items.filter((item) => item.kind === "user")
+            .length - 1,
+        ),
+      };
+      putHermesOutbox(entry);
+      transcriptRef.current.running = true;
+      markDelivery(entry, "sending");
+      setError(null);
+      if (transport === "ws" && deliverRef.current) {
+        deliverRef.current(entry).catch((err: unknown) => {
+          setError(
+            err instanceof Error ? err.message : "Message not delivered",
+          );
+        });
+      } else {
+        sendViaRest(entry);
+      }
+    },
+    [markDelivery, running, sendViaRest, sessionId, transport],
   );
 
   const handleStop = useCallback(() => {
@@ -372,9 +550,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
       <div className="flex items-center gap-2 border-b border-white/5 px-4 py-2.5">
         <Sparkles className="h-4 w-4 shrink-0 text-indigo-400" />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-white">
-            {title}
-          </div>
+          <div className="truncate text-sm font-medium text-white">{title}</div>
           <div className="text-[11px] text-white/40">
             Hermes session
             {transport === "rest" && " · live events unavailable (polling)"}
@@ -450,7 +626,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
               onResume={noop}
               onToolResult={noopToolResult}
               onOptimisticToolResult={noop}
-              onRetryUserMessage={noop}
+              onRetryUserMessage={retryUserMessage}
             />
           ))}
         </div>

--- a/dashboard/src/lib/hermes-gateway.ts
+++ b/dashboard/src/lib/hermes-gateway.ts
@@ -17,7 +17,8 @@
 import { apiUrl } from "@/lib/api/core";
 import { getValidJwt } from "@/lib/auth";
 
-export type HermesGatewayState = "idle" | "connecting" | "open" | "closed" | "error";
+export type HermesGatewayState =
+  "idle" | "connecting" | "open" | "closed" | "error";
 
 export interface HermesGatewayEvent<P = unknown> {
   type: string;
@@ -75,8 +76,13 @@ export class HermesGatewayClient {
   /** Connect and resolve once the socket is open (the server then emits a
    * `gateway.ready` event through `onEvent`). */
   connect(): Promise<void> {
-    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
       return Promise.resolve();
+    }
+    if (this.ws?.readyState === WebSocket.CONNECTING) {
+      return Promise.reject(
+        new Error("Hermes gateway connection already in progress"),
+      );
     }
     this.closedByUser = false;
     const jwt = getValidJwt();
@@ -132,6 +138,7 @@ export class HermesGatewayClient {
       };
       ws.onclose = () => {
         clearTimeout(connectTimer);
+        if (this.ws === ws) this.ws = null;
         this.failAllPending(new Error("Hermes gateway connection closed"));
         this.setState(this.closedByUser ? "closed" : "error");
         if (!settled) {

--- a/dashboard/src/lib/hermes-outbox.test.ts
+++ b/dashboard/src/lib/hermes-outbox.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import {
+  getHermesOutbox,
+  hermesDeliveryObserved,
+  putHermesOutbox,
+  removeHermesOutbox,
+  type HermesOutboxEntry,
+} from "./hermes-outbox";
+
+const entry: HermesOutboxEntry = {
+  id: "hermes-delivery-1",
+  sessionId: "session-1",
+  content: "Continue every Verity component",
+  createdAt: 1_725_000_000_000,
+  userOrdinal: 1,
+};
+
+describe("Hermes durable outbox", () => {
+  beforeEach(() => localStorage.clear());
+
+  test("persists and removes an outgoing prompt", () => {
+    putHermesOutbox(entry);
+    expect(getHermesOutbox("session-1")).toEqual([entry]);
+    expect(getHermesOutbox("another-session")).toEqual([]);
+
+    removeHermesOutbox(entry.id);
+    expect(getHermesOutbox("session-1")).toEqual([]);
+  });
+
+  test("uses the resume inflight snapshot as a lost-ack proof", () => {
+    expect(
+      hermesDeliveryObserved(entry, {
+        inflight: { user: "Continue every Verity component" },
+      }),
+    ).toBe(true);
+  });
+
+  test("uses the original user ordinal instead of an older duplicate", () => {
+    expect(
+      hermesDeliveryObserved(entry, {
+        messages: [
+          { role: "user", content: "Continue every Verity component" },
+        ],
+      }),
+    ).toBe(false);
+
+    expect(
+      hermesDeliveryObserved(entry, {
+        messages: [
+          { role: "user", content: "Continue every Verity component" },
+          { role: "user", content: "Continue every Verity component" },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/dashboard/src/lib/hermes-outbox.ts
+++ b/dashboard/src/lib/hermes-outbox.ts
@@ -1,0 +1,111 @@
+import type { HermesMessage } from "@/lib/api";
+
+const STORAGE_KEY = "sandboxed-hermes-outbox-v1";
+const MAX_ENTRIES = 50;
+
+export interface HermesOutboxEntry {
+  id: string;
+  sessionId: string;
+  content: string;
+  createdAt: number;
+  /** Number of durable user messages visible before this send. */
+  userOrdinal: number;
+}
+
+export interface HermesResumeEvidence {
+  messages?: HermesMessage[];
+  inflight?: { user?: string | null } | null;
+}
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function validEntry(value: unknown): value is HermesOutboxEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<HermesOutboxEntry>;
+  return (
+    typeof entry.id === "string" &&
+    typeof entry.sessionId === "string" &&
+    typeof entry.content === "string" &&
+    typeof entry.createdAt === "number" &&
+    typeof entry.userOrdinal === "number"
+  );
+}
+
+function readAll(): HermesOutboxEntry[] {
+  const target = storage();
+  if (!target) return [];
+  try {
+    const parsed = JSON.parse(target.getItem(STORAGE_KEY) ?? "[]") as unknown;
+    return Array.isArray(parsed) ? parsed.filter(validEntry) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(entries: HermesOutboxEntry[]) {
+  const target = storage();
+  if (!target) return;
+  try {
+    target.setItem(STORAGE_KEY, JSON.stringify(entries.slice(-MAX_ENTRIES)));
+  } catch {
+    // Storage can be unavailable in private browsing. The visible failed
+    // bubble remains the non-durable fallback.
+  }
+}
+
+export function createHermesDeliveryId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return `hermes-${crypto.randomUUID()}`;
+  }
+  return `hermes-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function putHermesOutbox(entry: HermesOutboxEntry) {
+  const entries = readAll().filter((candidate) => candidate.id !== entry.id);
+  entries.push(entry);
+  writeAll(entries);
+}
+
+export function removeHermesOutbox(id: string) {
+  writeAll(readAll().filter((entry) => entry.id !== id));
+}
+
+export function getHermesOutbox(sessionId: string): HermesOutboxEntry[] {
+  return readAll().filter((entry) => entry.sessionId === sessionId);
+}
+
+function normalize(text: string | null | undefined): string {
+  return (text ?? "").trim().replace(/\r\n/g, "\n");
+}
+
+/**
+ * Prove that Hermes accepted an outbox entry before retrying it.
+ *
+ * `prompt.submit` records `inflight.user` before returning its JSON-RPC ACK.
+ * If that ACK is lost with the socket, `session.resume` replays the inflight
+ * snapshot. Once the turn is durable, the user ordinal proves the same thing
+ * from persisted history. This closes the ambiguous-ACK window without ever
+ * submitting the prompt twice.
+ */
+export function hermesDeliveryObserved(
+  entry: HermesOutboxEntry,
+  evidence: HermesResumeEvidence,
+): boolean {
+  const expected = normalize(entry.content);
+  if (expected && normalize(evidence.inflight?.user) === expected) return true;
+
+  const users = (evidence.messages ?? []).filter(
+    (message) => message.role === "user" && normalize(message.content),
+  );
+  return normalize(users[entry.userOrdinal]?.content) === expected;
+}


### PR DESCRIPTION
## Summary
- persist Hermes prompts locally before WebSocket submission
- reconcile lost acknowledgements against session.resume inflight/history
- reconnect with backoff and surface failed delivery with explicit retry

## Validation
- targeted Vitest suite (12 tests)
- TypeScript noEmit
- ESLint on changed files
- Next.js production build
- cargo fmt --all --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Hermes message delivery and reconnect semantics; incorrect dedupe or redelivery could drop prompts or duplicate submits, though logic is guarded by inflight/history checks and tests.
> 
> **Overview**
> **Hermes desktop prompts are now persisted in a local outbox before send**, with delivery state shown on user bubbles (`sending` / `sent` / `failed`) and **retry wired through** `ChatItemRow`.
> 
> On WebSocket transport, **`HermesConversation` refactors the connection lifecycle**: `session.resume` runs after connect, reconciles pending outbox entries against **`inflight.user` and message history** via `hermesDeliveryObserved` (avoids double `prompt.submit` after a lost ACK), and **auto-reconnects with exponential backoff** when the gateway errors after a successful session. Redelivery only happens when resume shows the session is not already running.
> 
> New **`hermes-outbox`** module (localStorage, capped entries) plus Vitest coverage. **`HermesGatewayClient`** rejects overlapping `connect()` calls and clears the socket reference on `onclose` so reconnect logic can open a fresh connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f313a4e520444b6621e730cb89c4050d3fdb2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->