### PR TITLE
Let a chain test probe every entry, not just the first that answers

### DIFF
--- a/src/api/model_routing.rs
+++ b/src/api/model_routing.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path as AxumPath, State},
+    extract::{Path as AxumPath, Query, State},
     http::StatusCode,
     routing::{delete, get, post, put},
     Json, Router,
@@ -334,12 +334,117 @@ async fn resolve_chain(
 /// Runs behind the dashboard JWT (unlike `/v1/chat/completions`, which
 /// requires a proxy bearer), so the debug panel can exercise a chain without
 /// holding a proxy key.
+#[derive(Debug, Deserialize, Default)]
+pub struct TestChainQuery {
+    /// Probe every entry instead of stopping at the first that answers.
+    #[serde(default)]
+    pub all: bool,
+}
+
+/// One entry's liveness, from a real 1-token request to that exact upstream.
+#[derive(Debug, Serialize)]
+struct EntryProbe {
+    provider_id: String,
+    model_id: String,
+    ok: bool,
+    status: u16,
+    latency_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// Probe one `provider/model` directly, bypassing chain fallback.
+///
+/// Addressing the entry by its qualified id is what makes this a per-entry
+/// test: sending the chain id would let the proxy fall through to whichever
+/// entry still works, which is exactly the blindness this exists to remove.
+async fn probe_entry(
+    state: &Arc<super::routes::AppState>,
+    provider_id: &str,
+    model_id: &str,
+) -> EntryProbe {
+    let qualified = format!("{provider_id}/{model_id}");
+    let body = serde_json::json!({
+        "model": qualified,
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+    });
+    let body_bytes = bytes::Bytes::from(serde_json::to_vec(&body).expect("probe body serializes"));
+
+    let started = std::time::Instant::now();
+    let response = super::proxy::chat_completions_inner(
+        state.clone(),
+        axum::http::HeaderMap::new(),
+        body_bytes,
+    )
+    .await;
+    let status = response.status();
+    let latency_ms = started.elapsed().as_millis() as u64;
+
+    // Only failures carry their body: a success adds nothing an operator
+    // needs, and the point of this endpoint is to make failures legible.
+    let error = if status.is_success() {
+        None
+    } else {
+        axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .ok()
+            .map(|bytes| String::from_utf8_lossy(&bytes).chars().take(300).collect())
+    };
+
+    EntryProbe {
+        provider_id: provider_id.to_string(),
+        model_id: model_id.to_string(),
+        ok: status.is_success(),
+        status: status.as_u16(),
+        latency_ms,
+        error,
+    }
+}
+
 async fn test_chain(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
+    Query(query): Query<TestChainQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     if state.chain_store.get(&id).await.is_none() {
         return Err((StatusCode::NOT_FOUND, format!("Chain '{}' not found", id)));
+    }
+
+    if query.all {
+        // A chain "works" as soon as its first entry answers, which says
+        // nothing about the ones behind it. Measured on prod 2026-08-05:
+        // builtin/smart reported ok=true through MiniMax while its last
+        // resort, spark/gemma-4, could not serve at all — no vLLM image was
+        // installed on the node, so every model there was inactive. The
+        // fleet was one MiniMax hiccup from a full stop and no surface said
+        // so. Probing each entry is the only way to see fallback depth.
+        let standard_accounts =
+            super::ai_providers::read_standard_accounts(&state.config.working_dir);
+        let resolved = state
+            .chain_store
+            .resolve_chain(
+                &id,
+                &state.ai_providers,
+                &standard_accounts,
+                &state.health_tracker,
+            )
+            .await;
+
+        let mut entries = Vec::with_capacity(resolved.len());
+        for entry in &resolved {
+            entries.push(probe_entry(&state, &entry.provider_id, &entry.model_id).await);
+        }
+        let live = entries.iter().filter(|e| e.ok).count();
+        return Ok(Json(serde_json::json!({
+            // `ok` keeps its meaning — the chain can serve a request — so a
+            // caller that only checks `ok` is not silently given a stricter
+            // answer than it asked for. Depth is reported alongside.
+            "ok": live > 0,
+            "entries_total": entries.len(),
+            "entries_live": live,
+            "entries": entries,
+        })));
     }
 
     let body = serde_json::json!({
@@ -418,4 +523,76 @@ async fn list_fallback_events(
     State(state): State<Arc<super::routes::AppState>>,
 ) -> Json<Vec<crate::provider_health::FallbackEvent>> {
     Json(state.health_tracker.get_recent_events(200).await)
+}
+
+#[cfg(test)]
+mod chain_probe_tests {
+    use super::*;
+
+    /// `all` must default to false so the existing single-shot behaviour is
+    /// what an unchanged caller keeps getting.
+    #[test]
+    fn probing_every_entry_is_opt_in() {
+        let default: TestChainQuery = serde_json::from_str("{}").expect("empty query");
+        assert!(!default.all);
+
+        let explicit: TestChainQuery = serde_json::from_str(r#"{"all":true}"#).expect("query");
+        assert!(explicit.all);
+    }
+
+    /// A probe is addressed to `provider/model`, never to the chain id.
+    /// Sending the chain id would let the proxy fall through to whichever
+    /// entry still answers — which is exactly the blindness being removed:
+    /// on prod, builtin/smart reported ok=true through MiniMax while its last
+    /// resort could not serve at all.
+    #[test]
+    fn a_probe_targets_one_entry_not_the_chain() {
+        let source = include_str!("model_routing.rs");
+        let probe = source
+            .split("async fn probe_entry")
+            .nth(1)
+            .expect("probe_entry exists");
+        let body = probe.split("async fn test_chain").next().unwrap_or(probe);
+        assert!(
+            body.contains(r#"format!("{provider_id}/{model_id}")"#),
+            "probe_entry must address the qualified entry id"
+        );
+        assert!(
+            !body.contains(r#""model": id"#),
+            "probe_entry must not send the chain id, which would fall through"
+        );
+    }
+
+    #[test]
+    fn a_failing_entry_reports_its_status_and_a_bounded_error() {
+        let probe = EntryProbe {
+            provider_id: "spark".into(),
+            model_id: "gemma-4".into(),
+            ok: false,
+            status: 502,
+            latency_ms: 6_000,
+            error: Some("Image nvcr.io/nvidia/vllm missing".into()),
+        };
+        let json = serde_json::to_value(&probe).expect("probe serializes");
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["status"], 502);
+        assert_eq!(json["provider_id"], "spark");
+        assert!(json["error"].as_str().unwrap().contains("missing"));
+    }
+
+    #[test]
+    fn a_healthy_entry_carries_no_error_field() {
+        // Success bodies add nothing an operator needs; the endpoint exists to
+        // make failures legible, so a healthy entry stays terse.
+        let probe = EntryProbe {
+            provider_id: "minimax".into(),
+            model_id: "MiniMax-M3".into(),
+            ok: true,
+            status: 200,
+            latency_ms: 1_000,
+            error: None,
+        };
+        let json = serde_json::to_value(&probe).expect("probe serializes");
+        assert!(json.get("error").is_none(), "healthy probes stay terse");
+    }
 }


### PR DESCRIPTION
## What this would have caught

`POST /chains/builtin%2Fsmart/test` returned:

```json
{ "ok": true, "response": { "model": "MiniMax-M3", ... } }
```

Healthy. And it was — for the first entry. Probing each entry by hand told a very different story:

| entry | result |
|---|---|
| kimi/k3 | 429, in cooldown |
| zai/glm-5.2 | 429, in cooldown |
| minimax/MiniMax-M3 | **200 in 1s** |
| spark/gemma-4 | **502** |

And directly on the node:

```
{"error": "Image nvcr.io/nvidia/vllm:26.05.post1-py3 missing. Run install-vllm.sh gemma-4 first."}
```

Every model on the DGX was `active=False` — no vLLM image installed at all. The local no-quota fallback could serve nothing, and the entire autonomous fleet (Verity, the Lido audit, the benchmark, and the supervisor watching them) was one MiniMax hiccup away from a full stop. No surface reported it, because the chain genuinely did work.

## What it adds

`?all=true` resolves the chain and sends a real one-token request to **each** entry:

```json
{ "ok": true, "entries_total": 2, "entries_live": 1,
  "entries": [
    { "provider_id": "minimax", "model_id": "MiniMax-M3", "ok": true,  "status": 200, "latency_ms": 1013 },
    { "provider_id": "spark",   "model_id": "gemma-4",    "ok": false, "status": 502,
      "error": "Image nvcr.io/nvidia/vllm:26.05.post1-py3 missing…" }
  ] }
```

Each probe is addressed by its qualified `provider/model` id. That addressing **is** the feature: sending the chain id would let the proxy fall through to whichever entry still answers, reproducing the exact blindness this removes.

## Compatibility

- `all` defaults to false, so unchanged callers keep the existing single-shot behaviour.
- `ok` keeps its meaning — *the chain can serve a request* — so a caller reading only `ok` is not silently given a stricter answer than it asked for. Depth is reported alongside.
- Only failing entries carry their body; the endpoint exists to make failures legible, not to echo successes.

Cost is one token per entry.

## Tests

4 new, 1684 in the lib, clippy clean. One asserts the probe targets `provider/model` and never the chain id, since that distinction is the difference between this endpoint working and it lying.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exercises live upstream chat completion for every chain entry (token cost and load) but remains dashboard-JWT gated and opt-in; incorrect probe addressing would undermine the debugging goal but not broaden auth exposure.
> 
> **Overview**
> **Chain test** (`POST /api/model-routing/chains/:id/test`) gains an opt-in **`?all=true`** mode so operators can see **fallback depth**, not just whether the first healthy entry answers.
> 
> With **`all=true`**, the handler resolves the chain (same as `/resolve`), then runs a real 1-token **`ping`** against **each** entry via a new **`probe_entry`** helper. Each probe uses the qualified **`provider/model`** model id so the proxy cannot fall through the chain—addressing the chain id would reproduce the blind spot where a chain looked healthy while later entries were dead.
> 
> The JSON response adds **`entries_total`**, **`entries_live`**, and an **`entries`** array of per-entry **`ok`**, **`status`**, **`latency_ms`**, and a bounded **`error`** body only on failures. Top-level **`ok`** still means “at least one entry can serve,” so existing callers that only check **`ok`** behave the same when **`all`** is omitted (defaults to **false**).
> 
> Four unit tests cover default query parsing, probe addressing, and **`EntryProbe`** serialization shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8a715ef856e95ddbb3a70bbf08d89535cf4cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->