### PR TITLE
Keep a durable state timeline, and make the stall signal mean something

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -38,9 +38,92 @@ const DELIVERY_SCAN_LIMIT: usize = 600;
 /// is flagged stale-active.
 const STALE_ACTIVE_HOURS: i64 = 24;
 
+/// How often the state ingestor folds new deliveries into the timeline.
+///
+/// The window it re-reads overlaps generously; `record_state` is idempotent on
+/// a delivery's timestamp precisely so that overlap is free.
+const STATE_INGEST_INTERVAL_SECS: u64 = 60;
+
+/// Fold controller state signatures into the durable project timeline.
+///
+/// A background task rather than work done on read: ingesting inside the
+/// overview handler would be an unbounded write on a GET, and the history has
+/// to accumulate whether or not anyone has the board open — that is the whole
+/// point of asking "what has this project been doing for three days".
+pub fn spawn_state_ingestor(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(STATE_INGEST_INTERVAL_SECS)).await;
+            let Some(path) = hermes_state_db() else {
+                continue;
+            };
+            let deliveries = match tokio::task::spawn_blocking(move || {
+                read_deliveries(&path, DELIVERY_SCAN_LIMIT, None)
+            })
+            .await
+            {
+                Ok(Ok(deliveries)) => deliveries,
+                Ok(Err(error)) => {
+                    tracing::warn!("state ingest: hermes deliveries unavailable: {error}");
+                    continue;
+                }
+                Err(error) => {
+                    tracing::warn!("state ingest: join failed: {error}");
+                    continue;
+                }
+            };
+            // read_deliveries returns newest-first; replay oldest-first so a
+            // run of the same state lands as one extended row rather than
+            // being rejected as out-of-order.
+            for delivery in deliveries.into_iter().rev() {
+                // Both are required: the routing key says which project the
+                // row belongs to, the descriptor says what to record. A
+                // delivery carrying only a key has reported no state.
+                let (Some(slug), Some(descriptor)) =
+                    (delivery.signature.as_deref(), delivery.state.as_deref())
+                else {
+                    continue;
+                };
+                let headline = Some(delivery.headline.as_str()).filter(|h| !h.is_empty());
+                if let Err(error) =
+                    state
+                        .projects
+                        .record_state(slug, descriptor, headline, &delivery.at)
+                {
+                    tracing::warn!("state ingest: {slug}: {error}");
+                }
+            }
+        }
+    });
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StateQuery {
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// A project's state history, newest first.
+pub async fn project_state(
+    State(state): State<Arc<AppState>>,
+    AxumPath(slug): AxumPath<String>,
+    Query(query): Query<StateQuery>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if !is_plain_key(&slug) {
+        return Err((StatusCode::BAD_REQUEST, "invalid project slug".to_string()));
+    }
+    let limit = query.limit.unwrap_or(50).min(200);
+    let states = state
+        .projects
+        .state_timeline(&slug, limit)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    Ok(Json(serde_json::json!({ "slug": slug, "states": states })))
+}
+
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/overview", get(projects_overview))
+        .route("/:slug/state", get(project_state))
         .route("/:slug/updates", get(project_updates))
         .route("/:slug/action", axum::routing::post(project_action))
         .route(
@@ -111,7 +194,14 @@ pub struct DeliveryUpdate {
     body: Option<String>,
     session_id: String,
     at: String,
+    /// Routing key: the FIRST field of the STATE_SIGNATURE trailer. Says which
+    /// project the delivery belongs to, not what state it is in.
     signature: Option<String>,
+    /// The rest of the trailer — the fields that actually describe the state
+    /// (`phase1-stack|7dba916|clean-ready|ci-failures-3-prs|…`). Two deliveries
+    /// with the same value reported the same world.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<String>,
     blocker: Option<String>,
 }
 
@@ -314,7 +404,8 @@ struct ProjectRowBuilder {
     /// Health inputs, accumulated alongside the display chips.
     health_inputs: Vec<OwnedHealthInput>,
     latest_update: Option<DeliveryUpdate>,
-    recent_signatures: Vec<Option<String>>,
+    /// The three newest state descriptors, for the stall signal.
+    recent_states: Vec<Option<String>>,
     updates_count: usize,
 }
 
@@ -326,17 +417,17 @@ impl ProjectRowBuilder {
             missions: Vec::new(),
             health_inputs: Vec::new(),
             latest_update: None,
-            recent_signatures: Vec::new(),
+            recent_states: Vec::new(),
             updates_count: 0,
         }
     }
 
     /// Deliveries arrive newest-first; keep the first as latest and remember
-    /// the three most recent signatures for the repeated-state stall signal.
+    /// the three most recent *state descriptors* for the stall signal.
     fn push_delivery(&mut self, delivery: DeliveryUpdate) {
         self.updates_count += 1;
-        if self.recent_signatures.len() < 3 {
-            self.recent_signatures.push(delivery.signature.clone());
+        if self.recent_states.len() < 3 {
+            self.recent_states.push(delivery.state.clone());
         }
         if self.latest_update.is_none() {
             self.latest_update = Some(delivery);
@@ -367,12 +458,17 @@ impl ProjectRowBuilder {
             }
             // Same non-silent state three ticks in a row: the controller
             // keeps reporting an unchanged world — the phantom-lease shape.
-            if latest.signature.is_some()
-                && self.recent_signatures.len() >= 3
+            // Compare the state descriptor, not the routing key. The key is
+            // near-constant within a row by construction, so the old
+            // comparison fired for essentially every project with three
+            // updates — carrying no information at all, and flagging projects
+            // making progress every tick identically to genuinely stuck ones.
+            if latest.state.is_some()
+                && self.recent_states.len() >= 3
                 && self
-                    .recent_signatures
+                    .recent_states
                     .iter()
-                    .all(|signature| signature == &latest.signature)
+                    .all(|state| state == &latest.state)
             {
                 attention.push("same state on 3 consecutive updates".to_string());
             }
@@ -836,20 +932,27 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
         headline = tag_title.unwrap_or_default();
     }
 
-    let signature = content
-        .lines()
-        .rev()
-        .find_map(|line| {
-            let trimmed = line.trim();
-            trimmed
-                .strip_prefix("[STATE_SIGNATURE:")
-                .and_then(|rest| rest.strip_suffix(']'))
-        })
+    // `[STATE_SIGNATURE: <routing-key>|<state fields…>]`. The first field says
+    // WHICH project; everything after it says WHAT state it is in. Conflating
+    // the two is what made the stall signal meaningless — see `state` below.
+    let trailer = content.lines().rev().find_map(|line| {
+        let trimmed = line.trim();
+        trimmed
+            .strip_prefix("[STATE_SIGNATURE:")
+            .and_then(|rest| rest.strip_suffix(']'))
+    });
+    let signature = trailer
         .and_then(|inner| inner.split('|').next())
         .map(|key| key.trim().to_string())
         // Reject template placeholders like `<project>` and anything that
         // isn't a plain routing key.
         .filter(|key| is_plain_key(key));
+    // The state descriptor: the trailer minus its routing key. Empty when the
+    // controller emitted a key and nothing else, which is not a state.
+    let state = trailer
+        .and_then(|inner| inner.split_once('|'))
+        .map(|(_, rest)| rest.trim().to_string())
+        .filter(|rest| !rest.is_empty());
 
     // "Bloqué par:" / "Blocked by:" field, when it names a real blocker.
     let blocker = content.lines().find_map(|line| {
@@ -893,6 +996,7 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
         session_id: session_id.to_string(),
         at,
         signature,
+        state,
         blocker,
     }
 }
@@ -917,6 +1021,78 @@ mod tests {
             .as_deref()
             .is_some_and(|b| b.contains("lease writer fantôme")));
         assert!(!parsed.at.is_empty());
+    }
+
+    /// The trailer's first field routes; the rest describes the state. Keeping
+    /// them apart is the whole fix — see the stall-signal test below.
+    #[test]
+    fn the_state_descriptor_is_the_trailer_minus_its_routing_key() {
+        let content = "[Cron delivery: x]\nTitre\n\
+                       [STATE_SIGNATURE: verity|phase1-stack|7dba916|clean-ready|none]\n";
+        let parsed = parse_delivery("sess-1", 1_754_000_000.0, content);
+        assert_eq!(parsed.signature.as_deref(), Some("verity"));
+        assert_eq!(
+            parsed.state.as_deref(),
+            Some("phase1-stack|7dba916|clean-ready|none")
+        );
+    }
+
+    #[test]
+    fn a_routing_key_with_no_state_fields_is_not_a_state() {
+        let content = "[Cron delivery: x]\nTitre\n[STATE_SIGNATURE: verity]\n";
+        let parsed = parse_delivery("sess-1", 1_754_000_000.0, content);
+        assert_eq!(parsed.signature.as_deref(), Some("verity"));
+        assert_eq!(parsed.state, None);
+
+        // A trailing separator with nothing after it is the same absence.
+        let content = "[Cron delivery: x]\nTitre\n[STATE_SIGNATURE: verity|  ]\n";
+        assert_eq!(parse_delivery("s", 1.0, content).state, None);
+    }
+
+    /// The signal used to compare the *routing key*, which is near-constant
+    /// within a project row by construction — so it fired for essentially
+    /// every project with three updates, flagging steady progress and a real
+    /// stall identically. Measured on prod: 6 of 26 rows, i.e. exactly those
+    /// with three or more deliveries.
+    #[test]
+    fn the_stall_signal_tracks_the_state_not_the_routing_key() {
+        let delivery = |state: &str, at: &str| DeliveryUpdate {
+            headline: "h".into(),
+            body: None,
+            session_id: "s".into(),
+            at: at.into(),
+            signature: Some("verity".into()),
+            state: Some(state.into()),
+            blocker: None,
+        };
+
+        // Same project, three genuinely different states: not a stall.
+        let mut moving = ProjectRowBuilder::new("verity".into());
+        for (i, state) in ["a|1", "b|2", "c|3"].iter().enumerate() {
+            moving.push_delivery(delivery(state, &format!("2026-08-04T1{i}:00:00Z")));
+        }
+        let row = moving.finish(&[], None, None, "2026-08-04T20:00:00Z");
+        assert!(
+            !row.attention_reasons
+                .iter()
+                .any(|r| r.contains("3 consecutive")),
+            "a project changing state every tick must not be flagged: {:?}",
+            row.attention_reasons
+        );
+
+        // Same state three times running: that is the stall worth reporting.
+        let mut stuck = ProjectRowBuilder::new("verity".into());
+        for i in 0..3 {
+            stuck.push_delivery(delivery("blocked|same", &format!("2026-08-04T1{i}:00:00Z")));
+        }
+        let row = stuck.finish(&[], None, None, "2026-08-04T20:00:00Z");
+        assert!(
+            row.attention_reasons
+                .iter()
+                .any(|r| r.contains("3 consecutive")),
+            "an unchanged state must still be flagged: {:?}",
+            row.attention_reasons
+        );
     }
 
     #[test]
@@ -1026,6 +1202,7 @@ mod tests {
             at: "2026-08-04T12:00:00Z".into(),
             session_id: "cron_e594d751447d_20260804_120931".into(),
             signature: None,
+            state: None,
             blocker: None,
         });
         let row = builder.finish(
@@ -1052,6 +1229,7 @@ mod tests {
             at: "2026-08-04T12:00:00Z".into(),
             session_id: "cron_e594d751447d_20260804_120931".into(),
             signature: None,
+            state: None,
             blocker: None,
         });
         let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -30,6 +30,22 @@ CREATE TABLE IF NOT EXISTS project_bindings (
     bound_at           TEXT NOT NULL,
     bound_by           TEXT
 );
+
+-- One row per *distinct consecutive* state a project reported. A controller
+-- that reports the same signature for six hours produces one row with
+-- observations=24, not 24 rows: the question worth answering is "how long has
+-- it been saying this", and a flat event log makes that a scan.
+CREATE TABLE IF NOT EXISTS project_state_events (
+    slug          TEXT NOT NULL,
+    signature     TEXT NOT NULL,
+    headline      TEXT,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at  TEXT NOT NULL,
+    observations  INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (slug, first_seen_at)
+);
+CREATE INDEX IF NOT EXISTS idx_state_events_slug_seen
+    ON project_state_events(slug, last_seen_at DESC);
 "#;
 
 /// A project's control conversation and how we know about it.
@@ -163,6 +179,134 @@ impl ProjectsStore {
             .map_err(|e| e.to_string())?;
         Ok(removed > 0)
     }
+
+    /// Record that `slug` reported `signature` at `at`.
+    ///
+    /// Collapses repeats: re-reporting the state a project is already in
+    /// extends the open row rather than opening a new one. The count that
+    /// results is the durable form of the overview's in-memory "same signature
+    /// three ticks running" heuristic, which could only ever see the deliveries
+    /// still inside the scan window.
+    ///
+    /// Idempotent on `at`: the ingestor re-reads an overlapping window every
+    /// cycle, so replaying a delivery it has already seen must not inflate the
+    /// count. Returns the resulting observation count for this state.
+    pub fn record_state(
+        &self,
+        slug: &str,
+        signature: &str,
+        headline: Option<&str>,
+        at: &str,
+    ) -> Result<u32, String> {
+        let connection = self.lock()?;
+        let current: Option<(String, String, String, u32)> = connection
+            .query_row(
+                "SELECT signature, first_seen_at, last_seen_at, observations \
+                 FROM project_state_events WHERE slug = ?1 \
+                 ORDER BY last_seen_at DESC LIMIT 1",
+                params![slug],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()
+            .map_err(|e| e.to_string())?;
+
+        if let Some((open_signature, first_seen_at, last_seen_at, observations)) = current {
+            if open_signature == signature {
+                // Already counted, or older than what we have: nothing to do.
+                if at <= last_seen_at.as_str() {
+                    return Ok(observations);
+                }
+                connection
+                    .execute(
+                        "UPDATE project_state_events \
+                         SET last_seen_at = ?1, observations = observations + 1, \
+                             headline = COALESCE(?2, headline) \
+                         WHERE slug = ?3 AND first_seen_at = ?4",
+                        params![at, headline, slug, first_seen_at],
+                    )
+                    .map_err(|e| e.to_string())?;
+                return Ok(observations + 1);
+            }
+            // A delivery older than the newest state we hold is a replay from
+            // the ingestor's overlap, not a transition. Recording it would
+            // fabricate a flap between two states the project never made.
+            if at <= last_seen_at.as_str() {
+                return Ok(0);
+            }
+        }
+
+        connection
+            .execute(
+                "INSERT INTO project_state_events \
+                   (slug, signature, headline, first_seen_at, last_seen_at, observations) \
+                 VALUES (?1, ?2, ?3, ?4, ?4, 1) \
+                 ON CONFLICT(slug, first_seen_at) DO NOTHING",
+                params![slug, signature, headline, at],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(1)
+    }
+
+    /// A project's state history, newest first.
+    pub fn state_timeline(&self, slug: &str, limit: usize) -> Result<Vec<ProjectState>, String> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare(
+                "SELECT signature, headline, first_seen_at, last_seen_at, observations \
+                 FROM project_state_events WHERE slug = ?1 \
+                 ORDER BY last_seen_at DESC LIMIT ?2",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map(params![slug, limit as i64], |row| {
+                Ok(ProjectState {
+                    signature: row.get(0)?,
+                    headline: row.get(1)?,
+                    first_seen_at: row.get(2)?,
+                    last_seen_at: row.get(3)?,
+                    observations: row.get(4)?,
+                })
+            })
+            .map_err(|e| e.to_string())?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())
+    }
+
+    /// Observation counts for the state each project is *currently* in.
+    ///
+    /// One query for the whole overview: per-row lookups would put a query per
+    /// project inside a page render.
+    pub fn current_state_observations(&self) -> Result<HashMap<String, u32>, String> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare(
+                "SELECT slug, observations FROM project_state_events e \
+                 WHERE last_seen_at = ( \
+                   SELECT MAX(last_seen_at) FROM project_state_events \
+                   WHERE slug = e.slug \
+                 )",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+            })
+            .map_err(|e| e.to_string())?;
+        rows.collect::<Result<HashMap<_, _>, _>>()
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// One distinct state a project reported, with how long it stayed there.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProjectState {
+    pub signature: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headline: Option<String>,
+    pub first_seen_at: String,
+    pub last_seen_at: String,
+    /// How many deliveries reported this same state in a row.
+    pub observations: u32,
 }
 
 #[cfg(test)]
