### PR TITLE
Let an agent ask what it can do instead of inferring it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,17 @@ MAX_PARALLEL_MISSIONS=1
 # (CPUWeight lower than system.slice + an aggregate CPUQuota) — see DEBUGGING.md.
 # MISSION_CPU_WEIGHT=40
 # MISSION_CPU_QUOTA=400%
+#
+# Container /tmp. systemd-nspawn mounts a tmpfs on /tmp inside every container,
+# sized at 10% of host RAM (6.3G on a 64G box). That scratch is therefore priced
+# in RAM, competes with the caps above, fails *silently* when full (0-byte logs,
+# empty dirs), and is invisible to df and to the disk watcher. Point this at a
+# directory on a data disk to back each container's /tmp with a per-workspace
+# directory instead: margin becomes the filesystem's, RAM cost becomes zero, and
+# the tree becomes prunable/measurable from the host. Takes effect when a
+# container leader next starts. Unset (default) = stock tmpfs.
+# SANDBOXED_SH_CONTAINER_TMP_ROOT=/srv/sandboxed-storage/containers-tmp
+# SANDBOXED_SH_CONTAINER_TMP_RETENTION_HOURS=72
 
 # =============================================================================
 # Auth (JWT)

--- a/agents.md
+++ b/agents.md
@@ -172,6 +172,33 @@ Gotchas:
 - Unset env (default) = no scope wrapping at all, so Docker installs without
   systemd PID 1 stay on the direct path.
 
+## Resource isolation (container `/tmp`)
+
+systemd-nspawn mounts a **tmpfs on `/tmp` inside every container**, sized at 10%
+of host RAM (6.3G on a 64G box). Mission scratch — multi-GB audit trees, cert
+runs, Ask sandbox copies — therefore lands in *RAM*, priced against the same
+budget as the caps above. Setting `SANDBOXED_SH_CONTAINER_TMP_ROOT` backs each
+container's `/tmp` with a per-workspace directory on a data disk instead
+(`container_tmp.rs`, bound in `start_persistent_container_leader`). Retention for
+stale scratch is `SANDBOXED_SH_CONTAINER_TMP_RETENTION_HOURS` (default 72); the
+sweep rides the mission-workspace GC cadence.
+
+Gotchas:
+- **A full container `/tmp` is silent.** Writes get ENOSPC, but tooling that
+  doesn't check leaves 0-byte logs and empty directories — no crash, no alert.
+  In the 2026-08-05 incident two containers sat at zero bytes free for ~2 days.
+- **It is invisible from the host.** Host-side `containers/<ws>/tmp` is an empty
+  shadow of the tmpfs, so `df`, the disk watcher, and the workspace GC all
+  report healthy numbers. To inspect it you must enter the namespace via the
+  nspawn **child** pid (the nspawn pid itself still shows the host fs):
+  `p=$(pgrep -f "systemd-nspawn .*--machine=sandboxed-<ws>-"|head -1); c=$(pgrep -P $p|head -1); nsenter -t $c -m -- df -h /tmp`
+- **Raising the tmpfs size is not the fix.** Eleven containers at the default
+  already oversubscribe a 62G box; disk-backing it is what buys real margin.
+- Takes effect only when a container leader next starts (execs `nsenter` into
+  the existing leader), so rollout is per-container as they cycle.
+- Unset (default) = stock nspawn tmpfs, so shipping this changes nothing until
+  the env is set.
+
 ## Operational notes
 
 - **No central OpenCode server needed**: Missions spawn per-workspace CLI

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1467,10 +1467,18 @@ pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Opti
             }
             Ok(out) => {
                 log_sandbox_command_failure("copy", &out);
+                // The copy command creates the destination before filling it,
+                // so a failure part-way through (a full `/tmp` is the usual
+                // one) strands a partial tree that nothing else will ever
+                // collect — the caller only tears down sandboxes it was
+                // handed. That turns one failed Ask into permanently lost
+                // scratch space, which makes the next Ask likelier to fail.
+                cleanup_sandbox(exec, base_work_dir, &sandbox_host).await;
                 None
             }
             Err(error) => {
                 tracing::warn!(stage = "copy", %error, "Ask sandbox command failed to start");
+                cleanup_sandbox(exec, base_work_dir, &sandbox_host).await;
                 None
             }
         };
@@ -1496,10 +1504,12 @@ pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Opti
         }
         Ok(out) => {
             log_sandbox_command_failure("git-worktree", &out);
+            cleanup_sandbox(exec, base_work_dir, &sandbox_host).await;
             None
         }
         Err(error) => {
             tracing::warn!(stage = "git-worktree", %error, "Ask sandbox command failed to start");
+            cleanup_sandbox(exec, base_work_dir, &sandbox_host).await;
             None
         }
     }
