### PR TITLE
Let project bindings follow conversation continuations

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7759,19 +7759,29 @@ pub async fn create_mission(
             .as_deref()
             .map(str::trim)
             .filter(|session| !session.is_empty())
-            .and_then(
-                |session| match state.projects.project_for_session(session) {
-                    Ok(slug) => slug,
-                    Err(error) => {
-                        tracing::warn!(
-                            session_id = session,
-                            error = %error,
-                            "could not resolve a project for the origin session"
-                        );
-                        None
+            .and_then(|session| {
+                // A conversation rolls over into a continuation, and the
+                // binding names whichever id the operator declared — often
+                // several rollovers above this one. Walk up the ancestry,
+                // nearest first, so the closest binding wins.
+                let chain = match super::projects_overview::hermes_state_db_path() {
+                    Some(path) => super::session_chain::ancestry(&path, session),
+                    None => vec![session.to_string()],
+                };
+                chain.iter().find_map(|candidate| {
+                    match state.projects.project_for_session(candidate) {
+                        Ok(slug) => slug,
+                        Err(error) => {
+                            tracing::warn!(
+                                session_id = candidate,
+                                error = %error,
+                                "could not resolve a project for the origin session"
+                            );
+                            None
+                        }
                     }
-                },
-            ),
+                })
+            }),
     };
     let track = nonblank(&req.track);
     let intent = nonblank(&req.intent);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -61,6 +61,7 @@ mod routes;
 pub(crate) mod runners;
 pub mod scope_reaper;
 pub mod secrets;
+pub mod session_chain;
 pub mod settings;
 pub(crate) mod spark;
 pub(crate) mod supervision;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -139,6 +139,11 @@ fn hermes_projects_dir() -> Option<PathBuf> {
         .filter(|path| path.is_dir())
 }
 
+/// Path to Hermes' `state.db`, for callers that need the continuation chain.
+pub fn hermes_state_db_path() -> Option<PathBuf> {
+    hermes_state_db()
+}
+
 fn hermes_state_db() -> Option<PathBuf> {
     std::env::var("HERMES_STATE_DB")
         .ok()
@@ -235,10 +240,28 @@ pub async fn projects_overview(
         .as_deref()
         .map(read_trackers)
         .unwrap_or_default();
-    let bindings = state
+    let mut bindings = state
         .projects
         .bindings()
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    // A binding names the conversation the operator declared. That id goes
+    // stale as soon as Hermes compresses the conversation and forks a
+    // continuation — measured on the Lido audit, four times in one night. The
+    // declared value stays the stored fact; the live tip is resolved here, the
+    // same way Hermes resolves its own routes.
+    if let Some(path) = hermes_state_db() {
+        for conversation in bindings.values_mut() {
+            let tip = super::session_chain::live_tip(&path, &conversation.session_id);
+            if tip != conversation.session_id {
+                tracing::debug!(
+                    declared = %conversation.session_id,
+                    live = %tip,
+                    "binding followed a conversation continuation"
+                );
+                conversation.session_id = tip;
+            }
+        }
+    }
     let archived = trackers_dir
         .as_deref()
         .and_then(|dir| dir.parent().map(|p| p.join("archive")))

--- a/src/api/session_chain.rs
+++ b/src/api/session_chain.rs
@@ -1,0 +1,181 @@
+//! Walk Hermes conversation continuation chains.
+//!
+//! Hermes compresses a long conversation and forks a continuation, linked to
+//! its parent by `sessions.parent_session_id`. A project binding names one
+//! session id, so the binding goes stale the moment the conversation rolls
+//! over — measured on the Lido audit, four times in a single night.
+//!
+//! Hermes solves this on its own side by treating the stored route as a
+//! *declared* fact and resolving forward at read time. This mirrors that,
+//! reading the same `state.db` that the projects board already opens read-only.
+//! Nothing here writes.
+//!
+//! Both directions are needed, for different questions:
+//!
+//! * **Forward** — "the operator bound `verity` to session X; which
+//!   conversation should the board open today?" Walk down to the live tip.
+//! * **Backward** — "a mission was spawned from session Y; which project does
+//!   it belong to?" Walk up until an ancestor matches a binding.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Depth cap for either walk.
+///
+/// A cycle in `parent_session_id` should be impossible, but a malformed row
+/// must not hang a request that runs on a page render. The `seen` set already
+/// makes a cycle terminate; this bounds a pathologically long legitimate chain
+/// too. Real chains are single digits.
+const MAX_CHAIN_DEPTH: usize = 64;
+
+fn open(db_path: &Path) -> Option<rusqlite::Connection> {
+    rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).ok()
+}
+
+/// The live continuation tip of `session_id`, following children forward.
+///
+/// Returns `session_id` itself when it has no continuation, when the database
+/// is unreadable, or when the row does not exist. Degrading to the declared id
+/// is the right failure: it is what the operator asked for, and a stale answer
+/// beats no answer on a display path.
+pub fn live_tip(db_path: &Path, session_id: &str) -> String {
+    let Some(connection) = open(db_path) else {
+        return session_id.to_string();
+    };
+    let mut current = session_id.to_string();
+    let mut seen: HashSet<String> = HashSet::from([current.clone()]);
+
+    for _ in 0..MAX_CHAIN_DEPTH {
+        let child: Option<String> = connection
+            .query_row(
+                "SELECT id FROM sessions WHERE parent_session_id = ?1 \
+                 ORDER BY id DESC LIMIT 1",
+                [&current],
+                |row| row.get(0),
+            )
+            .ok();
+        match child {
+            Some(next) if seen.insert(next.clone()) => current = next,
+            _ => break,
+        }
+    }
+    current
+}
+
+/// `session_id` and its ancestors, nearest first.
+///
+/// Used to attribute a mission: the conversation it was spawned from may be
+/// several continuations below the one an operator actually bound.
+pub fn ancestry(db_path: &Path, session_id: &str) -> Vec<String> {
+    let mut chain = vec![session_id.to_string()];
+    let Some(connection) = open(db_path) else {
+        return chain;
+    };
+    let mut current = session_id.to_string();
+    let mut seen: HashSet<String> = HashSet::from([current.clone()]);
+
+    for _ in 0..MAX_CHAIN_DEPTH {
+        let parent: Option<String> = connection
+            .query_row(
+                "SELECT parent_session_id FROM sessions WHERE id = ?1",
+                [&current],
+                |row| row.get(0),
+            )
+            .ok()
+            .flatten();
+        match parent {
+            Some(next) if !next.trim().is_empty() && seen.insert(next.clone()) => {
+                chain.push(next.clone());
+                current = next;
+            }
+            _ => break,
+        }
+    }
+    chain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a state.db with just the columns these walks touch.
+    fn db(rows: &[(&str, Option<&str>)]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("state.db");
+        let connection = rusqlite::Connection::open(&path).expect("open");
+        connection
+            .execute(
+                "CREATE TABLE sessions (id TEXT PRIMARY KEY, parent_session_id TEXT)",
+                [],
+            )
+            .expect("schema");
+        for (id, parent) in rows {
+            connection
+                .execute(
+                    "INSERT INTO sessions (id, parent_session_id) VALUES (?1, ?2)",
+                    rusqlite::params![id, parent],
+                )
+                .expect("insert");
+        }
+        (dir, path)
+    }
+
+    /// The shape measured on the Lido audit: bound once, rolled over four times.
+    #[test]
+    fn the_tip_is_the_end_of_the_chain() {
+        let (_dir, path) = db(&[
+            ("30e544", None),
+            ("fad004", Some("30e544")),
+            ("527c1a", Some("fad004")),
+            ("e15a30", Some("527c1a")),
+        ]);
+        assert_eq!(live_tip(&path, "30e544"), "e15a30");
+        assert_eq!(live_tip(&path, "527c1a"), "e15a30");
+        assert_eq!(live_tip(&path, "e15a30"), "e15a30");
+    }
+
+    #[test]
+    fn ancestry_reaches_the_bound_session_from_a_descendant() {
+        let (_dir, path) = db(&[
+            ("30e544", None),
+            ("fad004", Some("30e544")),
+            ("527c1a", Some("fad004")),
+            ("e15a30", Some("527c1a")),
+        ]);
+        assert_eq!(
+            ancestry(&path, "e15a30"),
+            vec!["e15a30", "527c1a", "fad004", "30e544"]
+        );
+    }
+
+    #[test]
+    fn an_unknown_session_resolves_to_itself() {
+        // Not an error: the caller asked about something this database does
+        // not know, and inventing an answer would be worse than echoing.
+        let (_dir, path) = db(&[("a", None)]);
+        assert_eq!(live_tip(&path, "ghost"), "ghost");
+        assert_eq!(ancestry(&path, "ghost"), vec!["ghost"]);
+    }
+
+    #[test]
+    fn an_unreadable_database_degrades_to_the_declared_id() {
+        let missing = std::path::Path::new("/nonexistent/state.db");
+        assert_eq!(live_tip(missing, "sess"), "sess");
+        assert_eq!(ancestry(missing, "sess"), vec!["sess"]);
+    }
+
+    /// A malformed parent link must not hang a page render.
+    #[test]
+    fn a_cycle_terminates() {
+        let (_dir, path) = db(&[("a", Some("b")), ("b", Some("a"))]);
+        assert_eq!(live_tip(&path, "a"), "b");
+        let chain = ancestry(&path, "a");
+        assert_eq!(chain, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn a_blank_parent_is_no_parent() {
+        let (_dir, path) = db(&[("root", Some("")), ("child", Some("root"))]);
+        assert_eq!(ancestry(&path, "child"), vec!["child", "root"]);
+    }
+}


### PR DESCRIPTION
## The drift

Hermes compresses a long conversation and forks a **continuation**, linked by `sessions.parent_session_id`. Its own route store handles this: the stored id is a *declared* fact and resolution walks forward at read time.

The sandboxed.sh `project_bindings` table did not. So the two stores held the same fact and drifted apart on every rollover.

Measured while writing this patch — the Lido audit chain:

```
20260804_193446_30e544   ← what was bound
20260805_021303_fad004
20260805_032442_527c1a
20260805_074400_e15a30   ← what I resynced by hand an hour ago
20260805_084129_dfd5c0   ← the live tip now
```

Five rollovers in one night, and the manual resync was already stale. Re-pointing by hand cannot keep up with something that happens on its own schedule.

## Both directions

| direction | question | walk |
|---|---|---|
| forward | the operator bound `verity` to session X — which conversation should the board open today? | down to the live tip |
| backward | a mission was spawned from session Y — which project owns it? | up the ancestry, nearest binding wins |

The **backward** walk is the one that silently corrupted data. A mission created in a fifth-generation continuation resolved to no project at all, so it stayed invisible to the health rollup, the state timeline, `project_prefix` inventory, and the writer-slot counts controllers use to judge their own capacity.

## Why resolve-on-read

Three alternatives were considered and rejected:

- **Hermes pushes to sandboxed.sh on migration** — needs credentials and network, and a failed push leaves the drift *silent*, which is the failure mode this whole area keeps producing.
- **Drop the sandboxed.sh table, read Hermes' routes** — single source of truth, but the dashboard could no longer bind a project Hermes does not know, and its buttons would write into another service's database.
- **Resolve on read** — the binding stays the declared fact, resolution follows the chain. It mirrors what Hermes already does, and uses the `state.db` this repo already opens read-only.

Nothing here writes.

## Failure behaviour

An unreadable database, an unknown session, or a malformed parent link all degrade to the declared id. A stale answer beats no answer on a display path, and the declared id is what the operator asked for. A cycle terminates via a `seen` set, with a depth cap so a pathological chain cannot hang a page render.

## Tests

6 new, 1694 in the lib, clippy clean. They pin the real five-generation shape in both directions, the unknown/unreadable/blank-parent degradations, and cycle termination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission project tagging and board conversation links via read-only SQLite; failures degrade to declared ids but wrong ancestry could mis-attribute missions if `state.db` is stale or malformed.
> 
> **Overview**
> **Project bindings and mission attribution now follow Hermes conversation continuations** instead of going stale when a bound session is compressed and forked.
> 
> A new read-only `session_chain` module walks `sessions.parent_session_id` in Hermes `state.db`: **`live_tip`** follows children to the current conversation; **`ancestry`** walks up from a descendant. Stored bindings stay the operator-declared id; resolution happens at read time (same pattern as Hermes routes). Unreadable DBs, unknown sessions, cycles, and long chains degrade safely (declared id, depth cap 64).
> 
> On the **projects board**, bound `session_id` values are rewritten to the live tip before rows are built so “open conversation” points at today’s thread. When inferring **project from `origin_session_id`** on mission create/update, the code walks the ancestry chain and uses the nearest ancestor that still matches a binding—so missions spawned from a continuation inherit the right project tag again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd2b81ca539d0eed88cf00dfbcbec367f33e32f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->