### PR TITLE
Only arbitrate the PR writer lease when a patch could change it

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -840,6 +840,50 @@ mod stall_guard_tests {
         reset_stall_guard(boss);
     }
 
+    #[test]
+    fn project_patches_only_arbitrate_the_writer_lease_when_they_could_change_it() {
+        let parse = |json: &str| -> UpdateMissionProjectRequest {
+            serde_json::from_str(json).expect("valid patch")
+        };
+
+        // Retagging metadata cannot make a mission a writer, so it must not be
+        // gated on someone else's lease.
+        assert!(!patch_can_change_writer_status(&parse(
+            r#"{"project":"verity","track":"phase1d/core-c3"}"#
+        )));
+        assert!(!patch_can_change_writer_status(&parse(r#"{}"#)));
+        assert!(!patch_can_change_writer_status(&parse(
+            r#"{"desired_state":"green","next_check_at":"2026-08-05T00:00:00Z"}"#
+        )));
+
+        // Anything `becomes_writer` is derived from still arbitrates.
+        assert!(patch_can_change_writer_status(&parse(
+            r#"{"github_pr":"https://github.com/o/r/pull/1"}"#
+        )));
+        assert!(patch_can_change_writer_status(&parse(r#"{"writer":true}"#)));
+        assert!(patch_can_change_writer_status(&parse(
+            r#"{"writer":false}"#
+        )));
+        assert!(patch_can_change_writer_status(&parse(
+            r#"{"intent":"implementation"}"#
+        )));
+        assert!(patch_can_change_writer_status(&parse(
+            r#"{"tags":["pr-writer"]}"#
+        )));
+
+        // An explicit null is a clear, not an absence: dropping the PR or the
+        // intent changes writer status just as much as setting one.
+        assert!(patch_can_change_writer_status(&parse(
+            r#"{"github_pr":null}"#
+        )));
+        assert!(patch_can_change_writer_status(&parse(r#"{"intent":null}"#)));
+
+        // A patch that mixes both still arbitrates.
+        assert!(patch_can_change_writer_status(&parse(
+            r#"{"project":"verity","writer":true}"#
+        )));
+    }
+
     #[tokio::test]
     async fn delete_rejects_paused_mission_until_resumed_or_cancelled() {
         let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
@@ -9377,6 +9421,20 @@ pub struct UpdateMissionProjectRequest {
     pub next_check_at: Option<Option<String>>,
 }
 
+/// Whether this patch could change the mission's PR-writer status.
+///
+/// `becomes_writer` is derived entirely from `github_pr`, `writer`, `intent`
+/// and `tags`. A patch carrying none of them leaves writer status exactly as it
+/// was, so there is no transition to arbitrate — and re-running the lease check
+/// anyway can only reject an edit over a state the mission was already in.
+///
+/// That is not hypothetical: retagging a mission's project returned 409 forever
+/// whenever some *other* mission held the writer lease for the PR this one
+/// happens to reference, which made 32 missions permanently unmaintainable.
+fn patch_can_change_writer_status(req: &UpdateMissionProjectRequest) -> bool {
+    req.github_pr.is_some() || req.writer.is_some() || req.intent.is_some() || req.tags.is_some()
+}
+
 /// Set or update project tagging metadata for a mission.
 #[derive(Debug, Deserialize)]
 pub struct UpdateMissionOriginRequest {
@@ -9466,6 +9524,9 @@ pub async fn update_mission_project(
         .map_err(internal_error)?
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Mission {} not found", id)))?;
 
+    // Read before the normalize step below consumes `req`'s fields.
+    let could_change_writer_status = patch_can_change_writer_status(&req);
+
     // Normalize: blank string patches clear the field; tags are trimmed.
     let normalize = |patch: Option<Option<String>>| -> Option<Option<String>> {
         patch.map(|inner| {
@@ -9534,7 +9595,7 @@ pub async fn update_mission_project(
         tags = Some(effective_tags.clone());
     }
 
-    let writer_guard = if becomes_writer {
+    let writer_guard = if becomes_writer && could_change_writer_status {
         Some(
             acquire_durable_pr_writer_lock(&state.control)
                 .await


### PR DESCRIPTION
## The bug

`update_mission_project` computes `becomes_writer` from four fields — `github_pr`, `writer`, `intent`, `tags` — and then runs the writer-lease conflict check **on every patch**, whatever the patch contained.

The consequence is that a mission which merely *references* a PR that some other mission is writing can never have its metadata edited again. The handler re-derives `becomes_writer` from the mission's own unchanged state, finds the other holder, and answers 409. Forever. There is no patch that gets you out, because the check does not depend on what you are patching.

## How it surfaced

Retagging mission projects on prod (#729). 32 `verity-core` missions rejected every attempt across repeated passes:

```
FAIL 958e851a: HTTP Error 409: Conflict
FAIL 8d119566: HTTP Error 409: Conflict
...
[verity] pass 2: 871 missions in family, 32 need retagging
    applied 0, failed 32
```

The patch was `{"project": "verity", "track": "core"}` — nothing that could make anything a writer. The other 721 missions in the same run went through fine; these 32 differ only in referencing a PR held elsewhere.

## The fix

Gate the lease acquisition and conflict check on whether the patch could change writer status at all. A patch carrying none of the four determining fields leaves writer status exactly as it was, so it cannot create a new conflict and there is nothing to arbitrate.

The predicate is read before the normalize step, since that consumes `req`'s fields.

## Test

One test, and the half worth having is the `null` cases: `deserialize_string_patch` makes absent and explicit-null distinct, and clearing `github_pr` or `intent` changes writer status just as much as setting one — so `{"github_pr": null}` must still arbitrate while `{"project": "verity"}` must not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when writer lease conflicts are enforced on a core mission update path; incorrect predicate logic could allow duplicate writers or skip needed arbitration.
> 
> **Overview**
> Fixes **`update_mission_project`** returning **409** on metadata-only patches (e.g. `project` / `track` retagging) when the mission already references a PR whose writer lease is held elsewhere. The handler used to run the durable writer lock and conflict check whenever the mission *would* be a writer after applying the patch, even if the patch did not touch any of the fields that affect writer status.
> 
> Adds **`patch_can_change_writer_status`**, true only when the patch includes `github_pr`, `writer`, `intent`, or `tags` (including explicit `null` clears). Writer lease acquisition and the global conflict check now run only when **`becomes_writer && could_change_writer_status`**. The flag is computed before field normalization consumes `req`.
> 
> Adds a unit test covering non-writer patches, writer-affecting fields, and the absent vs `null` distinction for `github_pr` / `intent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725b7c90ea47951e7063e602869913d328122b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->