### PR TITLE
Give ask_mission real margin under the cron idle watchdog

### DIFF
--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1959,14 +1959,22 @@ impl AssistantMcp {
             let tid = parse_uuid(tid)?;
             body["thread_id"] = json!(tid.to_string());
         }
-        // Ask turns make multiple sequential LLM/tool calls; give the
-        // synchronous /ask request most of the Hermes-side 600s MCP budget
-        // (the shared client default of 120s would abort long asks).
+        // Ask turns make multiple sequential LLM/tool calls, so the shared
+        // client default of 120s would abort long asks. But TWO budgets sit
+        // above this call, and both are 600s: the Hermes-side MCP request
+        // timeout, and the cron scheduler's idle watchdog — which counts from
+        // the moment the tool STARTS, so id resolution, connect time and this
+        // whole request all spend it. At 570s the margin was 30s; measured
+        // 2026-08-06 05:18, a busy mission ate it and the watchdog killed the
+        // whole tick ("idle for 600s — last activity: executing tool:
+        // ask_mission"), turning one slow answer into a failed controller
+        // run. 450s keeps ample room for real asks and returns a clean
+        // "mission busy" error while both outer budgets still have 150s left.
         let response = self
             .api_post_with_timeout(
                 &format!("/api/control/missions/{id}/ask"),
                 body,
-                Some(std::time::Duration::from_secs(570)),
+                Some(std::time::Duration::from_secs(450)),
             )
             .await?;
         if !response.status().is_success() {


### PR DESCRIPTION
## Measured

```
05:18:18 ERROR cron.scheduler: Job 'MiniMax-M3 benchmark full-263 status'
  idle for 600s (inactivity limit 600s)
  last_activity=executing tool: mcp__sandboxed_assistant__ask_mission
```

One slow answer from a busy mission killed the whole controller tick, and the delivered report blamed *"provider timeout. Fallback chain was exhausted"* — wrong on both counts.

## Why 570s was never safe

The 570s HTTP timeout was sized against one budget: the Hermes-side 600s MCP request timeout. But a **second** 600s budget sits above the call — the cron scheduler's idle watchdog — and it counts from the moment the tool *starts*. Short-id resolution and connect time spend it before the HTTP clock even begins. The 30s margin was an assumption that all overhead fits in 30s; on 2026-08-06 it did not.

## The change

570 → **450s**. Ample for real ask turns (the healthy ones observed run well under that), and a hung ask now returns a clean "mission busy" error while both outer budgets still hold 150s — the controller tick survives, reports the busy mission truthfully, and retries next tick.

One line plus the comment that names both budgets, so the next person sizing this timeout knows the watchdog exists — not knowing it is exactly how 570 happened.

`assistant-mcp`: 41 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single timeout constant and comment in assistant-mcp; behavior change is earlier timeout on hung asks, intended to improve cron job reliability.
> 
> **Overview**
> Lowers the per-request HTTP timeout for **`ask_mission`** from **570s to 450s** so slow asks fail with a bounded client error instead of running until the **cron scheduler’s 600s idle watchdog** (which starts when the tool begins, not when the HTTP call starts) kills the whole controller tick.
> 
> The inline comment now documents **both** outer 600s limits—the Hermes MCP request timeout and the cron idle watchdog—and why margin must cover id resolution and connect time before the POST clock runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1870bdc236f446f868cbd720201765c848051d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->