### PR TITLE
Projects board: open the conversation a project reports into

### DIFF
--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -244,4 +244,39 @@ describe("ProjectsBoard", () => {
     );
     expect(await screen.findByText("Bien reçu.")).toBeInTheDocument();
   });
+  test("links a project to the conversation its updates come from", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity",
+          latest_update: {
+            headline: "Slice fermée",
+            body: null,
+            session_id: "api-94765bde00d93d7f",
+            at: "2026-08-04T07:11:00Z",
+            signature: "verity",
+            blocker: null,
+          },
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    const link = await screen.findByTitle("Conversation");
+    expect(link).toHaveAttribute(
+      "href",
+      "/control?session=api-94765bde00d93d7f",
+    );
+  });
+
+  test("offers no conversation link before a project has an update", async () => {
+    mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
+
+    renderBoard();
+
+    // The slug renders in both the list row and the detail heading.
+    expect(await screen.findAllByText("verity")).not.toHaveLength(0);
+    expect(screen.queryByTitle("Conversation")).not.toBeInTheDocument();
+  });
 });

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -25,6 +25,7 @@ import {
   Play,
   Search,
   Send,
+  Sparkles,
   Trash2,
 } from "lucide-react";
 
@@ -392,38 +393,57 @@ function ProjectListRow({
 }
 
 /** Icon button for the detail-pane action bar. */
+/** One control in the project action row. Renders a link when `href` is given
+ * (navigation, so middle-click and open-in-new-tab work), a button otherwise. */
 function ActionButton({
   icon: Icon,
   label,
   onClick,
+  href,
   busy,
   danger,
 }: {
   icon: LucideIcon;
   label: string;
-  onClick: () => void;
+  onClick?: () => void;
+  href?: string;
   busy?: boolean;
   danger?: boolean;
 }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={busy}
-      title={label}
-      className={cn(
-        "flex items-center gap-1.5 rounded-lg border px-2 py-1 text-[11px] transition-colors disabled:opacity-50",
-        danger
-          ? "border-amber-400/25 bg-amber-500/10 text-amber-300 hover:border-amber-400/50"
-          : "border-white/[0.08] bg-white/[0.03] text-white/50 hover:border-white/20 hover:text-white/80",
-      )}
-    >
+  const className = cn(
+    "flex items-center gap-1.5 rounded-lg border px-2 py-1 text-[11px] transition-colors disabled:opacity-50",
+    danger
+      ? "border-amber-400/25 bg-amber-500/10 text-amber-300 hover:border-amber-400/50"
+      : "border-white/[0.08] bg-white/[0.03] text-white/50 hover:border-white/20 hover:text-white/80",
+  );
+  const content = (
+    <>
       {busy ? (
         <Loader className="h-3 w-3 animate-spin" />
       ) : (
         <Icon className="h-3 w-3" />
       )}
       {label}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} title={label} className={cn(className, "no-underline")}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      title={label}
+      className={className}
+    >
+      {content}
     </button>
   );
 }
@@ -451,8 +471,19 @@ function ProjectActions({ project }: { project: ProjectRow }) {
     [project.slug, mutate],
   );
 
+  // The conversation this project reports into: whichever Hermes session sent
+  // its most recent update. Absent until a project has had one.
+  const conversationSessionId = project.latest_update?.session_id ?? null;
+
   return (
     <div className="flex flex-wrap items-center gap-1.5">
+      {conversationSessionId && (
+        <ActionButton
+          icon={Sparkles}
+          label="Conversation"
+          href={`/control?session=${encodeURIComponent(conversationSessionId)}`}
+        />
+      )}
       {project.bucket === "paused" ? (
         <ActionButton
           icon={Play}


### PR DESCRIPTION
Each project's updates are delivered by a Hermes session, but the board gave no way to reach it — the origin session id was only visible as text in an update footer.

## What

The project action row gains a **Conversation** button, left of Pause/Archive/Delete, linking to `/control?session=<id>`. That opens the conversation in the Conversations tab, rendered through the shared transcript pipeline (#721).

- The target is the session behind the project's most recent update (`latest_update.session_id`).
- The button is omitted entirely for a project that has never received an update, so it never points nowhere.
- `ActionButton` now renders a `Link` when given an `href`, so middle-click and open-in-new-tab behave like any other navigation; the button path is unchanged.

## Tested

Browser, against the prod backend: clicked through from the `verity-benchmark` project and landed on its cron delivery session, showing the same update text the card displays plus the tool calls that produced it. Two new unit tests cover the href and the absent-update case (9 board tests green), plus typecheck.

Screenshots in the PR thread below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only navigation and a small ActionButton refactor; no API, auth, or data-layer changes.
> 
> **Overview**
> Adds a **Conversation** control on the projects board detail pane so reviewers can jump from a project to the Hermes session that delivered its latest update (`latest_update.session_id` → `/control?session=…`). The control is hidden when the project has never received an update.
> 
> `ActionButton` now accepts an optional `href` and renders a Next.js `Link` (same styling as the button) so middle-click and new-tab navigation work; existing pause/archive/delete actions stay on the button path.
> 
> Two unit tests cover the link `href` and the no-update case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e4969484aec1185d4e2e209996f068c77f31e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->