@@ -221,5 +365,142 @@ mod tests {
         let all = store.bindings().expect("all");
         assert_eq!(all["verity"].session_id, "shared");
         assert_eq!(all["verity-docs"].session_id, "shared");
+    }
+
+    // ---- state timeline ----
+
+    #[test]
+    fn repeating_a_state_extends_it_instead_of_opening_a_new_one() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        for (i, at) in [
+            "2026-08-04T10:00:00Z",
+            "2026-08-04T10:15:00Z",
+            "2026-08-04T10:30:00Z",
+        ]
+        .iter()
+        .enumerate()
+        {
+            let count = store
+                .record_state("verity", "phase1-blocked", Some("still blocked"), at)
+                .expect("record");
+            assert_eq!(count as usize, i + 1);
+        }
+        let timeline = store.state_timeline("verity", 10).expect("timeline");
+        assert_eq!(timeline.len(), 1);
+        assert_eq!(timeline[0].observations, 3);
+        assert_eq!(timeline[0].first_seen_at, "2026-08-04T10:00:00Z");
+        assert_eq!(timeline[0].last_seen_at, "2026-08-04T10:30:00Z");
+    }
+
+    #[test]
+    fn a_new_state_opens_a_new_row_and_leaves_the_old_one_closed() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .record_state("verity", "blocked", None, "2026-08-04T10:00:00Z")
+            .expect("record");
+        store
+            .record_state("verity", "blocked", None, "2026-08-04T10:15:00Z")
+            .expect("record");
+        store
+            .record_state("verity", "merged", None, "2026-08-04T10:30:00Z")
+            .expect("record");
+
+        let timeline = store.state_timeline("verity", 10).expect("timeline");
+        assert_eq!(timeline.len(), 2);
+        assert_eq!(timeline[0].signature, "merged");
+        assert_eq!(timeline[0].observations, 1);
+        assert_eq!(timeline[1].signature, "blocked");
+        assert_eq!(timeline[1].observations, 2);
+        assert_eq!(timeline[1].last_seen_at, "2026-08-04T10:15:00Z");
+    }
+
+    /// The ingestor re-reads an overlapping window each cycle. Replaying a
+    /// delivery it has already counted must not inflate the observation count,
+    /// or "how long has it been stuck" grows purely from polling frequency.
+    #[test]
+    fn replaying_a_delivery_does_not_inflate_the_count() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .record_state("verity", "blocked", None, "2026-08-04T10:00:00Z")
+            .expect("record");
+        store
+            .record_state("verity", "blocked", None, "2026-08-04T10:15:00Z")
+            .expect("record");
+        for _ in 0..5 {
+            store
+                .record_state("verity", "blocked", None, "2026-08-04T10:15:00Z")
+                .expect("replay");
+        }
+        let timeline = store.state_timeline("verity", 10).expect("timeline");
+        assert_eq!(timeline[0].observations, 2);
+    }
+
+    /// An out-of-order delivery from the overlap window must not be recorded
+    /// as a transition — that would fabricate a flap between two states the
+    /// project never actually made.
+    #[test]
+    fn an_older_delivery_never_fabricates_a_transition() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .record_state("verity", "blocked", None, "2026-08-04T10:00:00Z")
+            .expect("record");
+        store
+            .record_state("verity", "merged", None, "2026-08-04T11:00:00Z")
+            .expect("record");
+        // Arrives late, older than the current state.
+        store
+            .record_state("verity", "blocked", None, "2026-08-04T10:30:00Z")
+            .expect("late");
+
+        let timeline = store.state_timeline("verity", 10).expect("timeline");
+        assert_eq!(timeline.len(), 2, "no third row for the replayed state");
+        assert_eq!(timeline[0].signature, "merged");
+    }
+
+    #[test]
+    fn projects_keep_separate_timelines() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .record_state("verity", "a", None, "2026-08-04T10:00:00Z")
+            .expect("record");
+        store
+            .record_state("lido", "b", None, "2026-08-04T10:01:00Z")
+            .expect("record");
+        store
+            .record_state("lido", "b", None, "2026-08-04T10:02:00Z")
+            .expect("record");
+
+        let observations = store.current_state_observations().expect("observations");
+        assert_eq!(observations.get("verity"), Some(&1));
+        assert_eq!(observations.get("lido"), Some(&2));
+    }
+
+    #[test]
+    fn an_unknown_project_has_an_empty_timeline() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        assert!(store
+            .state_timeline("nope", 10)
+            .expect("timeline")
+            .is_empty());
+        assert!(store
+            .current_state_observations()
+            .expect("observations")
+            .is_empty());
+    }
+
+    #[test]
+    fn a_headline_backfills_but_never_erases() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .record_state("verity", "s", None, "2026-08-04T10:00:00Z")
+            .expect("record");
+        store
+            .record_state("verity", "s", Some("now we know"), "2026-08-04T10:15:00Z")
+            .expect("record");
+        store
+            .record_state("verity", "s", None, "2026-08-04T10:30:00Z")
+            .expect("record");
+        let timeline = store.state_timeline("verity", 10).expect("timeline");
+        assert_eq!(timeline[0].headline.as_deref(), Some("now we know"));
     }
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -559,6 +559,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     });
 
     super::validation::spawn_outbox_forwarder(Arc::clone(&state));
