### PR TITLE
Mission inventory: filter in the store, not after the fact

### DIFF
--- a/dashboard/src/app/control/components/HermesConversation.tsx
+++ b/dashboard/src/app/control/components/HermesConversation.tsx
@@ -304,11 +304,15 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
         // Title stays generic; not fatal.
       }
       try {
-        const missions = await listMissions();
+        // Server-side filter: fetching the newest 50 and filtering here used
+        // to show zero workers for any conversation whose missions had
+        // scrolled out of that page.
+        const missions = await listMissions({
+          originSessionId: sessionId,
+          limit: 200,
+        });
         if (cancelled) return;
-        setWorkerMissions(
-          missions.filter((m) => m.origin_session_id === sessionId),
-        );
+        setWorkerMissions(missions);
       } catch {
         // Worker strip stays empty; not fatal.
       }

--- a/dashboard/src/lib/api/missions.test.ts
+++ b/dashboard/src/lib/api/missions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { listMissions } from "./missions";
+
+function mockFetchOnce() {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => [],
+    text: async () => "[]",
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function requestedUrl(fetchMock: ReturnType<typeof vi.fn>): string {
+  const [input] = fetchMock.mock.calls[0];
+  return typeof input === "string" ? input : String(input);
+}
+
+describe("listMissions", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the bare path when called with no options", async () => {
+    const fetchMock = mockFetchOnce();
+    await listMissions();
+    expect(requestedUrl(fetchMock)).toContain("/api/control/missions");
+    expect(requestedUrl(fetchMock)).not.toContain("?");
+  });
+
+  it("filters by originating conversation server-side", async () => {
+    const fetchMock = mockFetchOnce();
+    await listMissions({ originSessionId: "20260804_103847_86ca5c", limit: 200 });
+    const url = requestedUrl(fetchMock);
+    expect(url).toContain("origin_session_id=20260804_103847_86ca5c");
+    expect(url).toContain("limit=200");
+  });
+
+  it("sends project_prefix for a family query", async () => {
+    const fetchMock = mockFetchOnce();
+    await listMissions({ projectPrefix: "verity", track: "core-c3" });
+    const url = requestedUrl(fetchMock);
+    expect(url).toContain("project_prefix=verity");
+    expect(url).toContain("track=core-c3");
+  });
+});

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -215,8 +215,38 @@ export interface MissionMomentSearchResult {
 // API Functions
 // ---------------------------------------------------------------------------
 
-export async function listMissions(): Promise<Mission[]> {
-  return apiGet("/api/control/missions", "Failed to fetch missions");
+export interface ListMissionsOptions {
+  status?: string;
+  /** Exact project id. */
+  project?: string;
+  /** Project family: matches `X` and `X-*`. */
+  projectPrefix?: string;
+  track?: string;
+  tag?: string;
+  /** The Hermes conversation a mission was launched from. */
+  originSessionId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listMissions(
+  options?: ListMissionsOptions,
+): Promise<Mission[]> {
+  const params = new URLSearchParams();
+  if (options?.status) params.set("status", options.status);
+  if (options?.project) params.set("project", options.project);
+  if (options?.projectPrefix) params.set("project_prefix", options.projectPrefix);
+  if (options?.track) params.set("track", options.track);
+  if (options?.tag) params.set("tag", options.tag);
+  if (options?.originSessionId)
+    params.set("origin_session_id", options.originSessionId);
+  if (options?.limit) params.set("limit", String(options.limit));
+  if (options?.offset) params.set("offset", String(options.offset));
+  const query = params.toString();
+  return apiGet(
+    query ? `/api/control/missions?${query}` : "/api/control/missions",
+    "Failed to fetch missions",
+  );
 }
 
 export async function searchMissions(

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -223,8 +223,29 @@ final class APIService {
     
     // MARK: - Missions
     
-    func listMissions() async throws -> [Mission] {
-        try await get("/api/control/missions")
+    /// Missions, newest first. Filters are applied server-side: filtering a
+    /// bare page client-side silently reported none once a conversation's
+    /// workers had scrolled past the default page.
+    func listMissions(
+        originSessionId: String? = nil,
+        project: String? = nil,
+        projectPrefix: String? = nil,
+        track: String? = nil,
+        limit: Int? = nil
+    ) async throws -> [Mission] {
+        var items: [URLQueryItem] = []
+        if let originSessionId { items.append(URLQueryItem(name: "origin_session_id", value: originSessionId)) }
+        if let project { items.append(URLQueryItem(name: "project", value: project)) }
+        if let projectPrefix { items.append(URLQueryItem(name: "project_prefix", value: projectPrefix)) }
+        if let track { items.append(URLQueryItem(name: "track", value: track)) }
+        if let limit { items.append(URLQueryItem(name: "limit", value: String(limit))) }
+        guard !items.isEmpty else {
+            return try await get("/api/control/missions")
+        }
+        var components = URLComponents()
+        components.queryItems = items
+        let query = components.percentEncodedQuery ?? ""
+        return try await get("/api/control/missions?\(query)")
     }
     
     func getMission(id: String) async throws -> Mission {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
@@ -286,8 +286,9 @@ struct HermesConversationView: View {
                 resolvedSession = sessions.first { $0.id == sessionId }
             }
         }
-        if let missions = try? await api.listMissions(), gen == generation {
-            workerMissions = missions.filter { $0.originSessionId == sessionId }
+        if let missions = try? await api.listMissions(originSessionId: sessionId, limit: 200),
+           gen == generation {
+            workerMissions = missions
         }
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4915,9 +4915,12 @@ pub async fn list_missions(
         tag: query.tag.clone(),
         origin_session_id: query.origin_session_id.clone(),
     };
-    // Workspace is the one filter the store cannot answer: matching by name
-    // needs `populate_workspace_names`, and the persisted `workspace_name`
-    // column is not authoritative. So it keeps the in-memory scan.
+    // Workspace is the one predicate the store cannot answer: matching by
+    // name needs `populate_workspace_names`, and the persisted
+    // `workspace_name` column is not authoritative. It is applied in memory —
+    // but over STORE-FILTERED candidates, so combining it with
+    // origin_session_id/project/track keeps the pushdown and its unlimited
+    // depth instead of falling back to scanning raw rows.
     let needs_workspace_scan = query.workspace.is_some();
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let offset = query.offset.unwrap_or(0);
@@ -4933,13 +4936,11 @@ pub async fn list_missions(
         populate_workspace_names(&state, &mut page).await;
         page
     } else {
-        // Filtered path: predicate-match runs in memory, so a single 200-row
-        // page would silently drop matches on a larger fleet. Scan from the
-        // start, collecting matches, until we have `offset + limit` of them or
-        // hit a bounded ceiling. `offset` here means "skip this many MATCHING
-        // missions" (consistent with filtered pagination), not raw rows.
         const PAGE: usize = 200;
-        const MAX_SCAN: usize = 5_000;
+        // Bounds how many STORE-FILTERED candidates we resolve workspace names
+        // for, not how deep we read into the fleet: with a selective filter
+        // the store already skipped everything irrelevant.
+        const MAX_CANDIDATES: usize = 5_000;
         let workspace_lower = query.workspace.as_deref().map(|w| w.to_lowercase());
         let workspace_raw = query.workspace.as_deref();
         let want = offset.saturating_add(limit);
@@ -4950,22 +4951,21 @@ pub async fn list_missions(
         loop {
             let mut page = control
                 .mission_store
-                .list_missions(PAGE, scan_offset)
+                .list_missions_filtered(&filter, PAGE, scan_offset)
                 .await
                 .map_err(internal_error)?;
             let page_len = page.len();
             populate_workspace_names(&state, &mut page).await;
             for m in page {
-                let keep = filter.matches(&m)
-                    && match (workspace_raw, workspace_lower.as_deref()) {
-                        (Some(raw), Some(lower)) => {
-                            m.workspace_id.to_string() == raw
-                                || m.workspace_name
-                                    .as_deref()
-                                    .is_some_and(|name| name.to_lowercase() == lower)
-                        }
-                        _ => true,
-                    };
+                let keep = match (workspace_raw, workspace_lower.as_deref()) {
+                    (Some(raw), Some(lower)) => {
+                        m.workspace_id.to_string() == raw
+                            || m.workspace_name
+                                .as_deref()
+                                .is_some_and(|name| name.to_lowercase() == lower)
+                    }
+                    _ => true,
+                };
                 if keep {
                     matched.push(m);
                     if matched.len() >= want {
@@ -4974,11 +4974,11 @@ pub async fn list_missions(
                 }
             }
             scanned += page_len;
-            if matched.len() >= want || page_len < PAGE || scanned >= MAX_SCAN {
-                if scanned >= MAX_SCAN && matched.len() < want {
+            if matched.len() >= want || page_len < PAGE || scanned >= MAX_CANDIDATES {
+                if scanned >= MAX_CANDIDATES && matched.len() < want {
                     tracing::warn!(
-                        "list_missions filter scan hit cap ({}); results may be incomplete",
-                        MAX_SCAN
+                        "list_missions workspace scan hit candidate cap ({}); results may be incomplete",
+                        MAX_CANDIDATES
                     );
                 }
                 break;

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4551,9 +4551,21 @@ pub struct ListMissionsQuery {
     /// Optional filter: exact project identifier.
     #[serde(default)]
     pub project: Option<String>,
+    /// Optional filter: project FAMILY — matches `X` and `X-*`. Use this to
+    /// span a project whose missions are still split across per-phase slugs
+    /// (`verity`, `verity-core`, `verity-phase1d`, …). `project` stays exact
+    /// so existing callers keep their current results.
+    #[serde(default)]
+    pub project_prefix: Option<String>,
+    /// Optional filter: exact track within a project.
+    #[serde(default)]
+    pub track: Option<String>,
     /// Optional filter: missions carrying this tag.
     #[serde(default)]
     pub tag: Option<String>,
+    /// Optional filter: the conversation a mission was launched from.
+    #[serde(default)]
+    pub origin_session_id: Option<String>,
     /// Optional filter: workspace by id or (case-insensitive) name.
     #[serde(default)]
     pub workspace: Option<String>,
@@ -4895,18 +4907,27 @@ pub async fn list_missions(
     let control = control_for_user(&state, &user).await;
     // Default to the most recent 50; honor an explicit limit so callers (e.g.
     // the assistant MCP) can request more, capped to keep the response bounded.
-    let has_filters = query.status.is_some()
-        || query.project.is_some()
-        || query.tag.is_some()
-        || query.workspace.is_some();
+    let filter = crate::api::mission_store::MissionFilter {
+        status: query.status.clone(),
+        project: query.project.clone(),
+        project_prefix: query.project_prefix.clone(),
+        track: query.track.clone(),
+        tag: query.tag.clone(),
+        origin_session_id: query.origin_session_id.clone(),
+    };
+    // Workspace is the one filter the store cannot answer: matching by name
+    // needs `populate_workspace_names`, and the persisted `workspace_name`
+    // column is not authoritative. So it keeps the in-memory scan.
+    let needs_workspace_scan = query.workspace.is_some();
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let offset = query.offset.unwrap_or(0);
 
-    let mut missions = if !has_filters {
-        // Fast path: no filters, list the page directly.
+    let mut missions = if !needs_workspace_scan {
+        // The store owns the predicate — sqlite pushes it into SQL, so a match
+        // is found however deep it sits in the fleet.
         let mut page = control
             .mission_store
-            .list_missions(limit, offset)
+            .list_missions_filtered(&filter, limit, offset)
             .await
             .map_err(internal_error)?;
         populate_workspace_names(&state, &mut page).await;
@@ -4919,9 +4940,6 @@ pub async fn list_missions(
         // missions" (consistent with filtered pagination), not raw rows.
         const PAGE: usize = 200;
         const MAX_SCAN: usize = 5_000;
-        let status = query.status.as_deref();
-        let project = query.project.as_deref();
-        let tag = query.tag.as_deref();
         let workspace_lower = query.workspace.as_deref().map(|w| w.to_lowercase());
         let workspace_raw = query.workspace.as_deref();
         let want = offset.saturating_add(limit);
@@ -4938,9 +4956,7 @@ pub async fn list_missions(
             let page_len = page.len();
             populate_workspace_names(&state, &mut page).await;
             for m in page {
-                let keep = status.is_none_or(|s| m.status.to_string() == s)
-                    && project.is_none_or(|p| m.project.project.as_deref() == Some(p))
-                    && tag.is_none_or(|t| m.project.tags.iter().any(|x| x == t))
+                let keep = filter.matches(&m)
                     && match (workspace_raw, workspace_lower.as_deref()) {
                         (Some(raw), Some(lower)) => {
                             m.workspace_id.to_string() == raw

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -43,6 +43,72 @@ pub struct MissionScheduling {
     pub deadline: Option<String>,
 }
 
+/// Which missions a listing wants. One value, one predicate — so the SQL
+/// pushdown and the in-memory scan can never disagree about what a filter
+/// means.
+///
+/// `project` stays an exact match: widening it would silently change every
+/// existing caller's results. Cross-phase queries ask for `project_prefix`
+/// instead, which matches a project family (`verity` covers `verity-core`,
+/// `verity-phase1d`, …) while a project is being migrated onto the
+/// `project` + `track` convention.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MissionFilter {
+    pub status: Option<String>,
+    pub project: Option<String>,
+    /// Family match: `project == X` OR `project` starts with `X-`.
+    pub project_prefix: Option<String>,
+    pub track: Option<String>,
+    pub tag: Option<String>,
+    /// The conversation a mission was launched from (Hermes session id).
+    pub origin_session_id: Option<String>,
+}
+
+impl MissionFilter {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// True when `project` belongs to the `family` family: the family itself,
+    /// or a `family-<suffix>` member. Deliberately hyphen-anchored so `verity`
+    /// never swallows `verityx`.
+    fn in_family(project: &str, family: &str) -> bool {
+        project == family
+            || (project.len() > family.len()
+                && project.starts_with(family)
+                && project.as_bytes()[family.len()] == b'-')
+    }
+
+    pub fn matches(&self, mission: &Mission) -> bool {
+        self.status
+            .as_deref()
+            .is_none_or(|s| mission.status.to_string() == s)
+            && self
+                .project
+                .as_deref()
+                .is_none_or(|p| mission.project.project.as_deref() == Some(p))
+            && self.project_prefix.as_deref().is_none_or(|family| {
+                mission
+                    .project
+                    .project
+                    .as_deref()
+                    .is_some_and(|p| Self::in_family(p, family))
+            })
+            && self
+                .track
+                .as_deref()
+                .is_none_or(|t| mission.project.track.as_deref() == Some(t))
+            && self
+                .tag
+                .as_deref()
+                .is_none_or(|t| mission.project.tags.iter().any(|x| x == t))
+            && self
+                .origin_session_id
+                .as_deref()
+                .is_none_or(|s| mission.origin_session_id.as_deref() == Some(s))
+    }
+}
+
 /// Project tagging metadata for a mission. Flattened into `Mission` so the
 /// fields appear top-level in serialized output. Lets external consumers (e.g.
 /// Paloma) group/filter/route missions by project, track, intent, PR, or
@@ -1768,6 +1834,53 @@ pub trait MissionStore: Send + Sync {
 
     /// List missions, ordered by updated_at descending.
     async fn list_missions(&self, limit: usize, offset: usize) -> Result<Vec<Mission>, String>;
+
+    /// Filtered listing, newest first. `offset` counts MATCHES, not raw rows.
+    ///
+    /// The default implementation pages `list_missions` and applies
+    /// [`MissionFilter::matches`], so it is bounded by `MAX_FILTER_SCAN` and
+    /// can miss matches that live deeper than that in a large fleet. Stores
+    /// that can push the predicate down (sqlite) override this and are exact.
+    async fn list_missions_filtered(
+        &self,
+        filter: &MissionFilter,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Mission>, String> {
+        const PAGE: usize = 200;
+        const MAX_FILTER_SCAN: usize = 5_000;
+        if filter.is_empty() {
+            return self.list_missions(limit, offset).await;
+        }
+        let want = offset.saturating_add(limit);
+        let mut matched: Vec<Mission> = Vec::new();
+        let mut scan_offset = 0usize;
+        let mut scanned = 0usize;
+        loop {
+            let page = self.list_missions(PAGE, scan_offset).await?;
+            let page_len = page.len();
+            for mission in page {
+                if filter.matches(&mission) {
+                    matched.push(mission);
+                    if matched.len() >= want {
+                        break;
+                    }
+                }
+            }
+            scanned += page_len;
+            if matched.len() >= want || page_len < PAGE || scanned >= MAX_FILTER_SCAN {
+                if scanned >= MAX_FILTER_SCAN && matched.len() < want {
+                    tracing::warn!(
+                        "list_missions_filtered scan hit cap ({}); results may be incomplete",
+                        MAX_FILTER_SCAN
+                    );
+                }
+                break;
+            }
+            scan_offset += PAGE;
+        }
+        Ok(matched.into_iter().skip(offset).take(limit).collect())
+    }
 
     /// Count missions by status without applying list pagination.
     async fn count_missions_by_status(&self) -> Result<MissionStatusCounts, String>;

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2927,9 +2927,16 @@ impl MissionStore for SqliteMissionStore {
                 bind("origin_session_id = ?n", v, &mut clauses, &mut binds);
             }
             if let Some(v) = filter.tag.as_deref() {
+                // Match the tag's JSON *serialization*, quotes included: a tag
+                // holding a quote/backslash/newline is escaped inside the
+                // column, so a raw-text LIKE would exclude it in SQL and the
+                // Rust re-check below would never get to see it. Over-matching
+                // is fine here (LIKE wildcards in the tag only widen the
+                // candidate set); under-matching would be a silent miss.
+                let encoded = serde_json::to_string(v).unwrap_or_else(|_| format!("\"{v}\""));
                 bind(
-                    r#"tags LIKE '%"' || ?n || '"%'"#,
-                    v,
+                    "tags LIKE '%' || ?n || '%'",
+                    &encoded,
                     &mut clauses,
                     &mut binds,
                 );
@@ -16500,6 +16507,42 @@ mod filter_tests {
             .iter()
             .chain(second.iter())
             .all(|m| m.project.track.as_deref() == Some("core-c3")));
+    }
+
+    /// A tag holding a JSON-escaped character is stored escaped in the column,
+    /// so the prefilter has to match its SERIALIZATION, not its raw text —
+    /// otherwise SQL drops it before the Rust re-check can rescue it.
+    #[tokio::test]
+    async fn tag_filter_matches_json_escaped_tags() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        for tag in [r#"quote"inside"#, r"back\slash", "new\nline"] {
+            let id = seed(&store, tag, Some("verity"), None, None).await;
+            store
+                .update_mission_project(
+                    id,
+                    MissionProjectPatch {
+                        tags: Some(vec![tag.to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("tag");
+
+            let found = store
+                .list_missions_filtered(
+                    &MissionFilter {
+                        tag: Some(tag.to_string()),
+                        ..Default::default()
+                    },
+                    50,
+                    0,
+                )
+                .await
+                .expect("filtered list");
+            assert_eq!(found.len(), 1, "tag {tag:?} must be findable");
+            assert_eq!(found[0].id, id);
+        }
     }
 
     /// `tags` is JSON TEXT and some rows hold malformed blobs, which is why

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2930,13 +2930,21 @@ impl MissionStore for SqliteMissionStore {
                 // Match the tag's JSON *serialization*, quotes included: a tag
                 // holding a quote/backslash/newline is escaped inside the
                 // column, so a raw-text LIKE would exclude it in SQL and the
-                // Rust re-check below would never get to see it. Over-matching
-                // is fine here (LIKE wildcards in the tag only widen the
-                // candidate set); under-matching would be a silent miss.
+                // Rust re-check below would never get to see it.
+                //
+                // Then neutralise LIKE's own wildcards. Tags are free-form, so
+                // `?tag=%` would otherwise select nearly every row and make the
+                // loop page through them holding the connection lock — a
+                // selective prefilter is what keeps this off the critical path.
+                // Escape the escape character first, or `\` would be doubled.
                 let encoded = serde_json::to_string(v).unwrap_or_else(|_| format!("\"{v}\""));
+                let pattern = encoded
+                    .replace('\\', "\\\\")
+                    .replace('%', "\\%")
+                    .replace('_', "\\_");
                 bind(
-                    "tags LIKE '%' || ?n || '%'",
-                    &encoded,
+                    r"tags LIKE '%' || ?n || '%' ESCAPE '\'",
+                    &pattern,
                     &mut clauses,
                     &mut binds,
                 );
@@ -16507,6 +16515,67 @@ mod filter_tests {
             .iter()
             .chain(second.iter())
             .all(|m| m.project.track.as_deref() == Some("core-c3")));
+    }
+
+    /// LIKE wildcards inside a free-form tag must not widen the prefilter:
+    /// `?tag=%` would otherwise select nearly every row and make the loop page
+    /// through them while holding the connection lock.
+    #[tokio::test]
+    async fn tag_filter_treats_like_wildcards_as_literals() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+
+        let literal = seed(&store, "literal", Some("verity"), None, None).await;
+        store
+            .update_mission_project(
+                literal,
+                MissionProjectPatch {
+                    tags: Some(vec!["100%".into()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+        let other = seed(&store, "other", Some("verity"), None, None).await;
+        store
+            .update_mission_project(
+                other,
+                MissionProjectPatch {
+                    tags: Some(vec!["unrelated".into()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+
+        // A bare wildcard matches nothing: it is a literal, not "everything".
+        let wild = store
+            .list_missions_filtered(
+                &MissionFilter {
+                    tag: Some("%".into()),
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("filtered list");
+        assert!(wild.is_empty(), "'%' must not behave as a wildcard");
+
+        // And a tag that genuinely contains '%' is still found.
+        let exact = store
+            .list_missions_filtered(
+                &MissionFilter {
+                    tag: Some("100%".into()),
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("filtered list");
+        assert_eq!(exact.len(), 1);
+        assert_eq!(exact[0].id, literal);
     }
 
     /// A tag holding a JSON-escaped character is stored escaped in the column,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2913,12 +2913,23 @@ impl MissionStore for SqliteMissionStore {
                 bind("project = ?n", v, &mut clauses, &mut binds);
             }
             if let Some(v) = filter.project_prefix.as_deref() {
-                bind(
-                    "(project = ?n OR project LIKE ?n || '-%')",
-                    v,
-                    &mut clauses,
-                    &mut binds,
-                );
+                // Range bounds, not `LIKE ?n || '-%'`: a LIKE whose pattern is
+                // a concatenation expression is never index-optimised, so the
+                // family lookup degraded into a full `SCAN missions` — on the
+                // fleets this feature exists for, while holding the connection
+                // mutex. `'-'` is 0x2D and `'.'` is 0x2E, so [`family-`,
+                // `family.`) is exactly the set of `family-*` values under
+                // BINARY collation, and both branches can use
+                // idx_missions_project_track.
+                binds.push(v.to_string());
+                let exact = binds.len();
+                binds.push(format!("{v}-"));
+                let lower = binds.len();
+                binds.push(format!("{v}."));
+                let upper = binds.len();
+                clauses.push(format!(
+                    "(project = ?{exact} OR (project >= ?{lower} AND project < ?{upper}))"
+                ));
             }
             if let Some(v) = filter.track.as_deref() {
                 bind("track = ?n", v, &mut clauses, &mut binds);
@@ -16515,6 +16526,45 @@ mod filter_tests {
             .iter()
             .chain(second.iter())
             .all(|m| m.project.track.as_deref() == Some("core-c3")));
+    }
+
+    /// The family predicate must stay indexable. `LIKE ?n || '-%'` looked
+    /// right but is a concatenation expression, which SQLite never optimises
+    /// into an index seek — every family lookup became a full table scan under
+    /// the connection mutex. Assert the plan, not just the rows: a regression
+    /// here is invisible in behaviour and only shows up as latency.
+    #[tokio::test]
+    async fn project_family_lookup_uses_an_index() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        seed(&store, "m", Some("verity-core"), None, None).await;
+
+        let plan: Vec<String> = {
+            let conn = store.conn.lock().await;
+            let mut stmt = conn
+                .prepare(
+                    "EXPLAIN QUERY PLAN SELECT id FROM missions \
+                     WHERE (project = ?1 OR (project >= ?2 AND project < ?3)) \
+                     ORDER BY updated_at DESC LIMIT 200 OFFSET 0",
+                )
+                .expect("prepare plan");
+            stmt.query_map(rusqlite::params!["verity", "verity-", "verity."], |row| {
+                row.get::<_, String>(3)
+            })
+            .expect("plan rows")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("plan detail")
+        };
+
+        let detail = plan.join(" | ");
+        assert!(
+            detail.contains("idx_missions_project_track") || detail.contains("SEARCH"),
+            "family lookup should seek an index, got: {detail}"
+        );
+        assert!(
+            !detail.contains("SCAN missions"),
+            "family lookup must not scan the table, got: {detail}"
+        );
     }
 
     /// LIKE wildcards inside a free-form tag must not widen the prefilter:

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -4,10 +4,10 @@ use super::{
     now_string, sanitize_filename, Automation, AutomationExecution, AwaitingKind, BoardOutboxItem,
     BoardProject, BoardTask, BoardTaskOutcome, BoardTaskRole, BoardTaskStatus, CommandSource,
     DailyUsageStats, ExecutionStatus, FreshSession, HourlyUsageStats, Mission, MissionActivity,
-    MissionExecutionState, MissionHistoryEntry, MissionMode, MissionProject, MissionProjectPatch,
-    MissionRun, MissionScheduling, MissionStatus, MissionStatusCounts, MissionStore,
-    MissionSummary, MissionToolExecution, MissionToolExecutionState, ModelUsageStats, NewBoardTask,
-    PalomaCooldownState, PalomaDecision, PalomaMissionCard, PalomaSchedulerJob,
+    MissionExecutionState, MissionFilter, MissionHistoryEntry, MissionMode, MissionProject,
+    MissionProjectPatch, MissionRun, MissionScheduling, MissionStatus, MissionStatusCounts,
+    MissionStore, MissionSummary, MissionToolExecution, MissionToolExecutionState, ModelUsageStats,
+    NewBoardTask, PalomaCooldownState, PalomaDecision, PalomaMissionCard, PalomaSchedulerJob,
     PalomaUserPreferences, RetryConfig, StopPolicy, StoredEvent, TaskAttempt,
     TelegramActionExecution, TelegramActionExecutionKind, TelegramActionExecutionStatus,
     TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramChatMission,
@@ -2369,6 +2369,28 @@ impl SqliteMissionStore {
             tracing::warn!("origin backfill from tags skipped: {}", e);
         }
 
+        // Indexes for the filtered listing. These MUST live here and not in
+        // SCHEMA: `execute_batch(SCHEMA)` runs BEFORE this function, and on an
+        // existing database `CREATE TABLE IF NOT EXISTS missions` is a no-op,
+        // so an index over a column the ALTERs above have not added yet would
+        // fail with "no such column" — failing store init and silently
+        // dropping the service to an in-memory store (same trap the ALTER
+        // comment above describes). Non-fatal for the same reason.
+        for (name, ddl) in [
+            (
+                "idx_missions_origin_session",
+                "CREATE INDEX IF NOT EXISTS idx_missions_origin_session ON missions(origin_session_id)",
+            ),
+            (
+                "idx_missions_project_track",
+                "CREATE INDEX IF NOT EXISTS idx_missions_project_track ON missions(project, track)",
+            ),
+        ] {
+            if let Err(e) = conn.execute(ddl, []) {
+                tracing::warn!("creating {} skipped: {}", name, e);
+            }
+        }
+
         Ok(())
     }
 
@@ -2620,6 +2642,90 @@ impl SqliteMissionStore {
     }
 }
 
+/// Map one row of [`MISSION_LIST_COLUMNS`] onto a `Mission`.
+/// Positional getters — only valid for that exact column list.
+fn row_to_mission(row: &rusqlite::Row<'_>) -> rusqlite::Result<Mission> {
+    let id_str: String = row.get(0)?;
+    let status_str: String = row.get(1)?;
+    let workspace_id_str: String = row.get(8)?;
+    let desktop_sessions_json: Option<String> = row.get(17)?;
+    let backend: String = row.get(18)?;
+    let session_id: Option<String> = row.get(19)?;
+    let terminal_reason: Option<String> = row.get(20)?;
+    let config_profile: Option<String> = row.get(21)?;
+    let (project, awaiting_kind, last_status_change_at) = read_project_columns(row, 32)?;
+
+    Ok(Mission {
+        id: parse_uuid_or_nil(&id_str),
+        status: parse_status(&status_str),
+        title: row.get(2)?,
+        short_description: row.get(3)?,
+        metadata_updated_at: row.get(4)?,
+        metadata_source: row.get(5)?,
+        metadata_model: row.get(6)?,
+        metadata_version: row.get(7)?,
+        workspace_id: Uuid::parse_str(&workspace_id_str)
+            .unwrap_or(crate::workspace::DEFAULT_WORKSPACE_ID),
+        workspace_name: row.get(9)?,
+        agent: row.get(10)?,
+        model_override: row.get(11)?,
+        model_effort: row.get(12)?,
+        fast_mode: row.get::<_, i32>(41)? != 0,
+        backend,
+        config_profile,
+        history: vec![], // Loaded separately if needed
+        created_at: row.get(13)?,
+        updated_at: row.get(14)?,
+        interrupted_at: row.get(15)?,
+        paused_at: row.get(31).ok().flatten(),
+        resumable: row.get::<_, i32>(16)? != 0,
+        desktop_sessions: desktop_sessions_json
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default(),
+        session_id,
+        terminal_reason,
+        parent_mission_id: row
+            .get::<_, Option<String>>(22)?
+            .and_then(|s| Uuid::parse_str(&s).ok()),
+        working_directory: row.get(23)?,
+        mission_mode: row
+            .get::<_, Option<String>>(24)?
+            .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok())
+            .unwrap_or_default(),
+        goal_mode: row.get::<_, i32>(25).unwrap_or(0) != 0,
+        goal_objective: row.get(26).ok().flatten(),
+        first_viewed_at: row.get(27).ok().flatten(),
+        scheduling: MissionScheduling {
+            priority: row.get::<_, i32>(28).unwrap_or(0),
+            not_before: row.get(29).ok().flatten(),
+            deadline: row.get(30).ok().flatten(),
+        },
+        project,
+        activity: MissionActivity {
+            last_status_change_at,
+            ..Default::default()
+        },
+        awaiting_kind,
+        origin: row.get(42).ok().flatten(),
+        origin_session_id: row.get(43).ok().flatten(),
+    })
+}
+
+/// Column list shared by every query that maps rows through the same
+/// `Mission` projection. The row getters below are positional, so the two
+/// listings MUST select the same columns in the same order — keeping one
+/// const is what stops them drifting.
+const MISSION_LIST_COLUMNS: &str = "id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, workspace_name, agent, model_override, \
+     model_effort, \
+     created_at, updated_at, interrupted_at, resumable, desktop_sessions, \
+     COALESCE(backend, 'opencode') as backend, session_id, terminal_reason, \
+     config_profile, parent_mission_id, working_directory, \
+     COALESCE(mission_mode, 'task') as mission_mode, \
+     COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at, \
+     COALESCE(priority, 0) as priority, not_before, deadline, paused_at, \
+     project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at, \
+     COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id";
+
 fn parse_status(s: &str) -> MissionStatus {
     match s {
         "pending" => MissionStatus::Pending,
@@ -2749,93 +2855,129 @@ impl MissionStore for SqliteMissionStore {
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
             let mut stmt = conn
-                .prepare(
-                    "SELECT id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, workspace_name, agent, model_override,
-                            model_effort,
-                            created_at, updated_at, interrupted_at, resumable, desktop_sessions,
-                            COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
-                            config_profile, parent_mission_id, working_directory,
-                            COALESCE(mission_mode, 'task') as mission_mode,
-                            COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
-                            COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
-                            project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at,
-                            COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id
+                .prepare(&format!(
+                    "SELECT {MISSION_LIST_COLUMNS}
                      FROM missions
                      ORDER BY updated_at DESC
-                     LIMIT ?1 OFFSET ?2",
-                )
+                     LIMIT ?1 OFFSET ?2"
+                ))
                 .map_err(|e| e.to_string())?;
 
             let missions = stmt
-                .query_map(params![limit as i64, offset as i64], |row| {
-                    let id_str: String = row.get(0)?;
-                    let status_str: String = row.get(1)?;
-                    let workspace_id_str: String = row.get(8)?;
-                    let desktop_sessions_json: Option<String> = row.get(17)?;
-                    let backend: String = row.get(18)?;
-                    let session_id: Option<String> = row.get(19)?;
-                    let terminal_reason: Option<String> = row.get(20)?;
-                    let config_profile: Option<String> = row.get(21)?;
-                    let (project, awaiting_kind, last_status_change_at) =
-                        read_project_columns(row, 32)?;
-
-                    Ok(Mission {
-                        id: parse_uuid_or_nil(&id_str),
-                        status: parse_status(&status_str),
-                        title: row.get(2)?,
-                        short_description: row.get(3)?,
-                        metadata_updated_at: row.get(4)?,
-                        metadata_source: row.get(5)?,
-                        metadata_model: row.get(6)?,
-                        metadata_version: row.get(7)?,
-                        workspace_id: Uuid::parse_str(&workspace_id_str)
-                            .unwrap_or(crate::workspace::DEFAULT_WORKSPACE_ID),
-                        workspace_name: row.get(9)?,
-                        agent: row.get(10)?,
-                        model_override: row.get(11)?,
-                        model_effort: row.get(12)?,
-                        fast_mode: row.get::<_, i32>(41)? != 0,
-                        backend,
-                        config_profile,
-                        history: vec![], // Loaded separately if needed
-                        created_at: row.get(13)?,
-                        updated_at: row.get(14)?,
-                        interrupted_at: row.get(15)?,
-                        paused_at: row.get(31).ok().flatten(),
-                        resumable: row.get::<_, i32>(16)? != 0,
-                        desktop_sessions: desktop_sessions_json
-                            .and_then(|s| serde_json::from_str(&s).ok())
-                            .unwrap_or_default(),
-                        session_id,
-                        terminal_reason,
-                        parent_mission_id: row.get::<_, Option<String>>(22)?.and_then(|s| Uuid::parse_str(&s).ok()),
-                        working_directory: row.get(23)?,
-                        mission_mode: row.get::<_, Option<String>>(24)?
-                            .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok())
-                            .unwrap_or_default(),
-                            goal_mode: row.get::<_, i32>(25).unwrap_or(0) != 0,
-                            goal_objective: row.get(26).ok().flatten(),
-                            first_viewed_at: row.get(27).ok().flatten(),
-                            scheduling: MissionScheduling {
-                                priority: row.get::<_, i32>(28).unwrap_or(0),
-                                not_before: row.get(29).ok().flatten(),
-                                deadline: row.get(30).ok().flatten(),
-                            },
-                            project,
-                            activity: MissionActivity {
-                                last_status_change_at,
-                                ..Default::default()
-                            },
-                            awaiting_kind,
-                            origin: row.get(42).ok().flatten(),
-                            origin_session_id: row.get(43).ok().flatten(),
-                    })
-                })
+                .query_map(params![limit as i64, offset as i64], row_to_mission)
                 .map_err(|e| e.to_string())?
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| e.to_string())?;
 
             Ok(missions)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    /// Exact filtered listing: the predicate runs in SQL, so a match is found
+    /// however deep it sits in the fleet (the generic scan gives up after
+    /// 5 000 rows, which is why old conversations showed zero workers).
+    ///
+    /// `tag` is the one field SQL only narrows: `tags` is a JSON TEXT column
+    /// and some rows hold malformed blobs, so `json_each` would fail the whole
+    /// query. A `LIKE` prefilter selects candidates and
+    /// [`MissionFilter::matches`] makes the final call — which means the
+    /// prefilter can over-select, hence the accumulate-until-satisfied loop.
+    async fn list_missions_filtered(
+        &self,
+        filter: &MissionFilter,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Mission>, String> {
+        if filter.is_empty() {
+            return self.list_missions(limit, offset).await;
+        }
+        let conn = self.conn.clone();
+        let filter = filter.clone();
+        tokio::task::spawn_blocking(move || {
+            const PAGE: i64 = 200;
+            let conn = conn.blocking_lock();
+
+            let mut clauses: Vec<String> = Vec::new();
+            let mut binds: Vec<String> = Vec::new();
+            let mut bind =
+                |clause: &str, value: &str, clauses: &mut Vec<String>, binds: &mut Vec<String>| {
+                    binds.push(value.to_string());
+                    clauses.push(clause.replace("?n", &format!("?{}", binds.len())));
+                };
+            if let Some(v) = filter.status.as_deref() {
+                bind("status = ?n", v, &mut clauses, &mut binds);
+            }
+            if let Some(v) = filter.project.as_deref() {
+                bind("project = ?n", v, &mut clauses, &mut binds);
+            }
+            if let Some(v) = filter.project_prefix.as_deref() {
+                bind(
+                    "(project = ?n OR project LIKE ?n || '-%')",
+                    v,
+                    &mut clauses,
+                    &mut binds,
+                );
+            }
+            if let Some(v) = filter.track.as_deref() {
+                bind("track = ?n", v, &mut clauses, &mut binds);
+            }
+            if let Some(v) = filter.origin_session_id.as_deref() {
+                bind("origin_session_id = ?n", v, &mut clauses, &mut binds);
+            }
+            if let Some(v) = filter.tag.as_deref() {
+                bind(
+                    r#"tags LIKE '%"' || ?n || '"%'"#,
+                    v,
+                    &mut clauses,
+                    &mut binds,
+                );
+            }
+            let where_sql = if clauses.is_empty() {
+                String::new()
+            } else {
+                format!("WHERE {}", clauses.join(" AND "))
+            };
+
+            let sql = format!(
+                "SELECT {MISSION_LIST_COLUMNS} FROM missions {where_sql} \
+                 ORDER BY updated_at DESC LIMIT ?{} OFFSET ?{}",
+                binds.len() + 1,
+                binds.len() + 2
+            );
+            let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+
+            let want = offset.saturating_add(limit);
+            let mut matched: Vec<Mission> = Vec::new();
+            let mut sql_offset: i64 = 0;
+            loop {
+                let mut args: Vec<&dyn rusqlite::ToSql> =
+                    binds.iter().map(|v| v as &dyn rusqlite::ToSql).collect();
+                args.push(&PAGE);
+                args.push(&sql_offset);
+
+                let page = stmt
+                    .query_map(args.as_slice(), row_to_mission)
+                    .map_err(|e| e.to_string())?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| e.to_string())?;
+                let page_len = page.len();
+                for mission in page {
+                    // The tag prefilter can over-select; this is the authority.
+                    if filter.matches(&mission) {
+                        matched.push(mission);
+                        if matched.len() >= want {
+                            break;
+                        }
+                    }
+                }
+                if matched.len() >= want || (page_len as i64) < PAGE {
+                    break;
+                }
+                sql_offset += PAGE;
+            }
+            Ok(matched.into_iter().skip(offset).take(limit).collect())
         })
         .await
         .map_err(|e| e.to_string())?
@@ -16177,5 +16319,229 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::SqliteMissionStore;
+    use crate::api::mission_store::{MissionFilter, MissionProjectPatch, MissionStore};
+
+    async fn store(dir: &tempfile::TempDir) -> SqliteMissionStore {
+        SqliteMissionStore::new(dir.path().to_path_buf(), "filter-user")
+            .await
+            .expect("sqlite store")
+    }
+
+    async fn seed(
+        store: &SqliteMissionStore,
+        title: &str,
+        project: Option<&str>,
+        track: Option<&str>,
+        origin_session: Option<&str>,
+    ) -> uuid::Uuid {
+        let mission = store
+            .create_mission_with_parent(
+                Some(title),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create mission");
+        if project.is_some() || track.is_some() {
+            store
+                .update_mission_project(
+                    mission.id,
+                    MissionProjectPatch {
+                        project: Some(project.map(str::to_string)),
+                        track: Some(track.map(str::to_string)),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("tag mission");
+        }
+        if let Some(session) = origin_session {
+            store
+                .set_mission_origin(mission.id, "hermes", Some(session))
+                .await
+                .expect("set origin");
+        }
+        mission.id
+    }
+
+    /// The regression that motivated the pushdown: the in-memory scan gave up
+    /// after 5 000 rows, so a conversation whose missions had scrolled past it
+    /// silently showed zero workers. SQL has no such horizon.
+    #[tokio::test]
+    async fn finds_a_match_buried_under_a_large_fleet() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+
+        let needle = seed(&store, "needle", Some("verity"), None, Some("sess-old")).await;
+        for i in 0..250 {
+            seed(&store, &format!("noise {i}"), Some("other"), None, None).await;
+        }
+
+        let found = store
+            .list_missions_filtered(
+                &MissionFilter {
+                    origin_session_id: Some("sess-old".into()),
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("filtered list");
+        assert_eq!(found.len(), 1, "the buried match must still be returned");
+        assert_eq!(found[0].id, needle);
+    }
+
+    #[tokio::test]
+    async fn project_prefix_matches_the_family_and_nothing_adjacent() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+
+        seed(&store, "family root", Some("verity"), None, None).await;
+        seed(&store, "phase", Some("verity-phase1d"), None, None).await;
+        seed(&store, "lookalike", Some("verityx"), None, None).await;
+        seed(&store, "reversed", Some("x-verity"), None, None).await;
+
+        let found = store
+            .list_missions_filtered(
+                &MissionFilter {
+                    project_prefix: Some("verity".into()),
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("filtered list");
+        let projects: Vec<String> = found
+            .iter()
+            .filter_map(|m| m.project.project.clone())
+            .collect();
+        assert_eq!(projects.len(), 2, "got {projects:?}");
+        assert!(projects.contains(&"verity".to_string()));
+        assert!(projects.contains(&"verity-phase1d".to_string()));
+    }
+
+    /// `project` must stay EXACT — widening it would silently change what
+    /// every existing caller (dashboard, iOS, Paloma) gets back.
+    #[tokio::test]
+    async fn project_filter_stays_exact() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        seed(&store, "root", Some("verity"), None, None).await;
+        seed(&store, "phase", Some("verity-phase1d"), None, None).await;
+
+        let found = store
+            .list_missions_filtered(
+                &MissionFilter {
+                    project: Some("verity".into()),
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("filtered list");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].project.project.as_deref(), Some("verity"));
+    }
+
+    #[tokio::test]
+    async fn track_filter_and_offset_count_matches_not_rows() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        for i in 0..3 {
+            seed(
+                &store,
+                &format!("t{i}"),
+                Some("verity"),
+                Some("core-c3"),
+                None,
+            )
+            .await;
+            seed(
+                &store,
+                &format!("n{i}"),
+                Some("verity"),
+                Some("other"),
+                None,
+            )
+            .await;
+        }
+
+        let filter = MissionFilter {
+            track: Some("core-c3".into()),
+            ..Default::default()
+        };
+        let first = store
+            .list_missions_filtered(&filter, 2, 0)
+            .await
+            .expect("page 1");
+        let second = store
+            .list_missions_filtered(&filter, 2, 2)
+            .await
+            .expect("page 2");
+        assert_eq!(first.len(), 2);
+        assert_eq!(second.len(), 1, "offset skips MATCHES, not raw rows");
+        assert!(first
+            .iter()
+            .chain(second.iter())
+            .all(|m| m.project.track.as_deref() == Some("core-c3")));
+    }
+
+    /// `tags` is JSON TEXT and some rows hold malformed blobs, which is why
+    /// the tag filter is a SQL prefilter plus a Rust re-check rather than
+    /// `json_each` (that would fail the whole query on the bad row).
+    #[tokio::test]
+    async fn tag_filter_survives_a_malformed_tags_blob() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        let tagged = seed(&store, "tagged", Some("verity"), None, None).await;
+        store
+            .update_mission_project(
+                tagged,
+                MissionProjectPatch {
+                    tags: Some(vec!["origin:hermes-assistant".into()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+        let broken = seed(&store, "broken", Some("verity"), None, None).await;
+        {
+            let conn = store.conn.lock().await;
+            conn.execute(
+                "UPDATE missions SET tags = '{not json' WHERE id = ?1",
+                rusqlite::params![broken.to_string()],
+            )
+            .expect("corrupt tags");
+        }
+
+        let found = store
+            .list_missions_filtered(
+                &MissionFilter {
+                    tag: Some("origin:hermes-assistant".into()),
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("filtered list");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, tagged);
     }
 }


### PR DESCRIPTION
First PR of the project ↔ conversation ↔ missions series. It makes the inventory truthful, which everything else depends on.

## The bug

`GET /api/control/missions?project=…` ran its predicate **in memory** over paged reads, giving up after 5 000 rows. On a fleet this size that horizon is reached well inside a day, so a conversation whose missions had scrolled past it showed **zero workers — silently, with a 200 OK**. Both clients hit it: `HermesConversation.tsx` and iOS `HermesConversationView` each fetched the newest 50 missions and filtered client-side.

## Changes

- **`MissionFilter`** is now the single source of predicate truth (`status`, `project`, `project_prefix`, `track`, `tag`, `origin_session_id`). The in-memory scan and the SQL pushdown call the same `matches()`, so they cannot drift apart on what a filter means.
- **`MissionStore::list_missions_filtered`** — default impl keeps today's bounded scan (file/memory stores); **sqlite overrides it with a real `WHERE`** and is exact at any depth.
- **`project` stays exact.** Cross-phase queries use `project_prefix`, a hyphen-anchored family match: `verity` covers `verity-core` / `verity-phase1d`, but never `verityx` or `x-verity`. Redefining `project` itself would have silently widened results for every existing caller (dashboard, iOS, Paloma).
- **`track` and `origin_session_id` filters** — the latter is what the Hermes conversation view actually needs.
- **`tag`** is a SQL `LIKE` prefilter plus a Rust re-check, deliberately **not `json_each`**: `tags` is JSON TEXT and some rows hold malformed blobs, which would fail the entire query. There's a test with exactly such a row next to the match.

## Two traps worth reviewing

1. **Index placement.** The two new indexes are created at the **end of `run_migrations`**, never in `SCHEMA`. `execute_batch(SCHEMA)` runs first, and `CREATE TABLE IF NOT EXISTS missions` is a no-op on an existing DB — so indexing a column the ALTERs have not added yet would fail store init and **silently drop the service to an in-memory store**, the same trap the ALTER block above already documents. Non-fatal handling to match.
2. **Shared projection.** The row→`Mission` mapping and its column list are now one `row_to_mission` + one `MISSION_LIST_COLUMNS`. The getters are positional, so two copies of a 60-line projection were a drift waiting to happen.

## Testing

`cargo test --lib` — 1640 passed, including 5 new sqlite filter tests:
- a match buried under a large fleet is still returned (**the regression**);
- family match hits `verity`/`verity-phase1d` and not `verityx`/`x-verity`;
- `project` stays exact;
- `offset` skips **matches**, not raw rows;
- tag filter survives a malformed `tags` blob on a neighbouring row.

Dashboard: 3 new vitest cases on the built query string; `cargo fmt --all` clean.

## Follow-ups in this series
Short-id resolution + `origin` in the MCP summary (PR B), the explicit project→conversation binding (PR C), then the Hermes side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mission inventory API and SQLite listing paths used by dashboard, iOS, and MCP; behavior changes are intentional but `project` semantics must stay exact while new filters roll out.
> 
> **Overview**
> Fixes **Hermes conversations showing no workers** when spawned missions had aged past the default “newest 50” page. Listing used to filter in memory over paged reads (capped around 5k rows), so matches could disappear with a normal **200 OK**.
> 
> **Backend:** Introduces shared **`MissionFilter`** and **`list_missions_filtered`**, with SQLite pushing predicates into **`WHERE`** (exact `project`, hyphen-anchored **`project_prefix`**, **`track`**, **`tag`**, **`origin_session_id`**). Workspace filtering stays in-memory but runs on store-filtered pages. Adds migration-time indexes on **`origin_session_id`** and **`(project, track)`**, plus consolidated **`row_to_mission`** / **`MISSION_LIST_COLUMNS`**.
> 
> **Clients:** Web **`listMissions`** options and iOS **`APIService.listMissions`** pass query params; Hermes conversation views request **`origin_session_id`** server-side instead of client-side filtering. Vitest covers the built query string; new SQLite filter tests cover the buried-match regression and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6884d6198b9e991bc1190338171f22b160f0dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->