### PR TITLE
Make silently-idle workers visible and debuggable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,13 @@ MAX_PARALLEL_MISSIONS=1
 # container leader next starts. Unset (default) = stock tmpfs.
 # SANDBOXED_SH_CONTAINER_TMP_ROOT=/srv/sandboxed-storage/containers-tmp
 # SANDBOXED_SH_CONTAINER_TMP_RETENTION_HOURS=72
+#
+# Idle-worker watchdog. A child (worker) mission parked in a non-terminal
+# status (pending / awaiting_user / acknowledged) with no activity for this
+# many seconds gets reported to its parent mission via a control message, so
+# the boss learns about a silently-stuck worker instead of having to poll.
+# One notification per stall episode. 0 disables. Default 3600 (1h).
+# SANDBOXED_SH_IDLE_WORKER_NOTIFY_SECS=3600
 
 # =============================================================================
 # Auth (JWT)

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5315,6 +5315,7 @@ async fn populate_activity(control: &ControlState, missions: &mut [Mission]) {
             return;
         }
     };
+    let now = chrono::Utc::now();
     for mission in missions.iter_mut() {
         if let Some((last_event, last_output)) = activity.get(&mission.id) {
             mission.activity.last_agent_event_at = last_event.clone();
@@ -5329,6 +5330,162 @@ async fn populate_activity(control: &ControlState, missions: &mut [Mission]) {
         .flatten()
         .max();
         mission.activity.last_activity_at = last_activity;
+
+        // Staleness is server-computed so consumers (LLM orchestrators
+        // especially) read a verdict word instead of doing timestamp math —
+        // in practice they don't, and idle workers go unnoticed for hours.
+        let idle_seconds = mission
+            .activity
+            .last_activity_at
+            .as_deref()
+            .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+            .map(|ts| (now - ts.with_timezone(&chrono::Utc)).num_seconds().max(0) as u64);
+        mission.activity.idle_seconds = idle_seconds;
+        mission.activity.idle_for = idle_seconds.map(humanize_idle);
+        mission.activity.health_verdict = idle_seconds
+            .and_then(|idle| mission_health_verdict(mission.status, idle))
+            .map(str::to_string);
+    }
+}
+
+/// Render a duration in seconds as a compact human string ("45s", "12m",
+/// "2h30m", "16h", "3d"). Meant for LLM/UI consumption, not parsing.
+pub(crate) fn humanize_idle(seconds: u64) -> String {
+    if seconds < 60 {
+        return format!("{}s", seconds);
+    }
+    let minutes = seconds / 60;
+    if minutes < 60 {
+        return format!("{}m", minutes);
+    }
+    let hours = minutes / 60;
+    if hours < 24 {
+        let rem_minutes = minutes % 60;
+        if hours < 6 && rem_minutes > 0 {
+            return format!("{}h{:02}m", hours, rem_minutes);
+        }
+        return format!("{}h", hours);
+    }
+    format!("{}d", hours / 24)
+}
+
+/// Server-side staleness verdict for a mission given its status and idle time.
+/// Returns `None` for terminal statuses — a finished mission is not "stalled",
+/// however old it is. Thresholds are deliberately coarse: the point is to make
+/// "this worker has produced nothing for hours" jump out of a listing, not to
+/// diagnose precisely why.
+pub(crate) fn mission_health_verdict(
+    status: MissionStatus,
+    idle_seconds: u64,
+) -> Option<&'static str> {
+    const QUIET_AFTER: u64 = 300; // 5 min without events while active
+    const STALLED_AFTER: u64 = 1800; // 30 min: something is wrong
+    const QUEUE_STUCK_AFTER: u64 = 900; // pending that never dispatched
+    const BACKGROUND_STALLED_AFTER: u64 = 21_600; // 6h of background work
+
+    let verdict = match status {
+        MissionStatus::Active => {
+            if idle_seconds < QUIET_AFTER {
+                "working"
+            } else if idle_seconds < STALLED_AFTER {
+                "quiet"
+            } else {
+                "stalled"
+            }
+        }
+        MissionStatus::Pending => {
+            if idle_seconds < QUEUE_STUCK_AFTER {
+                "queued"
+            } else {
+                "stuck_queued"
+            }
+        }
+        MissionStatus::AwaitingUser | MissionStatus::Acknowledged => {
+            if idle_seconds < STALLED_AFTER {
+                "parked"
+            } else {
+                "stalled_parked"
+            }
+        }
+        MissionStatus::WaitingBackground => {
+            if idle_seconds < BACKGROUND_STALLED_AFTER {
+                "waiting_background"
+            } else {
+                "stalled_background"
+            }
+        }
+        MissionStatus::Paused => "paused",
+        MissionStatus::Completed
+        | MissionStatus::Failed
+        | MissionStatus::Interrupted
+        | MissionStatus::Blocked
+        | MissionStatus::NotFeasible => return None,
+    };
+    Some(verdict)
+}
+
+#[cfg(test)]
+mod health_verdict_tests {
+    use super::*;
+
+    #[test]
+    fn active_missions_go_working_quiet_stalled() {
+        assert_eq!(
+            mission_health_verdict(MissionStatus::Active, 10),
+            Some("working")
+        );
+        assert_eq!(
+            mission_health_verdict(MissionStatus::Active, 600),
+            Some("quiet")
+        );
+        assert_eq!(
+            mission_health_verdict(MissionStatus::Active, 7200),
+            Some("stalled")
+        );
+    }
+
+    #[test]
+    fn parked_missions_stall_after_threshold() {
+        assert_eq!(
+            mission_health_verdict(MissionStatus::AwaitingUser, 60),
+            Some("parked")
+        );
+        // The A.3 incident shape: a worker sitting acknowledged for 16h must
+        // not read as healthy.
+        assert_eq!(
+            mission_health_verdict(MissionStatus::Acknowledged, 16 * 3600),
+            Some("stalled_parked")
+        );
+    }
+
+    #[test]
+    fn terminal_missions_have_no_verdict() {
+        assert_eq!(
+            mission_health_verdict(MissionStatus::Completed, 999_999),
+            None
+        );
+        assert_eq!(mission_health_verdict(MissionStatus::Failed, 0), None);
+    }
+
+    #[test]
+    fn pending_missions_flag_a_stuck_queue() {
+        assert_eq!(
+            mission_health_verdict(MissionStatus::Pending, 60),
+            Some("queued")
+        );
+        assert_eq!(
+            mission_health_verdict(MissionStatus::Pending, 3600),
+            Some("stuck_queued")
+        );
+    }
+
+    #[test]
+    fn idle_durations_render_compactly() {
+        assert_eq!(humanize_idle(45), "45s");
+        assert_eq!(humanize_idle(12 * 60), "12m");
+        assert_eq!(humanize_idle(2 * 3600 + 30 * 60), "2h30m");
+        assert_eq!(humanize_idle(16 * 3600), "16h");
+        assert_eq!(humanize_idle(3 * 86_400), "3d");
     }
 }
 

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -204,6 +204,20 @@ pub struct MissionActivity {
     /// consumer derive staleness with a single field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_activity_at: Option<String>,
+    /// Seconds since `last_activity_at`, computed at read time. Consumers
+    /// (LLM orchestrators especially) should never have to subtract two
+    /// RFC3339 timestamps to decide whether a worker looks alive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_seconds: Option<u64>,
+    /// Human rendering of `idle_seconds` (e.g. "16h", "2h30m", "45s").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_for: Option<String>,
+    /// Server-computed staleness verdict for non-terminal missions
+    /// (`working`, `quiet`, `stalled`, `parked`, `stalled_parked`, `queued`,
+    /// `stuck_queued`, `waiting_background`, `stalled_background`, `paused`).
+    /// Absent for terminal missions. See `mission_health_verdict`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health_verdict: Option<String>,
 }
 
 /// Durable execution truth for one mission runner generation. Mission status

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -29,7 +29,7 @@ use super::control::MissionStatus;
 #[allow(unused_imports)]
 use super::control::*;
 use super::mission_runner::TOOL_CALL_STALL_GRACE_SECS;