+    super::projects_overview::spawn_state_ingestor(Arc::clone(&state));
 
     // Remote-node fleet monitor: periodic heartbeat polling so
     // `/api/remote-nodes` and dispatch decisions read cached statuses


### PR DESCRIPTION
## The bug this starts from

The controller trailer carries two different things:

```
[STATE_SIGNATURE: verity|phase1-stack|7dba916|clean-ready|ci-failures-3-prs|phase1h-redispatch-needed]
                  ^^^^^^ routing key    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the actual state
```

`parse_delivery` kept only the first field, and the board's **"same state on 3 consecutive updates"** signal compared *that*. Within one project row the routing key is near-constant by construction — so the signal fired for essentially every project with three deliveries.

Measured on prod before the fix: **6 of 26 rows**, and those 6 are exactly the ones with ≥3 updates.

| project | updates | flagged |
|---|---|---|
| verity-roadmap | 80 | yes |
| verity-benchmark | 66 | yes |
| reliability-roadmap-fable5 | 45 | yes |
| lean-silicon | 16 | yes |
| unsolvedmath-l1 | 16 | yes |
| verity-lido | 9 | yes |

A project making progress every single tick was flagged identically to one genuinely wedged. The signal carried no information at all.

## What changes

**`DeliveryUpdate` gains `state`** — the trailer minus its routing key — and the stall signal compares that. A trailer with a key and nothing after it is not a state and stays `None`.