@@ -1543,8 +1553,13 @@ fn log_sandbox_command_failure(stage: &str, output: &std::process::Output) {
 pub async fn cleanup_sandbox(exec: &WorkspaceExec, base_work_dir: &Path, sandbox: &Path) {
     let base_str = exec.translate_path_for_container(base_work_dir);
     let sandbox_str = exec.translate_path_for_container(sandbox);
+    // `prune` matters for the failure path: a `worktree add` that died partway
+    // leaves an admin entry in `.git/worktrees` that `rm -rf` alone cannot
+    // clear, and which then blocks re-using that path. It only drops entries
+    // whose directory is already gone, so healthy worktrees are untouched.
     let cmd = format!(
-        "git -C {b} worktree remove --force {s} 2>/dev/null || rm -rf {s}",
+        "git -C {b} worktree remove --force {s} 2>/dev/null || rm -rf {s}; \
+         git -C {b} worktree prune 2>/dev/null || true",
         b = single_quote(&base_str),
         s = single_quote(&sandbox_str)
     );

--- a/src/api/capabilities.rs
+++ b/src/api/capabilities.rs
@@ -1,0 +1,182 @@
+//! `GET /api/capabilities` — what the caller can actually do here.
+//!
+//! An autonomous agent that wants to know whether it may dispatch a mission or
+//! push to GitHub has, until now, had to infer it from whatever fields it could
+//! find. On 2026-08-05 one of them read `github_enabled` on `/api/health`,
+//! concluded "GitHub is disabled in this environment", and from that concluded
+//! it could not dispatch a mission. Neither conclusion follows:
+//! `github_enabled` gates the dashboard's *login button* and says nothing about
+//! either mission dispatch or git access.
+//!
+//! The fix is not a better field name — that only makes the next wrong
+//! inference less likely, not impossible. It is an endpoint that answers the
+//! question directly, so no inference is needed. A capability here reports
+//! three things, and the third is the one that ends the guessing:
+//!
+//! * `available` — can the caller do this, right now;
+//! * `detail` — the observed fact behind that verdict, never a restatement of
+//!   it ("connected as `octocat`", not "GitHub is available");
+//! * `remedy` — what to do when it is unavailable. An agent that is told what
+//!   would fix the situation reports a blocker; one that is not invents a
+//!   cause.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use axum::{extract::State, Json};
+use serde::Serialize;
+
+use super::routes::AppState;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Capability {
+    /// Whether the caller can do this now.
+    pub available: bool,
+    /// The observed fact behind the verdict — what was checked, not a
+    /// paraphrase of `available`.
+    pub detail: String,
+    /// What would make an unavailable capability available. Omitted when the
+    /// capability is available, because there is nothing to remedy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remedy: Option<String>,
+}
+
+impl Capability {
+    fn available(detail: impl Into<String>) -> Self {
+        Self {
+            available: true,
+            detail: detail.into(),
+            remedy: None,
+        }
+    }
+
+    fn unavailable(detail: impl Into<String>, remedy: impl Into<String>) -> Self {
+        Self {
+            available: false,
+            detail: detail.into(),
+            remedy: Some(remedy.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesResponse {
+    /// Keyed by capability name so a client can look one up without knowing
+    /// the whole set, and so adding a capability never breaks an old reader.
+    pub capabilities: BTreeMap<String, Capability>,
+}
+
+/// Report what this deployment can do for the authenticated caller.
+///
+/// Every verdict comes from live state — the workspace store, the GitHub
+/// connection store — not from configuration alone. Configuration says what was
+/// intended; these say what is true.
+pub async fn get_capabilities(State(state): State<Arc<AppState>>) -> Json<CapabilitiesResponse> {
+    let mut capabilities = BTreeMap::new();
+
+    let workspace_count = state.workspaces.list().await.len();
+    capabilities.insert(
+        "mission_dispatch".to_string(),
+        if workspace_count > 0 {
+            Capability::available(format!(
+                "{workspace_count} workspace(s) configured; POST /api/control/missions"
+            ))
+        } else {
+            Capability::unavailable(
+                "no workspaces configured, and a mission needs one to run in",
+                "create a workspace: POST /api/workspaces",
+            )
+        },
+    );
+
+    // This is the capability the incident was actually about. The connected
+    // account's token is what gets injected into each mission workspace as git
+    // credentials (see `workspace::git_credentials`), so a connection here is
+    // the difference between a mission that can push and one that cannot.
+    capabilities.insert(
+        "github_push".to_string(),
+        match state.github_connection.get().await {
+            Some(connection) => Capability::available(format!(
+                "connected as '{}'; the token is injected into mission workspaces as git credentials",
+                connection.login
+            )),
+            None => Capability::unavailable(
+                "no GitHub account is connected, so mission workspaces get no git credentials",
+                "connect one: POST /api/integrations/github/authorize (device flow, \
+                 no per-deployment OAuth App required)",
+            ),
+        },
+    );
+
+    // Included precisely because it is the field that was misread. Naming it
+    // for what it gates, next to the two capabilities it does NOT gate, is
+    // what makes the distinction hard to miss.
+    capabilities.insert(
+        "dashboard_github_login".to_string(),
+        if state.config.auth.github_enabled() {
+            Capability::available("'Sign in with GitHub' is offered on the dashboard login screen")
+        } else {
+            Capability::unavailable(
+                "'Sign in with GitHub' is not offered on the dashboard login screen; \
+                 this gates human login only and affects neither mission dispatch nor git access",
+                "set GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, \
+                 GITHUB_OAUTH_ALLOWLIST and JWT_SECRET",
+            )
+        },
+    );
+
+    Json(CapabilitiesResponse { capabilities })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_available_capability_carries_no_remedy() {
+        // A remedy on something that already works reads as a required action
+        // and sends an agent off to "fix" a healthy deployment.
+        let capability = Capability::available("connected as 'octocat'");
+        assert!(capability.available);
+        assert!(capability.remedy.is_none());
+    }
+
+    #[test]
+    fn an_unavailable_capability_always_carries_one() {
+        let capability = Capability::unavailable("no account connected", "connect one");
+        assert!(!capability.available);
+        assert_eq!(capability.remedy.as_deref(), Some("connect one"));
+    }
+
+    #[test]
+    fn the_remedy_is_omitted_from_the_wire_when_absent() {
+        let json = serde_json::to_string(&Capability::available("fine")).expect("serialize");
+        assert!(!json.contains("remedy"), "got {json}");
+    }
+
+    /// The detail must say what was *observed*. A detail that only restates
+    /// `available` gives an agent nothing to reason with, which is how the
+    /// original misreading happened.
+    #[test]
+    fn the_detail_names_the_observation_not_the_verdict() {
+        let capability = Capability::unavailable(
+            "no GitHub account is connected, so mission workspaces get no git credentials",
+            "connect one",
+        );
+        assert!(capability.detail.contains("no GitHub account is connected"));
+        assert!(!capability.detail.eq_ignore_ascii_case("unavailable"));
+    }
+
+    #[test]
+    fn capabilities_are_keyed_by_name() {
+        // A map, not a list: a client looks up the one capability it cares
+        // about, and adding a new one never shifts an index out from under it.
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert("github_push".to_string(), Capability::available("ok"));
+        let response = CapabilitiesResponse { capabilities };
+        let json = serde_json::to_value(&response).expect("serialize");
+        assert!(json["capabilities"]["github_push"]["available"]
+            .as_bool()
+            .unwrap());
+    }
+}

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -70,6 +70,10 @@ async fn run_loop(state: Arc<AppState>) {
     loop {
         interval.tick().await;
         run_configured_sweep(&state, "scheduled").await;
+        // Container `/tmp` scratch shares this cadence but not this GC's
+        // settings: it is disk hygiene for a path no mission record points at,
+        // so it is gated only on the feature being enabled.
+        crate::container_tmp::sweep_if_enabled().await;
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,6 +20,7 @@ pub mod ask;
 mod auth;
 pub mod automation_variables;
 pub mod backends;
+pub mod capabilities;
 pub mod claudecode;
 pub mod codex_usage;
 mod console;

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1180,6 +1180,13 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             "/api/monitoring/memory-health",
             get(super::monitoring::memory_health_handler),
         )
+        // What the caller can actually do here — so an agent asks instead of
+        // inferring a capability from an auth field. Authenticated: it names
+        // the connected GitHub account.
+        .route(
+            "/api/capabilities",
+            get(super::capabilities::get_capabilities),
+        )
         // Library management endpoints
         .nest("/api/library", library_api::routes())
         // Workspace management endpoints
@@ -1488,6 +1495,7 @@ async fn health(State(state): State<Arc<AppState>>) -> (HeaderMap, Json<HealthRe
             max_iterations: state.config.max_iterations,
             library_remote,
             github_enabled: state.config.auth.github_enabled(),
+            dashboard_github_login_enabled: state.config.auth.github_enabled(),
         }),
     )
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -247,8 +247,24 @@ pub struct HealthResponse {
     /// Whether "Sign in with GitHub" is configured and offered to clients.
     /// Requires `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`,
     /// `GITHUB_OAUTH_ALLOWLIST`, and `JWT_SECRET` to all be set.
+    ///
+    /// DEPRECATED NAME, kept for the dashboard and iOS clients that already
+    /// read it. Prefer [`Self::dashboard_github_login_enabled`], which says
+    /// what the flag actually gates. An autonomous agent read this one on
+    /// 2026-08-05, concluded "GitHub is disabled in this environment", and
+    /// then concluded it could not dispatch a mission — two wrong inferences,
+    /// the first invited by the name.
     #[serde(default)]
     pub github_enabled: bool,
+
+    /// Same value as [`Self::github_enabled`], under a name that cannot be
+    /// mistaken for "this server can use GitHub". It gates one thing: the
+    /// "Sign in with GitHub" button on the dashboard login screen.
+    ///
+    /// Nothing about mission git access is derivable from it. Ask
+    /// `GET /api/capabilities` instead.
+    #[serde(default)]
+    pub dashboard_github_login_enabled: bool,
 }
 
 /// Login request for dashboard auth.

--- a/src/container_tmp.rs
+++ b/src/container_tmp.rs
@@ -1,0 +1,473 @@
+//! Disk-backed `/tmp` for container workspaces.
+//!
+//! systemd-nspawn mounts a tmpfs on `/tmp` inside every container, sized at 10%
+//! of host RAM (6.3G on a 64G box). Three consequences, all of which we hit in
+//! production on 2026-08-05:
+//!
+//! 1. **It is RAM.** Mission scratch — multi-GB audit trees, cert runs, Ask
+//!    sandbox copies — competes with the host and with `missions.slice`'s own
+//!    memory caps. Sizing it generously is not free the way disk is: eleven
+//!    containers at the default already oversubscribe a 62G box.
+//! 2. **Filling it fails quietly.** Writes return ENOSPC, but scripts that
+//!    don't check leave 0-byte logs and empty directories behind. Two
+//!    containers sat wedged at zero bytes free for ~2 days before anyone
+//!    noticed, because nothing crashed.
+//! 3. **It is invisible from the host.** The host-side `containers/<ws>/tmp` is
+//!    an empty shadow, so `df`, the disk watcher, and the workspace GC all
+//!    report reassuring numbers while the container has nothing left.
+//!
+//! When [`ROOT_ENV`] is set, each container's `/tmp` is bind-mounted from a
+//! per-workspace directory under that root instead. The margin becomes whatever
+//! the backing filesystem has, the RAM cost drops to zero, and — because it is
+//! now an ordinary host path — both the disk watcher and [`sweep_root`] below
+//! can finally see it.
+//!
+//! Unset (default) = unchanged tmpfs behaviour, so shipping this is a no-op
+//! until the env is enabled (Docker installs without systemd PID 1 keep the
+//! stock nspawn path).
+
+use std::fs;
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Host directory backing every container `/tmp`. Unset = feature disabled.
+pub const ROOT_ENV: &str = "SANDBOXED_SH_CONTAINER_TMP_ROOT";
+
+/// How long an untouched scratch entry survives a sweep.
+pub const RETENTION_ENV: &str = "SANDBOXED_SH_CONTAINER_TMP_RETENTION_HOURS";
+
+/// Conservative by default: a build can legitimately leave a tree untouched for
+/// a long stretch while it works elsewhere, and the disk-backed margin means
+/// there is no pressure to reclaim aggressively.
+pub const DEFAULT_RETENTION_HOURS: u64 = 72;
+
+/// Entries nspawn mounts *into* `/tmp` at container start. They are mount
+/// points, not scratch: removing them fails with EBUSY at best, and takes the
+/// container's X11 socket with it at worst.
+const RUNTIME_MOUNTPOINTS: &[&str] = &[".X11-unix"];
+
+/// Depth cap for the staleness walk. A pathological tree (symlink loops are
+/// excluded, but deeply nested `node_modules` are not) should cost bounded work
+/// and, when the cap is hit, be treated as *in use* rather than deleted.
+const MAX_WALK_DEPTH: usize = 64;
+
+/// Resolve the configured root, or `None` when the feature is disabled.
+pub fn root() -> Option<PathBuf> {
+    std::env::var(ROOT_ENV)
+        .ok()
+        .map(|raw| raw.trim().to_string())
+        .filter(|raw| !raw.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Reduce a workspace name to a single safe path component.
+///
+/// Workspace names reach us from user-facing configuration, so they can contain
+/// separators, `..`, or unicode. The result is only ever joined onto the
+/// configured root, and must not be able to escape it.
+pub fn sanitize_component(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            out.push(ch);
+        } else {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches(['-', '.'].as_slice()).to_string();
+    if trimmed.is_empty() {
+        "workspace".to_string()
+    } else {
+        trimmed
+    }
+}
+
+/// Per-workspace `/tmp` backing directory under `root`.
+pub fn dir_in(root: &Path, workspace_name: &str) -> PathBuf {
+    root.join(sanitize_component(workspace_name))
+}
+
+/// Per-workspace `/tmp` backing directory, or `None` when disabled.
+pub fn dir_for(workspace_name: &str) -> Option<PathBuf> {
+    root().map(|root| dir_in(&root, workspace_name))
+}
+
+/// Reset a workspace's `/tmp` backing directory ahead of a container start.
+///
+/// A container leader start *is* that container's boot, and `/tmp` is empty on
+/// boot — matching tmpfs semantics here keeps the disk-backed variant a drop-in
+/// and stops a workspace that cycles often from accumulating forever. A failed
+/// clear is not fatal: a stale tree is still a better `/tmp` than none.
+pub fn prepare(dir: &Path) -> io::Result<()> {
+    match fs::remove_dir_all(dir) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(
+                path = %dir.display(),
+                %error,
+                "Could not clear the container /tmp directory; reusing it as-is"
+            );
+        }
+    }
+    fs::create_dir_all(dir)?;
+    // Sticky + world-writable, exactly as `/tmp` is expected to be: the
+    // container runs its own uid space and unprivileged tooling writes here.
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o1777))
+}
+
+/// Configured retention for stale scratch.
+pub fn retention() -> Duration {
+    let hours = std::env::var(RETENTION_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|hours| (1..=24 * 365).contains(hours))
+        .unwrap_or(DEFAULT_RETENTION_HOURS);
+    Duration::from_secs(hours * 3600)
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SweepStats {
+    pub scanned: usize,
+    pub removed: usize,
+    pub bytes_freed: u64,
+    pub errors: usize,
+}
+
+/// Prune scratch entries that nothing has touched since `cutoff`.
+///
+/// Only the *contents* of each per-workspace directory are candidates — the
+/// workspace directory itself stays, because a running container has it
+/// bind-mounted onto `/tmp`.
+pub fn sweep_root(root: &Path, cutoff: SystemTime) -> SweepStats {
+    let mut stats = SweepStats::default();
+    let Ok(workspaces) = fs::read_dir(root) else {
+        return stats;
+    };
+    for workspace in workspaces.flatten() {
+        if workspace
+            .file_type()
+            .map(|kind| kind.is_dir())
+            .unwrap_or(false)
+        {
+            sweep_workspace_dir(&workspace.path(), cutoff, &mut stats);
+        }
+    }
+    stats
+}
+
+fn sweep_workspace_dir(dir: &Path, cutoff: SystemTime, stats: &mut SweepStats) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        stats.errors += 1;
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if RUNTIME_MOUNTPOINTS
+            .iter()
+            .any(|reserved| name == std::ffi::OsStr::new(reserved))
+        {
+            continue;
+        }
+        let path = entry.path();
+        stats.scanned += 1;
+        if !tree_is_idle_since(&path, cutoff, 0) {
+            continue;
+        }
+        let bytes = tree_size(&path, 0);
+        // `symlink_metadata`, not `is_dir()`: a symlink pointing at a directory
+        // answers `true` to the latter, and `remove_dir_all` refuses to unlink
+        // a symlink — the entry would fail every sweep forever.
+        let is_real_dir = fs::symlink_metadata(&path)
+            .map(|meta| meta.is_dir())
+            .unwrap_or(false);
+        let removed = if is_real_dir {
+            fs::remove_dir_all(&path)
+        } else {
+            fs::remove_file(&path)
+        };
+        match removed {
+            Ok(()) => {
+                stats.removed += 1;
+                stats.bytes_freed += bytes;
+            }
+            Err(error) => {
+                stats.errors += 1;
+                tracing::warn!(
+                    path = %path.display(),
+                    %error,
+                    "Could not remove stale container /tmp entry"
+                );
+            }
+        }
+    }
+}
+
+/// `true` when nothing in the tree has been modified since `cutoff`.
+///
+/// Deliberately biased toward keeping: anything we cannot stat, cannot read, or
+/// that nests deeper than [`MAX_WALK_DEPTH`] counts as active. A top-level
+/// directory's own mtime is not enough — a long build writes deep inside a tree
+/// whose root was last touched when it was created.
+fn tree_is_idle_since(path: &Path, cutoff: SystemTime, depth: usize) -> bool {
+    if depth > MAX_WALK_DEPTH {
+        return false;
+    }
+    let Ok(meta) = fs::symlink_metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    if modified >= cutoff {
+        return false;
+    }
+    // Never traverse a symlink: it can point outside the sweep root, and its
+    // own mtime is the only thing we are entitled to judge it by.
+    if !meta.is_dir() {
+        return true;
+    }
+    let Ok(entries) = fs::read_dir(path) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if !tree_is_idle_since(&entry.path(), cutoff, depth + 1) {
+            return false;
+        }
+    }
+    true
+}
+
+fn tree_size(path: &Path, depth: usize) -> u64 {
+    if depth > MAX_WALK_DEPTH {
+        return 0;
+    }
+    let Ok(meta) = fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if !meta.is_dir() {
+        return meta.len();
+    }
+    let Ok(entries) = fs::read_dir(path) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .map(|entry| tree_size(&entry.path(), depth + 1))
+        .sum()
+}
+
+/// Sweep the configured root, if the feature is enabled. Called from the
+/// mission-workspace GC loop so all periodic disk hygiene shares one cadence.
+pub async fn sweep_if_enabled() {
+    let Some(root) = root() else {
+        return;
+    };
+    let retention = retention();
+    let started = std::time::Instant::now();
+    let stats = tokio::task::spawn_blocking(move || {
+        let cutoff = SystemTime::now()
+            .checked_sub(retention)
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        sweep_root(&root, cutoff)
+    })
+    .await
+    .unwrap_or_default();
+
+    if stats.removed > 0 || stats.errors > 0 {
+        tracing::info!(
+            scanned = stats.scanned,
+            removed = stats.removed,
+            bytes_freed = stats.bytes_freed,
+            errors = stats.errors,
+            retention_hours = retention.as_secs() / 3600,
+            duration_ms = started.elapsed().as_millis() as u64,
+            "container /tmp sweep finished",
+        );
+    } else {
+        tracing::debug!(
+            scanned = stats.scanned,
+            duration_ms = started.elapsed().as_millis() as u64,
+            "container /tmp sweep found nothing to reclaim",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn touch(path: &Path, age: Duration) {
+        fs::write(path, b"x").unwrap();
+        set_age(path, age);
+    }
+
+    /// Age a symlink itself. `File::set_times` follows links, so the only way
+    /// to stamp the link (rather than its target) is `lutimes`.
+    fn set_symlink_age(path: &Path, age: Duration) {
+        use std::os::unix::ffi::OsStrExt;
+
+        let when = SystemTime::now() - age;
+        let secs = when
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as libc::time_t;
+        let times = [
+            libc::timeval {
+                tv_sec: secs,
+                tv_usec: 0,
+            },
+            libc::timeval {
+                tv_sec: secs,
+                tv_usec: 0,
+            },
+        ];
+        let raw = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        let rc = unsafe { libc::lutimes(raw.as_ptr(), times.as_ptr()) };
+        assert_eq!(rc, 0, "lutimes failed for {}", path.display());
+    }
+
+    fn set_age(path: &Path, age: Duration) {
+        let when = SystemTime::now() - age;
+        let times = fs::FileTimes::new().set_modified(when).set_accessed(when);
+        // Directories need an explicit open; `File::options` handles both.
+        let file = fs::File::options()
+            .write(!path.is_dir())
+            .read(true)
+            .open(path)
+            .unwrap();
+        file.set_times(times).unwrap();
+    }
+
+    #[test]
+    fn sanitize_component_cannot_escape_the_root() {
+        assert_eq!(sanitize_component("../../etc"), "etc");
+        assert_eq!(sanitize_component("a/b"), "a-b");
+        assert_eq!(sanitize_component(".."), "workspace");
+        assert_eq!(sanitize_component(""), "workspace");
+        assert_eq!(
+            sanitize_component("verity-integration-a"),
+            "verity-integration-a"
+        );
+
+        let root = Path::new("/srv/tmp");
+        assert_eq!(dir_in(root, "../../etc"), root.join("etc"));
+    }
+
+    #[test]
+    fn prepare_creates_a_sticky_world_writable_dir_and_clears_stale_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("assistant");
+        fs::create_dir_all(dir.join("leftover")).unwrap();
+
+        prepare(&dir).unwrap();
+
+        assert!(dir.is_dir());
+        assert!(
+            !dir.join("leftover").exists(),
+            "container /tmp starts empty"
+        );
+        let mode = fs::metadata(&dir).unwrap().permissions().mode();
+        assert_eq!(mode & 0o7777, 0o1777);
+    }
+
+    #[test]
+    fn sweep_removes_idle_trees_and_keeps_active_ones() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("dumbcontracts");
+        fs::create_dir_all(&workspace).unwrap();
+
+        // Stale: the whole tree is old.
+        let stale = workspace.join("pr25-cert.8TywLP");
+        fs::create_dir_all(&stale).unwrap();
+        touch(&stale.join("out.log"), Duration::from_secs(96 * 3600));
+        set_age(&stale, Duration::from_secs(96 * 3600));
+
+        // Active: the directory itself looks old, but a build is writing deep
+        // inside it. This is the case a top-level mtime check gets wrong.
+        let active = workspace.join("ep1039-audit.j8LCqV");
+        fs::create_dir_all(active.join("build")).unwrap();
+        touch(&active.join("build/fresh.o"), Duration::from_secs(60));
+        set_age(&active.join("build"), Duration::from_secs(96 * 3600));
+        set_age(&active, Duration::from_secs(96 * 3600));
+
+        let cutoff = SystemTime::now() - Duration::from_secs(72 * 3600);
+        let stats = sweep_root(tmp.path(), cutoff);
+
+        assert!(!stale.exists(), "idle scratch is reclaimed");
+        assert!(active.exists(), "a tree with fresh contents is left alone");
+        assert_eq!(stats.removed, 1);
+        assert_eq!(stats.scanned, 2);
+        assert_eq!(stats.errors, 0);
+    }
+
+    #[test]
+    fn sweep_never_touches_runtime_mountpoints() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("assistant");
+        let x11 = workspace.join(".X11-unix");
+        fs::create_dir_all(&x11).unwrap();
+        set_age(&x11, Duration::from_secs(30 * 24 * 3600));
+
+        let stats = sweep_root(tmp.path(), SystemTime::now());
+
+        assert!(x11.exists(), ".X11-unix is a mount point, not scratch");
+        assert_eq!(stats.removed, 0);
+        assert_eq!(stats.scanned, 0);
+    }
+
+    #[test]
+    fn sweep_reclaims_a_stale_symlink_without_following_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("misc");
+        fs::create_dir_all(&workspace).unwrap();
+
+        // Freshly-written data outside the sweep root, reachable only through a
+        // stale link inside it. Missions really do this: we saw
+        // `/tmp/b3v2 -> /workspaces/mission-a163ed85/b3v2-storage` in
+        // production. Following the link would judge the entry by the target's
+        // activity and, worse, delete someone else's files.
+        let outside = tmp.path().join("outside-target");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("keep.txt"), b"important").unwrap();
+
+        let link = workspace.join("b3v2");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        set_symlink_age(&link, Duration::from_secs(96 * 3600));
+
+        let cutoff = SystemTime::now() - Duration::from_secs(72 * 3600);
+        let stats = sweep_root(tmp.path(), cutoff);
+
+        assert!(
+            fs::symlink_metadata(&link).is_err(),
+            "the stale link itself is reclaimed"
+        );
+        assert!(
+            outside.join("keep.txt").exists(),
+            "the sweep must not follow a link out of the root"
+        );
+        assert_eq!(stats.removed, 1);
+    }
+
+    #[test]
+    fn a_fresh_symlink_keeps_its_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("misc");
+        let stale = workspace.join("mission-scratch");
+        fs::create_dir_all(&stale).unwrap();
+        std::os::unix::fs::symlink(tmp.path().join("elsewhere"), stale.join("live")).unwrap();
+        set_age(&stale, Duration::from_secs(96 * 3600));
+
+        let cutoff = SystemTime::now() - Duration::from_secs(72 * 3600);
+        let stats = sweep_root(tmp.path(), cutoff);
+
+        assert!(
+            stale.exists(),
+            "a just-created link means the tree is in use"
+        );
+        assert_eq!(stats.removed, 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod api;
 pub mod backend;
 pub mod backend_config;
 pub mod config;
+pub mod container_tmp;
 pub mod cost;
 pub mod github_connection;
 pub mod hermes_tools;

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -1719,6 +1719,31 @@ impl WorkspaceExec {
             ));
         }
 
