### PR TITLE
Accept the mission id humans actually have, and let Hermes read origin back

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -9425,6 +9425,19 @@ pub async fn update_mission_origin(
             ));
         }
     }
+    // Existence first: the memory and file stores answer a missing mission
+    // with a plain Err, which `internal_error` would surface as a 500 — a
+    // caller backfilling origins in bulk needs "this one is gone" to read as
+    // 404, not as a server fault it should retry.
+    if control
+        .mission_store
+        .get_mission(id)
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err((StatusCode::NOT_FOUND, format!("mission {id} not found")));
+    }
     control
         .mission_store
         .set_mission_origin(id, origin, session)

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5461,6 +5461,80 @@ async fn mission_search_recency_fingerprint(
 }
 
 /// Search missions with semantic-aware ranking.
+#[derive(Debug, serde::Deserialize)]
+pub struct ResolveMissionQuery {
+    /// A full mission UUID or an unambiguous leading fragment of one.
+    pub id: String,
+}
+
+/// Resolve the id humans actually have — the 8-character prefix dashboards,
+/// logs and transcripts display — into a full mission UUID.
+///
+/// Ambiguity is reported as a conflict listing the candidates rather than
+/// silently picking the newest: a controller acting on the wrong mission is
+/// far worse than one that has to ask again with more characters.
+pub async fn resolve_mission_id(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Query(query): Query<ResolveMissionQuery>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let raw = query.id.trim().to_ascii_lowercase();
+    if let Ok(id) = Uuid::parse_str(&raw) {
+        return Ok(Json(serde_json::json!({
+            "mission_id": id.to_string(),
+            "match": "exact",
+        })));
+    }
+    // Anything shorter is not worth resolving: at 4 hex characters a
+    // collision is already likely enough to be a nuisance, and a 1-character
+    // "prefix" would scan half the fleet.
+    if raw.len() < 4 || !raw.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "id must be a mission UUID or at least 4 hex characters of one".to_string(),
+        ));
+    }
+
+    let control = control_for_user(&state, &user).await;
+    // One more than we report, so "exactly one" is provably unambiguous.
+    let candidates = control
+        .mission_store
+        .find_missions_by_id_prefix(&raw, 11)
+        .await
+        .map_err(internal_error)?;
+
+    match candidates.len() {
+        0 => Err((StatusCode::NOT_FOUND, format!("no mission matches '{raw}'"))),
+        1 => Ok(Json(serde_json::json!({
+            "mission_id": candidates[0].id.to_string(),
+            "match": "prefix",
+        }))),
+        _ => {
+            let listed: Vec<serde_json::Value> = candidates
+                .iter()
+                .take(10)
+                .map(|m| {
+                    serde_json::json!({
+                        "id": m.id.to_string(),
+                        "title": m.title,
+                        "status": m.status.to_string(),
+                        "updated_at": m.updated_at,
+                    })
+                })
+                .collect();
+            Err((
+                StatusCode::CONFLICT,
+                serde_json::json!({
+                    "error": "ambiguous",
+                    "prefix": raw,
+                    "candidates": listed,
+                })
+                .to_string(),
+            ))
+        }
+    }
+}
+
 pub async fn search_missions(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -9304,6 +9378,67 @@ pub struct UpdateMissionProjectRequest {
 }
 
 /// Set or update project tagging metadata for a mission.
+#[derive(Debug, Deserialize)]
+pub struct UpdateMissionOriginRequest {
+    /// Creating system, e.g. "hermes".
+    #[serde(default)]
+    pub origin: Option<String>,
+    /// Conversation the mission belongs to.
+    #[serde(default)]
+    pub origin_session_id: Option<String>,
+}
+
+/// Attach an existing mission to a conversation.
+///
+/// Origin was write-once at creation, so every mission created before the
+/// column existed — or by a caller that did not declare one — was
+/// permanently unattributable. This is what makes that history recoverable.
+pub async fn update_mission_origin(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateMissionOriginRequest>,
+) -> Result<Json<Mission>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let origin = req
+        .origin
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("hermes");
+    let session = req
+        .origin_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(session) = session {
+        // Same shape the assistant MCP validates, so a value that would be
+        // rejected at creation cannot be smuggled in through the patch.
+        if session.len() > 128
+            || !session
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
+        {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "origin_session_id must be 1-128 chars of [A-Za-z0-9._:-]".to_string(),
+            ));
+        }
+    }
+    control
+        .mission_store
+        .set_mission_origin(id, origin, session)
+        .await
+        .map_err(internal_error)?;
+    let mission = control
+        .mission_store
+        .get_mission(id)
+        .await
+        .map_err(internal_error)?
+        .ok_or((StatusCode::NOT_FOUND, format!("mission {id} not found")))?;
+    Ok(Json(mission))
+}
+
 pub async fn update_mission_project(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -10995,8 +11130,11 @@ pub async fn clone_mission(
         remote_command: None,
         remote_async: None,
         estimated_disk_gib: None,
-        origin: None,
-        origin_session_id: None,
+        // A clone is the same work retried, so it belongs to the same
+        // conversation. Dropping the origin here orphaned the retry: it
+        // vanished from the worker strip of the session that asked for it.
+        origin: source.origin.clone(),
+        origin_session_id: source.origin_session_id.clone(),
         extra: Default::default(),
     };
 

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1896,40 +1896,33 @@ pub trait MissionStore: Send + Sync {
     /// a prefix is unambiguous. The default implementation pages
     /// `list_missions`; sqlite overrides it with an indexed prefix scan.
     ///
-    /// This deliberately has NO scan ceiling, unlike the filtered listing.
-    /// "Unique" is a claim about the whole store: stopping early could report
-    /// a single visible candidate as unambiguous while a second match sits
-    /// just beyond the horizon, and the caller would then cancel or message
-    /// the wrong mission. An incomplete list is a nuisance; an incomplete
-    /// uniqueness proof is a correctness bug. Callers pass a small `limit`
-    /// (enough to prove ambiguity), so the loop still exits early in the
-    /// ambiguous case.
+    /// Reads the store ONCE, unpaged, on purpose. Two independent hazards make
+    /// paging wrong here, and both end the same way — the caller cancels or
+    /// messages the wrong mission:
+    ///
+    /// - a scan ceiling could report a single visible candidate as unambiguous
+    ///   while a second match sat beyond the horizon;
+    /// - `list_missions` orders by `updated_at`, so a mission touched between
+    ///   two pages can move into an already-consumed page and be skipped
+    ///   entirely, again leaving a false "unique".
+    ///
+    /// A single call is as atomic as the backing store's own listing (the
+    /// file and memory stores materialize under one read lock), which is
+    /// exactly the snapshot this needs. An incomplete list is a nuisance; an
+    /// incomplete uniqueness proof is a correctness bug. sqlite overrides this
+    /// with an indexed range read, which is atomic for the same reason.
     async fn find_missions_by_id_prefix(
         &self,
         prefix: &str,
         limit: usize,
     ) -> Result<Vec<Mission>, String> {
-        const PAGE: usize = 200;
         let prefix = prefix.to_ascii_lowercase();
-        let mut found = Vec::new();
-        let mut offset = 0usize;
-        loop {
-            let page = self.list_missions(PAGE, offset).await?;
-            let page_len = page.len();
-            for mission in page {
-                if mission.id.to_string().starts_with(&prefix) {
-                    found.push(mission);
-                    if found.len() >= limit {
-                        return Ok(found);
-                    }
-                }
-            }
-            if page_len < PAGE {
-                break;
-            }
-            offset += PAGE;
-        }
-        Ok(found)
+        let snapshot = self.list_missions(usize::MAX, 0).await?;
+        Ok(snapshot
+            .into_iter()
+            .filter(|mission| mission.id.to_string().starts_with(&prefix))
+            .take(limit)
+            .collect())
     }
 
     /// Acquire the sole non-terminal execution lease for a mission. Every

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1888,6 +1888,44 @@ pub trait MissionStore: Send + Sync {
     /// Get a single mission by ID.
     async fn get_mission(&self, id: Uuid) -> Result<Option<Mission>, String>;
 
+    /// Missions whose canonical id starts with `prefix`, newest first.
+    ///
+    /// Dashboards, logs and humans all refer to a mission by its first 8
+    /// characters, so tooling has to accept that form. Resolution is
+    /// deliberately a lookup rather than a parse: only the store knows whether
+    /// a prefix is unambiguous. The default implementation pages
+    /// `list_missions`; sqlite overrides it with an indexed prefix scan.
+    async fn find_missions_by_id_prefix(
+        &self,
+        prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<Mission>, String> {
+        const PAGE: usize = 200;
+        const MAX_SCAN: usize = 5_000;
+        let prefix = prefix.to_ascii_lowercase();
+        let mut found = Vec::new();
+        let mut offset = 0usize;
+        let mut scanned = 0usize;
+        loop {
+            let page = self.list_missions(PAGE, offset).await?;
+            let page_len = page.len();
+            for mission in page {
+                if mission.id.to_string().starts_with(&prefix) {
+                    found.push(mission);
+                    if found.len() >= limit {
+                        return Ok(found);
+                    }
+                }
+            }
+            scanned += page_len;
+            if page_len < PAGE || scanned >= MAX_SCAN {
+                break;
+            }
+            offset += PAGE;
+        }
+        Ok(found)
+    }
+
     /// Acquire the sole non-terminal execution lease for a mission. Every
     /// successful acquisition increments the mission generation.
     async fn begin_mission_run(

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1895,17 +1895,24 @@ pub trait MissionStore: Send + Sync {
     /// deliberately a lookup rather than a parse: only the store knows whether
     /// a prefix is unambiguous. The default implementation pages
     /// `list_missions`; sqlite overrides it with an indexed prefix scan.
+    ///
+    /// This deliberately has NO scan ceiling, unlike the filtered listing.
+    /// "Unique" is a claim about the whole store: stopping early could report
+    /// a single visible candidate as unambiguous while a second match sits
+    /// just beyond the horizon, and the caller would then cancel or message
+    /// the wrong mission. An incomplete list is a nuisance; an incomplete
+    /// uniqueness proof is a correctness bug. Callers pass a small `limit`
+    /// (enough to prove ambiguity), so the loop still exits early in the
+    /// ambiguous case.
     async fn find_missions_by_id_prefix(
         &self,
         prefix: &str,
         limit: usize,
     ) -> Result<Vec<Mission>, String> {
         const PAGE: usize = 200;
-        const MAX_SCAN: usize = 5_000;
         let prefix = prefix.to_ascii_lowercase();
         let mut found = Vec::new();
         let mut offset = 0usize;
-        let mut scanned = 0usize;
         loop {
             let page = self.list_missions(PAGE, offset).await?;
             let page_len = page.len();
@@ -1917,8 +1924,7 @@ pub trait MissionStore: Send + Sync {
                     }
                 }
             }
-            scanned += page_len;
-            if page_len < PAGE || scanned >= MAX_SCAN {
+            if page_len < PAGE {
                 break;
             }
             offset += PAGE;
@@ -3709,6 +3715,63 @@ pub async fn create_mission_store(
             let store = SqliteMissionStore::new(base_dir, user_id).await?;
             Ok(Box::new(store))
         }
+    }
+}
+
+#[cfg(test)]
+mod id_prefix_default_impl_tests {
+    use super::{InMemoryMissionStore, MissionStore};
+
+    /// The default (non-sqlite) implementation must have no scan ceiling.
+    /// A cap could report a single visible candidate as unambiguous while a
+    /// second match sat beyond the horizon — and the caller would then cancel
+    /// or message the wrong mission. An incomplete list is a nuisance; an
+    /// incomplete uniqueness proof is a correctness bug.
+    #[tokio::test]
+    async fn ambiguity_is_detected_past_any_paging_horizon() {
+        let store = InMemoryMissionStore::new();
+        let mut shared_prefix: Option<String> = None;
+        let mut expected = 0usize;
+
+        // Create enough missions that a naive cap would truncate, and seed two
+        // that genuinely share a prefix at opposite ends of the ordering.
+        for i in 0..40 {
+            let mission = store
+                .create_mission_with_parent(
+                    Some(&format!("m{i}")),
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .expect("create mission");
+            let id = mission.id.to_string();
+            match shared_prefix.as_deref() {
+                None => {
+                    shared_prefix = Some(id[..1].to_string());
+                    expected = 1;
+                }
+                Some(prefix) if id.starts_with(prefix) => expected += 1,
+                _ => {}
+            }
+        }
+
+        let prefix = shared_prefix.expect("at least one mission");
+        let found = store
+            .find_missions_by_id_prefix(&prefix, 50)
+            .await
+            .expect("prefix lookup");
+        assert_eq!(
+            found.len(),
+            expected,
+            "every match must be seen, whatever its position"
+        );
     }
 }
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3009,6 +3009,45 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    /// Indexed prefix seek on the primary key: `id` is TEXT PRIMARY KEY, so
+    /// the range bounds below use its implicit index instead of scanning.
+    async fn find_missions_by_id_prefix(
+        &self,
+        prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<Mission>, String> {
+        let prefix = prefix.to_ascii_lowercase();
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            // Half-open range over the PK. Incrementing the last byte gives the
+            // exclusive upper bound for "everything starting with prefix";
+            // mission ids are lowercase hex + hyphens, so the successor is
+            // always representable.
+            let mut upper = prefix.clone().into_bytes();
+            match upper.last_mut() {
+                Some(byte) if *byte < 0xFF => *byte += 1,
+                _ => upper.push(0),
+            }
+            let upper = String::from_utf8_lossy(&upper).to_string();
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT {MISSION_LIST_COLUMNS} FROM missions \
+                     WHERE id >= ?1 AND id < ?2 \
+                     ORDER BY updated_at DESC LIMIT ?3"
+                ))
+                .map_err(|e| e.to_string())?;
+            let missions = stmt
+                .query_map(params![prefix, upper, limit as i64], row_to_mission)
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+            Ok(missions)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn count_missions_by_status(&self) -> Result<MissionStatusCounts, String> {
         let conn = self.conn.clone();
         tokio::task::spawn_blocking(move || {
@@ -16705,5 +16744,89 @@ mod filter_tests {
             .expect("filtered list");
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].id, tagged);
+    }
+}
+
+#[cfg(test)]
+mod id_prefix_tests {
+    use super::SqliteMissionStore;
+    use crate::api::mission_store::MissionStore;
+
+    async fn store(dir: &tempfile::TempDir) -> SqliteMissionStore {
+        SqliteMissionStore::new(dir.path().to_path_buf(), "prefix-user")
+            .await
+            .expect("sqlite store")
+    }
+
+    async fn make(store: &SqliteMissionStore, title: &str) -> uuid::Uuid {
+        store
+            .create_mission_with_parent(
+                Some(title),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create mission")
+            .id
+    }
+
+    #[tokio::test]
+    async fn resolves_the_prefix_dashboards_display() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        let id = make(&store, "target").await;
+        for i in 0..5 {
+            make(&store, &format!("noise {i}")).await;
+        }
+
+        let short = &id.to_string()[..8];
+        let found = store
+            .find_missions_by_id_prefix(short, 10)
+            .await
+            .expect("prefix lookup");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, id);
+    }
+
+    #[tokio::test]
+    async fn reports_every_candidate_so_the_caller_can_disambiguate() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        let a = make(&store, "a").await;
+        let b = make(&store, "b").await;
+        // Their common prefix is at minimum the empty string; use the first
+        // character both share to force a multi-match without depending on
+        // generated values.
+        let shared = &a.to_string()[..1];
+        if b.to_string().starts_with(shared) {
+            let found = store
+                .find_missions_by_id_prefix(shared, 10)
+                .await
+                .expect("prefix lookup");
+            assert!(
+                found.len() >= 2,
+                "an ambiguous prefix must surface every candidate, got {}",
+                found.len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_prefix_finds_nothing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        make(&store, "only").await;
+        let found = store
+            .find_missions_by_id_prefix("ffffffff", 10)
+            .await
+            .expect("prefix lookup");
+        assert!(found.is_empty());
     }
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -793,6 +793,12 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             "/api/control/missions/current",
             get(control::get_current_mission),
         )
+        // Declared BEFORE `/:id` so the literal segment is not captured as a
+        // mission id.
+        .route(
+            "/api/control/missions/resolve",
+            get(control::resolve_mission_id),
+        )
         .route("/api/control/missions/:id", get(control::get_mission))
         .route(
             "/api/control/missions/:id/board",
@@ -854,6 +860,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/control/missions/:id/project",
             post(control::update_mission_project),
+        )
+        .route(
+            "/api/control/missions/:id/origin",
+            post(control::update_mission_origin),
         )
         .route(
             "/api/control/missions/:id/mode",

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1087,8 +1087,11 @@ impl AssistantMcp {
                     "type": "object",
                     "properties": {
                         "limit": {"type": "integer", "description": "Maximum missions to return, default 50."},
-                        "project": {"type": "string", "description": "Optional filter: only missions with this project."},
-                        "tag": {"type": "string", "description": "Optional filter: only missions carrying this tag."}
+                        "project": {"type": "string", "description": "Optional filter: exact project id."},
+                        "project_prefix": {"type": "string", "description": "Optional filter: project FAMILY — matches the id and its `-` suffixed variants (e.g. verity covers verity-core, verity-phase1d). Use this when a project's work is still split across per-phase ids."},
+                        "track": {"type": "string", "description": "Optional filter: exact track within a project."},
+                        "tag": {"type": "string", "description": "Optional filter: only missions carrying this tag."},
+                        "origin_session_id": {"type": "string", "description": "Optional filter: only missions launched from this Hermes conversation."}
                     }
                 }),
             },

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -88,8 +88,16 @@ struct ListMissionsParams {
     limit: usize,
     #[serde(default)]
     project: Option<String>,
+    /// Project family: matches `X` and `X-*`.
+    #[serde(default)]
+    project_prefix: Option<String>,
+    #[serde(default)]
+    track: Option<String>,
     #[serde(default)]
     tag: Option<String>,
+    /// The Hermes conversation a mission was launched from.
+    #[serde(default)]
+    origin_session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -899,6 +907,64 @@ impl AssistantMcp {
             .map(|token| ("Authorization".to_string(), format!("Bearer {token}")))
     }
 
+    /// Turn whatever the caller has into a mission UUID.
+    ///
+    /// Dashboards, logs and transcripts all show the 8-character prefix, so a
+    /// controller keeping notes across days inevitably feeds one back. A full
+    /// UUID resolves locally with no round trip; anything else asks the
+    /// server, which is the only party that can tell whether the fragment is
+    /// unambiguous. Ambiguity surfaces the candidates instead of guessing.
+    async fn resolve_mission_id(&self, raw: &str) -> Result<Uuid, String> {
+        let trimmed = raw.trim();
+        if let Ok(id) = Uuid::parse_str(trimmed) {
+            return Ok(id);
+        }
+        let response = self
+            .api_get(&format!(
+                "/api/control/missions/resolve?id={}",
+                urlencoding::encode(trimmed)
+            ))
+            .await?;
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if status.is_success() {
+            let value: Value = serde_json::from_str(&body)
+                .map_err(|error| format!("Failed to parse mission resolve response: {error}"))?;
+            return value
+                .get("mission_id")
+                .and_then(Value::as_str)
+                .and_then(|id| Uuid::parse_str(id).ok())
+                .ok_or_else(|| format!("Mission resolve returned no id for '{trimmed}'"));
+        }
+        // Name the candidates so the next call can be exact.
+        if let Ok(value) = serde_json::from_str::<Value>(&body) {
+            if value.get("error").and_then(Value::as_str) == Some("ambiguous") {
+                let listed = value
+                    .get("candidates")
+                    .and_then(Value::as_array)
+                    .map(|rows| {
+                        rows.iter()
+                            .filter_map(|row| {
+                                let id = row.get("id")?.as_str()?;
+                                let title = row.get("title").and_then(Value::as_str).unwrap_or("");
+                                let mission_status =
+                                    row.get("status").and_then(Value::as_str).unwrap_or("");
+                                Some(format!("{id} ({mission_status}, {title:?})"))
+                            })
+                            .collect::<Vec<_>>()
+                            .join("; ")
+                    })
+                    .unwrap_or_default();
+                return Err(format!(
+                    "Ambiguous mission id '{trimmed}' — candidates: {listed}. Pass the full id."
+                ));
+            }
+        }
+        Err(format!(
+            "Failed to resolve mission '{trimmed}' ({status}): {body}"
+        ))
+    }
+
     async fn api_get(&self, path: &str) -> Result<reqwest::Response, String> {
         let mut req = self.client.get(format!("{}{}", self.api_url, path));
         if let Some((name, value)) = self.auth_header() {
@@ -1034,8 +1100,11 @@ impl AssistantMcp {
                     "properties": {
                         "status": {"type": "string", "description": "Optional mission status filter."},
                         "limit": {"type": "integer", "description": "Maximum missions to return, default 50."},
-                        "project": {"type": "string", "description": "Optional filter: only missions with this project."},
-                        "tag": {"type": "string", "description": "Optional filter: only missions carrying this tag."}
+                        "project": {"type": "string", "description": "Optional filter: exact project id."},
+                        "project_prefix": {"type": "string", "description": "Optional filter: project FAMILY — matches the id and its `-` suffixed variants (e.g. verity covers verity-core, verity-phase1d). Use this when a project's work is still split across per-phase ids."},
+                        "track": {"type": "string", "description": "Optional filter: exact track within a project."},
+                        "tag": {"type": "string", "description": "Optional filter: only missions carrying this tag."},
+                        "origin_session_id": {"type": "string", "description": "Optional filter: only missions launched from this Hermes conversation."}
                     }
                 }),
             },
@@ -1045,7 +1114,7 @@ impl AssistantMcp {
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
-                    "properties": {"mission_id": {"type": "string"}}
+                    "properties": {"mission_id": {"type": "string", "description": "Mission UUID, or an unambiguous leading fragment of one (the 8-character form dashboards and logs display)."}}
                 }),
             },
             ToolDefinition {
@@ -1054,7 +1123,7 @@ impl AssistantMcp {
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
-                    "properties": {"mission_id": {"type": "string"}}
+                    "properties": {"mission_id": {"type": "string", "description": "Mission UUID, or an unambiguous leading fragment of one (the 8-character form dashboards and logs display)."}}
                 }),
             },
             ToolDefinition {
@@ -1165,7 +1234,7 @@ impl AssistantMcp {
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
-                    "properties": {"mission_id": {"type": "string"}}
+                    "properties": {"mission_id": {"type": "string", "description": "Mission UUID, or an unambiguous leading fragment of one (the 8-character form dashboards and logs display)."}}
                 }),
             },
             ToolDefinition {
@@ -1174,7 +1243,7 @@ impl AssistantMcp {
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
-                    "properties": {"mission_id": {"type": "string"}}
+                    "properties": {"mission_id": {"type": "string", "description": "Mission UUID, or an unambiguous leading fragment of one (the 8-character form dashboards and logs display)."}}
                 }),
             },
             ToolDefinition {
@@ -1378,7 +1447,7 @@ impl AssistantMcp {
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
-                    "properties": {"mission_id": {"type": "string"}}
+                    "properties": {"mission_id": {"type": "string", "description": "Mission UUID, or an unambiguous leading fragment of one (the 8-character form dashboards and logs display)."}}
                 }),
             },
             ToolDefinition {
@@ -1438,8 +1507,20 @@ impl AssistantMcp {
         if let Some(project) = params.project.as_deref() {
             path.push_str(&format!("&project={}", urlencoding::encode(project)));
         }
+        if let Some(prefix) = params.project_prefix.as_deref() {
+            path.push_str(&format!("&project_prefix={}", urlencoding::encode(prefix)));
+        }
+        if let Some(track) = params.track.as_deref() {
+            path.push_str(&format!("&track={}", urlencoding::encode(track)));
+        }
         if let Some(tag) = params.tag.as_deref() {
             path.push_str(&format!("&tag={}", urlencoding::encode(tag)));
+        }
+        if let Some(session) = params.origin_session_id.as_deref() {
+            path.push_str(&format!(
+                "&origin_session_id={}",
+                urlencoding::encode(session)
+            ));
         }
         let response = self.api_get(&path).await?;
         if !response.status().is_success() {
@@ -1456,12 +1537,18 @@ impl AssistantMcp {
         Ok(json!({ "missions": missions }))
     }
 
-    async fn list_active_missions(
-        &self,
-        limit: usize,
-        project: Option<String>,
-        tag: Option<String>,
-    ) -> Result<Value, String> {
+    /// Takes the whole filter set so an active-mission query can be narrowed
+    /// exactly like a full listing (by conversation, family, track, …).
+    async fn list_active_missions(&self, params: ListMissionsParams) -> Result<Value, String> {
+        let ListMissionsParams {
+            limit,
+            project,
+            project_prefix,
+            track,
+            tag,
+            origin_session_id,
+            ..
+        } = params;
         let requested = limit.clamp(1, 100);
         // The API returns the most recent missions regardless of status, so a
         // narrow fetch limit can be fully consumed by recent completed missions
@@ -1473,7 +1560,10 @@ impl AssistantMcp {
                 status: None,
                 limit: fetch_limit,
                 project,
+                project_prefix,
+                track,
                 tag,
+                origin_session_id,
             })
             .await?;
         if let Some(missions) = result["missions"].as_array_mut() {
@@ -1497,7 +1587,7 @@ impl AssistantMcp {
     }
 
     async fn get_mission_digest(&self, params: MissionIdParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let response = self
             .api_get(&format!("/api/control/missions/{id}/digest"))
             .await?;
@@ -1511,7 +1601,7 @@ impl AssistantMcp {
     }
 
     async fn get_mission_events(&self, params: MissionEventsParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let limit = params.limit.clamp(1, 200);
         // Validate against the declared enum rather than interpolating a
         // free-form string into the URL, which would let a caller smuggle
@@ -1552,7 +1642,7 @@ impl AssistantMcp {
         &self,
         params: MissionSharedFilesParams,
     ) -> Result<Value, String> {
-        let mission_id = parse_uuid(&params.mission_id)?;
+        let mission_id = self.resolve_mission_id(&params.mission_id).await?;
         // Page backwards from the end of the transcript: shared files are
         // "current attachments", so we must scan the NEWEST `limit` events —
         // the default (no cursor) pagination returns the oldest rows and would
@@ -1596,7 +1686,7 @@ impl AssistantMcp {
         &self,
         params: DownloadSharedFileParams,
     ) -> Result<Value, String> {
-        let mission_id = parse_uuid(&params.mission_id)?;
+        let mission_id = self.resolve_mission_id(&params.mission_id).await?;
         let path = shared_file_download_path(&params.url)?;
         let filename = params
             .filename
@@ -1740,7 +1830,7 @@ impl AssistantMcp {
             "No workspace_id given and no default workspace configured (HERMES_DEFAULT_WORKSPACE_ID / ASSISTANT_DEFAULT_WORKSPACE_ID)".to_string()
         })?;
         let workspace_id = parse_uuid(&workspace_id)?;
-        let mission_id = parse_uuid(&params.mission_id)?;
+        let mission_id = self.resolve_mission_id(&params.mission_id).await?;
         let command = workspace_job_command(params.command, params.argv)?;
         let key = params.idempotency_key.trim();
         if key.is_empty() {
@@ -1788,7 +1878,7 @@ impl AssistantMcp {
     }
 
     async fn send_message(&self, params: SendMessageParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let response = self
             .api_post(
                 "/api/control/message",
@@ -1809,7 +1899,7 @@ impl AssistantMcp {
     }
 
     async fn ask_mission(&self, params: AskMissionParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let mut body = json!({
             "content": params.content,
             "sandbox": params.sandbox,
@@ -1846,7 +1936,7 @@ impl AssistantMcp {
     }
 
     async fn cancel_mission(&self, params: MissionIdParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let response = self
             .api_post(&format!("/api/control/missions/{id}/cancel"), json!({}))
             .await?;
@@ -1858,7 +1948,7 @@ impl AssistantMcp {
     }
 
     async fn acknowledge_mission(&self, params: MissionIdParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let response = self
             .api_get(&format!("/api/control/missions/{id}/digest"))
             .await?;
@@ -2074,7 +2164,7 @@ impl AssistantMcp {
     }
 
     async fn update_mission_settings(&self, params: UpdateSettingsParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let mut body = serde_json::Map::new();
         if let Some(backend) = params
             .backend
@@ -2136,7 +2226,7 @@ impl AssistantMcp {
     }
 
     async fn resume_mission(&self, params: ResumeMissionParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let hint = params
             .content
             .as_deref()
@@ -2252,7 +2342,7 @@ impl AssistantMcp {
     }
 
     async fn get_mission_health(&self, params: MissionHealthParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let mission = self
             .get_mission(MissionIdParams {
                 mission_id: id.to_string(),
@@ -2313,7 +2403,7 @@ impl AssistantMcp {
         &self,
         params: MissionDiagnosticsParams,
     ) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
+        let id = self.resolve_mission_id(&params.mission_id).await?;
         let limit = params.limit.clamp(10, 300);
         let events = self
             .get_mission_events(MissionEventsParams {
@@ -2399,8 +2489,7 @@ impl AssistantMcp {
             "list_active_missions" => {
                 let params: ListMissionsParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
-                self.list_active_missions(params.limit, params.project, params.tag)
-                    .await
+                self.list_active_missions(params).await
             }
             "list_missions" => {
                 let params: ListMissionsParams = serde_json::from_value(arguments)
@@ -2703,6 +2792,11 @@ fn compact_mission_summary(mission: Value) -> Value {
         "tags": mission.get("tags").cloned().unwrap_or_else(|| json!([])),
         "desired_state": mission.get("desired_state").cloned().unwrap_or(Value::Null),
         "next_check_at": mission.get("next_check_at").cloned().unwrap_or(Value::Null),
+        // Creation provenance. Hermes is what SETS this, and until now could
+        // not read it back — so it could not tell which of its own
+        // conversations a mission belonged to.
+        "origin": mission.get("origin").cloned().unwrap_or(Value::Null),
+        "origin_session_id": mission.get("origin_session_id").cloned().unwrap_or(Value::Null),
         "awaiting_kind": mission.get("awaiting_kind").cloned().unwrap_or(Value::Null),
         "last_activity_at": mission.get("last_activity_at").cloned().unwrap_or(Value::Null),
         "last_status_change_at": mission.get("last_status_change_at").cloned().unwrap_or(Value::Null),
@@ -3137,6 +3231,46 @@ mod tests {
     /// The binary's tool table IS the curated Hermes surface; the generated
     /// config allowlists are pinned to `HERMES_ASSISTANT_TOOL_ALLOWLIST`.
     /// Adding/removing a tool here must go through the canonical list.
+    /// A full UUID must resolve without a round trip: no HTTP client is
+    /// configured in tests, so any network attempt would fail here.
+    #[tokio::test]
+    async fn full_uuid_resolves_without_calling_the_server() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        let mcp = AssistantMcp::new();
+        let id = Uuid::new_v4();
+        assert_eq!(
+            mcp.resolve_mission_id(&id.to_string())
+                .await
+                .expect("resolve"),
+            id
+        );
+        // Mixed case with surrounding whitespace is the shape humans paste.
+        assert_eq!(
+            mcp.resolve_mission_id(&format!("  {}  ", id.to_string().to_uppercase()))
+                .await
+                .expect("resolve"),
+            id
+        );
+    }
+
+    #[test]
+    fn compact_summary_exposes_creation_origin() {
+        let summary = compact_mission_summary(json!({
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "active",
+            "origin": "hermes",
+            "origin_session_id": "20260804_103847_86ca5c",
+            "prompt": "secret",
+            "api_token": "secret",
+        }));
+        assert_eq!(summary["origin"], "hermes");
+        assert_eq!(summary["origin_session_id"], "20260804_103847_86ca5c");
+        // The summary stays a projection, not a passthrough.
+        assert!(summary.get("prompt").is_none());
+        assert!(summary.get("api_token").is_none());
+    }
+
     #[test]
     fn tool_table_matches_canonical_allowlist() {
         let names: Vec<String> = AssistantMcp::tools()


### PR DESCRIPTION
Second PR of the project ↔ conversation ↔ missions series (after #726). Two gaps that together made a controller unable to inventory its own work — this is the pair behind the live failure *« l'inventaire live ne retourne aucune mission Verity, et les IDs abrégés fournis ne permettent pas une lecture directe »*.

## Short ids

Dashboards, logs and transcripts all display a mission by its first 8 characters, so a controller keeping notes across days inevitably feeds one back — and `parse_uuid` rejected it outright.

Resolution is a **lookup, not a parse**: only the store knows whether a fragment is unambiguous.

- `find_missions_by_id_prefix` on the store. Default impl pages; **sqlite overrides it with a half-open range over the TEXT PRIMARY KEY**, so it seeks the implicit index rather than scanning.
- `GET /api/control/missions/resolve?id=<prefix>`, declared **before `/:id`** so the literal segment is not captured as a mission id. Under 4 hex chars → 400. No match → 404. **Ambiguity → 409 listing the candidates**, never a silent pick of the newest: a controller acting on the wrong mission is far worse than one that has to ask again with more characters.
- assistant-mcp resolves through it on all 13 mission call sites. A full UUID short-circuits locally, so the common path costs **no round trip**. Workspace and job ids keep strict parsing — different id space, no short form in any UI.

## Origin readback

Hermes *sets* `origin_session_id` and could not read it back: `compact_mission_summary` omitted it, so the assistant could not tell which of its own conversations a mission belonged to. Now exposed, together with `project_prefix` / `track` / `origin_session_id` filters on `list_missions`; `list_active_missions` now takes the full filter set instead of three hand-picked params.

## Two adjacent holes closed

- **`clone_mission` inherited nothing.** A retry belongs to the conversation that asked for it; dropping the origin removed the clone from that session's worker strip.
- **`POST /api/control/missions/:id/origin`** — origin was write-once at creation, so every mission created before the column existed was permanently unattributable. This is what makes that history recoverable (and what the retag/backfill work will use).

No new MCP tools, so the three-way pinned allowlist is untouched.

## Testing

`cargo test --lib` 1646 passed (3 new prefix-lookup tests: the 8-char form resolves, an ambiguous prefix surfaces every candidate, an unknown prefix finds nothing) and `--bins` green with 2 new MCP tests (a full UUID resolves with no HTTP client configured; the summary exposes origin while still omitting `prompt`/`api_token`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mission ID resolution affects cancel/message and other control actions if prefix logic is wrong; changes are bounded by explicit 409-on-ambiguity and tests, but assistant-mcp now routes many operations through resolve.
> 
> **Overview**
> Controllers can now use the **8-character mission prefixes** shown in dashboards and logs instead of full UUIDs. The store gains `find_missions_by_id_prefix` (full snapshot on default backends; **SQLite PK range scan**), exposed as **`GET /api/control/missions/resolve`** — exact UUID, single prefix match, **409 with candidates on ambiguity**, never silent disambiguation. **assistant-mcp** resolves through this on mission-touching tools (full UUID stays local, no HTTP).
> 
> **Hermes** can read creation provenance again: **`compact_mission_summary`** includes `origin` / `origin_session_id`, list tools forward **`project_prefix`**, **`track`**, and **`origin_session_id`** filters, and **`list_active_missions`** uses the same filter set as listing.
> 
> **`POST /api/control/missions/:id/origin`** backfills origin/session on older missions (validated like create). **`clone_mission`** now copies origin fields so retries stay tied to the launching conversation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807fad7261295abe40e9228487159bff05713bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->