### PR TITLE
iOS: Hermes sessions as first-class conversations

### DIFF
--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0530E5793E17B5BFB15E808A /* Automation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF62094FF29193B33EC7009 /* Automation.swift */; };
+		078E5F28B7022DCD1BC721FD /* HermesConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A79A00CA8E2F1246E970A8 /* HermesConversationTests.swift */; };
 		07ED817585C2EE9A5E11C851 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C433FADB27AED6165D3EE2E4 /* HistoryView.swift */; };
 		08D9C00F453EE16A24DC9C84 /* FilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9C3868787C973C5B65DFCD /* FilesView.swift */; };
 		094CD000ADB23893099CC839 /* WorkerPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A514C239AAC192BD2AE8038 /* WorkerPillView.swift */; };
@@ -30,6 +31,7 @@
 		4F14A189BFE75A1CA225B797 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */; };
 		50EBDCFBA58915481F5EC995 /* FidoApprovalOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B73495CB5FE8A01851005A /* FidoApprovalOverlay.swift */; };
 		51E9D9F51934DFC8EAD58CDC /* QueueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EAAE29E81F160F8E8409B7D /* QueueSheet.swift */; };
+		58A71FAA4BF80A3C1C866EF2 /* Hermes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7868B572B7E5DBED9E52D160 /* Hermes.swift */; };
 		58D2BEEDF2B4B34B3B98487C /* ToolUIOptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD083A671640B2F286D7C06 /* ToolUIOptionListView.swift */; };
 		5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4AC8C92D9F496B8152B8F /* ControlView.swift */; };
 		66E208F9D4759B79ED653374 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B74AB5DF6829813AE79229D /* ContentView.swift */; };
@@ -39,6 +41,7 @@
 		708B491B7A83A6648C03CA8A /* WorkerPeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF9A2A12846A5FFB3FC7497 /* WorkerPeekView.swift */; };
 		71559C7052796FED7EBACF3F /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018CEF52A93FCF430A128017 /* Theme.swift */; };
 		7E46D4311CFAF1F7A90E9AAD /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F4658A2D65748FC7AC5DE3 /* APIService.swift */; };
+		7E9D0E83D72B53C90238CDDC /* HermesConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8EAA60E82182885A782D60 /* HermesConversationView.swift */; };
 		7EF75A17733EE6E54126C7A7 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */; };
 		8573A897FBBC1697AE1AA7BA /* DesktopStreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880FCB82E3B58C3C3C6DABD6 /* DesktopStreamView.swift */; };
 		85E2D1C0C810F9A6435F06AE /* ImageMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4A3F89D6619F821ED8143D /* ImageMemoryCache.swift */; };
@@ -51,6 +54,7 @@
 		9F85D6D0E63005146E29B331 /* ToolUIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B920E504080EAEEA7CFD5201 /* ToolUIModels.swift */; };
 		A33E2BD727A828E6F776D94D /* MissionSwitcherSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED7C0B17601881E8725F04D /* MissionSwitcherSheet.swift */; };
 		A9B4F30DDAD9DBAEB009F77B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8600F588B036A2D57AEC9FC6 /* SettingsView.swift */; };
+		B12C86DF039026D6FFFD2B52 /* HermesConversationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F0AD1E30FB3F3BC08A39FB /* HermesConversationUITests.swift */; };
 		B2C28CDD378203A229D62B9B /* PhosphorIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17889CB07B4A4285DD87C30 /* PhosphorIcon.swift */; };
 		B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */; };
 		B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370F364BA05D1236D9B630AB /* ChatMessage.swift */; };
@@ -72,6 +76,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0BF574A38210A93AD4F2C434 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 89907ABAA4D1648BF3F7ADB0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AAACA90456A4A22561940B6B;
+			remoteInfo = SandboxedDashboard;
+		};
 		30D2F203A820EED8B3DE2898 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 89907ABAA4D1648BF3F7ADB0 /* Project object */;
@@ -86,6 +97,7 @@
 		081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerSheetView.swift; sourceTree = "<group>"; };
 		0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		0C6DBBABC4AE0FD4368A185C /* Mission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mission.swift; sourceTree = "<group>"; };
+		13A79A00CA8E2F1246E970A8 /* HermesConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesConversationTests.swift; sourceTree = "<group>"; };
 		1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResilienceTests.swift; sourceTree = "<group>"; };
 		1834CB7B575220FDE7679F7B /* NewMissionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMissionSheet.swift; sourceTree = "<group>"; };
 		1C19E1741AE5E4A19BDAAB98 /* SandboxedDashboard.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SandboxedDashboard.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,6 +111,7 @@
 		305649B3AA9B35712500F01B /* SandboxedDashboard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SandboxedDashboard.entitlements; sourceTree = "<group>"; };
 		370F364BA05D1236D9B630AB /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		384691169D9EC024B03AA57F /* WorkspacesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacesView.swift; sourceTree = "<group>"; };
+		3A8EAA60E82182885A782D60 /* HermesConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesConversationView.swift; sourceTree = "<group>"; };
 		3B74AB5DF6829813AE79229D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3B805F407A9145CA937B3917 /* BoardTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTask.swift; sourceTree = "<group>"; };
 		3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamService.swift; sourceTree = "<group>"; };
@@ -112,10 +125,12 @@
 		7559F3F4553AD74130B1BC34 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		76082CCC47D9D91308F4AE10 /* MarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownView.swift; sourceTree = "<group>"; };
 		778CFF752239E44DB252DB96 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		7868B572B7E5DBED9E52D160 /* Hermes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hermes.swift; sourceTree = "<group>"; };
 		7BF62094FF29193B33EC7009 /* Automation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Automation.swift; sourceTree = "<group>"; };
 		8080D5ADF84794AFE484FE17 /* SandboxedDashboardApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxedDashboardApp.swift; sourceTree = "<group>"; };
 		8600F588B036A2D57AEC9FC6 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		880FCB82E3B58C3C3C6DABD6 /* DesktopStreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamView.swift; sourceTree = "<group>"; };
+		8BF8C369AA9AEE45087D99CB /* SandboxedDashboardUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SandboxedDashboardUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D9C3868787C973C5B65DFCD /* FilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesView.swift; sourceTree = "<group>"; };
 		8EAAE29E81F160F8E8409B7D /* QueueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueSheet.swift; sourceTree = "<group>"; };
 		8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoApprovalState.swift; sourceTree = "<group>"; };
@@ -142,6 +157,7 @@
 		EB25F60D74459F14EEB22EFD /* ControlSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlSupportViews.swift; sourceTree = "<group>"; };
 		EB3EDA65C036030CC45BAD0E /* NavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationState.swift; sourceTree = "<group>"; };
 		EFD2C112534D498211B26C38 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		F2F0AD1E30FB3F3BC08A39FB /* HermesConversationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesConversationUITests.swift; sourceTree = "<group>"; };
 		F53686D00374BEDA33228269 /* ToolUIDataTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIDataTableView.swift; sourceTree = "<group>"; };
 		F6993AD59CA0D7392AAACDC2 /* BackendAgentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendAgentService.swift; sourceTree = "<group>"; };
 		F77025B7F25E968FE5757E18 /* ChatHistoryReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryReducer.swift; sourceTree = "<group>"; };
@@ -164,6 +180,7 @@
 			children = (
 				1C19E1741AE5E4A19BDAAB98 /* SandboxedDashboard.app */,
 				4802677F01F1504267EC2BE2 /* SandboxedDashboardTests.xctest */,