-use super::mission_store::{MissionExecutionState, MissionRun, MissionStore};
+use super::mission_store::{MissionExecutionState, MissionFilter, MissionRun, MissionStore};
 
 mod bg_autoresume;
 
@@ -403,6 +403,13 @@ pub(crate) async fn stuck_mission_watchdog_loop(
     // interrupted and the boss handles it, so this can never resume-storm.
     let mut auto_resumed_workers: HashSet<Uuid> = HashSet::new();
 
+    // Idle-child notification state: child id → (last_activity_at at the time
+    // we notified, notifications sent). One notification per stall episode —
+    // re-notify only if the child showed new activity and stalled again.
+    let mut idle_child_notified: std::collections::HashMap<Uuid, (String, u32)> =
+        std::collections::HashMap::new();
+    let idle_child_threshold = idle_worker_notify_threshold_secs();
+
     loop {
         tokio::time::sleep(CHECK_INTERVAL).await;
 
@@ -662,6 +669,195 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 }
             }
         }
+
+        // Case 3 — a CHILD mission parked in a non-terminal status with no
+        // activity for a long time. The boss learns about terminal workers via
+        // wait_for_worker, but a worker that ends its turn without delivering
+        // (awaiting_user → acknowledged) is silent: nothing tells the boss it
+        // has been sitting there for 16 hours. Ping the parent so detection is
+        // an event, not a discipline the boss must remember.
+        if let Some(threshold) = idle_child_threshold {
+            notify_parents_of_idle_children(
+                mission_store.as_ref(),
+                &cmd_tx,
+                threshold,
+                &mut idle_child_notified,
+            )
+            .await;
+        }
+    }
+}
+
+/// Idle threshold (seconds) before a parked child mission triggers a parent
+/// notification. Env-tunable; `0` disables the sweep entirely.
+fn idle_worker_notify_threshold_secs() -> Option<u64> {
+    const DEFAULT_SECS: u64 = 3600;
+    match std::env::var("SANDBOXED_SH_IDLE_WORKER_NOTIFY_SECS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(0) => None,
+            Ok(secs) => Some(secs),
+            Err(_) => {
+                tracing::warn!(
+                    value = %raw,
+                    "SANDBOXED_SH_IDLE_WORKER_NOTIFY_SECS is not a number; using default"
+                );
+                Some(DEFAULT_SECS)
+            }
+        },
+        Err(_) => Some(DEFAULT_SECS),
+    }
+}
+
+/// Whether a child mission's (status, idle) pair warrants pinging its parent.
+/// Only parked, non-terminal statuses count: Active stalls are the stuck-
+/// mission watchdog's job, WaitingBackground has its own auto-resume watcher,
+/// and Paused is an explicit operator decision.
+fn idle_child_needs_parent_ping(status: MissionStatus, idle_seconds: u64, threshold: u64) -> bool {
+    matches!(
+        status,
+        MissionStatus::Pending | MissionStatus::AwaitingUser | MissionStatus::Acknowledged
+    ) && idle_seconds >= threshold
+}
+
+/// Sweep recent missions for parked children idle past `threshold` and inject
+/// a strict control message into their parent mission. One notification per
+/// stall episode (keyed by the child's `last_activity` at notify time), capped
+/// per child so a permanently-ignored worker cannot spam its boss forever.
+async fn notify_parents_of_idle_children(
+    mission_store: &dyn MissionStore,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    threshold: u64,
+    notified: &mut std::collections::HashMap<Uuid, (String, u32)>,
+) {
+    const MAX_NOTIFICATIONS_PER_CHILD: u32 = 3;
+    const SCAN_LIMIT: usize = 200;
+
+    let missions = match mission_store
+        .list_missions_filtered(&MissionFilter::default(), SCAN_LIMIT, 0)
+        .await
+    {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!("Idle-child watchdog: list missions failed: {}", e);
+            return;
+        }
+    };
+
+    let candidates: Vec<_> = missions
+        .iter()
+        .filter(|m| m.parent_mission_id.is_some())
+        .filter(|m| {
+            matches!(
+                m.status,
+                MissionStatus::Pending | MissionStatus::AwaitingUser | MissionStatus::Acknowledged
+            )
+        })
+        .collect();
+
+    // Drop state for children that left the candidate set (went terminal or
+    // active again); if they re-park and stall, that's a fresh episode anyway.
+    let candidate_ids: HashSet<Uuid> = candidates.iter().map(|m| m.id).collect();
+    notified.retain(|id, _| candidate_ids.contains(id));
+
+    if candidates.is_empty() {
+        return;
+    }
+
+    let ids: Vec<Uuid> = candidates.iter().map(|m| m.id).collect();
+    let activity = match mission_store.get_mission_activity(&ids).await {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!("Idle-child watchdog: load activity failed: {}", e);
+            return;
+        }
+    };
+
+    let now = chrono::Utc::now();
+    for child in candidates {
+        // Same staleness basis as `populate_activity`: the most recent of
+        // updated_at and the newest persisted event.
+        let last_event = activity.get(&child.id).and_then(|(e, _)| e.clone());
+        let last_activity = [Some(child.updated_at.clone()), last_event]
+            .into_iter()
+            .flatten()
+            .max()
+            .unwrap_or_else(|| child.updated_at.clone());
+        let idle_seconds = match chrono::DateTime::parse_from_rfc3339(&last_activity) {
+            Ok(ts) => (now - ts.with_timezone(&chrono::Utc)).num_seconds().max(0) as u64,
+            Err(_) => continue,
+        };
+        if !idle_child_needs_parent_ping(child.status, idle_seconds, threshold) {
+            continue;
+        }
+
+        match notified.get(&child.id) {
+            // Already notified for this exact stall episode.
+            Some((at, _)) if *at == last_activity => continue,
+            Some((_, count)) if *count >= MAX_NOTIFICATIONS_PER_CHILD => continue,
+            _ => {}
+        }
+
+        let Some(parent_id) = child.parent_mission_id else {
+            continue;
+        };
+        // Never resurrect a finished orchestration over a leftover child; a
+        // terminal boss's stale workers are garbage-collection material, not
+        // an emergency.
+        match mission_store.get_mission(parent_id).await {
+            Ok(Some(parent)) if !parent.status.is_terminal() => {}
+            Ok(_) => continue,
+            Err(e) => {
+                tracing::warn!(
+                    child = %child.id,
+                    "Idle-child watchdog: parent lookup failed: {}",
+                    e
+                );
+                continue;
+            }
+        }
+
+        let idle_human = crate::api::control::humanize_idle(idle_seconds);
+        let title = child.title.as_deref().unwrap_or("untitled");
+        let content = format!(
+            "[worker-watchdog] Worker mission {id} ('{title}') has been idle for {idle} \
+in status {status}: no new events and no status change. It may be stalled, or parked \
+without having delivered. Inspect it with get_worker_diagnostics(mission_id=\"{id}\"), \
+then either send it corrective instructions (send_message_to_worker / retask_worker), \
+cancel it (cancel_worker), or accept its current output if the work is actually done. \
+This notification fires at most once per stall episode.",
+            id = child.id,
+            title = title,
+            idle = idle_human,
+            status = child.status,
+        );
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        if cmd_tx
+            .send(ControlCommand::UserMessage {
+                id: Uuid::new_v4(),
+                content,
+                agent: None,
+                target_mission_id: Some(parent_id),
+                strict: true,
+                source: Some("idle-worker-watchdog".to_string()),
+                respond: ack_tx,
+            })
+            .await
+            .is_err()
+        {
+            return; // actor gone; loop will exit on its own
+        }
+        let delivered = !matches!(ack_rx.await, Ok(UserMessageAck::Dropped));
+        let entry = notified.entry(child.id).or_insert((String::new(), 0));
+        entry.0 = last_activity;
+        entry.1 += 1;
+        tracing::info!(
+            child = %child.id,
+            parent = %parent_id,
+            idle_seconds,
+            delivered,
+            "Idle-child watchdog: notified parent of idle worker"
+        );
     }
 }
 
