### PR TITLE
Cmd+K: label Hermes sessions so search results stay readable

### DIFF
--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -1564,7 +1564,16 @@ export function MissionSwitcher({
                         )}
                         <Sparkles className="h-3.5 w-3.5 shrink-0 text-indigo-400" />
                         <div className="min-w-0 flex-1">
-                          <div className="truncate text-sm">{sessionTitle}</div>
+                          <div className="flex items-center gap-2">
+                            <span className="truncate text-sm">{sessionTitle}</span>
+                            {/* Search hides the section headers (results are
+                                ranked across both kinds), and the sparkles
+                                glyph also marks hermes-spawned missions — so
+                                the row needs a label that says what it is. */}
+                            <span className="inline-flex items-center rounded bg-indigo-500/10 border border-indigo-500/20 px-1 py-0.5 text-[8px] font-medium text-indigo-400 shrink-0">
+                              Session
+                            </span>
+                          </div>
                           <div className="truncate text-xs text-white/40">
                             Hermes session
                             {typeof item.session?.message_count === 'number'


### PR DESCRIPTION
## Why

The palette separates sessions from missions with a **Hermes sessions** section header — but headers are only emitted when the query is empty (`renderedRows` wraps every `section` push in `if (!normalizedSearchQuery)`), because a search returns a single list ranked across both kinds.

That left one cue during search: the sparkles glyph. It is also used to mark missions **spawned by** a Hermes session, so in a result set where most missions are hermes-origin, a session row and a mission row look alike.

## What

Session rows get a `Session` pill next to the title, matching the existing `Boss` / `Worker` / `Assistant` pill vocabulary in the same component. Text beats iconography here: it says what the row *is* rather than what it relates to.

No change to the mission-side marker, which keeps its "Spawned by a Hermes session" tooltip.

## Tested

Browser against prod: searched a term matching only missions (all hermes-origin, all showing the sparkles) and a term matching a session — the session row is now unmistakable. `mission-switcher` unit tests (22) and typecheck green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single presentational change in the mission switcher; no API, routing, or data logic.
> 
> **Overview**
> Hermes session rows in the mission switcher (Cmd+K) now show a **Session** pill beside the title, using the same indigo pill styling as **Boss**, **Worker**, and **Assistant** on mission rows.
> 
> That matters when search is active: section headers like **Hermes sessions** are omitted, so sessions and missions appear in one ranked list. The sparkles icon alone was ambiguous because it also marks missions spawned from a Hermes session. The pill makes session rows identifiable without changing mission-side Hermes markers or tooltips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c58bd879bb7d1292fe2fe093fc51d4f2135a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->