+				8BF8C369AA9AEE45087D99CB /* SandboxedDashboardUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -239,6 +256,14 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		69E84F6BBDAEC47870846B46 /* SandboxedDashboardUITests */ = {
+			isa = PBXGroup;
+			children = (
+				F2F0AD1E30FB3F3BC08A39FB /* HermesConversationUITests.swift */,
+			);
+			path = SandboxedDashboardUITests;
+			sourceTree = "<group>";
+		};
 		6DBC9AF3F2EFD0B5057A2EB6 /* SandboxedDashboard */ = {
 			isa = PBXGroup;
 			children = (
@@ -268,6 +293,7 @@
 			children = (
 				6DBC9AF3F2EFD0B5057A2EB6 /* SandboxedDashboard */,
 				A5A307A24CE6E469C4A2FA0D /* SandboxedDashboardTests */,
+				69E84F6BBDAEC47870846B46 /* SandboxedDashboardUITests */,
 				057719CAD3366030137C44B3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -287,6 +313,7 @@
 				2A33016C6075CC02E61C315A /* AutomationsView.swift */,
 				EB25F60D74459F14EEB22EFD /* ControlSupportViews.swift */,
 				D2E4AC8C92D9F496B8152B8F /* ControlView.swift */,
+				3A8EAA60E82182885A782D60 /* HermesConversationView.swift */,
 				D1EF1D3FCDDC536A1D824359 /* MessageBubbles.swift */,
 				AED7C0B17601881E8725F04D /* MissionSwitcherSheet.swift */,
 				1834CB7B575220FDE7679F7B /* NewMissionSheet.swift */,
@@ -298,6 +325,7 @@
 		A5A307A24CE6E469C4A2FA0D /* SandboxedDashboardTests */ = {
 			isa = PBXGroup;
 			children = (
+				13A79A00CA8E2F1246E970A8 /* HermesConversationTests.swift */,
 				7559F3F4553AD74130B1BC34 /* ModelTests.swift */,
 				1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */,
 				0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */,
@@ -325,6 +353,7 @@
 				370F364BA05D1236D9B630AB /* ChatMessage.swift */,
 				CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */,
 				492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */,
+				7868B572B7E5DBED9E52D160 /* Hermes.swift */,
 				0C6DBBABC4AE0FD4368A185C /* Mission.swift */,
 				E387E6A01D00EAD668074CCC /* WorkerBuckets.swift */,
 				97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */,
@@ -362,6 +391,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		8A8DCA11CAC3A5FFA56DC86C /* SandboxedDashboardUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E6D8F0304264974ECA11ADE5 /* Build configuration list for PBXNativeTarget "SandboxedDashboardUITests" */;
+			buildPhases = (
+				5CD092F6D3EAB34E8C939F58 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				67E18B6A61C28B344B3B9868 /* PBXTargetDependency */,
+			);
+			name = SandboxedDashboardUITests;
+			packageProductDependencies = (
+			);
+			productName = SandboxedDashboardUITests;
+			productReference = 8BF8C369AA9AEE45087D99CB /* SandboxedDashboardUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		AAACA90456A4A22561940B6B /* SandboxedDashboard */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 640B1F4E3BFED53BEE229DDD /* Build configuration list for PBXNativeTarget "SandboxedDashboard" */;
@@ -407,6 +454,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
+					8A8DCA11CAC3A5FFA56DC86C = {
+						ProvisioningStyle = Automatic;
+						TestTargetID = AAACA90456A4A22561940B6B;
+					};
 					AAACA90456A4A22561940B6B = {
 						ProvisioningStyle = Automatic;
 					};
@@ -431,6 +482,7 @@
 			targets = (
 				AAACA90456A4A22561940B6B /* SandboxedDashboard */,
 				C50B6EE186DD640BD408EEA7 /* SandboxedDashboardTests */,
+				8A8DCA11CAC3A5FFA56DC86C /* SandboxedDashboardUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -477,6 +529,8 @@
 				08D9C00F453EE16A24DC9C84 /* FilesView.swift in Sources */,
 				40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */,
 				C159E476E057E6691D1E0E85 /* GlassCard.swift in Sources */,
+				58A71FAA4BF80A3C1C866EF2 /* Hermes.swift in Sources */,
+				7E9D0E83D72B53C90238CDDC /* HermesConversationView.swift in Sources */,
 				07ED817585C2EE9A5E11C851 /* HistoryView.swift in Sources */,
 				85E2D1C0C810F9A6435F06AE /* ImageMemoryCache.swift in Sources */,
 				48ADF499E7EE67D254FBE45A /* LoadingView.swift in Sources */,
@@ -516,15 +570,29 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				078E5F28B7022DCD1BC721FD /* HermesConversationTests.swift in Sources */,
 				46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */,
 				2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */,
 				7EF75A17733EE6E54126C7A7 /* ThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5CD092F6D3EAB34E8C939F58 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B12C86DF039026D6FFFD2B52 /* HermesConversationUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		67E18B6A61C28B344B3B9868 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AAACA90456A4A22561940B6B /* SandboxedDashboard */;
+			targetProxy = 0BF574A38210A93AD4F2C434 /* PBXContainerItemProxy */;
+		};
 		A7EED4AADD2EC2E53F54C503 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = AAACA90456A4A22561940B6B /* SandboxedDashboard */;
@@ -719,6 +787,44 @@
 			};
 			name = Release;
 		};
+		D9B01233EE7EF545960BDAB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = md.thomas.openagent.dashboard.uitests;
+				PRODUCT_NAME = SandboxedDashboardUITests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SandboxedDashboard;
+			};
+			name = Release;
+		};
+		F266DC6E627F502AB5AA0977 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = md.thomas.openagent.dashboard.uitests;
+				PRODUCT_NAME = SandboxedDashboardUITests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SandboxedDashboard;
+			};
+			name = Debug;
+		};
 		F2D4B4EF1E0822D4A7B99DD4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -764,6 +870,15 @@
 			buildConfigurations = (
 				9EE7D2DC6546B7B54FAC22B8 /* Debug */,
 				8C8EAD06F422706D5016CAAE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		E6D8F0304264974ECA11ADE5 /* Build configuration list for PBXNativeTarget "SandboxedDashboardUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F266DC6E627F502AB5AA0977 /* Debug */,
+				D9B01233EE7EF545960BDAB1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/ios_dashboard/SandboxedDashboard/Info.plist
+++ b/ios_dashboard/SandboxedDashboard/Info.plist
@@ -56,6 +56,17 @@
     </dict>
     <key>CFBundleIconName</key>
     <string>AppIcon</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>md.thomas.openagent.dashboard.conversation</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>sandboxed</string>
+            </array>
+        </dict>
+    </array>
     <key>UIBackgroundModes</key>
     <array>
         <string>audio</string>

--- a/ios_dashboard/SandboxedDashboard/Models/Hermes.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Hermes.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+// Models for Hermes sessions — the assistant gateway's conversations, reached
+// through the backend proxy at `/api/assistant/hermes/api/sessions*` (which
+// swaps the dashboard JWT for Hermes' own API key server-side).
+//
+// A Hermes session is a conversation like a mission is, but owned by Hermes:
+// it can run on any platform (Telegram, cron, this app) and can spawn missions
+// as workers (`Mission.originSessionId`).
+
+// MARK: - Session
+
+struct HermesSession: Codable, Identifiable, Hashable {
+    let id: String
+    let source: String?
+    let model: String?
+    let title: String?
+    let startedAt: Double?
+    let endedAt: Double?
+    let lastActive: Double?
+    let preview: String?
+    let messageCount: Int?
+    let parentSessionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, source, model, title, preview
+        case startedAt = "started_at"
+        case endedAt = "ended_at"
+        case lastActive = "last_active"
+        case messageCount = "message_count"
+        case parentSessionId = "parent_session_id"
+    }
+
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: HermesSession, rhs: HermesSession) -> Bool { lhs.id == rhs.id }
+
+    /// Hermes leaves `title` null until its titler runs, so fall back to the
+    /// first-message preview before the raw id.
+    var displayTitle: String {
+        if let title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return title
+        }
+        if let preview, !preview.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return preview.count > 60 ? String(preview.prefix(60)) + "…" : preview
+        }
+        return "Session \(id.prefix(8))"
+    }
+
+    var lastActiveDate: Date? {
+        guard let seconds = lastActive ?? startedAt else { return nil }
+        return Date(timeIntervalSince1970: seconds)
+    }
+}
+
+/// Envelope of `GET /api/assistant/hermes/api/sessions`.
+struct HermesSessionList: Codable {
+    let data: [HermesSession]
+}
+
+/// Envelope of `POST /api/assistant/hermes/api/sessions`.
+struct HermesSessionEnvelope: Codable {
+    let session: HermesSession
+}
+
+// MARK: - Message
+
+struct HermesMessage: Codable, Identifiable {
+    /// Hermes numbers persisted messages; synthesized rows have no id.
+    let messageId: Int?
+    let sessionId: String?
+    let role: String
+    let content: String?
+    let toolCallId: String?
+    let toolName: String?
+    let timestamp: Double?
+    let reasoning: String?
+    let reasoningContent: String?
+    let toolCalls: [HermesToolCall]?
+
+    var id: String {
+        if let messageId { return "hermes-msg-\(messageId)" }
+        return "hermes-msg-\(sessionId ?? "?")-\(role)-\(timestamp ?? 0)"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case role, content, timestamp, reasoning
+        case messageId = "id"
+        case sessionId = "session_id"
+        case toolCallId = "tool_call_id"
+        case toolName = "tool_name"
+        case reasoningContent = "reasoning_content"
+        case toolCalls = "tool_calls"
+    }
+
+    var reasoningText: String? {
+        let text = (reasoningContent ?? reasoning ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+}
+
+/// A tool call attached to an assistant message (OpenAI-shaped).
+struct HermesToolCall: Codable {
+    let id: String?
+    let function: HermesToolFunction?
+
+    struct HermesToolFunction: Codable {
+        let name: String?
+        /// JSON-encoded argument object.
+        let arguments: String?
+    }
+
+    var toolName: String { function?.name ?? "tool" }
+}
+
+/// Envelope of `GET /api/assistant/hermes/api/sessions/:id/messages`.
+struct HermesMessageList: Codable {
+    let sessionId: String?
+    let data: [HermesMessage]
+
+    enum CodingKeys: String, CodingKey {
+        case data
+        case sessionId = "session_id"
+    }
+}
+
+// MARK: - Chat stream
+
+/// One named SSE event from `POST …/sessions/:id/chat/stream`.
+///
+/// Unlike the Ask stream (which carries a `type` field in the payload), Hermes
+/// puts the discriminator in the SSE `event:` line, so the name is attached
+/// while parsing rather than decoded.
+struct HermesStreamEvent {
+    let name: String
+    let text: String?
+    let toolName: String?
+    let preview: String?
+    let message: String?
+
+    /// Decodable half of the frame; `name` comes from the `event:` line.
+    struct Payload: Decodable {
+        let text: String?
+        let content: String?
+        let delta: String?
+        let toolName: String?
+        let preview: String?
+        let message: String?
+        let error: String?
+
+        enum CodingKeys: String, CodingKey {
+            case text, content, delta, preview, message, error
+            case toolName = "tool_name"
+        }
+    }
+
+    init(name: String, payload: Payload) {
+        self.name = name
+        self.text = payload.text ?? payload.content ?? payload.delta
+        self.toolName = payload.toolName
+        self.preview = payload.preview
+        self.message = payload.message ?? payload.error
+    }
+}
+
+/// Error carrying a Hermes stream failure, so it surfaces through the throw path.
+struct HermesStreamError: LocalizedError {
+    let message: String
+    var errorDescription: String? { message }
+}

--- a/ios_dashboard/SandboxedDashboard/Models/Hermes.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Hermes.swift
@@ -53,8 +53,30 @@ struct HermesSession: Codable, Identifiable, Hashable {
 }
 
 /// Envelope of `GET /api/assistant/hermes/api/sessions`.
+///
+/// Hermes has shipped this list under both `sessions` and `data` depending on
+/// the version; the web client accepts either, so decode both here too rather
+/// than let a gateway upgrade silently empty the session list (which reads as
+/// "Hermes not available" and hides the whole feature).
 struct HermesSessionList: Codable {
-    let data: [HermesSession]
+    let sessions: [HermesSession]
+
+    enum CodingKeys: String, CodingKey {
+        case sessions, data
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessions =
+            try container.decodeIfPresent([HermesSession].self, forKey: .sessions)
+            ?? container.decodeIfPresent([HermesSession].self, forKey: .data)
+            ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessions, forKey: .sessions)
+    }
 }
 
 /// Envelope of `POST /api/assistant/hermes/api/sessions`.
@@ -114,13 +136,31 @@ struct HermesToolCall: Codable {
 }
 
 /// Envelope of `GET /api/assistant/hermes/api/sessions/:id/messages`.
+///
+/// Same dual-key tolerance as `HermesSessionList` — a transcript that decodes
+/// to nothing would render as an empty conversation with no error.
 struct HermesMessageList: Codable {
     let sessionId: String?
-    let data: [HermesMessage]
+    let messages: [HermesMessage]
 
     enum CodingKeys: String, CodingKey {
-        case data
+        case messages, data
         case sessionId = "session_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = try container.decodeIfPresent(String.self, forKey: .sessionId)
+        messages =
+            try container.decodeIfPresent([HermesMessage].self, forKey: .messages)
+            ?? container.decodeIfPresent([HermesMessage].self, forKey: .data)
+            ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sessionId, forKey: .sessionId)
+        try container.encode(messages, forKey: .messages)
     }
 }
 

