### PR TITLE
Index track-only mission lookups

### DIFF
--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2385,6 +2385,16 @@ impl SqliteMissionStore {
                 "idx_missions_project_track",
                 "CREATE INDEX IF NOT EXISTS idx_missions_project_track ON missions(project, track)",
             ),
+            (
+                // `track` alone cannot use the composite above — SQLite can
+                // only seek an index by a prefix of its columns, and that one
+                // starts with `project`. Both client APIs and the control
+                // endpoint accept `track` without a project, so without this
+                // a rare or missing track scanned the whole fleet while the
+                // connection mutex was held, once per page.
+                "idx_missions_track_updated",
+                "CREATE INDEX IF NOT EXISTS idx_missions_track_updated ON missions(track, updated_at DESC)",
+            ),
         ] {
             if let Err(e) = conn.execute(ddl, []) {
                 tracing::warn!("creating {} skipped: {}", name, e);
@@ -16603,6 +16613,43 @@ mod filter_tests {
         assert!(
             !detail.contains("SCAN missions"),
             "family lookup must not scan the table, got: {detail}"
+        );
+    }
+
+    /// A `track` filter with no project must seek too. The composite index
+    /// starts with `project`, and SQLite can only seek an index by a prefix of
+    /// its columns — so track-alone fell back to `SCAN missions`, once per
+    /// page, with the connection mutex held. Both client APIs and the control
+    /// endpoint permit that combination, so it is a reachable path and not a
+    /// theoretical one.
+    #[tokio::test]
+    async fn track_only_lookup_uses_an_index() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        seed(&store, "m", Some("verity"), Some("core-c3"), None).await;
+
+        let plan: Vec<String> = {
+            let conn = store.conn.lock().await;
+            let mut stmt = conn
+                .prepare(
+                    "EXPLAIN QUERY PLAN SELECT id FROM missions \
+                     WHERE track = ?1 ORDER BY updated_at DESC LIMIT 200 OFFSET 0",
+                )
+                .expect("prepare plan");
+            stmt.query_map(rusqlite::params!["core-c3"], |row| row.get::<_, String>(3))
+                .expect("plan rows")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("plan detail")
+        };
+
+        let detail = plan.join(" | ");
+        assert!(
+            !detail.contains("SCAN missions"),
+            "track-only lookup must not scan the table, got: {detail}"
+        );
+        assert!(
+            detail.contains("idx_missions_track_updated"),
+            "track-only lookup should seek the track index, got: {detail}"
         );
     }
 


### PR DESCRIPTION
Addresses the outstanding Codex P2 on #726, which was correct.

## The problem

SQLite can only seek an index by a **prefix** of its columns. `idx_missions_project_track` starts with `project`, so a `track` filter supplied *without* a project cannot use it — and both client APIs and `GET /api/control/missions` accept exactly that combination.

The result was a full table traversal with the connection mutex held, repeated once per page. On a 7000-mission fleet a rare or misspelled track was the worst case: it scans everything and returns nothing.

## Verified, not assumed

`EXPLAIN QUERY PLAN` on the emitted query.

Before:
```
SCAN missions USING INDEX idx_missions_updated_at
```

After:
```
SEARCH missions USING INDEX idx_missions_track_updated (track=?)
```

The neighbouring plans are unaffected — I checked each rather than trusting that adding an index is free:

| query | plan |
|---|---|
| family (`project = ? OR project >= ? AND project < ?`) | `MULTI-INDEX OR` over `idx_missions_project_track` |
| exact project | `SEARCH … idx_missions_project_track (project=?)` |
| origin_session_id | `SEARCH … idx_missions_origin_session` |

## Placement

The index goes at the end of `run_migrations`, not in `SCHEMA` — the same trap the existing comment there documents. `execute_batch(SCHEMA)` runs *before* migrations, so on an existing database an index over a column the ALTERs have not added yet fails with "no such column", which fails store init and silently drops the service to an in-memory store.

## Test

Asserts the plan, not the rows. A regression here is invisible in behaviour and surfaces only as latency, which is exactly the kind of thing that goes unnoticed until a controller starts timing out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e46a0bd8dec061fdc224948d4189faf1c11dc863. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->