+        // Disk-backed `/tmp` (Layer 2, opt-in). nspawn's default is a tmpfs at
+        // 10% of host RAM — small, RAM-priced, silent when it fills, and
+        // invisible to every host-side disk check. See `container_tmp`.
+        //
+        // This is bound before the X11 socket on purpose for readability only:
+        // nspawn sorts custom mounts by destination depth, so `/tmp` is mounted
+        // before `/tmp/.X11-unix` regardless of argument order.
+        if let Some(tmp_dir) = crate::container_tmp::dir_for(&self.workspace.name) {
+            match crate::container_tmp::prepare(&tmp_dir) {
+                Ok(()) => {
+                    cmd.arg(format!("--bind={}:/tmp", tmp_dir.display()));
+                }
+                Err(error) => {
+                    // Falling back to the stock tmpfs keeps the container
+                    // bootable; a workspace with no `/tmp` at all would not be.
+                    tracing::warn!(
+                        workspace = %self.workspace.name,
+                        path = %tmp_dir.display(),
+                        %error,
+                        "Could not prepare a disk-backed /tmp; falling back to the nspawn tmpfs"
+                    );
+                }
+            }
+        }
+
         let x11_socket_path = Path::new("/tmp/.X11-unix");
         if x11_socket_path.exists() {
             cmd.arg("--bind=/tmp/.X11-unix");


### PR DESCRIPTION
## The incident

2026-08-05, an autonomous controller:

> GitHub is disabled in this environment (`github_enabled: false`). The sandboxed.sh control plane at 127.0.0.1:3000 doesn't have GitHub auth wired. Without MCP access to `mcp__sandboxed_assistant__*` tools, I cannot dispatch a mission from this session.

Two inferences, both wrong. `src/config.rs:361`:

```rust
pub fn github_enabled(&self) -> bool {
    github_oauth_client_id && github_oauth_client_secret
        && !github_oauth_allowlist.is_empty() && jwt_secret
}
```

That is the **"Sign in with GitHub" button on the dashboard login screen** — a human authentication method. It gates neither mission dispatch nor a workspace's git access, and the second inference does not even follow from the first.

## Why a rename is not enough

It makes the next wrong inference less likely, not impossible. The agent was not really asking about a flag; it was asking *"may I dispatch a mission, and can it push?"* — a question the API had no way to answer. So it inferred one from the nearest field bearing the right word.

## `GET /api/capabilities`

```json
{
  "capabilities": {
    "mission_dispatch": {
      "available": true,
      "detail": "7 workspace(s) configured; POST /api/control/missions"
    },
    "github_push": {
      "available": false,
      "detail": "no GitHub account is connected, so mission workspaces get no git credentials",
      "remedy": "connect one: POST /api/integrations/github/authorize (device flow, no per-deployment OAuth App required)"
    },
    "dashboard_github_login": {
      "available": false,
      "detail": "'Sign in with GitHub' is not offered on the dashboard login screen; this gates human login only and affects neither mission dispatch nor git access",
      "remedy": "set GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, GITHUB_OAUTH_ALLOWLIST and JWT_SECRET"
    }
  }
}
```

Three fields, and the third carries most of the value:

- **`detail`** names what was *observed*, never a paraphrase of `available`. "connected as `octocat`" gives an agent something to reason with; "GitHub is available" does not.
- **`remedy`** is what ends the guessing. An agent told what would fix a situation reports a blocker; one that is not invents a cause — which is exactly what happened.

Verdicts come from live state rather than configuration: the workspace store for dispatch, the **GitHub connection store** for push. That connection's token is what `workspace::git_credentials` injects into each mission workspace, so it is the fact the incident was actually about — and it is not `github_enabled`.

`dashboard_github_login` is reported deliberately, sitting next to the two capabilities it does *not* gate. Naming it for what it gates, in that company, is what makes the distinction hard to miss.

Keyed by name, not a list, so a client can look up one capability and adding another never breaks an old reader. Authenticated, since it names the connected account.

## `/api/health`

Gains `dashboard_github_login_enabled` — same value, unmistakable name. `github_enabled` stays and keeps its value: the dashboard and the iOS client read it. It is now documented as the deprecated spelling, with the incident recorded next to it.

## Tests

5 unit tests. The two worth reading are `an_available_capability_carries_no_remedy` (a remedy on a healthy capability reads as a required action and sends an agent off to "fix" a working deployment) and `the_detail_names_the_observation_not_the_verdict`.

## Not addressed here

The second half of the agent's message — why `mcp__sandboxed_assistant__*` tools were absent from that session — is a separate matter on the Hermes side. The MCP server is configured globally in `config.yaml` with `start_mission` in its include list, so its absence was situational, not configuration. Worth making that failure loud: an agent that sees a hole where tools should be will invent a reason for it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New API surface and nspawn bind mounts affect container startup and scratch retention; behavior is opt-in for /tmp and falls back to tmpfs on prepare failure, but misconfigured roots or aggressive sweeps could delete in-use scratch.
> 
> **Overview**
> **Capabilities for agents.** New authenticated `GET /api/capabilities` returns a map of `mission_dispatch`, `github_push`, and `dashboard_github_login`, each with `available`, observed `detail`, and optional `remedy` from live workspace and GitHub-connection state—not config flags alone. `/api/health` gains `dashboard_github_login_enabled` (same value as deprecated `github_enabled`) with docs calling out the 2026-08-05 misread.
> 
> **Container `/tmp` on disk (opt-in).** When `SANDBOXED_SH_CONTAINER_TMP_ROOT` is set, nspawn leaders bind per-workspace host dirs as `/tmp` (cleared on leader start); stale scratch is swept on the mission-workspace GC interval via `SANDBOXED_SH_CONTAINER_TMP_RETENTION_HOURS`. Unset env keeps stock tmpfs. `.env.example` and `agents.md` document silent ENOSPC and host invisibility of default tmpfs.
> 
> **Ask sandbox hygiene.** Failed isolated-copy prep now calls `cleanup_sandbox` so partial trees under `/tmp` are not left behind; teardown adds `git worktree prune` after failed `worktree add`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072f4a3d5d3bb6f1807139a88cab9c0c57a2705d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->