### PR TITLE
A project's control conversation is declared, not guessed

### DIFF
--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -356,6 +356,13 @@ describe("ProjectsBoard", () => {
     );
     mockedListHermesSessions.mockResolvedValue([
       { id: cronSession, title: "tick" },
+      // An ordinary session that has ENDED is just as unreachable as a cron
+      // tick: binding it would point every reply at a closed thread.
+      {
+        id: "20260801_120000_closed",
+        title: "Old thread",
+        ended_at: "2026-08-02T09:00:00Z",
+      },
       { id: "20260804_103847_86ca5c", title: "Verity dev #28" },
     ]);
 
@@ -374,6 +381,7 @@ describe("ProjectsBoard", () => {
       .getAllByRole("option")
       .map((o) => (o as HTMLOptionElement).value);
     expect(values).not.toContain(cronSession);
+    expect(values).not.toContain("20260801_120000_closed");
   });
 
   test("offers no conversation link before a project has an update", async () => {

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -8,17 +8,20 @@ import {
   postProjectAction,
 } from "@/lib/api/projects";
 import type { ProjectRow, ProjectsOverview } from "@/lib/api/projects";
-import { hermesChatStream } from "@/lib/api/hermes";
+import { hermesChatStream, listHermesSessions } from "@/lib/api/hermes";
 import ProjectsBoard from "./projects-board";
 
 vi.mock("@/lib/api/projects", () => ({
   getProjectsOverview: vi.fn(),
   getProjectUpdates: vi.fn(),
   postProjectAction: vi.fn(),
+  bindProjectConversation: vi.fn(),
+  unbindProjectConversation: vi.fn(),
 }));
 
 vi.mock("@/lib/api/hermes", () => ({
   hermesChatStream: vi.fn(),
+  listHermesSessions: vi.fn(),
 }));
 
 vi.mock("@/components/markdown-content", () => ({
@@ -26,6 +29,7 @@ vi.mock("@/components/markdown-content", () => ({
 }));
 
 const mockedOverview = vi.mocked(getProjectsOverview);
+const mockedListHermesSessions = vi.mocked(listHermesSessions);
 const mockedUpdates = vi.mocked(getProjectUpdates);
 const mockedAction = vi.mocked(postProjectAction);
 const mockedChat = vi.mocked(hermesChatStream);
@@ -299,8 +303,9 @@ describe("ProjectsBoard", () => {
       "href",
       "/control?session=20260804_103847_86ca5c",
     );
-    // Nothing to bind: it is already declared.
-    expect(screen.queryByTitle(/control conversation/i)).not.toBeInTheDocument();
+    // Already declared: the "choose one" affordance is gone (Rebind/Unbind
+    // remain, which is the point — the operator can still change their mind).
+    expect(screen.queryByTitle(/Choose the conversation/i)).not.toBeInTheDocument();
   });
 
   test("an inferred conversation offers to be bound", async () => {
@@ -326,7 +331,49 @@ describe("ProjectsBoard", () => {
 
     renderBoard();
 
-    expect(await screen.findByTitle(/control conversation/i)).toBeInTheDocument();
+    expect(
+      await screen.findByTitle(/Choose the conversation/i),
+    ).toBeInTheDocument();
+  });
+
+  test("binding never persists the inferred per-tick session", async () => {
+    const cronSession = "cron_e594d751447d_20260804_120931";
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity",
+          latest_update: {
+            headline: "tick",
+            body: null,
+            session_id: cronSession,
+            at: "2026-08-04T12:09:00Z",
+            signature: "verity",
+            blocker: null,
+          },
+          conversation: { session_id: cronSession, source: "latest_update" },
+        }),
+      ]),
+    );
+    mockedListHermesSessions.mockResolvedValue([
+      { id: cronSession, title: "tick" },
+      { id: "20260804_103847_86ca5c", title: "Verity dev #28" },
+    ]);
+
+    renderBoard();
+    fireEvent.click(await screen.findByTitle(/Choose the conversation/i));
+
+    // The per-tick session is filtered out: binding it would cement the very
+    // corpse this feature exists to replace.
+    await waitFor(() => {
+      const values = screen
+        .getAllByRole("option")
+        .map((o) => (o as HTMLOptionElement).value);
+      expect(values).toContain("20260804_103847_86ca5c");
+    });
+    const values = screen
+      .getAllByRole("option")
+      .map((o) => (o as HTMLOptionElement).value);
+    expect(values).not.toContain(cronSession);
   });
 
   test("offers no conversation link before a project has an update", async () => {

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -270,6 +270,65 @@ describe("ProjectsBoard", () => {
     );
   });
 
+  test("a declared binding wins over the session of the newest delivery", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity",
+          latest_update: {
+            headline: "tick",
+            body: null,
+            // A cron tick's throwaway session: already ended, unreachable.
+            session_id: "cron_e594d751447d_20260804_120931",
+            at: "2026-08-04T12:09:00Z",
+            signature: "verity",
+            blocker: null,
+          },
+          conversation: {
+            session_id: "20260804_103847_86ca5c",
+            source: "binding",
+          },
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    const link = await screen.findByTitle("Conversation");
+    expect(link).toHaveAttribute(
+      "href",
+      "/control?session=20260804_103847_86ca5c",
+    );
+    // Nothing to bind: it is already declared.
+    expect(screen.queryByTitle(/control conversation/i)).not.toBeInTheDocument();
+  });
+
+  test("an inferred conversation offers to be bound", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity",
+          latest_update: {
+            headline: "tick",
+            body: null,
+            session_id: "cron_e594d751447d_20260804_120931",
+            at: "2026-08-04T12:09:00Z",
+            signature: "verity",
+            blocker: null,
+          },
+          conversation: {
+            session_id: "cron_e594d751447d_20260804_120931",
+            source: "latest_update",
+          },
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    expect(await screen.findByTitle(/control conversation/i)).toBeInTheDocument();
+  });
+
   test("offers no conversation link before a project has an update", async () => {
     mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
 

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -504,16 +504,21 @@ function ProjectActions({ project }: { project: ProjectRow }) {
   const [picking, setPicking] = useState(false);
   const [sessions, setSessions] = useState<HermesSession[] | null>(null);
 
-  // Offer the conversations an operator could plausibly mean: a control
-  // conversation is one they talk in, so per-tick cron sessions are excluded —
-  // binding one would cement exactly the corpse this feature exists to avoid.
+  // Offer only conversations that can actually receive something. An ended
+  // session is unreachable whatever produced it, and a per-tick cron session
+  // is unreachable by construction — binding either would cement exactly the
+  // corpse this feature exists to avoid. `ended_at` is the general rule; the
+  // `cron_` check also catches a tick still in flight, which has no
+  // `ended_at` yet but will never be a conversation.
   const openPicker = useCallback(async () => {
     setPicking(true);
     setActionError(null);
     if (sessions) return;
     try {
       const all = await listHermesSessions(50);
-      setSessions(all.filter((s) => !s.id.startsWith("cron_")));
+      setSessions(
+        all.filter((s) => !s.ended_at && !s.id.startsWith("cron_")),
+      );
     } catch (err) {
       setActionError(String(err instanceof Error ? err.message : err));
     }

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   GitPullRequest,
   Inbox,
+  Link2,
   Loader,
   Pause,
   Play,
@@ -30,6 +31,8 @@ import {
 } from "lucide-react";
 
 import {
+  bindProjectConversation,
+  type ProjectConversation,
   getProjectsOverview,
   getProjectUpdates,
   postProjectAction,
@@ -398,6 +401,7 @@ function ProjectListRow({
 function ActionButton({
   icon: Icon,
   label,
+  title,
   onClick,
   href,
   busy,
@@ -405,6 +409,8 @@ function ActionButton({
 }: {
   icon: LucideIcon;
   label: string;
+  /** Hover text when the label alone does not explain the consequence. */
+  title?: string;
   onClick?: () => void;
   href?: string;
   busy?: boolean;
@@ -429,7 +435,7 @@ function ActionButton({
 
   if (href) {
     return (
-      <Link href={href} title={label} className={cn(className, "no-underline")}>
+      <Link href={href} title={title ?? label} className={cn(className, "no-underline")}>
         {content}
       </Link>
     );
@@ -440,7 +446,7 @@ function ActionButton({
       type="button"
       onClick={onClick}
       disabled={busy}
-      title={label}
+      title={title ?? label}
       className={className}
     >
       {content}
@@ -450,7 +456,7 @@ function ActionButton({
 
 function ProjectActions({ project }: { project: ProjectRow }) {
   const { mutate } = useSWRConfig();
-  const [busy, setBusy] = useState<ProjectAction | null>(null);
+  const [busy, setBusy] = useState<ProjectAction | "bind" | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
@@ -471,9 +477,34 @@ function ProjectActions({ project }: { project: ProjectRow }) {
     [project.slug, mutate],
   );
 
-  // The conversation this project reports into: whichever Hermes session sent
-  // its most recent update. Absent until a project has had one.
-  const conversationSessionId = project.latest_update?.session_id ?? null;
+  // The conversation this project reports into. A declared binding is
+  // authoritative; otherwise the newest delivery's session is only a GUESS —
+  // and for a cron-driven project that guess is a throwaway per-tick session
+  // that has already ended, which is why binding it is offered right here.
+  // The dashboard ships via Vercel and the backend deploys separately, so a
+  // window exists where this field is not served yet. Fall back to the old
+  // inference rather than dropping the button — tagged as a guess either way.
+  const conversation: ProjectConversation | null =
+    project.conversation ??
+    (project.latest_update?.session_id
+      ? {
+          session_id: project.latest_update.session_id,
+          source: "latest_update" as const,
+        }
+      : null);
+  const conversationSessionId = conversation?.session_id ?? null;
+  const conversationIsGuess = conversation?.source === "latest_update";
+
+  const bindConversation = useCallback(async () => {
+    if (!conversationSessionId) return;
+    setBusy("bind");
+    try {
+      await bindProjectConversation(project.slug, conversationSessionId);
+      await mutate("projects-overview");
+    } finally {
+      setBusy(null);
+    }
+  }, [project.slug, conversationSessionId, mutate]);
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
@@ -482,6 +513,15 @@ function ProjectActions({ project }: { project: ProjectRow }) {
           icon={Sparkles}
           label="Conversation"
           href={`/control?session=${encodeURIComponent(conversationSessionId)}`}
+        />
+      )}
+      {conversationIsGuess && (
+        <ActionButton
+          icon={Link2}
+          label="Bind"
+          title="Make this the project's control conversation. Until it is bound, the link above follows whichever session sent the last update — for a cron-driven project that is a per-tick session which has already ended."
+          busy={busy === "bind"}
+          onClick={bindConversation}
         />
       )}
       {project.bucket === "paused" ? (
@@ -719,6 +759,11 @@ function ProjectDetail({
               key={`${update.session_id}-${update.at}-${index}`}
               update={update}
               defaultExpanded={index === 0}
+              replyToSessionId={
+                project.conversation?.source === "binding"
+                  ? project.conversation.session_id
+                  : update.session_id
+              }
             />
           ))}
         </div>
@@ -835,9 +880,14 @@ function bodyWithoutHeadline(body: string, headline: string): string {
 function UpdateEntry({
   update,
   defaultExpanded,
+  replyToSessionId,
 }: {
   update: ProjectDeliveryUpdate;
   defaultExpanded: boolean;
+  /** Where a reply should go — the project's bound conversation when one is
+   *  declared. Replying into the delivery's own session would land in a cron
+   *  tick that has already ended. */
+  replyToSessionId: string;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   return (
@@ -869,7 +919,7 @@ function UpdateEntry({
             </p>
           </div>
         )}
-        {expanded && <ReplyComposer sessionId={update.session_id} />}
+        {expanded && <ReplyComposer sessionId={replyToSessionId} />}
       </div>
     </div>
   );

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -28,10 +28,12 @@ import {
   Send,
   Sparkles,
   Trash2,
+  Unlink,
 } from "lucide-react";
 
 import {
   bindProjectConversation,
+  unbindProjectConversation,
   type ProjectConversation,
   getProjectsOverview,
   getProjectUpdates,
@@ -42,6 +44,10 @@ import {
   type ProjectMissionChip,
   type ProjectRow,
 } from "@/lib/api/projects";
+import {
+  listHermesSessions,
+  type HermesSession,
+} from "@/lib/api/hermes";
 import { hermesChatStream } from "@/lib/api/hermes";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -495,16 +501,53 @@ function ProjectActions({ project }: { project: ProjectRow }) {
   const conversationSessionId = conversation?.session_id ?? null;
   const conversationIsGuess = conversation?.source === "latest_update";
 
-  const bindConversation = useCallback(async () => {
-    if (!conversationSessionId) return;
-    setBusy("bind");
+  const [picking, setPicking] = useState(false);
+  const [sessions, setSessions] = useState<HermesSession[] | null>(null);
+
+  // Offer the conversations an operator could plausibly mean: a control
+  // conversation is one they talk in, so per-tick cron sessions are excluded —
+  // binding one would cement exactly the corpse this feature exists to avoid.
+  const openPicker = useCallback(async () => {
+    setPicking(true);
+    setActionError(null);
+    if (sessions) return;
     try {
-      await bindProjectConversation(project.slug, conversationSessionId);
+      const all = await listHermesSessions(50);
+      setSessions(all.filter((s) => !s.id.startsWith("cron_")));
+    } catch (err) {
+      setActionError(String(err instanceof Error ? err.message : err));
+    }
+  }, [sessions]);
+
+  const bindConversation = useCallback(
+    async (sessionId: string) => {
+      setBusy("bind");
+      setActionError(null);
+      try {
+        await bindProjectConversation(project.slug, sessionId);
+        await mutate("projects-overview");
+        setPicking(false);
+      } catch (err) {
+        setActionError(String(err instanceof Error ? err.message : err));
+      } finally {
+        setBusy(null);
+      }
+    },
+    [project.slug, mutate],
+  );
+
+  const unbindConversation = useCallback(async () => {
+    setBusy("bind");
+    setActionError(null);
+    try {
+      await unbindProjectConversation(project.slug);
       await mutate("projects-overview");
+    } catch (err) {
+      setActionError(String(err instanceof Error ? err.message : err));
     } finally {
       setBusy(null);
     }
-  }, [project.slug, conversationSessionId, mutate]);
+  }, [project.slug, mutate]);
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
@@ -515,14 +558,24 @@ function ProjectActions({ project }: { project: ProjectRow }) {
           href={`/control?session=${encodeURIComponent(conversationSessionId)}`}
         />
       )}
-      {conversationIsGuess && (
+      {conversationIsGuess ? (
         <ActionButton
           icon={Link2}
-          label="Bind"
-          title="Make this the project's control conversation. Until it is bound, the link above follows whichever session sent the last update — for a cron-driven project that is a per-tick session which has already ended."
+          label="Bind…"
+          title="Choose the conversation this project reports into. Until one is declared, the link above follows whichever session sent the last update — for a cron-driven project that is a per-tick session which has already ended."
           busy={busy === "bind"}
-          onClick={bindConversation}
+          onClick={openPicker}
         />
+      ) : (
+        conversation && (
+          <ActionButton
+            icon={Link2}
+            label="Rebind…"
+            title="Point this project at a different control conversation."
+            busy={busy === "bind"}
+            onClick={openPicker}
+          />
+        )
       )}
       {project.bucket === "paused" ? (
         <ActionButton
@@ -568,6 +621,44 @@ function ProjectActions({ project }: { project: ProjectRow }) {
           }
         }}
       />
+      {conversation?.source === "binding" && (
+        <ActionButton
+          icon={Unlink}
+          label="Unbind"
+          title="Stop declaring a control conversation for this project. The link falls back to whichever session sent the last update."
+          busy={busy === "bind"}
+          onClick={unbindConversation}
+        />
+      )}
+      {picking && (
+        <div className="mt-1 flex w-full flex-wrap items-center gap-1.5">
+          <select
+            className="min-w-0 flex-1 rounded-md border border-white/[0.06] bg-white/[0.03] px-2 py-1 text-[11px] text-[rgb(var(--text))]"
+            defaultValue=""
+            onChange={(event) => {
+              if (event.target.value) void bindConversation(event.target.value);
+            }}
+          >
+            <option value="" disabled>
+              {sessions === null
+                ? "Loading conversations…"
+                : sessions.length === 0
+                  ? "No conversation available"
+                  : "Choose the control conversation…"}
+            </option>
+            {(sessions ?? []).map((session) => (
+              <option key={session.id} value={session.id}>
+                {session.title || session.preview || session.id}
+              </option>
+            ))}
+          </select>
+          <ActionButton
+            icon={ArrowLeft}
+            label="Cancel"
+            onClick={() => setPicking(false)}
+          />
+        </div>
+      )}
       {actionError && (
         <span className="text-[11px] text-amber-300">{actionError}</span>
       )}

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -3,7 +3,7 @@
  * project-tagged missions, and cron delivery updates.
  */
 
-import { apiGet, apiPost } from "./core";
+import { apiDel, apiGet, apiPost, apiPut } from "./core";
 
 export interface ProjectTracker {
   slug: string;
@@ -30,6 +30,15 @@ export interface ProjectDeliveryUpdate {
 
 export type ProjectBucket = "attention" | "active" | "paused" | "archived";
 
+export interface ProjectConversation {
+  session_id: string;
+  /** `binding` = declared by an operator; `latest_update` = guessed from the
+   *  newest delivery, which for a cron-driven project is a throwaway session
+   *  that has already ended. Render the two differently. */
+  source: "binding" | "latest_update";
+  bound_at?: string;
+}
+
 export interface ProjectRow {
   slug: string;
   bucket: ProjectBucket;
@@ -38,6 +47,7 @@ export interface ProjectRow {
   latest_update: ProjectDeliveryUpdate | null;
   updates_count: number;
   attention_reasons: string[];
+  conversation?: ProjectConversation | null;
 }
 
 export interface ProjectsOverview {
@@ -82,5 +92,23 @@ export async function postProjectAction(
     `/api/projects/${encodeURIComponent(slug)}/action`,
     { action },
     "Failed to apply project action",
+  );
+}
+
+export async function bindProjectConversation(
+  slug: string,
+  sessionId: string,
+): Promise<void> {
+  await apiPut(
+    `/api/projects/${encodeURIComponent(slug)}/conversation`,
+    { session_id: sessionId },
+    "Failed to bind the project conversation",
+  );
+}
+
+export async function unbindProjectConversation(slug: string): Promise<void> {
+  await apiDel(
+    `/api/projects/${encodeURIComponent(slug)}/conversation`,
+    "Failed to unbind the project conversation",
   );
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -49,6 +49,7 @@ pub mod oauth_reconcile;
 pub mod opencode;
 pub mod paloma;
 pub mod projects_overview;
+pub mod projects_store;
 mod provider_usage_cache;
 pub(crate) mod providers;
 pub(crate) mod proxy;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 
 use super::control::events::MissionStatus;
 use super::mission_store::Mission;
+use super::projects_store::ProjectConversation;
 use super::routes::AppState;
 
 /// Terminal missions younger than this stay on the board (recent history).
@@ -42,6 +43,10 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/overview", get(projects_overview))
         .route("/:slug/updates", get(project_updates))
         .route("/:slug/action", axum::routing::post(project_action))
+        .route(
+            "/:slug/conversation",
+            axum::routing::put(bind_project_conversation).delete(unbind_project_conversation),
+        )
 }
 
 fn hermes_projects_dir() -> Option<PathBuf> {
@@ -93,6 +98,12 @@ struct ProjectRow {
     latest_update: Option<DeliveryUpdate>,
     updates_count: usize,
     attention_reasons: Vec<String>,
+    /// The conversation to open for this project. An explicit binding wins;
+    /// otherwise the newest delivery's session is offered as a GUESS, tagged
+    /// as such — cron controllers open a throwaway session per tick, so an
+    /// inferred conversation is very often already ended.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conversation: Option<ProjectConversation>,
 }
 
 pub async fn projects_overview(
@@ -105,6 +116,10 @@ pub async fn projects_overview(
         .as_deref()
         .map(read_trackers)
         .unwrap_or_default();
+    let bindings = state
+        .projects
+        .bindings()
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
     let archived = trackers_dir
         .as_deref()
         .and_then(|dir| dir.parent().map(|p| p.join("archive")))
@@ -192,7 +207,8 @@ pub async fn projects_overview(
         .into_values()
         .map(|builder| {
             let forced = overrides.get(&builder.slug).cloned();
-            builder.finish(&archived, forced.as_deref())
+            let binding = bindings.get(&builder.slug).cloned();
+            builder.finish(&archived, forced.as_deref(), binding)
         })
         .collect();
     projects.sort_by(|a, b| {
@@ -285,7 +301,12 @@ impl ProjectRowBuilder {
         }
     }
 
-    fn finish(mut self, archived: &[String], forced: Option<&str>) -> ProjectRow {
+    fn finish(
+        mut self,
+        archived: &[String],
+        forced: Option<&str>,
+        binding: Option<ProjectConversation>,
+    ) -> ProjectRow {
         self.missions
             .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
         self.missions.truncate(8);
@@ -389,6 +410,18 @@ impl ProjectRowBuilder {
             }
         };
 
+        let conversation = binding.or_else(|| {
+            self.latest_update
+                .as_ref()
+                .map(|update| update.session_id.clone())
+                .filter(|session_id| !session_id.is_empty())
+                .map(|session_id| ProjectConversation {
+                    session_id,
+                    source: "latest_update",
+                    bound_at: None,
+                })
+        });
+
         ProjectRow {
             slug: self.slug,
             bucket,
@@ -397,6 +430,7 @@ impl ProjectRowBuilder {
             latest_update: self.latest_update,
             updates_count: self.updates_count,
             attention_reasons: attention,
+            conversation,
         }
     }
 }
@@ -533,6 +567,64 @@ pub struct ProjectActionRequest {
 
 /// Apply a board action to a project: `pause` / `archive` / `delete` set the
 /// override, `resume` / `unarchive` / `restore` clear it.
+#[derive(Debug, serde::Deserialize)]
+pub struct BindConversationRequest {
+    pub session_id: String,
+}
+
+/// Declare which conversation a project reports into.
+///
+/// Deliberately explicit: the inferred value (newest delivery's session) is
+/// almost always a cron tick's throwaway session, which is already ended and
+/// cannot be replied to.
+pub async fn bind_project_conversation(
+    State(state): State<Arc<AppState>>,
+    AxumPath(slug): AxumPath<String>,
+    Json(request): Json<BindConversationRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    // `is_plain_key` also rejects path traversal, which the slug-length check
+    // in `project_action` does not.
+    if !is_plain_key(&slug) {
+        return Err((StatusCode::BAD_REQUEST, "invalid project slug".to_string()));
+    }
+    let session_id = request.session_id.trim();
+    if session_id.is_empty()
+        || session_id.len() > 128
+        || !session_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "session_id must be 1-128 chars of [A-Za-z0-9._:-]".to_string(),
+        ));
+    }
+    let conversation = state
+        .projects
+        .set_binding(&slug, session_id, None)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    Ok(Json(serde_json::json!({
+        "slug": slug,
+        "conversation": conversation,
+    })))
+}
+
+pub async fn unbind_project_conversation(
+    State(state): State<Arc<AppState>>,
+    AxumPath(slug): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if !is_plain_key(&slug) {
+        return Err((StatusCode::BAD_REQUEST, "invalid project slug".to_string()));
+    }
+    let removed = state
+        .projects
+        .clear_binding(&slug)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    Ok(Json(
+        serde_json::json!({ "slug": slug, "unbound": removed }),
+    ))
+}
+
 pub async fn project_action(
     AxumPath(slug): AxumPath<String>,
     Json(request): Json<ProjectActionRequest>,
@@ -799,7 +891,7 @@ mod tests {
         builder.push_delivery(parse_delivery("s", 3.0, SAMPLE));
         builder.push_delivery(parse_delivery("s", 2.0, SAMPLE));
         builder.push_delivery(parse_delivery("s", 1.0, SAMPLE));
-        let row = builder.finish(&[], None);
+        let row = builder.finish(&[], None, None);
         assert_eq!(row.bucket, "attention");
         assert!(row.attention_reasons.iter().any(|r| r.contains("blocker")));
         assert!(row
@@ -840,7 +932,7 @@ mod tests {
                 github_pr: None,
             });
         }
-        let row = builder.finish(&[], None);
+        let row = builder.finish(&[], None, None);
         let failed_lines: Vec<&String> = row
             .attention_reasons
             .iter()
@@ -856,7 +948,7 @@ mod tests {
         builder.push_delivery(parse_delivery("s", 3.0, SAMPLE));
         builder.push_delivery(parse_delivery("s", 2.0, SAMPLE));
         builder.push_delivery(parse_delivery("s", 1.0, SAMPLE));
-        let row = builder.finish(&[], Some("paused"));
+        let row = builder.finish(&[], Some("paused"), None);
         assert_eq!(row.bucket, "paused");
         // Reasons stay visible in the detail pane even when silenced.
         assert!(!row.attention_reasons.is_empty());
@@ -870,7 +962,51 @@ mod tests {
             status_line: Some("paused (drained)".to_string()),
             updated_at: None,
         });
-        let row = builder.finish(&[], None);
+        let row = builder.finish(&[], None, None);
         assert_eq!(row.bucket, "paused");
+    }
+
+    /// An explicit binding must win over the inferred session, and the
+    /// inferred one must be labelled as a guess so the UI can offer to bind it.
+    #[test]
+    fn explicit_binding_wins_over_the_inferred_session() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder.push_delivery(DeliveryUpdate {
+            headline: "tick".into(),
+            body: None,
+            at: "2026-08-04T12:00:00Z".into(),
+            session_id: "cron_e594d751447d_20260804_120931".into(),
+            signature: None,
+            blocker: None,
+        });
+        let row = builder.finish(
+            &[],
+            None,
+            Some(ProjectConversation {
+                session_id: "20260804_103847_86ca5c".into(),
+                source: "binding",
+                bound_at: Some("2026-08-04T13:00:00Z".into()),
+            }),
+        );
+        let conversation = row.conversation.expect("conversation");
+        assert_eq!(conversation.session_id, "20260804_103847_86ca5c");
+        assert_eq!(conversation.source, "binding");
+    }
+
+    #[test]
+    fn without_a_binding_the_latest_update_is_offered_as_a_guess() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder.push_delivery(DeliveryUpdate {
+            headline: "tick".into(),
+            body: None,
+            at: "2026-08-04T12:00:00Z".into(),
+            session_id: "cron_e594d751447d_20260804_120931".into(),
+            signature: None,
+            blocker: None,
+        });
+        let row = builder.finish(&[], None, None);
+        let conversation = row.conversation.expect("conversation");
+        assert_eq!(conversation.source, "latest_update");
+        assert_eq!(conversation.bound_at, None);
     }
 }

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -1,0 +1,225 @@
+//! Durable, explicitly-declared facts about a project.
+//!
+//! Today a project's conversation is *inferred* from whichever session
+//! produced its newest delivery. That guess is wrong in the common case: cron
+//! controllers open a throwaway session per tick and end it, so the inferred
+//! conversation is a corpse that nobody can reply to (measured on Verity: 52
+//! deliveries across 52 distinct ended sessions). A project's control
+//! conversation is a decision, not a statistic, so it is stored.
+//!
+//! This lives in its own SQLite file rather than the `board-overrides.json`
+//! overlay for three reasons: that overlay is unwritable (503) whenever
+//! `HERMES_PROJECTS_DIR` is missing, its reader silently discards the whole
+//! file on any shape change, and it is read-modify-write — fine for a human
+//! toggling a bucket, not for something written per tick.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use chrono::Utc;
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+
+pub type SharedProjectsStore = Arc<ProjectsStore>;
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS project_bindings (
+    slug               TEXT PRIMARY KEY NOT NULL,
+    control_session_id TEXT NOT NULL,
+    bound_at           TEXT NOT NULL,
+    bound_by           TEXT
+);
+"#;
+
+/// A project's control conversation and how we know about it.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProjectConversation {
+    pub session_id: String,
+    /// `"binding"` when explicitly declared, `"latest_update"` when inferred
+    /// from the newest delivery. Callers render the two differently: a guess
+    /// invites a "bind this" action, a binding does not.
+    pub source: &'static str,
+    /// Only set for an explicit binding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bound_at: Option<String>,
+}
+
+pub struct ProjectsStore {
+    connection: Mutex<Connection>,
+}
+
+impl ProjectsStore {
+    pub fn open(path: PathBuf) -> anyhow::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let connection = Connection::open(path)?;
+        connection.pragma_update(None, "journal_mode", "WAL")?;
+        connection.execute_batch(SCHEMA)?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn open_in_memory() -> anyhow::Result<Self> {
+        let connection = Connection::open_in_memory()?;
+        connection.execute_batch(SCHEMA)?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    fn lock(&self) -> Result<MutexGuard<'_, Connection>, String> {
+        self.connection
+            .lock()
+            .map_err(|_| "projects database lock poisoned".to_string())
+    }
+
+    /// Every explicit binding, keyed by project slug. Read once per overview
+    /// render rather than per row.
+    pub fn bindings(&self) -> Result<HashMap<String, ProjectConversation>, String> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare("SELECT slug, control_session_id, bound_at FROM project_bindings")
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    ProjectConversation {
+                        session_id: row.get(1)?,
+                        source: "binding",
+                        bound_at: row.get::<_, Option<String>>(2)?,
+                    },
+                ))
+            })
+            .map_err(|e| e.to_string())?;
+        let mut out = HashMap::new();
+        for row in rows {
+            let (slug, conversation) = row.map_err(|e| e.to_string())?;
+            out.insert(slug, conversation);
+        }
+        Ok(out)
+    }
+
+    pub fn binding(&self, slug: &str) -> Result<Option<ProjectConversation>, String> {
+        let connection = self.lock()?;
+        connection
+            .query_row(
+                "SELECT control_session_id, bound_at FROM project_bindings WHERE slug = ?1",
+                params![slug],
+                |row| {
+                    Ok(ProjectConversation {
+                        session_id: row.get(0)?,
+                        source: "binding",
+                        bound_at: row.get::<_, Option<String>>(1)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+    }
+
+    /// Bind (or re-bind) a project's control conversation.
+    ///
+    /// Re-binding is a normal operation — an operator opening a fresh thread
+    /// for the same project — so this upserts rather than refusing.
+    pub fn set_binding(
+        &self,
+        slug: &str,
+        session_id: &str,
+        bound_by: Option<&str>,
+    ) -> Result<ProjectConversation, String> {
+        let now = Utc::now().to_rfc3339();
+        let connection = self.lock()?;
+        connection
+            .execute(
+                "INSERT INTO project_bindings (slug, control_session_id, bound_at, bound_by) \
+                 VALUES (?1, ?2, ?3, ?4) \
+                 ON CONFLICT(slug) DO UPDATE SET \
+                   control_session_id = excluded.control_session_id, \
+                   bound_at = excluded.bound_at, \
+                   bound_by = excluded.bound_by",
+                params![slug, session_id, now, bound_by],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(ProjectConversation {
+            session_id: session_id.to_string(),
+            source: "binding",
+            bound_at: Some(now),
+        })
+    }
+
+    /// Returns whether a binding existed.
+    pub fn clear_binding(&self, slug: &str) -> Result<bool, String> {
+        let connection = self.lock()?;
+        let removed = connection
+            .execute(
+                "DELETE FROM project_bindings WHERE slug = ?1",
+                params![slug],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(removed > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binding_round_trips_and_rebinds_in_place() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        assert!(store.binding("verity").expect("read").is_none());
+
+        let bound = store
+            .set_binding("verity", "20260804_103847_86ca5c", Some("thomas"))
+            .expect("bind");
+        assert_eq!(bound.session_id, "20260804_103847_86ca5c");
+        assert_eq!(bound.source, "binding");
+
+        // Re-binding is the "I opened a new thread" workflow, not an error.
+        store
+            .set_binding("verity", "20260805_090000_aaaaaa", None)
+            .expect("rebind");
+        assert_eq!(
+            store
+                .binding("verity")
+                .expect("read")
+                .expect("bound")
+                .session_id,
+            "20260805_090000_aaaaaa",
+            "a project has exactly one control conversation"
+        );
+
+        assert!(store.clear_binding("verity").expect("clear"));
+        assert!(!store.clear_binding("verity").expect("clear again"));
+        assert!(store.binding("verity").expect("read").is_none());
+    }
+
+    #[test]
+    fn bindings_are_isolated_per_project() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store.set_binding("verity", "sess-a", None).expect("bind");
+        store.set_binding("lido", "sess-b", None).expect("bind");
+        let all = store.bindings().expect("all");
+        assert_eq!(all.len(), 2);
+        assert_eq!(all["verity"].session_id, "sess-a");
+        assert_eq!(all["lido"].session_id, "sess-b");
+    }
+
+    /// Two projects may legitimately report into one conversation.
+    #[test]
+    fn one_conversation_can_serve_several_projects() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store.set_binding("verity", "shared", None).expect("bind");
+        store
+            .set_binding("verity-docs", "shared", None)
+            .expect("bind");
+        let all = store.bindings().expect("all");
+        assert_eq!(all["verity"].session_id, "shared");
+        assert_eq!(all["verity-docs"].session_id, "shared");
+    }
+}

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -159,6 +159,8 @@ pub struct AppState {
     pub fleet: Arc<crate::remote_node::FleetMonitor>,
     /// Persistent project validation campaigns, gates, receipts, and delivery outbox.
     pub validation: super::validation::SharedValidationStore,
+    /// Explicitly-declared project facts (control conversation binding).
+    pub projects: super::projects_store::SharedProjectsStore,
 }
 
 /// Start the HTTP server.
@@ -500,6 +502,9 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             .working_dir
             .join(".sandboxed-sh/validation-campaigns.db"),
     )?);
+    let projects = Arc::new(super::projects_store::ProjectsStore::open(
+        config.working_dir.join(".sandboxed-sh/projects.db"),
+    )?);
 
     let state = Arc::new(AppState {
         config: config.clone(),
@@ -550,6 +555,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         codex_usage: super::codex_usage::CodexUsageStore::new(),
         fleet: Arc::new(crate::remote_node::FleetMonitor::new()),
         validation,
+        projects,
     });
 
     super::validation::spawn_outbox_forwarder(Arc::clone(&state));


### PR DESCRIPTION
Third PR of the series (after #726, #727). This is the structural one.

## The defect

The projects board opens *"the conversation a project reports into"* by taking the session behind its **newest delivery**. For a cron-driven project that guess is a corpse: controllers open a throwaway session per tick and end it. Measured on Verity: **52 deliveries across 52 distinct `ended` sessions**. So the button lands in a dead one-tick session nobody can reply to, and its target changes on every tick.

A control conversation is a *decision*, not a statistic. So it gets stored.

## Changes

- **New `src/api/projects_store.rs`** — its own SQLite file, `project_bindings(slug PK, control_session_id, bound_at, bound_by)`, following the `ValidationStore` pattern already in the codebase.
- **`PUT` / `DELETE /api/projects/:slug/conversation`**. Slug validated with `is_plain_key`, which also blocks the path traversal that `project_action`'s length-only check does not.
- **`ProjectRow.conversation = {session_id, source}`** — an explicit binding wins; otherwise the inferred session is still offered but **labelled `latest_update`**. Keeping the guess while presenting it as truth was the actual defect; a client can now render "bind this" instead of pretending it knows.
- TS client: `ProjectConversation`, `bindProjectConversation`, `unbindProjectConversation`.

## Why not `board-overrides.json`

It was the obvious place and it is the wrong one: that overlay **503s** whenever `HERMES_PROJECTS_DIR` moves, its reader is `from_str::<HashMap<String,String>>(...).unwrap_or_default()` so **widening the value shape silently erases every existing bucket override**, and it is read-modify-write — acceptable for a human toggling a bucket, not for something written per tick.

## Design notes

Re-binding **upserts**: pointing a project at a fresh thread is a normal workflow, not an error. One conversation may serve several projects (`session_id` is not unique); a project has exactly one control conversation, which is the cardinality `origin_session_id` needs — a mission has one home.

## Testing

`cargo test --lib` 1652 passed, including binding round-trip/rebind/clear, per-project isolation, one-conversation-many-projects, and the two precedence cases (explicit binding wins; without one the inferred session is returned tagged as a guess).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New persisted bindings and reply routing change where operator messages land; mistakes could misdirect control traffic, though scope is projects-board UX rather than core auth.
> 
> **Overview**
> Projects no longer treat the **newest delivery’s session** as the control conversation. Operators can **declare** which Hermes session a project reports into, with the API still exposing an inferred `latest_update` guess when nothing is bound.
> 
> **Backend:** Adds `projects_store` (SQLite `project_bindings`) and **`PUT` / `DELETE /api/projects/:slug/conversation`**. Overview rows include **`conversation: { session_id, source }`** — explicit bindings win over inference. Slug validation uses `is_plain_key` (path traversal); `session_id` is validated on bind.
> 
> **Dashboard:** **Bind / Rebind / Unbind** and a session picker (excludes **ended** sessions and **`cron_`** tick sessions). **Conversation** links and **inline replies** use the bound session when `source === "binding"`; otherwise behavior falls back to the last-update session with a **Bind…** affordance.
> 
> **Client:** `ProjectConversation`, `bindProjectConversation`, `unbindProjectConversation` in the projects API module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96917a339629bf743499b0e66e155e5097b3162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->