### PR TITLE
iOS: projects, their health, and the conversation that drives them

### DIFF
--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -35,9 +35,11 @@
 		58D2BEEDF2B4B34B3B98487C /* ToolUIOptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD083A671640B2F286D7C06 /* ToolUIOptionListView.swift */; };
 		5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4AC8C92D9F496B8152B8F /* ControlView.swift */; };
 		66E208F9D4759B79ED653374 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B74AB5DF6829813AE79229D /* ContentView.swift */; };
+		66F676EDC1A217D788AF9656 /* ProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16444DBBDC6D78A5324C783D /* ProjectTests.swift */; };
 		6846AB79778CDF4CC216B7D1 /* SandboxedDashboardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8080D5ADF84794AFE484FE17 /* SandboxedDashboardApp.swift */; };
 		692C694570F45D74CCBAC75B /* TerminalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6922E2F0E17EDB3A8400D473 /* TerminalState.swift */; };
 		6A15DF1CBD6B0A3716B9FE94 /* WorkerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */; };
+		6EC32F7CE8BFDB84428DFF4A /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C648C1D5FC7491563EE824 /* Project.swift */; };
 		708B491B7A83A6648C03CA8A /* WorkerPeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF9A2A12846A5FFB3FC7497 /* WorkerPeekView.swift */; };
 		71559C7052796FED7EBACF3F /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018CEF52A93FCF430A128017 /* Theme.swift */; };
 		7E46D4311CFAF1F7A90E9AAD /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F4658A2D65748FC7AC5DE3 /* APIService.swift */; };
@@ -95,9 +97,11 @@
 /* Begin PBXFileReference section */
 		018CEF52A93FCF430A128017 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerSheetView.swift; sourceTree = "<group>"; };
+		08C648C1D5FC7491563EE824 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		0C6DBBABC4AE0FD4368A185C /* Mission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mission.swift; sourceTree = "<group>"; };
 		13A79A00CA8E2F1246E970A8 /* HermesConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesConversationTests.swift; sourceTree = "<group>"; };
+		16444DBBDC6D78A5324C783D /* ProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTests.swift; sourceTree = "<group>"; };
 		1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResilienceTests.swift; sourceTree = "<group>"; };
 		1834CB7B575220FDE7679F7B /* NewMissionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMissionSheet.swift; sourceTree = "<group>"; };
 		1C19E1741AE5E4A19BDAAB98 /* SandboxedDashboard.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SandboxedDashboard.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -328,6 +332,7 @@
 				13A79A00CA8E2F1246E970A8 /* HermesConversationTests.swift */,
 				7559F3F4553AD74130B1BC34 /* ModelTests.swift */,
 				1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */,
+				16444DBBDC6D78A5324C783D /* ProjectTests.swift */,
 				0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */,
 			);
 			path = SandboxedDashboardTests;
@@ -355,6 +360,7 @@
 				492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */,
 				7868B572B7E5DBED9E52D160 /* Hermes.swift */,
 				0C6DBBABC4AE0FD4368A185C /* Mission.swift */,
+				08C648C1D5FC7491563EE824 /* Project.swift */,
 				E387E6A01D00EAD668074CCC /* WorkerBuckets.swift */,
 				97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */,
 			);
@@ -542,6 +548,7 @@
 				110C67FF7A62B86FB7AD4CD0 /* NetworkMonitor.swift in Sources */,
 				D0646F9EE2D2E984F0446C57 /* NewMissionSheet.swift in Sources */,
 				B2C28CDD378203A229D62B9B /* PhosphorIcon.swift in Sources */,
+				6EC32F7CE8BFDB84428DFF4A /* Project.swift in Sources */,
 				51E9D9F51934DFC8EAD58CDC /* QueueSheet.swift in Sources */,
 				95B7AB5DBEB42E107EBE06FB /* RunningMissionsBar.swift in Sources */,
 				6846AB79778CDF4CC216B7D1 /* SandboxedDashboardApp.swift in Sources */,
@@ -573,6 +580,7 @@
 				078E5F28B7022DCD1BC721FD /* HermesConversationTests.swift in Sources */,
 				46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */,
 				2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */,