@@ -872,5 +1068,50 @@ mod tests {
         run.heartbeat_at = now.to_rfc3339();
         run.execution_state = MissionExecutionState::Stopping;
         assert!(!chatgpt_ui_run_proves_liveness(&run, now));
+    }
+
+    #[test]
+    fn idle_child_ping_covers_parked_statuses_past_threshold() {
+        // The A.3 incident shape: acknowledged for 16h.
+        assert!(idle_child_needs_parent_ping(
+            MissionStatus::Acknowledged,
+            16 * 3600,
+            3600
+        ));
+        assert!(idle_child_needs_parent_ping(
+            MissionStatus::AwaitingUser,
+            3600,
+            3600
+        ));
+        assert!(idle_child_needs_parent_ping(
+            MissionStatus::Pending,
+            7200,
+            3600
+        ));
+        // Below threshold: parked is normal end-of-turn, not a stall.
+        assert!(!idle_child_needs_parent_ping(
+            MissionStatus::AwaitingUser,
+            60,
+            3600
+        ));
+    }
+
+    #[test]
+    fn idle_child_ping_never_fires_for_active_terminal_or_paused() {
+        for status in [
+            MissionStatus::Active,            // stuck-mission watchdog's job
+            MissionStatus::WaitingBackground, // bg auto-resume watcher's job
+            MissionStatus::Paused,            // operator decision
+            MissionStatus::Completed,
+            MissionStatus::Failed,
+            MissionStatus::Interrupted,
+            MissionStatus::Blocked,
+            MissionStatus::NotFeasible,
+        ] {
+            assert!(
+                !idle_child_needs_parent_ping(status, 1_000_000, 3600),
+                "{status} must not trigger a parent ping"
+            );
+        }
     }
 }

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -158,6 +158,14 @@ struct GetWorkerStatusParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct GetWorkerDiagnosticsParams {
+    mission_id: String,
+    /// How many recent events to include (default 30, max 200).
+    #[serde(default)]
+    event_limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
 struct CancelWorkerParams {
     mission_id: String,
 }
@@ -800,7 +808,15 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "list_worker_missions".to_string(),
-                description: "List all worker missions spawned by this boss mission.".to_string(),
+                description: "List all worker missions spawned by this boss mission as compact rows: status, server-computed health_verdict (working/quiet/stalled/parked/stalled_parked/stuck_queued/...), idle_for, and the worker's last words. Workers needing attention are repeated in `attention`. Use get_worker_status for the full record.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {}
+                }),
+            },
+            ToolDefinition {
+                name: "check_workers_health".to_string(),
+                description: "Report ONLY the workers that look stuck: idle past server thresholds while non-terminal (verdicts stalled, stalled_parked, stuck_queued, stalled_background). Cheap — call it at the start of a turn to catch a worker that has been silently idle for hours. Empty `anomalies` means nobody is stuck.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {}
@@ -816,6 +832,24 @@ impl OrchestratorMcp {
                         "mission_id": {
                             "type": "string",
                             "description": "UUID of the worker mission"
+                        }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "get_worker_diagnostics".to_string(),
+                description: "Debug a worker that has been quiet too long: health verdict + idle time, execution state, the tail of its event stream, its last assistant message, its last error, and verification of any push it claims (did the branch actually reach the remote?). Use this BEFORE deciding to message, retask, or cancel a stalled worker.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id"],
+                    "properties": {
+                        "mission_id": {
+                            "type": "string",
+                            "description": "UUID of the worker mission to diagnose"
+                        },
+                        "event_limit": {
+                            "type": "integer",
+                            "description": "How many recent events to include (default 30, max 200)"
                         }
                     }
                 }),
