### PR TITLE
Hide STATE_SIGNATURE trailers in Hermes views and name sessions by routing key

### DIFF
--- a/dashboard/src/app/control/components/HermesConversation.tsx
+++ b/dashboard/src/app/control/components/HermesConversation.tsx
@@ -27,6 +27,7 @@ import {
   type HermesOutboxEntry,
 } from "@/lib/hermes-outbox";
 import { EnhancedInput } from "@/components/enhanced-input";
+import { stateSignatureKeyFromMessages } from "@/lib/hermes-state-signature";
 import { cn } from "@/lib/utils";
 
 import {
@@ -71,6 +72,10 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [session, setSession] = useState<HermesSession | null>(null);
+  // Routing key from the transcript's last [STATE_SIGNATURE: …] trailer —
+  // the display name of last resort for sessions that never got a title
+  // (cron controllers), matching what the desktop sidebar shows.
+  const [signatureKey, setSignatureKey] = useState<string | null>(null);
   const [workerMissions, setWorkerMissions] = useState<Mission[]>([]);
   const [input, setInput] = useState("");
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(
@@ -152,6 +157,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
       const messages = await getHermesSessionMessages(sessionId);
       if (disposed || generationRef.current !== generation) return;
       transcript.reset(hermesHistoryToItems(messages));
+      setSignatureKey(stateSignatureKeyFromMessages(messages));
       syncFromTranscript();
       setHistoryLoaded(true);
     };
@@ -193,6 +199,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
         : await getHermesSessionMessages(sessionId);
       if (disposed || generationRef.current !== generation) return;
       transcript.reset(hermesHistoryToItems(messages));
+      setSignatureKey(stateSignatureKeyFromMessages(messages));
       transcript.running = Boolean(result?.running);
 
       const pending = getHermesOutbox(sessionId);
@@ -333,6 +340,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
           const transcript = transcriptRef.current;
           if (!transcript.running && fresh.length !== transcript.items.length) {
             transcript.reset(fresh);
+            setSignatureKey(stateSignatureKeyFromMessages(messages));
             syncFromTranscript();
           }
         } catch {
@@ -539,6 +547,7 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
 
   const title =
     session?.title?.trim() ||
+    signatureKey ||
     session?.preview?.trim() ||
     `Session ${sessionId.slice(0, 8)}`;
 

--- a/dashboard/src/app/control/hermes-session-adapter.ts
+++ b/dashboard/src/app/control/hermes-session-adapter.ts
@@ -1,5 +1,6 @@
 import type { HermesMessage } from "@/lib/api";
 import type { HermesGatewayEvent } from "@/lib/hermes-gateway";
+import { stripStateSignature } from "@/lib/hermes-state-signature";
 import type { ChatItem } from "./events-reducer";
 
 /**
@@ -58,7 +59,12 @@ export function hermesHistoryToItems(messages: HermesMessage[]): ChatItem[] {
     const id =
       message.id == null ? localId("hh") : `hermes-msg-${String(message.id)}`;
     const timestamp = parseTimestamp(message.timestamp);
-    const content = (message.content ?? "").trim();
+    const rawContent = (message.content ?? "").trim();
+    // STATE_SIGNATURE trailers are controller routing metadata, not prose:
+    // strip them from conversational rows. Tool results keep the raw text —
+    // a tool output that legitimately ends with a signature (e.g. reading
+    // the tracker page) must not be truncated.
+    const content = stripStateSignature(rawContent).trim();
 
     if (message.role === "user") {
       if (content) {
@@ -134,19 +140,19 @@ export function hermesHistoryToItems(messages: HermesMessage[]): ChatItem[] {
         if (existing.kind === "tool") {
           items[index] = {
             ...existing,
-            result: content,
+            result: rawContent,
             hasResult: true,
             endTime: timestamp,
           };
         }
-      } else if (content) {
+      } else if (rawContent) {
         items.push({
           kind: "tool",
           id,
           toolCallId: callId ?? id,
           name: message.tool_name ?? "tool",
           args: undefined,
-          result: content,
+          result: rawContent,
           isUiTool: false,
           startTime: timestamp,
           endTime: timestamp,
@@ -270,7 +276,7 @@ export class HermesLiveTranscript {
 
   private finalizeAssistant(finalText?: string) {
     this.finalizeThinking();
-    const text = (finalText ?? this.streamText).trim();
+    const text = stripStateSignature(finalText ?? this.streamText).trim();
     const streamId = this.streamItemId;
     this.streamItemId = null;
     this.streamText = "";

--- a/dashboard/src/components/hermes/hermes-thread.tsx
+++ b/dashboard/src/components/hermes/hermes-thread.tsx
@@ -24,6 +24,7 @@ import {
   type HermesSession,
 } from "@/lib/api";
 import { LazyMarkdownContent } from "@/components/markdown-content";
+import { stripStateSignature } from "@/lib/hermes-state-signature";
 import { cn } from "@/lib/utils";
 
 /** One rendered row in the Hermes transcript. Tool/thinking rows are built
@@ -52,7 +53,8 @@ function persistedRows(messages: HermesMessage[]): ChatItem[] {
         ? localId("hist")
         : `persisted-${String(message.id)}`;
     if (message.role === "user" || message.role === "assistant") {
-      const content = (message.content ?? "").trim();
+      // STATE_SIGNATURE trailers are controller routing metadata, not prose.
+      const content = stripStateSignature(message.content ?? "").trim();
       if (content) rows.push({ id, role: message.role, content });
     } else if (message.role === "tool") {
       rows.push({
@@ -346,8 +348,13 @@ export function HermesThread({ className }: { className?: string }) {
               return next;
             });
           },
-          onCompleted: (finalContent) => {
-            if (stale() || !finalContent.trim()) return;
+          onCompleted: (rawFinalContent) => {
+            if (stale() || !rawFinalContent.trim()) return;
+            // The deltas may have streamed a STATE_SIGNATURE trailer into the
+            // bubble; the authoritative patch below erases it. A signature-only
+            // turn patches the bubble to empty rather than leaving metadata.
+            const finalContent = stripStateSignature(rawFinalContent).trim();
+            if (!streamAssistantIdRef.current && !finalContent) return;
             // Authoritative turn text: replace the streamed bubble (deltas can
             // be lossy) or append if the turn produced no deltas.
             const id = streamAssistantIdRef.current;

--- a/dashboard/src/lib/hermes-state-signature.test.ts
+++ b/dashboard/src/lib/hermes-state-signature.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractStateSignatureKey,
+  stateSignatureKeyFromMessages,
+  stripStateSignature,
+} from "./hermes-state-signature";
+
+const SIGNATURE =
+  "[STATE_SIGNATURE: lean-silicon|phase-c-bridges|7a1c0aab/2cf06f78/874ea558|external-ci-wait|external-ci|formal-and-lint+gds-settling]";
+
+describe("stripStateSignature", () => {
+  it("removes a trailing signature and surrounding whitespace", () => {
+    const body = `Phase C is progressing.\n\n${SIGNATURE}\n\n\n`;
+    expect(stripStateSignature(body)).toBe("Phase C is progressing.");
+  });
+
+  it("removes stacked trailing signatures", () => {
+    const body = `Done.\n\n[STATE_SIGNATURE: a|b]\n[STATE_SIGNATURE: c|d]\n`;
+    expect(stripStateSignature(body)).toBe("Done.");
+  });
+
+  it("leaves a signature quoted mid-message intact", () => {
+    const body = `The trailer looks like ${SIGNATURE} and routes the reply.`;
+    expect(stripStateSignature(body)).toBe(body);
+  });
+
+  it("returns a signature-only body as empty", () => {
+    expect(stripStateSignature(`${SIGNATURE}\n`).trim()).toBe("");
+  });
+
+  it("is a no-op on plain text", () => {
+    expect(stripStateSignature("hello world")).toBe("hello world");
+  });
+});
+
+describe("extractStateSignatureKey", () => {
+  it("returns the first field of the signature", () => {
+    expect(extractStateSignatureKey(`Report.\n${SIGNATURE}`)).toBe(
+      "lean-silicon",
+    );
+  });
+
+  it("returns the LAST signature's key when several appear", () => {
+    const body = "[STATE_SIGNATURE: old-key|x]\ntext\n[STATE_SIGNATURE: new-key|y]";
+    expect(extractStateSignatureKey(body)).toBe("new-key");
+  });
+
+  it("returns null when no signature is present", () => {
+    expect(extractStateSignatureKey("no trailer here")).toBeNull();
+  });
+});
+
+describe("stateSignatureKeyFromMessages", () => {
+  it("scans backwards through assistant messages", () => {
+    const key = stateSignatureKeyFromMessages([
+      { role: "assistant", content: `old\n[STATE_SIGNATURE: stale-key|x]` },
+      { role: "user", content: "next task" },
+      { role: "assistant", content: `latest\n${SIGNATURE}` },
+      { role: "user", content: "thanks" },
+    ]);
+    expect(key).toBe("lean-silicon");
+  });
+
+  it("ignores user messages and returns null without signatures", () => {
+    expect(
+      stateSignatureKeyFromMessages([
+        { role: "user", content: "[STATE_SIGNATURE: not-from-assistant|x]" },
+        { role: "assistant", content: "plain reply" },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/dashboard/src/lib/hermes-state-signature.ts
+++ b/dashboard/src/lib/hermes-state-signature.ts
@@ -1,0 +1,52 @@
+/**
+ * Hermes controller sessions (crons especially) end their replies with a
+ * machine-readable trailer the projects board uses for routing:
+ *
+ *   [STATE_SIGNATURE: lean-silicon|phase-c-bridges|7a1c0aab/…|external-ci-wait]
+ *
+ * The first field is the controller's routing key (project slug). The trailer
+ * is control-plane metadata, not prose — transcripts shown to a human must
+ * strip it, and it doubles as the best available display name for sessions
+ * that never got a title (a cron session otherwise renders as "Session
+ * cron_bef…").
+ */
+
+// A trailer at the very END of a message, tolerating trailing whitespace.
+// `[^\]]` (not `.`) so a signature spanning lines still matches.
+const TRAILING_SIGNATURE_RE = /\s*\[STATE_SIGNATURE:[^\]]*\]\s*$/;
+
+const SIGNATURE_KEY_RE = /\[STATE_SIGNATURE:\s*([^|\]]+)/g;
+
+/** Remove trailing `[STATE_SIGNATURE: …]` trailer(s) from a message body.
+ * Only trailers are stripped — a signature quoted mid-text stays intact. */
+export function stripStateSignature(content: string): string {
+  let out = content;
+  while (TRAILING_SIGNATURE_RE.test(out)) {
+    out = out.replace(TRAILING_SIGNATURE_RE, "");
+  }
+  return out;
+}
+
+/** Routing key (first `|`-separated field) of the LAST state signature in a
+ * body, or null when the body carries none. */
+export function extractStateSignatureKey(content: string): string | null {
+  let key: string | null = null;
+  for (const match of content.matchAll(SIGNATURE_KEY_RE)) {
+    const candidate = match[1]?.trim();
+    if (candidate) key = candidate;
+  }
+  return key;
+}
+
+/** Scan a transcript (oldest→newest) for the most recent routing key. */
+export function stateSignatureKeyFromMessages(
+  messages: Array<{ role?: string | null; content?: string | null }>,
+): string | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.role !== "assistant" || !message.content) continue;
+    const key = extractStateSignatureKey(message.content);
+    if (key) return key;
+  }
+  return null;
+}