--- a/ios_dashboard/SandboxedDashboard/Models/Mission.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Mission.swift
@@ -113,6 +113,11 @@ struct Mission: Codable, Identifiable, Hashable {
     let firstViewedAt: String?
     let resumable: Bool
     let parentMissionId: String?
+    /// Which system created this mission ("hermes" for the assistant MCP).
+    let origin: String?
+    /// Hermes session that spawned this mission, when `origin == "hermes"`.
+    /// Lets clients group the mission as a worker of that conversation.
+    let originSessionId: String?
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
@@ -139,6 +144,8 @@ struct Mission: Codable, Identifiable, Hashable {
         case interruptedAt = "interrupted_at"
         case firstViewedAt = "first_viewed_at"
         case parentMissionId = "parent_mission_id"
+        case origin
+        case originSessionId = "origin_session_id"
     }
 
     init(from decoder: Decoder) throws {
@@ -165,6 +172,8 @@ struct Mission: Codable, Identifiable, Hashable {
         firstViewedAt = try container.decodeIfPresent(String.self, forKey: .firstViewedAt)
         resumable = try container.decodeIfPresent(Bool.self, forKey: .resumable) ?? false
         parentMissionId = try container.decodeIfPresent(String.self, forKey: .parentMissionId)
+        origin = try container.decodeIfPresent(String.self, forKey: .origin)
+        originSessionId = try container.decodeIfPresent(String.self, forKey: .originSessionId)
     }
 
     var displayTitle: String {

--- a/ios_dashboard/SandboxedDashboard/SandboxedDashboardApp.swift
+++ b/ios_dashboard/SandboxedDashboard/SandboxedDashboardApp.swift
@@ -20,6 +20,9 @@ struct SandboxedDashboardApp: App {
         WindowGroup {
             ContentView()
                 .preferredColorScheme(.dark)
+                .onOpenURL { url in
+                    NavigationState.shared.handle(url: url)
+                }
         }
     }
 }

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -670,6 +670,140 @@ final class APIService {
         )
     }
 
+    // MARK: - Hermes sessions
+    //
+    // Hermes conversations, reached through the backend proxy which swaps this
+    // app's JWT for Hermes' own API key server-side. The app never sees that
+    // key, and only the `/api/sessions*` surface is exposed.
+
+    private static let hermesProxy = "/api/assistant/hermes"
+
+    func listHermesSessions(limit: Int = 30) async throws -> [HermesSession] {
+        let list: HermesSessionList = try await get(
+            "\(Self.hermesProxy)/api/sessions?source=api_server&limit=\(limit)"
+        )
+        return list.data
+    }
+
+    func createHermesSession(title: String? = nil) async throws -> HermesSession {
+        struct Body: Encodable { let title: String? }
+        let envelope: HermesSessionEnvelope = try await post(
+            "\(Self.hermesProxy)/api/sessions",
+            body: Body(title: title)
+        )
+        return envelope.session
+    }
+
+    func getHermesSessionMessages(sessionId: String) async throws -> [HermesMessage] {
+        let list: HermesMessageList = try await get(
+            "\(Self.hermesProxy)/api/sessions/\(sessionId)/messages"
+        )
+        return list.data
+    }
+
+    func deleteHermesSession(sessionId: String) async throws {
+        let _: EmptyResponse = try await delete("\(Self.hermesProxy)/api/sessions/\(sessionId)")
+    }
+
+    /// Send a message to a Hermes session and stream the turn back.
+    ///
+    /// Hermes emits *named* SSE events (`event: assistant.delta`, `tool.started`,
+    /// …) rather than a `type` field in the payload, so the frame parser here is
+    /// hand-rolled instead of reusing the Ask stream's line decoder. Cancelling
+    /// the task aborts the run server-side.
+    func hermesChatStream(
+        sessionId: String,
+        message: String
+    ) -> AsyncThrowingStream<HermesStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    guard
+                        let url = makeURL(
+                            "\(Self.hermesProxy)/api/sessions/\(sessionId)/chat/stream")
+                    else {
+                        throw APIError.invalidURL
+                    }
+                    var request = URLRequest(url: url)
+                    request.httpMethod = "POST"
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                    if let token = jwtToken {
+                        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                    }
+                    struct Body: Encodable { let message: String }
+                    request.httpBody = try JSONEncoder().encode(Body(message: message))
+
+                    let (bytes, response) = try await Self.askSession.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else {
+                        throw APIError.invalidResponse
+                    }
+                    if http.statusCode == 401 {
+                        markSessionExpired()
+                        throw APIError.unauthorized
+                    }
+                    guard (200..<300).contains(http.statusCode) else {
+                        throw APIError.httpError(http.statusCode, nil)
+                    }
+
+                    let decoder = JSONDecoder()
+                    var eventName = ""
+                    var payloadRaw = ""
+                    var sawTerminal = false
+
+                    // Emit the frame accumulated so far. SSE frames end at a
+                    // blank line; `bytes.lines` already strips the newlines.
+                    func flushFrame() throws {
+                        defer {
+                            eventName = ""
+                            payloadRaw = ""
+                        }
+                        guard !eventName.isEmpty, !payloadRaw.isEmpty,
+                            let data = payloadRaw.data(using: .utf8),
+                            let payload = try? decoder.decode(
+                                HermesStreamEvent.Payload.self, from: data)
+                        else { return }
+                        let event = HermesStreamEvent(name: eventName, payload: payload)
+                        if event.name == "error" {
+                            throw HermesStreamError(
+                                message: event.message ?? "Hermes run failed")
+                        }
+                        if event.name == "done" || event.name == "run.completed" {
+                            sawTerminal = true
+                        }
+                        continuation.yield(event)
+                    }
+
+                    for try await rawLine in bytes.lines {
+                        // nginx can preserve upstream CRLF line endings.
+                        let line = rawLine.hasSuffix("\r") ? String(rawLine.dropLast()) : rawLine
+                        if line.isEmpty {
+                            try flushFrame()
+                        } else if line.hasPrefix("event:") {
+                            eventName = String(line.dropFirst(6))
+                                .trimmingCharacters(in: .whitespaces)
+                        } else if line.hasPrefix("data:") {
+                            payloadRaw += String(line.dropFirst(5))
+                                .trimmingCharacters(in: .whitespaces)
+                        }
+                        // Comment lines (`: keepalive`) are ignored.
+                    }
+                    try flushFrame()
+
+                    // A truncated stream that never delivered a terminal event
+                    // is a failure, not a silent success.
+                    if !sawTerminal {
+                        throw HermesStreamError(message: "Stream ended before completion")
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
     // MARK: - Queue Management
 
     func getQueue() async throws -> [QueuedMessage] {

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -682,7 +682,7 @@ final class APIService {
         let list: HermesSessionList = try await get(
             "\(Self.hermesProxy)/api/sessions?source=api_server&limit=\(limit)"
         )
-        return list.data
+        return list.sessions
     }
 
     func createHermesSession(title: String? = nil) async throws -> HermesSession {
@@ -698,7 +698,7 @@ final class APIService {
         let list: HermesMessageList = try await get(
             "\(Self.hermesProxy)/api/sessions/\(sessionId)/messages"
         )
-        return list.data
+        return list.messages
     }
 
     func deleteHermesSession(sessionId: String) async throws {

--- a/ios_dashboard/SandboxedDashboard/Services/NavigationState.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/NavigationState.swift
@@ -17,20 +17,56 @@ final class NavigationState {
     
     /// Mission ID to open in Control tab (set from History, cleared after use)
     var pendingMissionId: String?
-    
+
+    /// Hermes session id to open in the Control tab. Cleared after use, like
+    /// `pendingMissionId` — the tab shows one conversation at a time.
+    var pendingHermesSessionId: String?
+
     private init() {}
-    
+
     /// Navigate to Control tab with a specific mission
     func openMission(_ missionId: String) {
         pendingMissionId = missionId
         selectedTab = .control
         HapticService.selectionChanged()
     }
-    
+
     /// Consume the pending mission ID (called by ControlView)
     func consumePendingMission() -> String? {
         let id = pendingMissionId
         pendingMissionId = nil
         return id
+    }
+
+    /// Navigate to the Control tab showing a Hermes conversation.
+    func openHermesSession(_ sessionId: String) {
+        pendingHermesSessionId = sessionId
+        selectedTab = .control
+        HapticService.selectionChanged()
+    }
+
+    /// Handle a `sandboxed://` deep link.
+    ///
+    /// Supported: `sandboxed://mission/<id>` and `sandboxed://session/<id>` —
+    /// the two conversation kinds, mirroring the web's `?mission=` / `?session=`.
+    func handle(url: URL) {
+        guard url.scheme?.lowercased() == "sandboxed" else { return }
+        // Both `sandboxed://session/<id>` (host = "session") and
+        // `sandboxed:///session/<id>` (empty host) are accepted.
+        var components = url.pathComponents.filter { $0 != "/" }
+        if let host = url.host, !host.isEmpty {
+            components.insert(host, at: 0)
+        }
+        guard components.count >= 2 else { return }
+        let identifier = components[1]
+        guard !identifier.isEmpty else { return }
+        switch components[0].lowercased() {
+        case "mission":
+            openMission(identifier)
+        case "session":
+            openHermesSession(identifier)
+        default:
+            break
+        }
     }
 }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -251,6 +251,12 @@ struct ControlView: View {
     @State private var showMissionSwitcher = false
     @State private var recentMissions: [Mission] = []
 
+    // Hermes session state. When `viewingHermesSessionId` is set the tab shows
+    // that conversation instead of a mission — same surface, other kind of
+    // conversation. Selecting a mission anywhere clears it.
+    @State private var hermesSessions: [HermesSession] = []
+    @State private var viewingHermesSessionId: String?
+
     // Desktop stream state
     @State private var showDesktopStream = false
     @State private var desktopDisplayId = ":101"
@@ -279,7 +285,7 @@ struct ControlView: View {
     
     var body: some View {
         bodyContent
-            .navigationTitle(viewingMission?.displayTitle ?? "Control")
+            .navigationTitle(navigationTitleText)
             .navigationBarTitleDisplayMode(.inline)
             // Keep the bar opaque: without this the conversation scrolls
             // through the title/buttons because SwiftUI can't always find
@@ -288,14 +294,24 @@ struct ControlView: View {
             .toolbarBackground(Theme.backgroundPrimary, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
-                ToolbarItem(placement: .principal) { AnyView(principalToolbarContent) }
-                ToolbarItem(placement: .topBarLeading) { AnyView(leadingToolbarContent) }
+                // A Hermes conversation draws its own header and has none of
+                // the mission affordances (thoughts, Ask, mission actions), so
+                // only the switcher stays — it's the way back out.
+                if viewingHermesSessionId == nil {
+                    ToolbarItem(placement: .principal) { AnyView(principalToolbarContent) }
+                    ToolbarItem(placement: .topBarLeading) { AnyView(leadingToolbarContent) }
+                }
                 ToolbarItem(placement: .topBarTrailing) { AnyView(missionSwitcherToolbarButton) }
-                ToolbarItem(placement: .topBarTrailing) { AnyView(overflowMenuToolbarItem) }
+                if viewingHermesSessionId == nil {
+                    ToolbarItem(placement: .topBarTrailing) { AnyView(overflowMenuToolbarItem) }
+                }
             }
         .task { await coldStart() }
         .onChange(of: nav.pendingMissionId) { _, newId in
             handlePendingMissionId(newId)
+        }
+        .onChange(of: nav.pendingHermesSessionId) { _, newId in
+            handlePendingHermesSessionId(newId)
         }
         .onChange(of: currentMission?.id) { _, newId in
             syncViewingMissionFromCurrent(newId: newId)
@@ -385,6 +401,10 @@ struct ControlView: View {
                     showNewMissionSheet = false
                     Task { await createNewMission(options: options) }
                 },
+                onCreateHermesSession: {
+                    showNewMissionSheet = false
+                    Task { await createHermesSession() }
+                },
                 onCancel: {
                     showNewMissionSheet = false
                 }
@@ -400,6 +420,7 @@ struct ControlView: View {
         }
         .sheet(isPresented: $showMissionSwitcher) {
             missionSwitcherSheetContent
+                .task { await loadHermesSessions() }
         }
         .sheet(isPresented: $showQueueSheet) {
             QueueSheet(
@@ -497,11 +518,17 @@ struct ControlView: View {
         MissionSwitcherSheet(
             runningMissions: runningMissions,
             recentMissions: recentMissions,
+            hermesSessions: hermesSessions,
             currentMissionId: currentMission?.id,
             viewingMissionId: viewingMissionId,
+            viewingHermesSessionId: viewingHermesSessionId,
             onSelectMission: { missionId in
                 showMissionSwitcher = false
                 Task { await switchToMission(id: missionId) }
+            },
+            onSelectHermesSession: { sessionId in
+                showMissionSwitcher = false
+                openHermesSession(sessionId)
             },
             onResumeMission: { missionId in
                 showMissionSwitcher = false
@@ -602,6 +629,7 @@ struct ControlView: View {
             }
             .foregroundStyle(runningMissions.isEmpty ? Theme.textSecondary : Theme.accent)
         }
+        .accessibilityLabel("Switch mission")
     }
 
     /// Trailing toolbar: overflow `...` menu with all the actions.
@@ -775,12 +803,27 @@ struct ControlView: View {
 
     /// Top-level body ZStack — opaque single-View so the long modifier
     /// chain on `body` doesn't blow the SwiftUI type-checker budget.
+    /// The tab hosts two conversation kinds; the title follows whichever is
+    /// on screen. The Hermes view draws its own header, so keep this generic.
+    private var navigationTitleText: String {
+        if viewingHermesSessionId != nil { return "Conversation" }
+        return viewingMission?.displayTitle ?? "Control"
+    }
+
     private var bodyContent: some View {
         ZStack {
             Theme.backgroundPrimary.ignoresSafeArea()
-            backgroundGlows
-            mainContentStack
-            diagnosticsOverlay
+            if let sessionId = viewingHermesSessionId {
+                HermesConversationView(
+                    sessionId: sessionId,
+                    session: hermesSessions.first { $0.id == sessionId }
+                )
+                .id(sessionId)
+            } else {
+                backgroundGlows
+                mainContentStack
+                diagnosticsOverlay
+            }
         }
     }
 
@@ -880,7 +923,52 @@ struct ControlView: View {
     private func handlePendingMissionId(_ newId: String?) {
         guard let missionId = newId else { return }
         nav.pendingMissionId = nil
+        viewingHermesSessionId = nil
         Task { await loadMission(id: missionId) }
+    }
+
+    /// Handle a `sandboxed://session/<id>` deep link (or an in-app request
+    /// routed through `NavigationState`).
+    private func handlePendingHermesSessionId(_ newId: String?) {
+        guard let sessionId = newId else { return }
+        nav.pendingHermesSessionId = nil
+        openHermesSession(sessionId)
+        if hermesSessions.isEmpty {
+            Task { await loadHermesSessions() }
+        }
+    }
+
+    /// Show a Hermes session in this tab, replacing whatever mission was
+    /// being viewed. The mission stream keeps running underneath.
+    private func openHermesSession(_ sessionId: String) {
+        viewingHermesSessionId = sessionId
+        HapticService.selectionChanged()
+    }
+
+    /// Hermes conversations for the switcher. The request doubles as the
+    /// availability probe: when Hermes isn't adopted, it fails and the
+    /// section simply stays empty.
+    private func loadHermesSessions() async {
+        hermesSessions = (try? await api.listHermesSessions(limit: 30)) ?? []
+    }
+
+    /// Start a fresh Hermes conversation and show it.
+    private func createHermesSession() async {
+        do {
+            let session = try await api.createHermesSession()
+            hermesSessions.insert(session, at: 0)
+            openHermesSession(session.id)
+        } catch {
+            // Surface in the mission transcript, the same way stream errors do
+            // — the sheet is already dismissed at this point.
+            messages.append(
+                ChatMessage(
+                    id: "error-\(Date().timeIntervalSince1970)",
+                    type: .error,
+                    content: "Could not start a Hermes session: \(error.localizedDescription)"
+                )
+            )
+        }
     }
 
     /// On change of `currentMission?.id`: if no mission is being viewed yet,
@@ -1233,7 +1321,10 @@ struct ControlView: View {
     /// Groups consecutive tool calls together for collapsed display (like dashboard).
     /// Thinking messages are always elided here — they live in the thoughts sheet
     /// only. Showing them inline duplicated the same content twice on screen.
-    private static func buildGroupedItems(from messages: [ChatMessage]) -> [GroupedChatItem] {
+    /// Collapse a flat message list into rendered rows (tool runs grouped,
+    /// thinking elided). Shared with the Hermes session view so both
+    /// conversation kinds group identically.
+    static func buildGroupedItems(from messages: [ChatMessage]) -> [GroupedChatItem] {
         var result: [GroupedChatItem] = []
         var currentToolGroup: [ChatMessage] = []
 
@@ -3668,6 +3759,9 @@ struct ControlView: View {
     }
     
     private func switchToMission(id: String) async {
+        // Leaving a Hermes session for a mission: the tab shows one
+        // conversation at a time.
+        viewingHermesSessionId = nil
         guard id != viewingMissionId else { return }
 
         // Set the target mission ID immediately for race condition tracking

--- a/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
@@ -203,12 +203,16 @@ struct HermesConversationView: View {
 
     private var composer: some View {
         HStack(spacing: 8) {
-            TextField("Message Hermes…", text: $input, axis: .vertical)
-                .lineLimit(1...5)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(Theme.card)
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            TextField(
+                historyLoaded ? "Message Hermes…" : "Loading session…",
+                text: $input,
+                axis: .vertical
+            )
+            .lineLimit(1...5)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Theme.card)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
 
             if isRunning {
                 Button(action: stop) {
@@ -231,8 +235,14 @@ struct HermesConversationView: View {
         .background(.ultraThinMaterial)
     }
 
+    /// Sending is held until the transcript has loaded: `loadHistory` replaces
+    /// the whole message list when it lands, so a send racing it would have its
+    /// optimistic bubble (and any stream events already folded in) wiped by the
+    /// older snapshot.
     private var canSend: Bool {
-        !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isRunning
+        !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isRunning
+            && historyLoaded
     }
 
     // MARK: - Loading
@@ -285,7 +295,7 @@ struct HermesConversationView: View {
 
     private func send() {
         let content = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !content.isEmpty, !isRunning else { return }
+        guard !content.isEmpty, !isRunning, historyLoaded else { return }
         input = ""
         errorText = nil
         HapticService.selectionChanged()

--- a/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
@@ -1,0 +1,640 @@
+import SwiftUI
+
+/// A Hermes session rendered with the mission transcript's own vocabulary.
+///
+/// Hermes conversations and missions are two kinds of the same thing here, so
+/// this view maps Hermes history and stream events onto `ChatMessage` and hands
+/// them to the shared renderer (`ControlView.buildGroupedItems` →
+/// `ConversationRowsView`). Tool runs group, thinking stays out of the main
+/// pane, and bubbles look identical to a mission's.
+///
+/// Transport is the backend's Hermes proxy: history over REST, one turn per
+/// `POST …/chat/stream` (named-event SSE). Turns started elsewhere (Telegram,
+/// cron) land on the next idle re-poll.
+struct HermesConversationView: View {
+    let sessionId: String
+    /// Known session metadata, when the caller already has it (avoids a fetch
+    /// just to render the title).
+    var session: HermesSession?
+
+    @State private var messages: [ChatMessage] = []
+    @State private var groupedItems: [GroupedChatItem] = []
+    @State private var expandedToolGroups: Set<String> = []
+    @State private var copiedMessageId: String?
+    @State private var input = ""
+    @State private var isRunning = false
+    @State private var historyLoaded = false
+    @State private var errorText: String?
+    @State private var resolvedSession: HermesSession?
+    @State private var workerMissions: [Mission] = []
+
+    /// Id of the assistant bubble currently being streamed into.
+    @State private var streamId: String?
+    /// Accumulated text of the in-flight assistant turn.
+    @State private var streamText = ""
+    /// Open tool bubbles by name — Hermes' REST tool events carry no call id,
+    /// so completions are matched FIFO against the calls of the same name.
+    @State private var openToolIdsByName: [String: [String]] = [:]
+    @State private var streamTask: Task<Void, Never>?
+    /// Bumped on session switch / send so superseded work can bail out.
+    @State private var generation = 0
+
+    private let api = APIService.shared
+    private let hermesTint = Color.indigo
+
+    private var title: String {
+        (session ?? resolvedSession)?.displayTitle ?? "Session \(sessionId.prefix(8))"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            if !workerMissions.isEmpty {
+                workerStrip
+            }
+            transcript
+            composer
+        }
+        .background(Theme.backgroundPrimary)
+        .task(id: sessionId) {
+            generation += 1
+            resetState()
+            await loadHistory()
+            await loadSessionMetadata()
+        }
+        .onDisappear {
+            streamTask?.cancel()
+            streamTask = nil
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(hermesTint)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                Text("Hermes session")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            Spacer(minLength: 8)
+            if isRunning {
+                HStack(spacing: 5) {
+                    ProgressView().controlSize(.small)
+                    Text("working")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Theme.backgroundSecondary)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.hairline).frame(height: 0.5)
+        }
+    }
+
+    /// Missions this session spawned (`origin_session_id`), as tappable chips.
+    private var workerStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                Text("Workers")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.textTertiary)
+                ForEach(workerMissions) { mission in
+                    Button {
+                        NavigationState.shared.openMission(mission.id)
+                    } label: {
+                        HStack(spacing: 5) {
+                            StatusDot(status: mission.status.statusType)
+                            Text(mission.displayTitle)
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.textSecondary)
+                                .lineLimit(1)
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Theme.card)
+                        .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+        }
+        .background(Theme.backgroundSecondary)
+    }
+
+    // MARK: - Transcript
+
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    if !historyLoaded {
+                        HStack(spacing: 8) {
+                            ProgressView().controlSize(.small)
+                            Text("Loading session…")
+                                .font(.footnote)
+                                .foregroundStyle(Theme.textMuted)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 40)
+                    } else if groupedItems.isEmpty {
+                        emptyState
+                    }
+
+                    ConversationRowsView(
+                        groupedItems: groupedItems,
+                        copiedMessageId: copiedMessageId,
+                        expandedToolGroups: $expandedToolGroups,
+                        onCopy: copy,
+                        onRetry: { _ in }
+                    )
+
+                    if let errorText {
+                        Text(errorText)
+                            .font(.caption)
+                            .foregroundStyle(Theme.error)
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Theme.error.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .id("error")
+                    }
+
+                    Color.clear.frame(height: 1).id("bottom")
+                }
+                .padding(16)
+            }
+            .onChange(of: groupedItems.count) { _, _ in
+                withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+            }
+            .onChange(of: streamText) { _, _ in
+                proxy.scrollTo("bottom", anchor: .bottom)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 22))
+                .foregroundStyle(hermesTint.opacity(0.5))
+            Text("Send the first message to start this session.")
+                .font(.footnote)
+                .foregroundStyle(Theme.textMuted)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    // MARK: - Composer
+
+    private var composer: some View {
+        HStack(spacing: 8) {
+            TextField("Message Hermes…", text: $input, axis: .vertical)
+                .lineLimit(1...5)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Theme.card)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            if isRunning {
+                Button(action: stop) {
+                    Image(systemName: "stop.circle.fill")
+                        .font(.system(size: 28))
+                        .foregroundStyle(Theme.error)
+                }
+                .accessibilityLabel("Stop")
+            } else {
+                Button(action: send) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 28))
+                        .foregroundStyle(canSend ? hermesTint : Theme.textMuted)
+                }
+                .disabled(!canSend)
+                .accessibilityLabel("Send")
+            }
+        }
+        .padding(12)
+        .background(.ultraThinMaterial)
+    }
+
+    private var canSend: Bool {
+        !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isRunning
+    }
+
+    // MARK: - Loading
+
+    private func resetState() {
+        streamTask?.cancel()
+        streamTask = nil
+        messages = []
+        groupedItems = []
+        expandedToolGroups = []
+        streamId = nil
+        streamText = ""
+        openToolIdsByName = [:]
+        isRunning = false
+        historyLoaded = false
+        errorText = nil
+        workerMissions = []
+        resolvedSession = nil
+    }
+
+    private func loadHistory() async {
+        let gen = generation
+        do {
+            let history = try await api.getHermesSessionMessages(sessionId: sessionId)
+            guard gen == generation else { return }
+            messages = HermesTranscript.chatMessages(from: history)
+            regroup()
+            historyLoaded = true
+        } catch {
+            guard gen == generation else { return }
+            historyLoaded = true
+            errorText = friendlyMessage(for: error)
+        }
+    }
+
+    /// Session title (when not supplied) and the missions this session spawned.
+    private func loadSessionMetadata() async {
+        let gen = generation
+        if session == nil {
+            if let sessions = try? await api.listHermesSessions(limit: 200), gen == generation {
+                resolvedSession = sessions.first { $0.id == sessionId }
+            }
+        }
+        if let missions = try? await api.listMissions(), gen == generation {
+            workerMissions = missions.filter { $0.originSessionId == sessionId }
+        }
+    }
+
+    // MARK: - Sending
+
+    private func send() {
+        let content = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty, !isRunning else { return }
+        input = ""
+        errorText = nil
+        HapticService.selectionChanged()
+
+        messages.append(
+            ChatMessage(type: .user, content: content, timestamp: Date())
+        )
+        isRunning = true
+        regroup()
+
+        let gen = generation
+        streamTask = Task {
+            do {
+                for try await event in api.hermesChatStream(
+                    sessionId: sessionId, message: content)
+                {
+                    if gen != generation || Task.isCancelled { return }
+                    apply(event)
+                }
+                if gen == generation { finishTurn() }
+            } catch is CancellationError {
+                if gen == generation { finishTurn() }
+            } catch {
+                guard gen == generation else { return }
+                finishTurn()
+                errorText = friendlyMessage(for: error)
+            }
+        }
+    }
+
+    private func stop() {
+        // Aborting the request cancels the run server-side.
+        streamTask?.cancel()
+        streamTask = nil
+        finishTurn()
+    }
+
+    // MARK: - Stream folding
+
+    private func apply(_ event: HermesStreamEvent) {
+        switch event.name {
+        case "assistant.delta":
+            guard let text = event.text, !text.isEmpty else { return }
+            streamText += text
+            upsertStreamBubble()
+        case "tool.progress":
+            // Hermes surfaces reasoning as progress on the `_thinking` tool.
+            guard event.toolName == "_thinking", let text = event.text, !text.isEmpty else {
+                return
+            }
+            appendThinking(text)
+        case "tool.started":
+            startTool(named: event.toolName ?? "tool", preview: event.preview)
+        case "tool.completed":
+            completeTool(named: event.toolName ?? "tool", result: event.preview, failed: false)
+        case "tool.failed":
+            completeTool(
+                named: event.toolName ?? "tool",
+                result: event.preview ?? event.message ?? "failed",
+                failed: true
+            )
+        case "assistant.completed":
+            // Authoritative final text for the turn — replaces the deltas.
+            if let text = event.text, !text.isEmpty {
+                streamText = text
+            }
+            flushAssistantBubble()
+        case "run.completed", "done":
+            finishTurn()
+        default:
+            break
+        }
+    }
+
+    private func upsertStreamBubble() {
+        if let streamId, let index = messages.firstIndex(where: { $0.id == streamId }) {
+            messages[index].content = streamText
+        } else {
+            let id = "hs-stream-\(UUID().uuidString)"
+            streamId = id
+            messages.append(
+                ChatMessage(
+                    id: id,
+                    type: .assistant(
+                        success: true, costCents: 0, costSource: .unknown,
+                        model: nil, sharedFiles: nil),
+                    content: streamText
+                )
+            )
+        }
+        regroup()
+    }
+
+    private func appendThinking(_ text: String) {
+        if let index = messages.lastIndex(where: { $0.isThinking }),
+            case .thinking(let done, _) = messages[index].type, !done
+        {
+            messages[index].content += text
+        } else {
+            messages.append(
+                ChatMessage(
+                    type: .thinking(done: false, startTime: Date()),
+                    content: text
+                )
+            )
+        }
+        regroup()
+    }
+
+    private func finalizeThinking() {
+        guard let index = messages.lastIndex(where: { $0.isThinking }),
+            case .thinking(let done, let start) = messages[index].type, !done
+        else { return }
+        let existing = messages[index]
+        messages[index] = ChatMessage(
+            id: existing.id,
+            type: .thinking(done: true, startTime: start),
+            content: existing.content,
+            timestamp: existing.timestamp
+        )
+    }
+
+    private func startTool(named name: String, preview: String?) {
+        // A tool run ends the current assistant segment; flush it so the tool
+        // bubble lands after the text that introduced it.
+        flushAssistantBubble()
+        let callId = "hs-tool-\(UUID().uuidString)"
+        openToolIdsByName[name, default: []].append(callId)
+        messages.append(
+            ChatMessage(
+                id: callId,
+                type: .toolCall(name: name, isActive: true),
+                content: preview ?? "",
+                toolData: ToolCallData(
+                    toolCallId: callId,
+                    name: name,
+                    args: preview.map { ["preview": $0] } ?? [:],
+                    startTime: Date(),
+                    endTime: nil,
+                    result: nil,
+                    state: .running
+                )
+            )
+        )
+        regroup()
+    }
+
+    private func completeTool(named name: String, result: String?, failed: Bool) {
+        guard var open = openToolIdsByName[name], !open.isEmpty else { return }
+        let callId = open.removeFirst()
+        openToolIdsByName[name] = open
+        guard let index = messages.firstIndex(where: { $0.id == callId }) else { return }
+        var data = messages[index].toolData
+        data?.endTime = Date()
+        data?.result = result
+        data?.state = failed ? .error : .success
+        let existing = messages[index]
+        messages[index] = ChatMessage(
+            id: existing.id,
+            type: .toolCall(name: name, isActive: false),
+            content: existing.content,
+            toolData: data,
+            timestamp: existing.timestamp
+        )
+        regroup()
+    }
+
+    /// Close the in-flight assistant bubble (if any) so later rows append after it.
+    private func flushAssistantBubble() {
+        finalizeThinking()
+        guard !streamText.isEmpty else {
+            streamId = nil
+            return
+        }
+        upsertStreamBubble()
+        streamId = nil
+        streamText = ""
+    }
+
+    private func finishTurn() {
+        flushAssistantBubble()
+        finalizeThinking()
+        // Any tool left open (stream cut mid-run) would spin forever.
+        for (name, ids) in openToolIdsByName {
+            for id in ids {
+                guard let index = messages.firstIndex(where: { $0.id == id }) else { continue }
+                var data = messages[index].toolData
+                data?.endTime = Date()
+                data?.state = .cancelled
+                let existing = messages[index]
+                messages[index] = ChatMessage(
+                    id: existing.id,
+                    type: .toolCall(name: name, isActive: false),
+                    content: existing.content,
+                    toolData: data,
+                    timestamp: existing.timestamp
+                )
+            }
+        }
+        openToolIdsByName = [:]
+        isRunning = false
+        streamTask = nil
+        regroup()
+    }
+
+    // MARK: - Helpers
+
+    private func regroup() {
+        groupedItems = ControlView.buildGroupedItems(from: messages)
+    }
+
+    private func copy(_ message: ChatMessage) {
+        UIPasteboard.general.string = message.content
+        copiedMessageId = message.id
+        HapticService.selectionChanged()
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            if copiedMessageId == message.id { copiedMessageId = nil }
+        }
+    }
+
+    private func friendlyMessage(for error: Error) -> String {
+        if let apiError = error as? APIError {
+            switch apiError {
+            case .httpError(let status, _) where status == 502 || status == 503:
+                return "Hermes is not reachable from this server."
+            default:
+                break
+            }
+        }
+        return error.localizedDescription
+    }
+}
+
+// MARK: - History mapping
+
+/// Maps persisted Hermes messages onto the shared `ChatMessage` model.
+enum HermesTranscript {
+    static func chatMessages(from history: [HermesMessage]) -> [ChatMessage] {
+        var result: [ChatMessage] = []
+        // Assistant tool_calls create the bubble; the later `tool` role message
+        // carrying the same id fills in its result.
+        var indexByToolCallId: [String: Int] = [:]
+
+        for message in history {
+            let timestamp = message.timestamp.map { Date(timeIntervalSince1970: $0) } ?? Date()
+            let content = (message.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+            switch message.role {
+            case "user":
+                guard !content.isEmpty else { continue }
+                result.append(
+                    ChatMessage(
+                        id: message.id, type: .user, content: content, timestamp: timestamp))
+
+            case "assistant":
+                if let reasoning = message.reasoningText {
+                    result.append(
+                        ChatMessage(
+                            id: "\(message.id)-thinking",
+                            type: .thinking(done: true, startTime: timestamp),
+                            content: reasoning,
+                            timestamp: timestamp
+                        )
+                    )
+                }
+                if !content.isEmpty {
+                    result.append(
+                        ChatMessage(
+                            id: message.id,
+                            type: .assistant(
+                                success: true, costCents: 0, costSource: .unknown,
+                                model: nil, sharedFiles: nil),
+                            content: content,
+                            timestamp: timestamp
+                        )
+                    )
+                }
+                for call in message.toolCalls ?? [] {
+                    let callId = call.id ?? "\(message.id)-\(call.toolName)"
+                    indexByToolCallId[callId] = result.count
+                    result.append(
+                        ChatMessage(
+                            id: "hermes-tool-\(callId)",
+                            type: .toolCall(name: call.toolName, isActive: false),
+                            content: "",
+                            toolData: ToolCallData(
+                                toolCallId: callId,
+                                name: call.toolName,
+                                args: decodeArguments(call.function?.arguments),
+                                startTime: timestamp,
+                                endTime: timestamp,
+                                // Historical calls whose result row never got
+                                // persisted must not render as still-running.
+                                result: "",
+                                state: .success
+                            ),
+                            timestamp: timestamp
+                        )
+                    )
+                }
+
+            case "tool":
+                if let callId = message.toolCallId, let index = indexByToolCallId[callId] {
+                    var data = result[index].toolData
+                    data?.result = content
+                    data?.endTime = timestamp
+                    let existing = result[index]
+                    result[index] = ChatMessage(
+                        id: existing.id,
+                        type: existing.type,
+                        content: existing.content,
+                        toolData: data,
+                        timestamp: existing.timestamp
+                    )
+                } else if !content.isEmpty {
+                    let name = message.toolName ?? "tool"
+                    result.append(
+                        ChatMessage(
+                            id: message.id,
+                            type: .toolCall(name: name, isActive: false),
+                            content: "",
+                            toolData: ToolCallData(
+                                toolCallId: message.toolCallId ?? message.id,
+                                name: name,
+                                args: [:],
+                                startTime: timestamp,
+                                endTime: timestamp,
+                                result: content,
+                                state: .success
+                            ),
+                            timestamp: timestamp
+                        )
+                    )
+                }
+
+            default:
+                continue
+            }
+        }
+        return result
+    }
+
+    private static func decodeArguments(_ raw: String?) -> [String: Any] {
+        guard let raw, let data = raw.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return raw.map { ["arguments": $0] } ?? [:]
+        }
+        return object
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Views/Control/MissionSwitcherSheet.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/MissionSwitcherSheet.swift
@@ -38,9 +38,14 @@ enum MissionQuickAction: Hashable {
 struct MissionSwitcherSheet: View {
     let runningMissions: [RunningMissionInfo]
     let recentMissions: [Mission]
+    /// Hermes conversations. Empty when Hermes isn't adopted on this backend,
+    /// which simply hides the section.
+    var hermesSessions: [HermesSession] = []
     let currentMissionId: String?
     let viewingMissionId: String?
+    var viewingHermesSessionId: String? = nil
     let onSelectMission: (String) -> Void
+    var onSelectHermesSession: ((String) -> Void)? = nil
     let onResumeMission: (String) -> Void
     let onFollowUpMission: (Mission) -> Void
     let onOpenFailureMission: (String) -> Void
@@ -103,6 +108,20 @@ struct MissionSwitcherSheet: View {
             backendSearchQuery,
             backendPart
         ].joined(separator: "||")
+    }
+
+    /// Sessions matching the current search (title/preview only — Hermes has
+    /// no server-side session search to defer to).
+    private var filteredHermesSessions: [HermesSession] {
+        guard !normalizedSearchQuery.isEmpty else { return hermesSessions }
+        return hermesSessions.filter {
+            normalizeMetadataText($0.displayTitle).contains(normalizedSearchQuery)
+        }
+    }
+
+    /// Missions this Hermes session spawned, rendered as its workers.
+    private func hermesWorkers(for sessionId: String) -> [Mission] {
+        recentMissions.filter { $0.originSessionId == sessionId }
     }
 
     private func bossWorkerIds(from missions: [Mission]) -> [String: [String]] {
@@ -346,6 +365,41 @@ struct MissionSwitcherSheet: View {
                                 },
                                 onCancel: { onCancelMission(info.missionId) }
                             )
+                        }
+                    }
+                }
+
+                // Hermes conversations, with the missions each one spawned
+                // nested under it as workers.
+                if !filteredHermesSessions.isEmpty {
+                    Section("Hermes Sessions") {
+                        ForEach(filteredHermesSessions) { session in
+                            HermesSessionRow(
+                                session: session,
+                                workerCount: hermesWorkers(for: session.id).count,
+                                isViewing: viewingHermesSessionId == session.id,
+                                onSelect: { onSelectHermesSession?(session.id) }
+                            )
+                            ForEach(hermesWorkers(for: session.id)) { worker in
+                                MissionRow(
+                                    missionId: worker.id,
+                                    displayName: missionDisplayName(for: worker),
+                                    title: worker.displayTitle,
+                                    shortDescription: missionCardDescription(for: worker),
+                                    backend: worker.backend,
+                                    status: worker.status,
+                                    isRunning: runningMissions.contains {
+                                        $0.missionId == worker.id
+                                    },
+                                    runningState: nil,
+                                    isViewing: viewingMissionId == worker.id,
+                                    isWorker: true,
+                                    quickActions: [],
+                                    onSelect: { onSelectMission(worker.id) },
+                                    onQuickAction: nil,
+                                    onCancel: nil
+                                )
+                            }
                         }
                     }
                 }
@@ -1015,5 +1069,60 @@ private struct MissionRow: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Hermes Session Row
+
+/// One Hermes conversation in the switcher. Deliberately lighter than
+/// `MissionRow`: a session has no status, workspace, or backend — only a
+/// title, its message count, and how many missions it spawned.
+private struct HermesSessionRow: View {
+    let session: HermesSession
+    let workerCount: Int
+    let isViewing: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 16)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(session.displayTitle)
+                        .font(.system(size: 14))
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundStyle(Theme.textTertiary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+
+                if isViewing {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var subtitle: String {
+        var parts = ["Hermes session"]
+        if let count = session.messageCount, count > 0 {
+            parts.append("\(count) messages")
+        }
+        if workerCount > 0 {
+            parts.append("\(workerCount) worker\(workerCount == 1 ? "" : "s")")
+        }
+        return parts.joined(separator: " · ")
     }
 }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/MissionSwitcherSheet.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/MissionSwitcherSheet.swift
@@ -124,6 +124,26 @@ struct MissionSwitcherSheet: View {
         recentMissions.filter { $0.originSessionId == sessionId }
     }
 
+    /// Missions already rendered under a visible Hermes session. They are
+    /// filtered out of Running / Just Completed / Recent so a session-spawned
+    /// mission appears once, under its session — mirroring the web switcher's
+    /// `addedIds` bookkeeping. Keyed on the *visible* sessions only: when a
+    /// search hides the session, its workers stay findable in the normal
+    /// sections.
+    private var nestedHermesWorkerIds: Set<String> {
+        guard !hermesSessions.isEmpty else { return [] }
+        let visibleSessionIds = Set(filteredHermesSessions.map(\.id))
+        guard !visibleSessionIds.isEmpty else { return [] }
+        return Set(
+            recentMissions.compactMap { mission in
+                guard let origin = mission.originSessionId,
+                    visibleSessionIds.contains(origin)
+                else { return nil }
+                return mission.id
+            }
+        )
+    }
+
     private func bossWorkerIds(from missions: [Mission]) -> [String: [String]] {
         var map: [String: [String]] = [:]
         for mission in missions {
@@ -340,7 +360,11 @@ struct MissionSwitcherSheet: View {
                 // Running missions — boss + nested workers, then standalone.
                 if !derivedOrderedRunning.isEmpty {
                     Section("Running") {
-                        ForEach(derivedOrderedRunning) { row in
+                        ForEach(
+                            derivedOrderedRunning.filter {
+                                !nestedHermesWorkerIds.contains($0.info.missionId)
+                            }
+                        ) { row in
                             let info = row.info
                             let mission = derivedMissionById[info.missionId]
                             MissionRow(
@@ -404,8 +428,18 @@ struct MissionSwitcherSheet: View {
                     }
                 }
 
-                missionSection("Just Completed", missions: derivedJustCompletedMissions)
-                missionSection("Recent", missions: derivedRecentMissionsForList)
+                missionSection(
+                    "Just Completed",
+                    missions: derivedJustCompletedMissions.filter {
+                        !nestedHermesWorkerIds.contains($0.id)
+                    }
+                )
+                missionSection(
+                    "Recent",
+                    missions: derivedRecentMissionsForList.filter {
+                        !nestedHermesWorkerIds.contains($0.id)
+                    }
+                )
 
                 if isBackendSearchLoading && !normalizedSearchQuery.isEmpty {
                     Section {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/NewMissionSheet.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/NewMissionSheet.swift
@@ -7,12 +7,22 @@
 
 import SwiftUI
 
+/// Value of `selectedAgentValue` for the Hermes entry. Hermes isn't a backend
+/// — picking it starts an assistant *session* rather than a mission.
+private let hermesAgentValue = "hermes:"
+
 struct NewMissionSheet: View {
     let workspaces: [Workspace]
     @Binding var selectedWorkspaceId: String?
     let onCreate: (NewMissionOptions) -> Void
+    /// Start a Hermes conversation instead of a mission. Absent callback hides
+    /// the Hermes entry entirely.
+    var onCreateHermesSession: (() -> Void)? = nil
     let onCancel: () -> Void
-    
+
+    /// Hermes reachable on this backend (probed once when the sheet loads).
+    @State private var hermesAvailable = false
+
     // Backend and agent selection
     @State private var backends: [Backend] = Backend.defaults
     @State private var enabledBackendIds: Set<String> = ["opencode", "claudecode", "amp", "codex", "gemini", "grok"]
@@ -51,19 +61,23 @@ struct NewMissionSheet: View {
                 // Form
                 ScrollView {
                     VStack(spacing: 20) {
-                        // Workspace selection
-                        sectionCard(title: "Workspace", icon: "server.rack") {
-                            workspaceSelector
+                        // A Hermes session has no workspace, backend or model
+                        // to pick — Hermes owns all of that.
+                        if !isHermesSelected {
+                            sectionCard(title: "Workspace", icon: "server.rack") {
+                                workspaceSelector
+                            }
                         }
-                        
+
                         // Agent selection (includes backend)
                         sectionCard(title: "Agent", icon: "cpu") {
                             agentSelector
                         }
-                        
-                        // Model override
-                        sectionCard(title: "Model Override", icon: "slider.horizontal.3") {
-                            modelSelector
+
+                        if !isHermesSelected {
+                            sectionCard(title: "Model Override", icon: "slider.horizontal.3") {
+                                modelSelector
+                            }
                         }
                     }
                     .padding(.horizontal, 16)
@@ -74,6 +88,10 @@ struct NewMissionSheet: View {
                 // Action buttons
                 VStack(spacing: 12) {
                     Button {
+                        if isHermesSelected {
+                            onCreateHermesSession?()
+                            return
+                        }
                         let parsed = CombinedAgent.parse(selectedAgentValue)
                         onCreate(NewMissionOptions(
                             workspaceId: selectedWorkspaceId,
@@ -83,8 +101,8 @@ struct NewMissionSheet: View {
                         ))
                     } label: {
                         HStack {
-                            Image(systemName: "play.fill")
-                            Text("Start Mission")
+                            Image(systemName: isHermesSelected ? "sparkles" : "play.fill")
+                            Text(isHermesSelected ? "Start Session" : "Start Mission")
                         }
                         .font(.body.weight(.semibold))
                         .foregroundStyle(.white)
@@ -93,8 +111,8 @@ struct NewMissionSheet: View {
                         .background(Theme.accent)
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
-                    .disabled(workspaces.isEmpty || isLoading)
-                    .opacity(workspaces.isEmpty || isLoading ? 0.5 : 1)
+                    .disabled(isStartDisabled)
+                    .opacity(isStartDisabled ? 0.5 : 1)
 
                     Button {
                         onCancel()
@@ -219,6 +237,15 @@ struct NewMissionSheet: View {
     
     // MARK: - Agent Selector
     
+    private var isHermesSelected: Bool { selectedAgentValue == hermesAgentValue }
+
+    private var isStartDisabled: Bool {
+        if isLoading { return true }
+        // A Hermes session needs no workspace, so an empty workspace list
+        // only blocks missions.
+        return isHermesSelected ? false : workspaces.isEmpty
+    }
+
     private var agentSelector: some View {
         VStack(spacing: 8) {
             if isLoading {
@@ -231,6 +258,9 @@ struct NewMissionSheet: View {
                 }
                 .padding(.vertical, 8)
             } else {
+                if hermesAvailable && onCreateHermesSession != nil {
+                    hermesSection
+                }
                 // Group agents by backend
                 ForEach(backends.filter { enabledBackendIds.contains($0.id) }) { backend in
                     let agents = backendAgents[backend.id] ?? []
@@ -239,6 +269,62 @@ struct NewMissionSheet: View {
                     }
                 }
             }
+        }
+    }
+
+    /// Hermes sits above the backends: it starts a conversation with the
+    /// assistant, which can then spawn missions as workers.
+    private var hermesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "sparkles")
+                    .font(.caption)
+                    .foregroundStyle(Theme.accent)
+                Text("Hermes")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .padding(.leading, 4)
+
+            Button {
+                selectedAgentValue = hermesAgentValue
+                HapticService.selectionChanged()
+            } label: {
+                HStack(spacing: 12) {
+                    ZStack {
+                        Circle()
+                            .fill(Theme.accent.opacity(0.15))
+                            .frame(width: 32, height: 32)
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(Theme.accent)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Assistant session")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(Theme.textPrimary)
+                        Text("Hermes plans and can spawn missions as workers")
+                            .font(.caption2)
+                            .foregroundStyle(Theme.textTertiary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                    selectionIndicator(isSelected: isHermesSelected)
+                }
+                .padding(8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHermesSelected ? Theme.accent.opacity(0.08) : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(
+                            isHermesSelected ? Theme.accent.opacity(0.3) : Color.clear,
+                            lineWidth: 1
+                        )
+                )
+            }
+            .buttonStyle(.plain)
         }
     }
     
@@ -444,6 +530,8 @@ struct NewMissionSheet: View {
         // form half-populated. (UX audit item #15.)
         async let backendDataTask = BackendAgentService.loadBackendsAndAgents()
         async let providersTask: ProvidersResponse? = try? api.listProviders()
+        // Probe Hermes: the session list doubles as the availability check.
+        async let hermesTask: [HermesSession]? = try? api.listHermesSessions(limit: 1)
 
         let data = await backendDataTask
         backends = data.backends
@@ -473,6 +561,7 @@ struct NewMissionSheet: View {
         }
 
         providers = (await providersTask)?.providers ?? []
+        hermesAvailable = (await hermesTask) != nil
     }
 }
 

--- a/ios_dashboard/SandboxedDashboardTests/HermesConversationTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/HermesConversationTests.swift
@@ -34,11 +34,43 @@ final class HermesConversationTests: XCTestCase {
             }]}
             """
         )
-        let session = try XCTUnwrap(list.data.first)
+        let session = try XCTUnwrap(list.sessions.first)
         XCTAssertEqual(session.id, "api-94765bde00d93d7f")
         XCTAssertEqual(session.messageCount, 21)
         // Hermes leaves `title` null until its titler runs; the preview stands in.
         XCTAssertEqual(session.displayTitle, "Reconcile Lido SRv3 closure")
+    }
+
+    func testSessionListAcceptsBothEnvelopeKeys() throws {
+        // Hermes has shipped this list under both keys; decoding only one would
+        // empty the list on a gateway upgrade, which reads as "not available".
+        let legacy = try decode(
+            HermesSessionList.self, #"{"object": "list", "data": [{"id": "api-1"}]}"#
+        )
+        XCTAssertEqual(legacy.sessions.map(\.id), ["api-1"])
+
+        let current = try decode(
+            HermesSessionList.self, #"{"object": "list", "sessions": [{"id": "api-2"}]}"#
+        )
+        XCTAssertEqual(current.sessions.map(\.id), ["api-2"])
+
+        let empty = try decode(HermesSessionList.self, #"{"object": "list"}"#)
+        XCTAssertTrue(empty.sessions.isEmpty)
+    }
+
+    func testMessageListAcceptsBothEnvelopeKeys() throws {
+        let legacy = try decode(
+            HermesMessageList.self,
+            #"{"session_id": "api-1", "data": [{"role": "user", "content": "hi"}]}"#
+        )
+        XCTAssertEqual(legacy.messages.count, 1)
+        XCTAssertEqual(legacy.sessionId, "api-1")
+
+        let current = try decode(
+            HermesMessageList.self,
+            #"{"session_id": "api-1", "messages": [{"role": "user", "content": "hi"}]}"#
+        )
+        XCTAssertEqual(current.messages.count, 1)
     }
 
     func testDisplayTitleFallsBackToShortIdWhenBlank() throws {

--- a/ios_dashboard/SandboxedDashboardTests/HermesConversationTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/HermesConversationTests.swift
@@ -1,0 +1,225 @@
+//
+//  HermesConversationTests.swift
+//  SandboxedDashboardTests
+//
+//  Hermes session decoding, transcript mapping, and deep links.
+//
+
+import XCTest
+
+@testable import sandboxed_sh
+
+final class HermesConversationTests: XCTestCase {
+
+    private func decode<T: Decodable>(_ type: T.Type, _ json: String) throws -> T {
+        try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+
+    // MARK: - Decoding
+
+    func testSessionDecodingFromListEnvelope() throws {
+        let list = try decode(
+            HermesSessionList.self,
+            """
+            {"object": "list", "data": [{
+                "id": "api-94765bde00d93d7f",
+                "source": "api_server",
+                "model": "gpt-5.6-sol",
+                "title": null,
+                "started_at": 1785410947.08,
+                "ended_at": null,
+                "message_count": 21,
+                "parent_session_id": null,
+                "preview": "Reconcile Lido SRv3 closure"
+            }]}
+            """
+        )
+        let session = try XCTUnwrap(list.data.first)
+        XCTAssertEqual(session.id, "api-94765bde00d93d7f")
+        XCTAssertEqual(session.messageCount, 21)
+        // Hermes leaves `title` null until its titler runs; the preview stands in.
+        XCTAssertEqual(session.displayTitle, "Reconcile Lido SRv3 closure")
+    }
+
+    func testDisplayTitleFallsBackToShortIdWhenBlank() throws {
+        let session = try decode(
+            HermesSession.self,
+            #"{"id": "api-0123456789abcdef", "title": "   ", "preview": null}"#
+        )
+        XCTAssertEqual(session.displayTitle, "Session api-0123")
+    }
+
+    // MARK: - Transcript mapping
+
+    func testHistoryMapsRolesOntoChatMessages() {
+        let history = [
+            makeMessage(id: 1, role: "user", content: "hello"),
+            makeMessage(id: 2, role: "assistant", content: "hi", reasoning: "pondering"),
+        ]
+
+        let items = HermesTranscript.chatMessages(from: history)
+
+        XCTAssertEqual(items.count, 3)
+        XCTAssertTrue(items[0].isUser)
+        XCTAssertEqual(items[0].content, "hello")
+        // Reasoning renders as a completed thinking row, ahead of the answer.
+        XCTAssertTrue(items[1].isThinking)
+        XCTAssertEqual(items[1].content, "pondering")
+        XCTAssertTrue(items[2].isAssistant)
+    }
+
+    func testEmptyAssistantContentDoesNotProduceABubble() {
+        let items = HermesTranscript.chatMessages(from: [
+            makeMessage(id: 1, role: "assistant", content: "   ")
+        ])
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    func testToolResultIsFoldedIntoItsCall() throws {
+        let history = [
+            makeMessage(
+                id: 1, role: "assistant", content: "",
+                toolCalls: [
+                    HermesToolCall(
+                        id: "call-1",
+                        function: .init(name: "terminal", arguments: #"{"command":"ls"}"#)
+                    )
+                ]
+            ),
+            makeMessage(id: 2, role: "tool", content: "file.txt", toolCallId: "call-1"),
+        ]
+
+        let items = HermesTranscript.chatMessages(from: history)
+
+        XCTAssertEqual(items.count, 1, "the tool result fills in the call, it is not a new row")
+        let tool = try XCTUnwrap(items.first?.toolData)
+        XCTAssertEqual(tool.name, "terminal")
+        XCTAssertEqual(tool.args["command"] as? String, "ls")
+        XCTAssertEqual(tool.resultString, "file.txt")
+        XCTAssertEqual(tool.state, .success)
+    }
+
+    func testToolCallWithoutAPersistedResultIsNotLeftRunning() throws {
+        // Regression: a call whose result row never got persisted used to
+        // render as "running for N days" (nil result reads as in-flight).
+        let items = HermesTranscript.chatMessages(from: [
+            makeMessage(
+                id: 1, role: "assistant", content: "",
+                toolCalls: [HermesToolCall(id: "call-9", function: .init(name: "search", arguments: nil))]
+            )
+        ])
+        let tool = try XCTUnwrap(items.first?.toolData)
+        XCTAssertNotNil(tool.result)
+        XCTAssertNotNil(tool.endTime)
+        XCTAssertTrue(tool.state.isComplete)
+    }
+
+    func testOrphanToolResultStillRenders() throws {
+        let items = HermesTranscript.chatMessages(from: [
+            makeMessage(id: 7, role: "tool", content: "done", toolCallId: "unknown", toolName: "bash")
+        ])
+        let tool = try XCTUnwrap(items.first?.toolData)
+        XCTAssertEqual(tool.name, "bash")
+        XCTAssertEqual(tool.resultString, "done")
+    }
+
+    // MARK: - Stream events
+
+    func testStreamEventReadsDeltaAndContentInterchangeably() throws {
+        let delta = HermesStreamEvent(
+            name: "assistant.delta",
+            payload: try decode(HermesStreamEvent.Payload.self, #"{"delta": "par"}"#)
+        )
+        XCTAssertEqual(delta.text, "par")
+
+        let completed = HermesStreamEvent(
+            name: "assistant.completed",
+            payload: try decode(HermesStreamEvent.Payload.self, #"{"content": "partial"}"#)
+        )
+        XCTAssertEqual(completed.text, "partial")
+
+        let failure = HermesStreamEvent(
+            name: "error",
+            payload: try decode(HermesStreamEvent.Payload.self, #"{"message": "boom"}"#)
+        )
+        XCTAssertEqual(failure.message, "boom")
+    }
+
+    // MARK: - Mission origin
+
+    func testMissionDecodesOriginSessionLink() throws {
+        let mission = try decode(
+            Mission.self,
+            """
+            {
+                "id": "m-1", "status": "active", "history": [],
+                "created_at": "2026-08-04T00:00:00Z", "updated_at": "2026-08-04T00:00:00Z",
+                "origin": "hermes", "origin_session_id": "api-1234"
+            }
+            """
+        )
+        XCTAssertEqual(mission.origin, "hermes")
+        XCTAssertEqual(mission.originSessionId, "api-1234")
+    }
+
+    func testMissionWithoutOriginStaysNil() throws {
+        let mission = try decode(
+            Mission.self,
+            """
+            {
+                "id": "m-2", "status": "active", "history": [],
+                "created_at": "2026-08-04T00:00:00Z", "updated_at": "2026-08-04T00:00:00Z"
+            }
+            """
+        )
+        XCTAssertNil(mission.origin)
+        XCTAssertNil(mission.originSessionId)
+    }
+
+    // MARK: - Deep links
+
+    @MainActor
+    func testDeepLinkRoutesSessionsAndMissions() throws {
+        let nav = NavigationState.shared
+
+        nav.handle(url: try XCTUnwrap(URL(string: "sandboxed://session/api-abc")))
+        XCTAssertEqual(nav.pendingHermesSessionId, "api-abc")
+        XCTAssertEqual(nav.selectedTab, .control)
+        nav.pendingHermesSessionId = nil
+
+        nav.handle(url: try XCTUnwrap(URL(string: "sandboxed://mission/m-1")))
+        XCTAssertEqual(nav.pendingMissionId, "m-1")
+        nav.pendingMissionId = nil
+
+        // Unknown hosts and foreign schemes are ignored.
+        nav.handle(url: try XCTUnwrap(URL(string: "sandboxed://workspace/w-1")))
+        nav.handle(url: try XCTUnwrap(URL(string: "https://example.com/session/x")))
+        XCTAssertNil(nav.pendingHermesSessionId)
+        XCTAssertNil(nav.pendingMissionId)
+    }
+
+    // MARK: - Helpers
+
+    private func makeMessage(
+        id: Int,
+        role: String,
+        content: String,
+        toolCallId: String? = nil,
+        toolName: String? = nil,
+        reasoning: String? = nil,
+        toolCalls: [HermesToolCall]? = nil
+    ) -> HermesMessage {
+        HermesMessage(
+            messageId: id,
+            sessionId: "api-test",
+            role: role,
+            content: content,
+            toolCallId: toolCallId,
+            toolName: toolName,
+            timestamp: 1_785_410_947,
+            reasoning: reasoning,
+            reasoningContent: nil,
+            toolCalls: toolCalls
+        )
+    }
+}

--- a/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
@@ -131,9 +131,12 @@ final class ModelTests: XCTestCase {
 
         XCTAssertTrue(source.contains("control-inline-thinking"))
         XCTAssertTrue(source.contains("guard viewingMissionIsRunning else { return nil }"))
-        XCTAssertTrue(source.contains("thoughts-timeline"))
-        XCTAssertTrue(source.contains("thought-latest"))
-        XCTAssertTrue(source.contains("thoughts-bottom"))
+        // The thoughts timeline moved to MessageBubbles.swift when ControlView
+        // was split; assert its anchors where they now live.
+        let bubbles = try messageBubblesSource()
+        XCTAssertTrue(bubbles.contains("thoughts-timeline"))
+        XCTAssertTrue(bubbles.contains("thought-latest"))
+        XCTAssertTrue(bubbles.contains("thoughts-bottom"))
         XCTAssertTrue(source.contains(".defaultScrollAnchor(.bottom)"))
         XCTAssertTrue(source.contains("ScrollAnchorState"))
         XCTAssertTrue(source.contains("case pinned"))
@@ -241,12 +244,20 @@ final class ModelTests: XCTestCase {
     }
 
     private func controlViewSource() throws -> String {
+        try controlSource(named: "ControlView.swift")
+    }
+
+    private func messageBubblesSource() throws -> String {
+        try controlSource(named: "MessageBubbles.swift")
+    }
+
+    private func controlSource(named filename: String) throws -> String {
         let testFile = URL(fileURLWithPath: #filePath)
-        let controlView = testFile
+        let source = testFile
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-            .appendingPathComponent("SandboxedDashboard/Views/Control/ControlView.swift")
-        return try String(contentsOf: controlView, encoding: .utf8)
+            .appendingPathComponent("SandboxedDashboard/Views/Control/\(filename)")
+        return try String(contentsOf: source, encoding: .utf8)
     }
 
     private func sharedControlReducerFixtures() throws -> SharedControlReducerFixtures {

--- a/ios_dashboard/SandboxedDashboardUITests/HermesConversationUITests.swift
+++ b/ios_dashboard/SandboxedDashboardUITests/HermesConversationUITests.swift
@@ -73,11 +73,21 @@ final class HermesConversationUITests: XCTestCase {
         }
         attach(app.windows.firstMatch.screenshot(), named: "switcher-with-sessions")
 
-        // First row under the section header.
-        let sessionRow = app.staticTexts.matching(
-            NSPredicate(format: "label BEGINSWITH %@", "Hermes session")
+        // First row under the section header. Target the row's Button, not the
+        // subtitle StaticText inside it: tapping the label does not reliably
+        // activate a plain-styled SwiftUI button in a List. The sheet also pins
+        // a search field over the bottom of the list, so scroll until the row
+        // is actually hittable rather than tapping through the search bar.
+        let sessionRow = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Hermes session ·")
         ).firstMatch
         XCTAssertTrue(sessionRow.waitForExistence(timeout: 10), "no session row rendered")
+        var nudges = 0
+        while !sessionRow.isHittable && nudges < 6 {
+            app.swipeUp()
+            nudges += 1
+        }
+        XCTAssertTrue(sessionRow.isHittable, "session row stayed covered by the search field")
         sessionRow.tap()
 
         // The conversation view: its own header subtitle and composer.

--- a/ios_dashboard/SandboxedDashboardUITests/HermesConversationUITests.swift
+++ b/ios_dashboard/SandboxedDashboardUITests/HermesConversationUITests.swift
@@ -1,0 +1,103 @@
+//
+//  HermesConversationUITests.swift
+//  SandboxedDashboardUITests
+//
+//  Drives the Hermes conversation surface against a real backend.
+//
+//  Credentials are never committed: the test reads them from the environment
+//  and skips itself when they're absent, so CI and other developers aren't
+//  broken by its absence. Run it with:
+//
+//    xcodebuild test -scheme SandboxedDashboard \
+//      -destination 'platform=iOS Simulator,name=<device>' \
+//      -only-testing:SandboxedDashboardUITests \
+//      TEST_RUNNER_SANDBOXED_API_URL=https://… \
+//      TEST_RUNNER_SANDBOXED_JWT=<token>
+//
+//  `TEST_RUNNER_`-prefixed variables are forwarded to the runner process by
+//  xcodebuild with the prefix stripped.
+//
+
+import XCTest
+
+final class HermesConversationUITests: XCTestCase {
+
+    override func setUp() {
+        continueAfterFailure = false
+    }
+
+    /// Opens the switcher, selects the first Hermes session, and checks the
+    /// conversation renders (header + composer). Exercises the whole chain:
+    /// session list → proxy → transcript mapping → shared renderer.
+    @MainActor
+    func testOpensAHermesSessionFromTheSwitcher() throws {
+        let environment = ProcessInfo.processInfo.environment
+        let app = XCUIApplication()
+        // `-key value` launch arguments land in UserDefaults' argument domain,
+        // which is how the app reads both of these — no test-only code path.
+        // Without them the app falls back to whatever this simulator was
+        // already configured with.
+        if let baseURL = environment["SANDBOXED_API_URL"], !baseURL.isEmpty,
+            let jwt = environment["SANDBOXED_JWT"], !jwt.isEmpty
+        {
+            app.launchArguments = ["-api_base_url", baseURL, "-jwt_token", jwt]
+        }
+        app.launch()
+
+        // The switcher lives behind the layers button in the control toolbar.
+        // Its absence means the app is sitting on the setup/login screen.
+        let switcher = app.buttons["Switch mission"]
+        guard switcher.waitForExistence(timeout: 30) else {
+            throw XCTSkip(
+                "App is not signed in. Pass SANDBOXED_API_URL / SANDBOXED_JWT via TEST_RUNNER_*, "
+                    + "or configure this simulator once by hand."
+            )
+        }
+        switcher.tap()
+
+        // Give the sheet's session fetch a beat, then scroll: the section sits
+        // below Running/Just Completed, and List only instantiates rows near
+        // the viewport, so an offscreen header genuinely does not exist yet.
+        let sessionsHeader = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Hermes Session")
+        ).firstMatch
+        _ = sessionsHeader.waitForExistence(timeout: 10)
+        var scrolls = 0
+        while !sessionsHeader.exists && scrolls < 12 {
+            app.swipeUp()
+            scrolls += 1
+        }
+        guard sessionsHeader.exists else {
+            attach(app.windows.firstMatch.screenshot(), named: "switcher-without-sessions")
+            throw XCTSkip("No Hermes sessions section — Hermes is not adopted on this backend")
+        }
+        attach(app.windows.firstMatch.screenshot(), named: "switcher-with-sessions")
+
+        // First row under the section header.
+        let sessionRow = app.staticTexts.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Hermes session")
+        ).firstMatch
+        XCTAssertTrue(sessionRow.waitForExistence(timeout: 10), "no session row rendered")
+        sessionRow.tap()
+
+        // The conversation view: its own header subtitle and composer.
+        XCTAssertTrue(
+            app.staticTexts["Hermes session"].waitForExistence(timeout: 20),
+            "the Hermes conversation header did not render"
+        )
+        XCTAssertTrue(
+            app.textViews["Message Hermes…"].exists
+                || app.textFields["Message Hermes…"].exists,
+            "the Hermes composer did not render"
+        )
+
+        attach(app.windows.firstMatch.screenshot(), named: "hermes-conversation")
+    }
+
+    private func attach(_ screenshot: XCUIScreenshot, named name: String) {
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ios_dashboard/project.yml
+++ b/ios_dashboard/project.yml
@@ -51,3 +51,20 @@ targets:
         BUNDLE_LOADER: "$(TEST_HOST)"
     dependencies:
       - target: SandboxedDashboard
+
+  SandboxedDashboardUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    deploymentTarget: "18.0"
+    sources:
+      - path: SandboxedDashboardUITests
+        excludes:
+          - "**/.DS_Store"
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: md.thomas.openagent.dashboard.uitests
+        PRODUCT_NAME: SandboxedDashboardUITests
+        GENERATE_INFOPLIST_FILE: "YES"
+        TEST_TARGET_NAME: SandboxedDashboard
+    dependencies:
+      - target: SandboxedDashboard


### PR DESCRIPTION
Phase 4 of the Hermes integration plan, mirroring the web work in #721: the iOS Control tab now hosts both conversation kinds.

## What

- **Hermes API layer** — `HermesSession` / `HermesMessage` models and `APIService` methods (list/create/delete sessions, fetch messages, chat stream) against the backend's `/api/assistant/hermes` proxy. The chat stream is named-event SSE (`event: assistant.delta`), so it gets its own frame parser rather than reusing the Ask decoder.
- **`HermesConversationView`** — maps Hermes history and stream events onto the shared `ChatMessage` model and renders them through the mission transcript pipeline (`ControlView.buildGroupedItems` → `ConversationRowsView`). Identical bubbles, tool grouping, thinking handling; no second renderer to maintain. `buildGroupedItems` went from `private static` to `static` for this — no behavior change.
- **Workers** — `Mission` gains `origin`/`origin_session_id` (already on the backend). The session view shows the missions it spawned as tappable chips; the switcher nests them under their session in a new "Hermes Sessions" section.
- **New-mission sheet** — a Hermes entry (probed on load, hidden when Hermes isn't adopted) starts a session instead of a mission, hiding the workspace/model pickers that don't apply.
- **Chrome** — mission-only toolbar items (thoughts, Ask, mission actions) hide on a session; the title becomes "Conversation"; the switcher stays as the way back out.
- **Deep links** — `sandboxed://session/<id>` and `sandboxed://mission/<id>`.

## Tested

Simulator, against the prod backend:

- New `HermesConversationTests` (11 unit tests): session decoding + title fallbacks, history→ChatMessage mapping, tool-result folding into its call, the "call without a persisted result must not render as still-running" regression, stream-event field aliasing, mission origin decoding, deep-link routing.
- New `SandboxedDashboardUITests` target with a test that launches the app, opens the switcher, scrolls to the Hermes section, opens a real session, and asserts the conversation header and composer render (screenshots attached to the result bundle). It **skips** cleanly when the app isn't signed in, so CI and other machines aren't broken; pass `TEST_RUNNER_SANDBOXED_API_URL` / `TEST_RUNNER_SANDBOXED_JWT` to run it with explicit credentials.
- Full suite green: 49 unit tests, 0 failures.

While verifying, `testControlViewKeepsIOSValidationAnchors` turned out to have been failing on master since the thoughts timeline moved to `MessageBubbles.swift`; it now asserts against that file, which is what brings the suite to zero failures.

## Notes

- The WS bridge from #721 is web-only for now: iOS uses REST history plus the per-turn SSE stream. Turns started elsewhere (Telegram, cron) appear on the next open rather than live. Moving iOS onto the bridge is a natural follow-up.
- No `ControlView` state refactor was needed: the Hermes view owns its own state and `ControlView` just branches on `viewingHermesSessionId`, the same shape as the web's conversation router.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large Control-tab branching and new streaming/chat paths, but scoped to iOS UI and the existing Hermes proxy; no auth or payment changes.
> 
> **Overview**
> Adds **Hermes assistant sessions** alongside missions on the iOS Control tab, aligned with the web Hermes work.
> 
> **API & models** — New `Hermes` types and `APIService` calls through `/api/assistant/hermes` (list/create/delete sessions, messages, and a **named-event SSE** chat stream with a dedicated frame parser). `Mission` now decodes `origin` / `origin_session_id` for session-spawned workers.
> 
> **UI** — `HermesConversationView` maps Hermes history and stream events into `ChatMessage` and reuses the mission transcript path (`ControlView.buildGroupedItems` → `ConversationRowsView`). `ControlView` switches on `viewingHermesSessionId`, trims mission-only toolbar chrome, and can start sessions from **New Mission** when Hermes is probed available. The switcher gains a **Hermes Sessions** section with nested worker missions deduped from other lists.
> 
> **Navigation** — `sandboxed://session/<id>` and `sandboxed://mission/<id>` deep links via `Info.plist` URL scheme and `NavigationState`.
> 
> **Tests** — `HermesConversationTests` (decoding, transcript mapping, deep links) and a new **UI test target** that opens a real session when credentials are provided; `ModelTests` fixed to assert thoughts anchors in `MessageBubbles.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2203fcb655dfd9b79aa40f9bbb55dd5875d77d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->