**A background ingestor** folds states into `project_state_events` every 60s, collapsing consecutive repeats into one row carrying `first_seen_at`, `last_seen_at` and an observation count. Exposed as `GET /api/projects/:slug/state`.

```json
{ "slug": "verity", "states": [
  { "signature": "phase1-stack|7dba916|clean-ready|none",
    "headline": "Verity Phase 1 — contrôle de progression",
    "first_seen_at": "2026-08-04T10:00:00Z",
    "last_seen_at": "2026-08-04T18:30:00Z",
    "observations": 34 }
]}
```

That answers *"what has this project been doing for three days"*, which the in-memory heuristic structurally could not — it only ever saw deliveries still inside the 600-row scan window.

## Design notes

- **Ingest in the background, not on read.** Doing it in the GET would be an unbounded write on a read path, and the history must accumulate whether or not anyone has the board open.
- **`record_state` is idempotent on the delivery timestamp**, so the ingestor's overlapping re-read costs nothing — otherwise "how long has it been stuck" would grow purely with polling frequency.
- **An older delivery is never recorded as a transition.** A replay from the overlap window would otherwise fabricate a flap between two states the project never actually made.
- Collapsed rows, not a flat event log: six hours in one state is one row with `observations=24`, not 24 rows, because the question worth answering is *how long*.

## Tests

24 tests across the two modules. The ones that matter are the refusals: a routing key with no state fields is not a state, a replayed delivery does not inflate the count, an out-of-order delivery does not fabricate a transition, and a project changing state every tick is *not* flagged while one repeating itself still is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e7056d6ce6f7a28f3e89753743a79b7daba1bb0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->