### PR DESCRIPTION
## The two symptoms

1. Hermes controller sessions (crons especially) end each reply with a machine-readable trailer the projects board uses for routing:
   ```
   [STATE_SIGNATURE: lean-silicon|phase-c-bridges|7a1c0aab/2cf06f78/874ea558|external-ci-wait|external-ci|formal-and-lint+gds-settling]
   ```
   `/control?session=cron_…` and the `/assistant` chat rendered it verbatim at the bottom of every assistant message.
2. An untitled cron session's header showed **"Session cron_bef…"**, while the desktop sidebar shows a real name (`lean-silicon`).

## What this does

- **New `src/lib/hermes-state-signature.ts`** — one shared module for both concerns:
  - `stripStateSignature`: removes **trailing** trailers only (stacked trailers included). A signature *quoted mid-message* stays intact.
  - `stateSignatureKeyFromMessages`: newest assistant trailer's first field = the controller routing key.
- **`hermes-session-adapter`** (`/control?session=`): strips trailers from user/assistant rows, both persisted history and live-stream finalize. **Tool results deliberately keep raw text** — a `read_file` of a document that legitimately ends with a signature must not be truncated in the trace.
- **`HermesConversation` header**: title fallback becomes `title > routing key > preview > "Session <id8>"`, so the lean-silicon controller is called **lean-silicon**, matching the desktop app. The key is re-derived at all three transcript load sites (WS resume, REST initial, REST poll).
- **`hermes-thread`** (`/assistant` chat): strips on history and on the authoritative `onCompleted` patch — which also erases a trailer the deltas already streamed into the live bubble (signature-only turns patch the bubble to empty instead of leaving metadata).