+				66F676EDC1A217D788AF9656 /* ProjectTests.swift in Sources */,
 				7EF75A17733EE6E54126C7A7 /* ThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios_dashboard/SandboxedDashboard/Models/Mission.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Mission.swift
@@ -118,6 +118,10 @@ struct Mission: Codable, Identifiable, Hashable {
     /// Hermes session that spawned this mission, when `origin == "hermes"`.
     /// Lets clients group the mission as a worker of that conversation.
     let originSessionId: String?
+    /// Project this mission belongs to, e.g. "verity".
+    let project: String?
+    /// Workstream within the project, e.g. "phase1d/core-c3".
+    let track: String?
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
@@ -146,6 +150,7 @@ struct Mission: Codable, Identifiable, Hashable {
         case parentMissionId = "parent_mission_id"
         case origin
         case originSessionId = "origin_session_id"
+        case project, track
     }
 
     init(from decoder: Decoder) throws {
@@ -174,6 +179,17 @@ struct Mission: Codable, Identifiable, Hashable {
         parentMissionId = try container.decodeIfPresent(String.self, forKey: .parentMissionId)
         origin = try container.decodeIfPresent(String.self, forKey: .origin)
         originSessionId = try container.decodeIfPresent(String.self, forKey: .originSessionId)
+        project = try container.decodeIfPresent(String.self, forKey: .project)
+        track = try container.decodeIfPresent(String.self, forKey: .track)
+    }
+
+    /// "verity · phase1d/core-c3", or just the project, or nothing.
+    var projectLabel: String? {
+        switch (project?.isEmpty == false ? project : nil, track?.isEmpty == false ? track : nil) {
+        case let (.some(project), .some(track)): return "\(project) · \(track)"
+        case let (.some(project), .none): return project
+        default: return nil
+        }
     }
 
     var displayTitle: String {

--- a/ios_dashboard/SandboxedDashboard/Models/Project.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Project.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// A project row from `/api/projects/overview`.
+///
+/// The board joins three sources server-side (trackers, missions, Hermes
+/// deliveries); the phone consumes the result rather than re-deriving it, so
+/// there is exactly one definition of "which track is stuck" across web, iOS
+/// and desktop.
+struct ProjectSummary: Codable, Identifiable, Hashable {
+    var id: String { slug }
+
+    let slug: String
+    /// `attention` | `active` | `paused` | anything else the server adds.
+    let bucket: String
+    let attentionReasons: [String]
+    let updatesCount: Int
+    let health: ProjectHealth?
+    let conversation: ProjectConversation?
+    let latestUpdate: ProjectUpdate?
+
+    enum CodingKeys: String, CodingKey {
+        case slug, bucket, health, conversation
+        case attentionReasons = "attention_reasons"
+        case updatesCount = "updates_count"
+        case latestUpdate = "latest_update"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        slug = try container.decode(String.self, forKey: .slug)
+        bucket = try container.decodeIfPresent(String.self, forKey: .bucket) ?? "active"
+        attentionReasons = try container.decodeIfPresent([String].self, forKey: .attentionReasons) ?? []
+        updatesCount = try container.decodeIfPresent(Int.self, forKey: .updatesCount) ?? 0
+        health = try container.decodeIfPresent(ProjectHealth.self, forKey: .health)
+        conversation = try container.decodeIfPresent(ProjectConversation.self, forKey: .conversation)
+        latestUpdate = try container.decodeIfPresent(ProjectUpdate.self, forKey: .latestUpdate)
+    }
+
+    /// The conversation to open, but only when it is a real declared binding.
+    ///
+    /// An inferred conversation is almost always a cron tick's throwaway
+    /// session, already ended — offering it as something to tap would hand the
+    /// user a dead thread. The server labels the difference; honour it.
+    var boundSessionId: String? {
+        guard let conversation, conversation.source == "binding" else { return nil }
+        return conversation.sessionId
+    }
+
+    var needsAttention: Bool {
+        bucket == "attention" || (health?.tracksNeedingAttention ?? 0) > 0
+    }
+}
+
+struct ProjectConversation: Codable, Hashable {
+    let sessionId: String
+    /// `"binding"` when explicitly declared, `"latest_update"` when guessed.
+    let source: String
+    let boundAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case source
+        case sessionId = "session_id"
+        case boundAt = "bound_at"
+    }
+}
+
+struct ProjectUpdate: Codable, Hashable {
+    let headline: String
+    let at: String
+    let blocker: String?
+}
+
+/// Per-track rollup. Mirrors the server's `ProjectHealth`.
+struct ProjectHealth: Codable, Hashable {
+    let missions: Int
+    let active: Int
+    let failed: Int
+    let overdue: Int
+    let tracksNeedingAttention: Int
+    let tracks: [TrackHealth]
+
+    enum CodingKeys: String, CodingKey {
+        case missions, active, failed, overdue, tracks
+        case tracksNeedingAttention = "tracks_needing_attention"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        missions = try container.decodeIfPresent(Int.self, forKey: .missions) ?? 0
+        active = try container.decodeIfPresent(Int.self, forKey: .active) ?? 0
+        failed = try container.decodeIfPresent(Int.self, forKey: .failed) ?? 0
+        overdue = try container.decodeIfPresent(Int.self, forKey: .overdue) ?? 0
+        tracksNeedingAttention =
+            try container.decodeIfPresent(Int.self, forKey: .tracksNeedingAttention) ?? 0
+        tracks = try container.decodeIfPresent([TrackHealth].self, forKey: .tracks) ?? []
+    }
+
+    /// The tracks worth showing first. The server already sorts worst-first.
+    var worstTracks: [TrackHealth] {
+        Array(tracks.prefix(3))
+    }
+}
+
+struct TrackHealth: Codable, Hashable, Identifiable {
+    var id: String { track ?? "" }
+
+    let track: String?
+    let verdict: TrackVerdict
+    let missions: Int
+    let active: Int
+    let failed: Int
+    let completed: Int
+    let overdue: Int
+    let lastActivityAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case track, verdict, missions, active, failed, completed, overdue
+        case lastActivityAt = "last_activity_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        track = try container.decodeIfPresent(String.self, forKey: .track)
+        verdict = try container.decodeIfPresent(TrackVerdict.self, forKey: .verdict) ?? .idle
+        missions = try container.decodeIfPresent(Int.self, forKey: .missions) ?? 0
+        active = try container.decodeIfPresent(Int.self, forKey: .active) ?? 0
+        failed = try container.decodeIfPresent(Int.self, forKey: .failed) ?? 0
+        completed = try container.decodeIfPresent(Int.self, forKey: .completed) ?? 0
+        overdue = try container.decodeIfPresent(Int.self, forKey: .overdue) ?? 0
+        lastActivityAt = try container.decodeIfPresent(String.self, forKey: .lastActivityAt)
+    }
+
+    var displayTrack: String { track ?? "untracked" }
+}
+
+/// What a track needs from a human, if anything.
+///
+/// Decoding is lenient: a verdict this build does not know about becomes
+/// `.idle` rather than failing the whole projects list. A server that learns a
+/// new verdict must not blank the board on every phone that has not updated.
+enum TrackVerdict: String, Codable, Hashable {
+    case failing
+    case overdue
+    case active
+    case done
+    case idle
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = TrackVerdict(rawValue: raw) ?? .idle
+    }
+
+    var needsAttention: Bool {
+        self == .failing || self == .overdue
+    }
+}
+
+/// One state a project reported, from `/api/projects/:slug/state`.
+struct ProjectState: Codable, Hashable, Identifiable {
+    var id: String { firstSeenAt }
+
+    let signature: String
+    let headline: String?
+    let firstSeenAt: String
+    let lastSeenAt: String
+    /// How many deliveries reported this same state in a row.
+    let observations: Int
+
+    enum CodingKeys: String, CodingKey {
+        case signature, headline, observations
+        case firstSeenAt = "first_seen_at"
+        case lastSeenAt = "last_seen_at"
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -252,6 +252,34 @@ final class APIService {
         try await get("/api/control/missions/\(id)")
     }
 
+    // MARK: - Projects
+
+    private struct ProjectsOverview: Decodable {
+        let projects: [ProjectSummary]
+    }
+
+    /// The projects board: trackers, missions and Hermes deliveries already
+    /// joined server-side, including the per-track health rollup and each
+    /// project's declared control conversation.
+    func listProjects() async throws -> [ProjectSummary] {
+        let overview: ProjectsOverview = try await get("/api/projects/overview")
+        return overview.projects
+    }
+
+    private struct ProjectStates: Decodable {
+        let states: [ProjectState]
+    }
+
+    /// A project's state history, newest first — what it has been reporting
+    /// over days, rather than only the newest delivery.
+    func projectStates(slug: String, limit: Int = 20) async throws -> [ProjectState] {
+        let encoded = slug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? slug
+        let response: ProjectStates = try await get(
+            "/api/projects/\(encoded)/state?limit=\(limit)"
+        )
+        return response.states
+    }
+
     // MARK: - Mission task board
 
     /// Server-owned task board for a boss mission. Returns an empty board

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -256,6 +256,9 @@ struct ControlView: View {
     // conversation. Selecting a mission anywhere clears it.
     @State private var hermesSessions: [HermesSession] = []
     @State private var viewingHermesSessionId: String?
+    /// Projects board rows, loaded alongside the Hermes sessions. Empty when
+    /// the backend has no projects surface.
+    @State private var projects: [ProjectSummary] = []
 
     // Desktop stream state
     @State private var showDesktopStream = false
@@ -519,6 +522,7 @@ struct ControlView: View {
             runningMissions: runningMissions,
             recentMissions: recentMissions,
             hermesSessions: hermesSessions,
+            projects: projects,
             currentMissionId: currentMission?.id,
             viewingMissionId: viewingMissionId,
             viewingHermesSessionId: viewingHermesSessionId,
@@ -950,6 +954,9 @@ struct ControlView: View {
     /// section simply stays empty.
     private func loadHermesSessions() async {
         hermesSessions = (try? await api.listHermesSessions(limit: 30)) ?? []
+        // Same shape as above: the request doubles as the availability probe,
+        // so an older backend just leaves the section empty.
+        projects = (try? await api.listProjects()) ?? []
     }
 
     /// Start a fresh Hermes conversation and show it.

--- a/ios_dashboard/SandboxedDashboard/Views/Control/MissionSwitcherSheet.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/MissionSwitcherSheet.swift
@@ -41,6 +41,9 @@ struct MissionSwitcherSheet: View {
     /// Hermes conversations. Empty when Hermes isn't adopted on this backend,
     /// which simply hides the section.
     var hermesSessions: [HermesSession] = []
+    /// Projects board rows. Empty when the backend has no projects surface,
+    /// which simply hides the section.
+    var projects: [ProjectSummary] = []
     let currentMissionId: String?
     let viewingMissionId: String?
     var viewingHermesSessionId: String? = nil
@@ -116,6 +119,22 @@ struct MissionSwitcherSheet: View {
         guard !normalizedSearchQuery.isEmpty else { return hermesSessions }
         return hermesSessions.filter {
             normalizeMetadataText($0.displayTitle).contains(normalizedSearchQuery)
+        }
+    }
+
+    /// Projects worth listing: only those with a declared conversation, since
+    /// the row's whole purpose is to open one. A project whose conversation is
+    /// merely inferred would hand the user a dead cron session.
+    private var filteredProjects: [ProjectSummary] {
+        let bound = projects.filter { $0.boundSessionId != nil }
+        let matching = normalizedSearchQuery.isEmpty
+            ? bound
+            : bound.filter { normalizeMetadataText($0.slug).contains(normalizedSearchQuery) }
+        // Projects needing attention first; the rest alphabetical so the order
+        // does not shuffle between refreshes.
+        return matching.sorted {
+            if $0.needsAttention != $1.needsAttention { return $0.needsAttention }
+            return $0.slug < $1.slug
         }
     }
 
@@ -388,6 +407,25 @@ struct MissionSwitcherSheet: View {
                                     )
                                 },
                                 onCancel: { onCancelMission(info.missionId) }
+                            )
+                        }
+                    }
+                }
+
+                // Projects that have a declared control conversation. Tapping
+                // one opens that conversation — the same path as picking the
+                // session directly, so there is no second way to be viewing a
+                // conversation.
+                if !filteredProjects.isEmpty {
+                    Section("Projects") {
+                        ForEach(filteredProjects) { project in
+                            ProjectRow(
+                                project: project,
+                                isViewing: viewingHermesSessionId == project.boundSessionId,
+                                onSelect: {
+                                    guard let sessionId = project.boundSessionId else { return }
+                                    onSelectHermesSession?(sessionId)
+                                }
                             )
                         }
                     }
@@ -1157,6 +1195,69 @@ private struct HermesSessionRow: View {
         if workerCount > 0 {
             parts.append("\(workerCount) worker\(workerCount == 1 ? "" : "s")")
         }
+        return parts.joined(separator: " · ")
+    }
+}
+
+/// A project, opening its declared control conversation.
+private struct ProjectRow: View {
+    let project: ProjectSummary
+    let isViewing: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 10) {
+                Image(systemName: "square.stack.3d.up")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(project.needsAttention ? Theme.warning : Theme.accent)
+                    .frame(width: 16)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(project.slug)
+                        .font(.system(size: 14))
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundStyle(
+                            project.needsAttention ? Theme.warning : Theme.textTertiary
+                        )
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+
+                if isViewing {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Leads with what is wrong, because that is the reason to tap.
+    private var subtitle: String {
+        var parts: [String] = []
+        if let health = project.health {
+            if health.tracksNeedingAttention > 0 {
+                let n = health.tracksNeedingAttention
+                parts.append("\(n) track\(n == 1 ? "" : "s") need attention")
+            }
+            if let worst = health.tracks.first, worst.verdict.needsAttention {
+                parts.append("\(worst.displayTrack) \(worst.verdict.rawValue)")
+            }
+            if parts.isEmpty, health.active > 0 {
+                parts.append("\(health.active) running")
+            }
+            if parts.isEmpty, health.missions > 0 {
+                parts.append("\(health.missions) mission\(health.missions == 1 ? "" : "s")")
+            }
+        }
+        if parts.isEmpty { parts.append("Project") }
         return parts.joined(separator: " · ")
     }
 }

--- a/ios_dashboard/SandboxedDashboardTests/ProjectTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ProjectTests.swift
@@ -1,0 +1,165 @@
+//
+//  ProjectTests.swift
+//  SandboxedDashboardTests
+//
+//  The projects board as the phone consumes it.
+//
+
+import XCTest
+
+@testable import sandboxed_sh
+
+final class ProjectTests: XCTestCase {
+    private func decode(_ json: String) throws -> ProjectSummary {
+        try JSONDecoder().decode(ProjectSummary.self, from: Data(json.utf8))
+    }
+
+    func testDecodesAProjectWithHealthAndBinding() throws {
+        let project = try decode(
+            """
+            {
+              "slug": "verity",
+              "bucket": "attention",
+              "attention_reasons": ["blocker reported: CI"],
+              "updates_count": 80,
+              "conversation": {
+                "session_id": "20260804_103847_86ca5c",
+                "source": "binding",
+                "bound_at": "2026-08-04T17:05:39Z"
+              },
+              "health": {
+                "missions": 353, "active": 3, "failed": 12, "overdue": 2,
+                "tracks_needing_attention": 4,
+                "tracks": [
+                  { "track": "lean431-migration", "verdict": "failing",
+                    "missions": 6, "active": 0, "failed": 3, "completed": 3,
+                    "overdue": 0, "last_activity_at": "2026-08-03T21:14:02Z" }
+                ]
+              }
+            }
+            """
+        )
+        XCTAssertEqual(project.slug, "verity")
+        XCTAssertEqual(project.boundSessionId, "20260804_103847_86ca5c")
+        XCTAssertTrue(project.needsAttention)
+        XCTAssertEqual(project.health?.tracksNeedingAttention, 4)
+        XCTAssertEqual(project.health?.tracks.first?.verdict, .failing)
+        XCTAssertTrue(project.health?.tracks.first?.verdict.needsAttention ?? false)
+    }
+
+    /// An inferred conversation is almost always a cron tick's throwaway
+    /// session, already ended. Offering it as tappable would hand the user a
+    /// dead thread, so only a declared binding counts.
+    func testAnInferredConversationIsNotOfferedAsBound() throws {
+        let project = try decode(
+            """
+            {
+              "slug": "beal", "bucket": "active",
+              "conversation": {
+                "session_id": "cron_b039e22383e5_20260803_105450",
+                "source": "latest_update"
+              }
+            }
+            """
+        )
+        XCTAssertNil(project.boundSessionId)
+        XCTAssertEqual(project.conversation?.sessionId, "cron_b039e22383e5_20260803_105450")
+    }
+
+    func testAProjectWithNoConversationDecodes() throws {
+        let project = try decode(#"{"slug": "oraxen", "bucket": "paused"}"#)
+        XCTAssertNil(project.boundSessionId)
+        XCTAssertNil(project.health)
+        XCTAssertFalse(project.needsAttention)
+        XCTAssertEqual(project.updatesCount, 0)
+    }
+
+    /// A verdict this build does not know about must not blank the whole
+    /// board: the server may learn new ones long before every phone updates.
+    func testAnUnknownVerdictDegradesInsteadOfFailingTheList() throws {
+        let project = try decode(
+            """
+            {
+              "slug": "verity", "bucket": "active",
+              "health": {
+                "missions": 1, "active": 0, "failed": 0, "overdue": 0,
+                "tracks_needing_attention": 0,
+                "tracks": [{ "track": "t", "verdict": "quantum-entangled",
+                             "missions": 1, "active": 0, "failed": 0,
+                             "completed": 0, "overdue": 0 }]
+              }
+            }
+            """
+        )
+        XCTAssertEqual(project.health?.tracks.first?.verdict, .idle)
+    }
+
+    func testAnUntrackedBucketDisplaysAsUntracked() throws {
+        let project = try decode(
+            """
+            {
+              "slug": "verity", "bucket": "active",
+              "health": { "missions": 2, "active": 2, "failed": 0, "overdue": 0,
+                          "tracks_needing_attention": 0,
+                          "tracks": [{ "verdict": "active", "missions": 2,
+                                       "active": 2, "failed": 0, "completed": 0,
+                                       "overdue": 0 }] }
+            }
+            """
+        )
+        XCTAssertEqual(project.health?.tracks.first?.displayTrack, "untracked")
+        XCTAssertNil(project.health?.tracks.first?.track)
+    }
+
+    func testDecodesAStateTimelineEntry() throws {
+        let state = try JSONDecoder().decode(
+            ProjectState.self,
+            from: Data(
+                """
+                {
+                  "signature": "phase1-stack|7dba916|clean-ready|none",
+                  "headline": "Verity Phase 1",
+                  "first_seen_at": "2026-08-04T10:00:00Z",
+                  "last_seen_at": "2026-08-04T18:30:00Z",
+                  "observations": 34
+                }
+                """.utf8)
+        )
+        XCTAssertEqual(state.observations, 34)
+        XCTAssertEqual(state.id, "2026-08-04T10:00:00Z")
+    }
+}
+
+final class MissionProjectMetadataTests: XCTestCase {
+    private func mission(project: String?, track: String?) throws -> Mission {
+        var fields: [String] = [
+            #""id": "11111111-1111-1111-1111-111111111111""#,
+            #""status": "active""#,
+            #""history": []"#,
+            #""created_at": "2026-08-04T10:00:00Z""#,
+            #""updated_at": "2026-08-04T10:00:00Z""#,
+        ]
+        if let project { fields.append("\"project\": \"\(project)\"") }
+        if let track { fields.append("\"track\": \"\(track)\"") }
+        let json = "{\(fields.joined(separator: ","))}"
+        return try JSONDecoder().decode(Mission.self, from: Data(json.utf8))
+    }
+
+    func testDecodesProjectAndTrack() throws {
+        let decoded = try mission(project: "verity", track: "phase1d/core-c3")
+        XCTAssertEqual(decoded.project, "verity")
+        XCTAssertEqual(decoded.track, "phase1d/core-c3")
+        XCTAssertEqual(decoded.projectLabel, "verity · phase1d/core-c3")
+    }
+
+    func testAProjectWithoutATrackLabelsAsJustTheProject() throws {
+        XCTAssertEqual(try mission(project: "verity", track: nil).projectLabel, "verity")
+    }
+
+    /// Most missions carry no project at all (3909 of 7000 on prod), so the
+    /// absence has to be ordinary rather than an empty separator artefact.
+    func testAnUntaggedMissionHasNoLabel() throws {
+        XCTAssertNil(try mission(project: nil, track: nil).projectLabel)
+        XCTAssertNil(try mission(project: nil, track: "orphan-track").projectLabel)
+    }
+}


### PR DESCRIPTION
Closes the iOS half of the projects architecture. The phone could already list a Hermes conversation's workers (#730), but knew nothing about what sits underneath it.

## The gap

- `Mission` decoded neither `project` nor `track` — the fields exist in the API response and were simply dropped.
- No projects surface at all: no `/api/projects/overview` call, no health rollup, no awareness of the declared control conversation.

So the one client you actually carry could not answer *which project is stuck*.

## What lands

**`Mission` decodes `project` and `track`**, with a `projectLabel` reading `verity · phase1d/core-c3`. It is `nil` when untagged — the common case, since 3909 of 7000 missions on prod carry no project, so the absence has to be ordinary rather than an empty-separator artefact.

**`ProjectSummary` / `ProjectHealth` / `ProjectState`** mirror the server rollup (#732, #734). Consumed, not re-derived: "which track is stuck" keeps exactly one definition across web, iOS and desktop.

**A Projects section in the mission switcher**, worst-first, opening each project's control conversation through the *existing* session path. No new screen, and no second way to be viewing a conversation.

## Two deliberate refusals

**Only a declared binding is tappable.** An inferred conversation is almost always a cron tick's throwaway session, already ended — measured on Verity, 52 deliveries across 52 ended sessions. Rendering it as a button would hand the user a dead thread. The server labels `source: "binding"` vs `"latest_update"`; the row honours it.

**An unknown verdict decodes to `.idle`, not an error.** The server will learn new verdicts long before every phone updates, and one unrecognised string must not blank the entire board.

## Verification

Built and tested against a simulator (CI has no iOS job):

```
** BUILD SUCCEEDED **
ProjectTests                  6 tests, 0 failures
MissionProjectMetadataTests   3 tests, 0 failures
```

Two failures remain in `NetworkResilienceTests`, in a file this PR does not touch: it asserts `APIService.defaultBaseURL == ""` while the running bundle resolves a real backend URL. Pre-existing and local-only — `SandboxedDefaultAPIBaseURL` is not in the repo's `Info.plist`, and no workflow runs the iOS suite.

`project.pbxproj` is regenerated with `xcodegen` so the new files are registered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive models, API calls, and switcher UI with graceful degradation on missing endpoints; no auth or mission-control behavior changes.
> 
> **Overview**
> Adds the iOS side of the **projects** surface so the app can see which project/track is stuck and jump to its control conversation from the mission switcher.
> 
> **`Mission`** now decodes optional `project` and `track` from the API and exposes `projectLabel` (e.g. `verity · phase1d/core-c3`), staying `nil` when untagged.
> 
> New **`Project.swift`** models mirror the server rollup (`ProjectSummary`, health per track, `ProjectState`) with **lenient** decoding: unknown track verdicts become `.idle`, and only conversations with `source == "binding"` count as tappable (`boundSessionId`) so inferred cron sessions are not offered as dead threads.
> 
> **`APIService`** gains `listProjects()` and `projectStates(slug:)`. **`ControlView`** loads projects alongside Hermes sessions (empty on older backends). **`MissionSwitcherSheet`** adds a **Projects** section (attention-first, search-filtered) that opens the bound Hermes session via the existing session path—no new screen.
> 
> **`ProjectTests`** cover decoding, binding vs inferred conversation, and mission project labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d48d37a57373c3665b246c2a99301850112ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->