### PR TITLE
Add adopt_mission to the two other pinned allowlist copies

### DIFF
--- a/scripts/configure_hermes_reliability.py
+++ b/scripts/configure_hermes_reliability.py
@@ -29,6 +29,7 @@ ASSISTANT_TOOLS = [
     "ask_mission",
     "cancel_mission",
     "acknowledge_mission",
+    "adopt_mission",
     "get_compute_fleet",
     "list_workspaces",
     "get_workspace",

--- a/src/hermes_tools.rs
+++ b/src/hermes_tools.rs
@@ -29,6 +29,7 @@ pub const HERMES_ASSISTANT_TOOL_ALLOWLIST: &[&str] = &[
     "ask_mission",
     "cancel_mission",
     "acknowledge_mission",
+    "adopt_mission",
     "get_compute_fleet",
     "list_workspaces",
     "get_workspace",


### PR DESCRIPTION
## What happened

#747 added `adopt_mission` to the MCP tool table only. The `tool_table_matches_canonical_allowlist` guard went red **exactly as designed** — three copies of the allowlist exist (`assistant_mcp` table, `hermes_tools::HERMES_ASSISTANT_TOOL_ALLOWLIST`, `scripts/configure_hermes_reliability.py`), and the tests exist to force them to move together.

I merged #747 with the Test check red: the branch had no required checks and my merge did not look first. This PR clears the red on master.

Both guard tests pass, full `cargo test --lib`: 1720 passed. `assistant-mcp`: 41 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical allowlist sync with no new logic; guarded by existing equality tests between the three copies.
> 
> **Overview**
> **Aligns the pinned Hermes assistant tool allowlists** with the `assistant-mcp` surface by adding **`adopt_mission`** in `src/hermes_tools.rs` and `scripts/configure_hermes_reliability.py`.
> 
> This is a follow-up to #747, which registered the tool on the MCP binary only; the existing **`tool_table_matches_canonical_allowlist`** / **`reliability_script_allowlist_matches_canonical`** guards require all three copies to change together, so this clears the failing checks on master without changing tool behavior beyond making adoption available wherever those lists drive `tools.include`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a168ba7235a3f929e9a9f7af07b05901950b96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->