## Tests

- 10 new unit tests (`hermes-state-signature.test.ts`): trailing strip incl. stacked + whitespace, mid-message no-op, signature-only body, key extraction (first field, last-signature-wins), backwards transcript scan ignoring user rows.
- Full dashboard suite: **284 passed**, `tsc --noEmit` clean, eslint clean on touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only transcript and session title changes in the dashboard; no auth, API, or persistence changes.
> 
> **Overview**
> Hermes controller replies often end with **`[STATE_SIGNATURE: …]`** routing trailers that were shown verbatim in `/control` and `/assistant` chat. This PR treats that metadata as non-user-facing prose and centralizes handling in **`hermes-state-signature`**.
> 
> **`stripStateSignature`** removes only **trailing** trailers (including stacked ones); mid-message mentions stay. **`stateSignatureKeyFromMessages`** reads the newest assistant trailer’s first field as the controller routing key (e.g. `lean-silicon`). The control **`hermes-session-adapter`** and **`hermes-thread`** strip signatures from user/assistant history and from live turn completion; **tool result rows keep raw content** so file reads that legitimately contain a signature are not truncated.
> 
> **`HermesConversation`** uses the routing key in the header title fallback (`title → routing key → preview → Session id`), aligned with the desktop sidebar for untitled cron sessions, and refreshes that key whenever transcript history is loaded or REST-polled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c68006d9e212356851ce69ef208c278c61d3965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->