### PR TITLE
chatgpt-ui: accept sidebar nav as authentication evidence

### DIFF
--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -481,6 +481,22 @@ async def verify_authentication(page) -> None:
         if await account_controls.nth(index).is_visible():
             emit("diagnostic", message="stage=account_confirmed")
             return
+
+    # A UI rollout renamed the profile button and this check began failing
+    # closed on PROVISIONED profiles: measured 2026-08-06, all 12 pool
+    # profiles held session cookies valid for ~90 days while every mission
+    # died in seconds with "login is required". The sidebar's Library and
+    # Scheduled entries are account-only surfaces (anonymous ChatGPT has
+    # neither) and survive the rename — accept them as evidence before
+    # concluding the account is gone.
+    nav_evidence = page.locator(
+        'a[href*="/library"], a[href*="/scheduled"], '
+        '[data-testid="create-scheduled-task-button"]'
+    )
+    for index in range(await nav_evidence.count()):
+        if await nav_evidence.nth(index).is_visible():
+            emit("diagnostic", message="stage=account_confirmed_via_nav")
+            return
     raise PermissionError("authenticated account control not found")
 
 


### PR DESCRIPTION
## Measured

Three GPT-5.6 Pro cross-validation attempts died with `auth_error: "ChatGPT login is required in the configured profile; provision it interactively"` — in **~3 seconds** each, and the dispatching agent concluded the pool was systemically broken and asked the operator to re-provision 12 logins.

Ground truth, checked cookie-by-cookie on every profile:

```
chatgpt-profile      __Secure-next-auth.session-token   valid 90.0 d
chatgpt-profile-2..12                                   valid 86.9–88.5 d
```

**All twelve profiles are logged in.** Nothing needed re-provisioning.

## Cause

`verify_authentication` fails closed when no account-only control is visible:

```python
'[data-testid="accounts-profile-button"], button[aria-label*="account" i], …'
```

A ChatGPT UI rollout renamed those controls (the manual re-auth recipe recorded this on 2026-08-05: *"l'aria-label ne prouve plus rien — juge sur la nav Library+Scheduled"*). So a fully authenticated page raised `PermissionError("authenticated account control not found")`, reported as a login problem, quarantined the slot, and poisoned the pool's failure counters.

Fail-closed was the right design; the evidence list was just stale.

## The change

After the existing profile-button probe, accept the sidebar's **Library** and **Scheduled** entries as authentication evidence — account-only surfaces (anonymous ChatGPT has neither) that survive the rename, and exactly what the manual recipe already judges by. The login-button / `/auth/` URL check above is untouched: a genuinely logged-out profile still fails immediately.

## Also worth recording

The pool status API reports `state: "available"` for a slot that has simply *not failed recently* — it is not a login check, and reading it as one is what convinced the agent all 12 were fine while it simultaneously believed none could log in. The cookie sweep is the cheap ground truth; the probe script (`/root/probe_chatgpt_profiles.py`) is the full one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow selector addition in the UI driver’s auth probe; no changes to login detection or session handling.
> 
> **Overview**
> **`verify_authentication`** in `chatgpt_ui_driver.py` no longer treats a missing profile/account button as proof the session is logged out when the sidebar still shows account-only navigation.
> 
> After the existing profile-button probe, it now accepts visible **Library** or **Scheduled** links (and the scheduled-task control) as auth evidence and emits `stage=account_confirmed_via_nav`. The login-button and `/auth/` URL checks are unchanged, so genuinely logged-out profiles still fail fast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26bfb55bed34d17f6e56b80e3055ca1cdafa408b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->