@@ -1198,8 +1232,9 @@ impl OrchestratorMcp {
         Ok(mission)
     }
 
-    async fn list_workers(&self) -> Result<Value, String> {
-        // List all missions and filter for children of this boss mission
+    /// Fetch all child missions of this boss, push-claim enriched. Shared by
+    /// list_worker_missions and check_workers_health.
+    async fn fetch_workers(&self) -> Result<Vec<Value>, String> {
         let response = self
             .api_get("/api/control/missions?limit=100&offset=0")
             .await?;
@@ -1224,11 +1259,67 @@ impl OrchestratorMcp {
         for worker in workers.iter_mut() {
             enrich_with_push_claims(worker);
         }
+        Ok(workers)
+    }
+
+    async fn list_workers(&self) -> Result<Value, String> {
+        let workers = self.fetch_workers().await?;
+
+        // Compact rows instead of full mission dumps: a boss skimming ten
+        // full histories misses the one worker that has been idle for 16h.
+        // The server-computed health_verdict + idle_for are surfaced per row
+        // and anomalies are repeated in `attention` so they cannot be missed.
+        let rows: Vec<Value> = workers.iter().map(compact_worker_row).collect();
+        let attention: Vec<&Value> = rows
+            .iter()
+            .filter(|row| {
+                row.get("health_verdict")
+                    .and_then(Value::as_str)
+                    .is_some_and(verdict_is_anomalous)
+            })
+            .collect();
 
         Ok(json!({
-            "boss_mission_id": boss_id,
-            "worker_count": workers.len(),
-            "workers": workers,
+            "boss_mission_id": self.mission_id.to_string(),
+            "worker_count": rows.len(),
+            "workers": rows,
+            "attention": attention,
+            "hint": "Rows are compact. Use get_worker_status for the full mission record, and get_worker_diagnostics for any worker whose health_verdict is stalled/stalled_parked/stuck_queued.",
+        }))
+    }
+
+    /// Report only the workers that need the boss's attention. Cheap to call
+    /// at the start of every turn: an empty `anomalies` array means no worker
+    /// is silently stuck.
+    async fn check_workers_health(&self) -> Result<Value, String> {
+        let workers = self.fetch_workers().await?;
+        let checked = workers.len();
+        let anomalies: Vec<Value> = workers
+            .iter()
+            .filter(|w| {
+                worker_activity_field(w, "health_verdict")
+                    .and_then(Value::as_str)
+                    .is_some_and(verdict_is_anomalous)
+            })
+            .map(|w| {
+                let mut row = compact_worker_row(w);
+                let hint = stalled_worker_hint(&row);
+                if let Some(obj) = row.as_object_mut() {
+                    obj.insert("hint".to_string(), json!(hint));
+                }
+                row
+            })
+            .collect();
+
+        Ok(json!({
+            "checked": checked,
+            "anomaly_count": anomalies.len(),
+            "anomalies": anomalies,
+            "note": if anomalies.is_empty() {
+                "All workers are either progressing normally or in a terminal status."
+            } else {
+                "These workers have produced nothing for a long time. Diagnose each with get_worker_diagnostics before deciding to message, retask, or cancel it."
+            },
         }))
     }
 
@@ -1254,6 +1345,87 @@ impl OrchestratorMcp {
         enrich_with_push_claims(&mut mission);
 
         Ok(mission)
+    }
+
+    /// Debug view of one worker: health verdict, execution truth, the tail of
+    /// its event stream, its last words, its last error, and whether any push
+    /// it claims actually reached the remote. This is the tool to reach for
+    /// when a worker has been quiet too long and "status" alone explains
+    /// nothing.
+    async fn get_worker_diagnostics(
+        &self,
+        params: GetWorkerDiagnosticsParams,
+    ) -> Result<Value, String> {
+        let id = Uuid::parse_str(&params.mission_id)
+            .map_err(|_| "Invalid mission ID format".to_string())?;
+
+        let response = self
+            .api_get(&format!("/api/control/missions/{}", id))
+            .await?;
+        if !response.status().is_success() {
+            return Err(format!("Worker mission not found: {}", response.status()));
+        }
+        let mission: Value = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+        // Push claims are verified for ANY status here (get_worker_status only
+        // checks completed workers): a "busy" worker that claims pushes which
+        // never reached the remote is exactly the silent-no-op case.
+        let push_claims = compute_push_claims(&mission);
+
+        // Tail of the persisted event stream, most recent last.
+        let event_limit = params.event_limit.unwrap_or(30).clamp(1, 200);
+        let events_response = self
+            .api_get(&format!(
+                "/api/control/missions/{}/events?before_seq={}&limit={}&include_counts=false",
+                id,
+                i64::MAX,
+                event_limit
+            ))
+            .await?;
+        let events: Vec<Value> = if events_response.status().is_success() {
+            events_response.json().await.unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let recent_events: Vec<Value> = events.iter().map(compact_event).collect();
+        let last_error = events
+            .iter()
+            .rev()
+            .find(|e| {
+                e.get("event_type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|t| t.contains("error"))
+            })
+            .map(compact_event);
+
+        let compact = compact_worker_row(&mission);
+        let hint = stalled_worker_hint(&compact);
+
+        Ok(json!({
+            "mission_id": id.to_string(),
+            "title": mission.get("title"),
+            "status": mission.get("status"),
+            "health": {
+                "verdict": worker_activity_field(&mission, "health_verdict"),
+                "idle_seconds": worker_activity_field(&mission, "idle_seconds"),
+                "idle_for": worker_activity_field(&mission, "idle_for"),
+                "last_activity_at": worker_activity_field(&mission, "last_activity_at"),
+                "last_output_at": worker_activity_field(&mission, "last_output_at"),
+            },
+            "execution": mission.get("execution"),
+            "awaiting_kind": mission.get("awaiting_kind"),
+            "terminal_reason": mission.get("terminal_reason"),
+            "working_directory": mission.get("working_directory"),
+            "last_assistant_message": last_assistant_message(&mission)
+                .map(|s| truncate_chars(&s, 2000)),
+            "last_error": last_error,
+            "recent_events": recent_events,
+            "push_claims": push_claims,
+            "hint": hint,
+        }))
     }
 
     async fn cancel_worker(&self, params: CancelWorkerParams) -> Result<Value, String> {
@@ -2448,6 +2620,28 @@ impl OrchestratorMcp {
             // Check timeout
             if start.elapsed() > timeout {
                 let was_clamped = params.timeout_seconds > MAX_INTERNAL_TIMEOUT_SECS;
+                // If the worker produced nothing for longer than this entire
+                // wait, "call again" is the wrong advice — escalate to
+                // diagnostics instead of letting the boss poll a corpse.
+                let idle_seconds =
+                    worker_activity_field(&mission, "idle_seconds").and_then(Value::as_u64);
+                let verdict = worker_activity_field(&mission, "health_verdict")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let looks_stalled = verdict.as_deref().is_some_and(verdict_is_anomalous)
+                    || idle_seconds.is_some_and(|idle| idle > start.elapsed().as_secs().max(300));
+                let hint = if looks_stalled {
+                    format!(
+                        "Worker produced NO activity during this entire wait (idle {}, verdict {}). It may be stalled: run get_worker_diagnostics(mission_id=\"{}\") before waiting again, then message/retask/cancel it.",
+                        worker_activity_field(&mission, "idle_for")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown"),
+                        verdict.as_deref().unwrap_or("unknown"),
+                        id
+                    )
+                } else {
+                    "Worker has not reached a target status yet. Call wait_for_worker again to continue waiting.".to_string()
+                };
                 return Ok(json!({
                     "reached_target": false,
                     "internal_timeout": was_clamped,
@@ -2456,8 +2650,10 @@ impl OrchestratorMcp {
                     "elapsed_seconds": start.elapsed().as_secs(),
                     "effective_timeout_seconds": effective_timeout_secs,
                     "requested_timeout_seconds": params.timeout_seconds,
+                    "idle_seconds": idle_seconds,
+                    "health_verdict": verdict,
                     "mission": mission,
-                    "hint": "Worker has not reached a target status yet. Call wait_for_worker again to continue waiting.",
+                    "hint": hint,
                 }));
             }
 
@@ -2596,10 +2792,16 @@ impl OrchestratorMcp {
                 self.batch_create_workers(params).await
             }
             "list_worker_missions" => self.list_workers().await,
+            "check_workers_health" => self.check_workers_health().await,
             "get_worker_status" => {
                 let params: GetWorkerStatusParams =
                     serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
                 self.get_worker_status(params).await
+            }
+            "get_worker_diagnostics" => {
+                let params: GetWorkerDiagnosticsParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.get_worker_diagnostics(params).await
             }
             "cancel_worker" => {
                 let params: CancelWorkerParams =
@@ -3096,17 +3298,27 @@ fn enrich_with_push_claims(mission: &mut Value) {
         return;
     }
 
-    let Some(content) = last_assistant_message(mission) else {
+    let Some(claims) = compute_push_claims(mission) else {
         return;
     };
 
+    if let Some(obj) = mission.as_object_mut() {
+        obj.insert("push_claims".to_string(), Value::Array(claims));
+    }
+}
+
+/// Verify any push the worker's last message claims, for a mission in ANY
+/// status. Returns `None` when there is no push claim to verify.
+fn compute_push_claims(mission: &Value) -> Option<Vec<Value>> {
+    let content = last_assistant_message(mission)?;
+
     if !looks_like_push_claim(&content) {
-        return;
+        return None;
     }
 
     let branches = extract_branch_candidates(&content);
     if branches.is_empty() {
-        return;
+        return None;
     }
 
     let working_directory = mission
@@ -3130,10 +3342,92 @@ fn enrich_with_push_claims(mission: &mut Value) {
             "verified": verified,
         }));
     }
+    Some(claims)
+}
 
-    if let Some(obj) = mission.as_object_mut() {
-        obj.insert("push_claims".to_string(), Value::Array(claims));
+/// Server-computed verdicts that mean a worker needs the boss's attention.
+fn verdict_is_anomalous(verdict: &str) -> bool {
+    matches!(
+        verdict,
+        "stalled" | "stalled_parked" | "stuck_queued" | "stalled_background"
+    )
+}
+
+fn worker_activity_field<'a>(worker: &'a Value, key: &str) -> Option<&'a Value> {
+    worker.get("activity").and_then(|a| a.get(key))
+}
+
+/// Truncate to a character budget with an ellipsis, safe on any UTF-8.
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
     }
+    let mut out: String = s.chars().take(max_chars).collect();
+    out.push('…');
+    out
+}
+
+/// One compact row per worker for listings: enough to triage without paging
+/// through full mission histories. `health_verdict`/`idle_for` come from the
+/// server (`activity` block); `last_assistant_snippet` is the worker's last
+/// words, truncated.
+fn compact_worker_row(worker: &Value) -> Value {
+    json!({
+        "id": worker.get("id"),
+        "title": worker.get("title"),
+        "status": worker.get("status"),
+        "health_verdict": worker_activity_field(worker, "health_verdict"),
+        "idle_for": worker_activity_field(worker, "idle_for"),
+        "last_activity_at": worker_activity_field(worker, "last_activity_at"),
+        "backend": worker.get("backend"),
+        "awaiting_kind": worker.get("awaiting_kind"),
+        "terminal_reason": worker.get("terminal_reason"),
+        "working_directory": worker.get("working_directory"),
+        "last_assistant_snippet": last_assistant_message(worker)
+            .map(|s| truncate_chars(&s, 240)),
+        "push_claims": worker.get("push_claims"),
+    })
+}
+
+/// Actionable next step for a worker row, derived from its health verdict.
+fn stalled_worker_hint(row: &Value) -> Option<String> {
+    let verdict = row.get("health_verdict").and_then(Value::as_str)?;
+    let idle = row
+        .get("idle_for")
+        .and_then(Value::as_str)
+        .unwrap_or("a long time");
+    let id = row.get("id").and_then(Value::as_str).unwrap_or("<id>");
+    let hint = match verdict {
+        "stalled" => format!(
+            "Worker has been active but silent for {idle}. Run get_worker_diagnostics(mission_id=\"{id}\") to see its last events before deciding anything."
+        ),
+        "stalled_parked" => format!(
+            "Worker parked {idle} ago without a follow-up. It may have ended its turn without delivering: run get_worker_diagnostics(mission_id=\"{id}\"), then send_message_to_worker/retask_worker with concrete next steps, or cancel_worker if its work is obsolete."
+        ),
+        "stuck_queued" => format!(
+            "Worker has been pending for {idle} without dispatching. Check queue/scheduling constraints, or resume it with send_message_to_worker."
+        ),
+        "stalled_background" => format!(
+            "Worker has waited on background jobs for {idle}. Run get_worker_diagnostics(mission_id=\"{id}\") to check whether the job is alive."
+        ),
+        _ => return None,
+    };
+    Some(hint)
+}
+
+/// Compact projection of a persisted mission event for diagnostics output.
+fn compact_event(event: &Value) -> Value {
+    let content = event
+        .get("content")
+        .and_then(Value::as_str)
+        .map(|s| truncate_chars(s, 400));
+    json!({
+        "sequence": event.get("sequence"),
+        "type": event.get("event_type"),
+        "timestamp": event.get("timestamp"),
+        "tool_name": event.get("tool_name"),
+        "content": content,
+    })
 }
 
 /// Heuristic: did the worker claim to have pushed?
@@ -3706,8 +4000,10 @@ mod codex_auth_status_tests {
 #[cfg(test)]
 mod push_claim_tests {
     use super::{
-        ask_settled, enrich_with_push_claims, extract_branch_candidates, history_fingerprint,
-        is_plausible_branch, last_assistant_message, looks_like_push_claim, AskWorkerBaseline,
+        ask_settled, compact_event, compact_worker_row, enrich_with_push_claims,
+        extract_branch_candidates, history_fingerprint, is_plausible_branch,
+        last_assistant_message, looks_like_push_claim, stalled_worker_hint, truncate_chars,
+        verdict_is_anomalous, AskWorkerBaseline,
     };
     use serde_json::json;
 
@@ -3837,6 +4133,96 @@ mod push_claim_tests {
             last_assistant_message(&json!({ "history": [{ "role": "user", "content": "hi" }] })),
             None
         );
+    }
+
+    #[test]
+    fn compact_worker_row_surfaces_health_and_last_words() {
+        let worker = json!({
+            "id": "abc-123",
+            "title": "A.3 allocation extraction",
+            "status": "acknowledged",
+            "backend": "codex",
+            "activity": {
+                "health_verdict": "stalled_parked",
+                "idle_for": "16h",
+                "last_activity_at": "2026-08-05T00:00:00Z"
+            },
+            "history": [
+                { "role": "assistant", "content": "Acknowledged, starting on the extraction." }
+            ]
+        });
+        let row = compact_worker_row(&worker);
+        assert_eq!(row["health_verdict"], "stalled_parked");
+        assert_eq!(row["idle_for"], "16h");
+        assert_eq!(
+            row["last_assistant_snippet"],
+            "Acknowledged, starting on the extraction."
+        );
+        // No full history in the row.
+        assert!(row.get("history").is_none());
+    }
+
+    #[test]
+    fn anomalous_verdicts_are_exactly_the_stuck_ones() {
+        for v in [
+            "stalled",
+            "stalled_parked",
+            "stuck_queued",
+            "stalled_background",
+        ] {
+            assert!(verdict_is_anomalous(v), "{v} must be anomalous");
+        }
+        for v in [
+            "working",
+            "quiet",
+            "parked",
+            "queued",
+            "waiting_background",
+            "paused",
+            "",
+        ] {
+            assert!(!verdict_is_anomalous(v), "{v} must not be anomalous");
+        }
+    }
+
+    #[test]
+    fn stalled_worker_hint_names_the_worker_and_the_next_tool() {
+        let row = json!({
+            "id": "abc-123",
+            "health_verdict": "stalled_parked",
+            "idle_for": "16h"
+        });
+        let hint = stalled_worker_hint(&row).expect("hint for stalled_parked");
+        assert!(hint.contains("16h"));
+        assert!(hint.contains("get_worker_diagnostics(mission_id=\"abc-123\")"));
+        assert!(stalled_worker_hint(&json!({ "health_verdict": "working" })).is_none());
+        assert!(stalled_worker_hint(&json!({})).is_none());
+    }
+
+    #[test]
+    fn truncate_chars_is_utf8_safe() {
+        assert_eq!(truncate_chars("short", 10), "short");
+        assert_eq!(truncate_chars("abcdef", 3), "abc…");
+        // Multi-byte chars must not be split.
+        assert_eq!(truncate_chars("héllo wörld", 5), "héllo…");
+    }
+
+    #[test]
+    fn compact_event_truncates_content() {
+        let event = json!({
+            "sequence": 42,
+            "event_type": "tool_result",
+            "timestamp": "2026-08-05T12:00:00Z",
+            "tool_name": "bash",
+            "content": "x".repeat(1000),
+            "metadata": { "huge": "blob" }
+        });
+        let compact = compact_event(&event);
+        assert_eq!(compact["sequence"], 42);
+        assert_eq!(compact["type"], "tool_result");
+        let content = compact["content"].as_str().unwrap();
+        assert!(content.chars().count() <= 401);
+        assert!(compact.get("metadata").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## The incident

During the Lido/verity campaign, worker A.3 sat in `acknowledged` for **16 hours** with no PR and no activity before a human noticed. The raw signal existed the whole time — `activity.last_activity_at`, run heartbeats — but nothing distilled it into something a boss agent actually reads, and nothing *pushed* the anomaly at anyone. Detection relied on the boss remembering to subtract two RFC3339 timestamps; in practice it never does.

*(Follow-up to the mission-observability thread; intended for #747 originally, but that PR merged while this was being built.)*

## Four pieces, ordered by what would have prevented the 16h

**1. Idle-child watchdog → parent notification (`supervision.rs`)**
A child mission parked in a non-terminal status (`pending` / `awaiting_user` / `acknowledged`) with no activity past `SANDBOXED_SH_IDLE_WORKER_NOTIFY_SECS` (default 1h, `0` disables) gets reported to its **parent** via a strict control message naming the worker, its idle time, and the tools to react with. One notification per stall episode (keyed by the child's `last_activity` at notify time), capped at 3 per child, never fired at a terminal boss (a finished orchestration's leftovers are GC material, not an emergency). `Active` stalls stay the stuck-mission watchdog's job; `WaitingBackground` has its own auto-resume watcher; `Paused` is an operator decision. Detection becomes an event, not a discipline.

**2. Server-computed health verdict (`populate_activity`)**
Every non-terminal mission now carries `activity.idle_seconds`, `activity.idle_for` (`"16h"`), and `activity.health_verdict` (`working` / `quiet` / `stalled` / `parked` / `stalled_parked` / `queued` / `stuck_queued` / `waiting_background` / `stalled_background` / `paused`). Thresholds live server-side in one pure function; consumers — the dashboard, the orchestrator MCP, Hermes crons over REST — read a word.

**3. Orchestrator MCP triage + debug tools**
- `list_worker_missions` now returns **compact rows** (status, verdict, `idle_for`, last words, push claims) instead of full mission dumps, with anomalous workers repeated in `attention` so they can't be skimmed past.
- New `check_workers_health`: only the workers that look stuck, with per-worker actionable hints. Cheap to call at the start of every boss turn; empty `anomalies` = nobody is silently stuck.
- New `get_worker_diagnostics`: tail of the persisted event stream, last assistant message, last error, execution truth (state / heartbeat), and **push-claim verification for any status** — `get_worker_status` only verifies completed workers, but a busy-looking worker whose claimed pushes never reached the remote is exactly the silent-no-op case.

**4. `wait_for_worker` timeout escalation**
When the worker produced no activity for the entire wait window (or its verdict is anomalous), the timeout hint stops saying "call again" and points at `get_worker_diagnostics` → message / retask / cancel. The timeout payload now carries `idle_seconds` + `health_verdict`.

## Notes

- `.env.example` documents the new knob next to the other mission-resource envs.
- Watchdog delivery reuses the strict `UserMessage` path (same as board wake / worker dispatch): it reaches its exact target or is dropped, never leaks into another mission.
- Default-on with a 1h threshold; ops can retune or disable per install.

## Tests

- `health_verdict_tests` (5): verdict thresholds incl. the A.3 shape (acknowledged 16h → `stalled_parked`), terminal missions get no verdict, `humanize_idle` rendering.
- `supervision::tests` (+2): parent-ping predicate covers exactly the parked statuses past threshold; never fires for active/terminal/paused/waiting_background.
- `push_claim_tests` (+5): compact rows surface verdict + last words and drop history; anomalous-verdict set; hint names the worker and the next tool; UTF-8-safe truncation; event compaction.
- Full suites green: lib 1719 passed, orchestrator-mcp 32 passed, assistant-mcp 41 passed. `cargo fmt --all --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a default-on supervision path that injects control messages into parent missions and changes MCP list/diagnostic behavior; logic is bounded and tested but affects orchestration loops in production.
> 
> **Overview**
> Makes **silently idle worker missions** visible to orchestrators and bosses without manual timestamp math.
> 
> **Mission API activity** now includes `idle_seconds`, `idle_for`, and a status-aware **`health_verdict`** (e.g. `stalled`, `stalled_parked`, `stuck_queued`), computed in `populate_activity` via `mission_health_verdict` and `humanize_idle`.
> 
> **Supervision loop** gains an **idle-child watchdog**: parked child missions (`pending` / `awaiting_user` / `acknowledged`) idle past `SANDBOXED_SH_IDLE_WORKER_NOTIFY_SECS` (default 1h, `0` off) trigger a **strict `UserMessage` to the parent** boss, once per stall episode (max 3), only if the parent is still non-terminal. `.env.example` documents the knob.
> 
> **Orchestrator MCP** changes worker ergonomics: `list_worker_missions` returns **compact rows** plus an `attention` list; new **`check_workers_health`** and **`get_worker_diagnostics`** (event tail, errors, push-claim verification for any status); **`wait_for_worker`** timeouts escalate to diagnostics when the worker looked stalled for the whole wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a847efcbcf42fb08d8b52a09f01213f08656b88a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->