### PR TITLE
Tag a mission with the project of the conversation that spawned it

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7741,7 +7741,38 @@ pub async fn create_mission(
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     };
-    let project = nonblank(&req.project);
+    // A mission dispatched from a bound conversation inherits that project
+    // when the caller did not name one. Agents omit it often — 11 of the 39
+    // missions created in one 12h window on prod carried no project at all —
+    // and an untagged mission is invisible to every project-scoped view:
+    // the health rollup, the state timeline, the writer-slot counts, and the
+    // inventory the controllers themselves query. Making the tag structural
+    // beats asking every dispatcher to remember it.
+    //
+    // An explicit value always wins, including a deliberate blank, which is
+    // how a caller says "this belongs to no project".
+    let project = match nonblank(&req.project) {
+        Some(explicit) => Some(explicit),
+        None if req.project.is_some() => None,
+        None => req
+            .origin_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|session| !session.is_empty())
+            .and_then(
+                |session| match state.projects.project_for_session(session) {
+                    Ok(slug) => slug,
+                    Err(error) => {
+                        tracing::warn!(
+                            session_id = session,
+                            error = %error,
+                            "could not resolve a project for the origin session"
+                        );
+                        None
+                    }
+                },
+            ),
+    };
     let track = nonblank(&req.track);
     let intent = nonblank(&req.intent);
     let github_pr = nonblank(&req.github_pr);

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -168,6 +168,26 @@ impl ProjectsStore {
         })
     }
 
+    /// The project bound to `session_id`, if any.
+    ///
+    /// The reverse of [`Self::bindings`], used to tag a mission with the
+    /// project of the conversation that spawned it. Bindings are one project
+    /// per slug but several slugs may share a conversation, so this returns
+    /// the lexicographically first match: an arbitrary-but-stable choice is
+    /// better than a tag that changes between two calls.
+    pub fn project_for_session(&self, session_id: &str) -> Result<Option<String>, String> {
+        let connection = self.lock()?;
+        connection
+            .query_row(
+                "SELECT slug FROM project_bindings WHERE control_session_id = ?1 \
+                 ORDER BY slug LIMIT 1",
+                params![session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+    }
+
     /// Returns whether a binding existed.
     pub fn clear_binding(&self, slug: &str) -> Result<bool, String> {
         let connection = self.lock()?;
@@ -365,6 +385,68 @@ mod tests {
         let all = store.bindings().expect("all");
         assert_eq!(all["verity"].session_id, "shared");
         assert_eq!(all["verity-docs"].session_id, "shared");
+    }
+
+    // ---- reverse lookup ----
+
+    #[test]
+    fn a_bound_session_resolves_back_to_its_project() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store.set_binding("verity", "sess-a", None).expect("bind");
+        store.set_binding("lido", "sess-b", None).expect("bind");
+        assert_eq!(
+            store
+                .project_for_session("sess-a")
+                .expect("lookup")
+                .as_deref(),
+            Some("verity")
+        );
+        assert_eq!(
+            store
+                .project_for_session("sess-b")
+                .expect("lookup")
+                .as_deref(),
+            Some("lido")
+        );
+    }
+
+    #[test]
+    fn an_unbound_session_resolves_to_nothing() {
+        // Must be None rather than a guess: tagging a mission with the wrong
+        // project is worse than leaving it untagged, because a wrong tag is
+        // believed.
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store.set_binding("verity", "sess-a", None).expect("bind");
+        assert_eq!(
+            store.project_for_session("sess-unknown").expect("lookup"),
+            None
+        );
+        assert_eq!(store.project_for_session("").expect("lookup"), None);
+    }
+
+    #[test]
+    fn a_shared_conversation_resolves_stably() {
+        // Several projects may report into one conversation. Any answer is
+        // arbitrary, but it must not change between two identical calls.
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store.set_binding("zulu", "shared", None).expect("bind");
+        store.set_binding("alpha", "shared", None).expect("bind");
+        let first = store.project_for_session("shared").expect("lookup");
+        let second = store.project_for_session("shared").expect("lookup");
+        assert_eq!(first, second);
+        assert_eq!(first.as_deref(), Some("alpha"));
+    }
+
+    #[test]
+    fn rebinding_moves_the_reverse_lookup_too() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store.set_binding("verity", "old", None).expect("bind");
+        store.set_binding("verity", "new", None).expect("rebind");
+        assert_eq!(store.project_for_session("old").expect("lookup"), None);
+        assert_eq!(
+            store.project_for_session("new").expect("lookup").as_deref(),
+            Some("verity")
+        );
     }
 
     // ---- state timeline ----


### PR DESCRIPTION
## Measured, not assumed

Missions created on prod in one 12-hour window:

| | count |
|---|---|
| created | 39 |
| **untagged (no project)** | **11** |
| dispatched by Hermes | 34 |
| untagged among those | 6 |

The untagged ones are not ambiguous work:

```
a494881a  Review PR #158: validate_campaign_artifacts.py
065676d4  Lido P-SSZ-1 abstract-digest host-side guarded
53c997c6  Lido P-SSZ-1 abstract-digest certifier
61c0fecb  Lido PR #31 host-side guarded merge into campaign
```

## Why it matters

An untagged mission is invisible to every project-scoped view built on `project`: the health rollup (#732), the state timeline (#734), `project_prefix` inventory (#726), and the writer-slot counts controllers use to decide whether they have capacity.

That last one bites. A controller dispatched a writer, reported **"1/3 Lido writers live"** from its own bookkeeping, and the server-side inventory saw **zero** — because the mission carried `project=None`. Two views of the same fleet disagreeing, and the server-side one is what drives the capacity guardrails.

## The fix

`start_mission` already passes `origin_session_id`, and `project_bindings` already maps a project to its control conversation. So when a caller omits `project`, the server resolves it from that binding instead of asking every dispatcher to remember.

The MCP's own comment says a mission should not be born with null metadata — *"Paloma watchdogs then route by these, not titles"*. Nothing enforced it. This does.

## Deliberate refusals

- **An explicit value always wins**, including a deliberate blank: that is how a caller says "this belongs to no project".
- **An unbound session yields nothing.** A wrong tag is worse than a missing one, because a wrong tag is believed.
- **A shared conversation resolves stably** (lexicographically first). Several projects may report into one conversation; an arbitrary answer is fine, one that changes between two identical calls is not.

## Tests

14 in the store module, 1688 in the lib, clippy clean. The new ones pin the reverse lookup, the unbound case, stability under a shared conversation, and that rebinding moves the reverse lookup with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default mission metadata used by capacity guards and project-scoped views; wrong binding could mis-tag missions, though unbound sessions stay untagged and explicit project values still win.
> 
> **Overview**
> **Missions created without a `project` now pick up the project bound to `origin_session_id`**, so conversation-spawned work shows up in project-scoped health, timelines, and writer inventory instead of staying untagged.
> 
> `start_mission` still treats an explicit non-empty `project` as authoritative, and a deliberate blank `project` as “no project.” When the field is omitted, the server looks up `project_bindings` via new **`ProjectsStore::project_for_session`** (lexicographically first slug if several projects share one conversation); lookup failures log a warning and leave the tag unset rather than guessing.
> 
> Store tests cover reverse lookup, unbound sessions, stable shared-session resolution, and rebinding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34fa8ad011817d55e5eeb5a321e3d03030b0ff37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->