### PR TITLE
Persist webhook forward markers; set them only on delivered POSTs

### DIFF
--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -538,7 +538,7 @@ pub enum CancelMissionOutcome {
 // ==================== Mission Types ====================
 
 /// Mission status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MissionStatus {
     /// Mission created but hasn't received any messages yet

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -12675,262 +12675,378 @@ async fn paloma_webhook_forwarder_loop(
     http: reqwest::Client,
 ) {
     tracing::info!(webhook_url = %url, "Paloma mission-status webhook forwarder started");
-    // Track the last status seen per mission (for ALL transitions, not just
-    // forwardable ones) so we forward a status only when it actually CHANGED.
-    // This drops the re-emit `mark_mission_opened` broadcasts (it re-sends the
-    // current, unchanged status on first view) while still forwarding a genuine
-    // re-entry into a state. Single-task loop → a plain map needs no locking.
-    let mut last_status: std::collections::HashMap<Uuid, MissionStatus> =
-        std::collections::HashMap::new();
+    // The dedupe record is DURABLE and success-gated: a marker means "this
+    // status has been fully processed" — trivially on observation for
+    // non-forwardable statuses, only after a successful POST for forwardable
+    // ones. That closes the two loss windows the in-memory map had: a restart
+    // blanking history, and delivery failure counting as delivery. Divergence
+    // store-vs-marker is exactly the set of undelivered transitions, and the
+    // sweep retries them until they land.
+    let markers = super::webhook_markers::MarkerStore::load(&working_dir);
+    let first_boot = !markers.loaded_from_disk;
+    let markers = Arc::new(tokio::sync::Mutex::new(markers));
+    if first_boot {
+        // Adopt current history without forwarding any of it: pre-feature
+        // missions have long-settled statuses, and replaying them as fresh
+        // events would flood every bound conversation exactly once.
+        let mut adopted = 0usize;
+        let mut offset = 0usize;
+        let mut guard = markers.lock().await;
+        while offset < 5_000 {
+            let page = match mission_store.list_missions(500, offset).await {
+                Ok(page) => page,
+                Err(_) => break,
+            };
+            if page.is_empty() {
+                break;
+            }
+            let len = page.len();
+            for mission in page {
+                guard.set(mission.id, mission.status);
+                adopted += 1;
+            }
+            if len < 500 {
+                break;
+            }
+            offset += 500;
+        }
+        drop(guard);
+        tracing::info!(
+            adopted,
+            "webhook markers: first boot, adopted current mission statuses"
+        );
+    }
+    // Transitions currently being POSTed, so the sweep cannot double-send what
+    // the broadcast arm already has in flight (and vice versa).
+    let in_flight: Arc<tokio::sync::Mutex<std::collections::HashSet<(Uuid, MissionStatus)>>> =
+        Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new()));
     // Bound concurrent in-flight callbacks (each does a get_mission + HTTP POST).
     let sem = Arc::new(tokio::sync::Semaphore::new(8));
     // Process-monotonic sequence so the consumer can order events and dedupe
     // (at-least-once delivery: a single logical event keeps one `event_id`
     // across retries). Resets on restart — `event_id` is the durable key.
     let sequence = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    // One forwarding path shared by the live broadcast arm and the
+    // reconcile sweep below, so a transition can never be forwardable in
+    // one and skipped by the other.
+    let http_c = http.clone();
+    let url_c = url.clone();
+    let secret_c = secret.clone();
+    let mission_store_c = Arc::clone(&mission_store);
+    let workspaces_c = workspaces.clone();
+    let working_dir_c = working_dir.clone();
+    let sem_c = Arc::clone(&sem);
+    let sequence_c = Arc::clone(&sequence);
+    let markers_c = Arc::clone(&markers);
+    let in_flight_c = Arc::clone(&in_flight);
+    let forward = move |mission_id: Uuid,
+                        status: MissionStatus,
+                        old_status: Option<MissionStatus>| {
+        let http = http_c.clone();
+        let url = url_c.clone();
+        let secret = secret_c.clone();
+        let mission_store = Arc::clone(&mission_store_c);
+        let workspaces = workspaces_c.clone();
+        let working_dir = working_dir_c.clone();
+        let sem = Arc::clone(&sem_c);
+        let sequence = Arc::clone(&sequence_c);
+        let markers = Arc::clone(&markers_c);
+        let in_flight = Arc::clone(&in_flight_c);
+        // Stable per-logical-event identity for idempotent consumers.
+        let event_id = Uuid::new_v4();
+        let seq = sequence.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        // The mission load + POST run in a spawned, concurrency-bounded
+        // task so neither a slow DB read nor a slow webhook can stall the
+        // caller.
+        tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await;
+            let mission = mission_store.get_mission(mission_id).await.ok().flatten();
+            let title = mission
+                .as_ref()
+                .and_then(|mission| mission.title.clone())
+                .unwrap_or_else(|| mission_id.to_string());
+            let project = mission.as_ref().map(|m| &m.project);
+            let run = mission_store
+                .get_active_mission_run(mission_id)
+                .await
+                .ok()
+                .flatten();
+            let mut remote_jobs = crate::remote_node::job_ledger::load(&working_dir)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|handle| handle.mission_id == mission_id)
+                .map(|handle| {
+                    serde_json::json!({
+                        "job_id": handle.job_id,
+                        "node_id": handle.node_id,
+                        "kind": handle.kind,
+                        "accepted_at": handle.accepted_at,
+                        "heartbeat_at": handle.heartbeat_at,
+                        "identity": handle.identity,
+                    })
+                })
+                .collect::<Vec<_>>();
+            remote_jobs.extend(
+                crate::remote_node::job_ledger::terminal_receipts_for_mission(
+                    &working_dir,
+                    mission_id,
+                )
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .rev()
+                .take(16)
+                .map(|receipt| {
+                    serde_json::json!({
+                        "job_id": receipt.job_id,
+                        "node_id": receipt.node_id,
+                        "kind": "remote_build_receipt",
+                        "state": receipt.state,
+                        "started_at": receipt.started_at,
+                        "finished_at": receipt.finished_at,
+                        "exit_status": receipt.exit_status,
+                        "identity": receipt.identity,
+                        "artifacts": receipt.artifacts,
+                    })
+                }),
+            );
+            let terminal_reason = mission
+                .as_ref()
+                .and_then(|mission| mission.terminal_reason.as_deref());
+            let recommended_action = match terminal_reason {
+                Some("server_shutdown" | "orphan_no_runner") => "resume_once",
+                Some("auth_error") => "disable_provider_and_reroute",
+                Some("rate_limited" | "capacity_limited") => "reroute_or_queue",
+                Some("watchdog_stalled" | "cancelled") => "inspect_artifacts",
+                _ if status == MissionStatus::Interrupted => "reconcile_then_resume",
+                _ if status == MissionStatus::Failed => "classify_failure",
+                _ if status == MissionStatus::AwaitingUser => "inspect_result",
+                _ => "notify",
+            };
+            // Resolve workspace_name from the registry (the store row
+            // usually leaves it null), so the payload is self-contained.
+            let workspace_name = match mission.as_ref() {
+                Some(m) => match m.workspace_name.clone() {
+                    Some(name) => Some(name),
+                    None => workspaces.get(m.workspace_id).await.map(|ws| ws.name),
+                },
+                None => None,
+            };
+            let body = serde_json::json!({
+                // Idempotency / ordering (P#6): consumers dedupe on
+                // `event_id` and may order by `sequence`.
+                "event_id": event_id,
+                "sequence": seq,
+                "mission_id": mission_id,
+                "old_status": old_status,
+                "status": status,
+                // Event-type mirror of `status` so consumers with
+                // route-level event filters (e.g. the Hermes webhook
+                // platform reads `payload.type`) can drop unwanted
+                // transitions like `acknowledged` before spawning an
+                // agent run.
+                "type": status,
+                "title": title,
+                "short_description": mission
+                    .as_ref()
+                    .and_then(|m| m.short_description.clone()),
+                "workspace_id": mission.as_ref().map(|m| m.workspace_id),
+                "workspace_name": workspace_name,
+                "backend": mission.as_ref().map(|m| m.backend.clone()),
+                "terminal_reason": terminal_reason,
+                "resumable": matches!(status, MissionStatus::Interrupted | MissionStatus::Failed | MissionStatus::Blocked),
+                "recommended_action": recommended_action,
+                "execution": run.as_ref().map(|run| serde_json::json!({
+                    "run_id": run.run_id,
+                    "generation": run.generation,
+                    "state": run.execution_state,
+                    "heartbeat_at": run.heartbeat_at,
+                    "scope_unit": run.scope_unit,
+                })),
+                "remote_jobs": remote_jobs,
+                "updated_at": mission.as_ref().map(|m| m.updated_at.clone()),
+                // When the status itself last changed (P#5) — the most
+                // relevant staleness anchor for a status-change webhook.
+                "last_status_change_at": mission
+                    .as_ref()
+                    .and_then(|m| m.activity.last_status_change_at.clone()),
+                // Project tagging so Paloma can route by project/track/
+                // intent/PR instead of parsing titles.
+                "project": project.and_then(|p| p.project.clone()),
+                "track": project.and_then(|p| p.track.clone()),
+                "intent": project.and_then(|p| p.intent.clone()),
+                "github_pr": project.and_then(|p| p.github_pr.clone()),
+                "tags": project.map(|p| p.tags.clone()).unwrap_or_default(),
+                // Creation provenance. Without these, a status webhook
+                // lands in an isolated consumer session with no way
+                // back to the conversation that started the mission —
+                // results then sit acknowledged and unreported. The
+                // consumer routes the completion into `origin_session`.
+                //
+                // TRUST: `origin_session` is a routing HINT, not
+                // authority. It is declared by the creating client and
+                // the MCP transport carries no per-call session
+                // context to verify it against, so a delivery handler
+                // MUST confirm the target conversation actually
+                // references this mission_id before delivering there,
+                // and fall back to its default notification path
+                // otherwise.
+                "origin": mission.as_ref().and_then(|m| m.origin.clone()),
+                "origin_session": mission
+                    .as_ref()
+                    .and_then(|m| m.origin_session_id.clone()),
+                // Track state so a watchdog can tell "intentionally
+                // waiting (CI/review/external)" from "no worker = stuck".
+                "desired_state": project.and_then(|p| p.desired_state.clone()),
+                "next_check_at": project.and_then(|p| p.next_check_at.clone()),
+                // For awaiting_user, whether the agent needs a decision
+                // or is just waiting to be acked/merged.
+                "awaiting_kind": mission
+                    .as_ref()
+                    .and_then(|m| m.awaiting_kind)
+                    .map(|k| k.as_str()),
+            });
+
+            // Serialize once so the signature is computed over the
+            // exact bytes sent (consumers verify HMAC over the raw
+            // body, e.g. the Hermes webhook platform's GitHub-style
+            // `X-Hub-Signature-256` check).
+            let payload = match serde_json::to_vec(&body) {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        "Failed to serialize Paloma webhook payload: {}",
+                        err
+                    );
+                    return;
+                }
+            };
+            let signature = secret.as_ref().and_then(|secret| {
+                use hmac::{Hmac, Mac};
+                let mut mac = Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+                mac.update(&payload);
+                Some(format!(
+                    "sha256={}",
+                    hex::encode(mac.finalize().into_bytes())
+                ))
+            });
+
+            // At-least-once: retry transient failures with the SAME
+            // event_id so the consumer can dedupe. Bounded so a dead
+            // endpoint can't pile up tasks.
+            const MAX_ATTEMPTS: u32 = 3;
+            for attempt in 1..=MAX_ATTEMPTS {
+                let mut request = http
+                    .post(&url)
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .body(payload.clone());
+                if let Some(signature) = signature.as_deref() {
+                    request = request.header("X-Hub-Signature-256", signature);
+                }
+                match request.send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        // Only a delivered event earns its durable marker. An
+                        // exhausted retry leaves it unset, so the 60s sweep
+                        // re-sends until the consumer is reachable again.
+                        markers.lock().await.set(mission_id, status);
+                        break;
+                    }
+                    Ok(resp) => {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            webhook_url = %url,
+                            attempt,
+                            status = %resp.status(),
+                            "Paloma webhook returned non-success status"
+                        );
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            webhook_url = %url,
+                            attempt,
+                            "Failed to forward Paloma mission status webhook: {}",
+                            err
+                        );
+                    }
+                }
+                if attempt < MAX_ATTEMPTS {
+                    tokio::time::sleep(std::time::Duration::from_millis(250 * attempt as u64))
+                        .await;
+                }
+            }
+            in_flight.lock().await.remove(&(mission_id, status));
+        });
+    };
+    // The broadcast channel is lossy under bursts, and not every status
+    // writer broadcasts. Measured 2026-08-06: mission 45e54e0b reached
+    // awaiting_user and acknowledged at 09:35:42Z, its origin conversation
+    // was adopted and waiting, and neither transition was ever forwarded --
+    // no lag warning, nothing to retry, the conversation simply never woke.
+    // The sweep reconciles from the store: any mission whose CURRENT status
+    // is forwardable, differs from what we last forwarded, and changed
+    // recently is forwarded now. Older divergences are adopted silently so
+    // a fresh map after restart cannot replay history.
+    let mut reconcile = tokio::time::interval(std::time::Duration::from_secs(60));
+    reconcile.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
-        match events_rx.recv().await {
+        let recv = tokio::select! {
+            result = events_rx.recv() => Some(result),
+            _ = reconcile.tick() => None,
+        };
+        let Some(result) = recv else {
+            let missions = match mission_store.list_missions(400, 0).await {
+                Ok(missions) => missions,
+                Err(_) => continue,
+            };
+            for mission in missions {
+                let status = mission.status;
+                let prior = markers.lock().await.get(mission.id);
+                if prior == Some(status) {
+                    continue;
+                }
+                if !webhook_forwardable_status(status) {
+                    // Nothing to deliver; recording it keeps re-entry
+                    // detection exact (A -> B -> A must forward A again).
+                    markers.lock().await.set(mission.id, status);
+                    continue;
+                }
+                if !in_flight.lock().await.insert((mission.id, status)) {
+                    continue;
+                }
+                // No recency window: the marker file is the durable authority,
+                // so a divergence IS an undelivered transition, however old --
+                // that is the whole lossless-across-outages property. First
+                // boot cannot replay history because adoption above marked it.
+                tracing::info!(
+                    mission_id = %mission.id,
+                    ?status,
+                    "webhook reconcile: forwarding a status transition the \
+                     broadcast never delivered"
+                );
+                forward(mission.id, status, prior);
+            }
+            continue;
+        };
+        match result {
             Ok(AgentEvent::MissionStatusChanged {
                 mission_id, status, ..
             }) => {
-                // `insert` returns the prior value; forward only on a real change.
-                let old_status = last_status.insert(mission_id, status);
-                let changed = old_status != Some(status);
-                if !changed || !webhook_forwardable_status(status) {
+                let old_status = markers.lock().await.get(mission_id);
+                if old_status == Some(status) {
                     continue;
                 }
-
-                // Stable per-logical-event identity for idempotent consumers.
-                let event_id = Uuid::new_v4();
-                let seq = sequence.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-
-                // Everything else (the mission load + POST) runs in a spawned,
-                // concurrency-bounded task so neither a slow DB read nor a slow
-                // webhook can stall the broadcast receiver and lag-drop events.
-                let http = http.clone();
-                let url = url.clone();
-                let secret = secret.clone();
-                let mission_store = Arc::clone(&mission_store);
-                let workspaces = workspaces.clone();
-                let working_dir = working_dir.clone();
-                let sem = Arc::clone(&sem);
-                tokio::spawn(async move {
-                    let _permit = sem.acquire_owned().await;
-                    let mission = mission_store.get_mission(mission_id).await.ok().flatten();
-                    let title = mission
-                        .as_ref()
-                        .and_then(|mission| mission.title.clone())
-                        .unwrap_or_else(|| mission_id.to_string());
-                    let project = mission.as_ref().map(|m| &m.project);
-                    let run = mission_store
-                        .get_active_mission_run(mission_id)
-                        .await
-                        .ok()
-                        .flatten();
-                    let mut remote_jobs = crate::remote_node::job_ledger::load(&working_dir)
-                        .await
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter(|handle| handle.mission_id == mission_id)
-                        .map(|handle| {
-                            serde_json::json!({
-                                "job_id": handle.job_id,
-                                "node_id": handle.node_id,
-                                "kind": handle.kind,
-                                "accepted_at": handle.accepted_at,
-                                "heartbeat_at": handle.heartbeat_at,
-                                "identity": handle.identity,
-                            })
-                        })
-                        .collect::<Vec<_>>();
-                    remote_jobs.extend(
-                        crate::remote_node::job_ledger::terminal_receipts_for_mission(
-                            &working_dir,
-                            mission_id,
-                        )
-                        .await
-                        .unwrap_or_default()
-                        .into_iter()
-                        .rev()
-                        .take(16)
-                        .map(|receipt| {
-                            serde_json::json!({
-                                "job_id": receipt.job_id,
-                                "node_id": receipt.node_id,
-                                "kind": "remote_build_receipt",
-                                "state": receipt.state,
-                                "started_at": receipt.started_at,
-                                "finished_at": receipt.finished_at,
-                                "exit_status": receipt.exit_status,
-                                "identity": receipt.identity,
-                                "artifacts": receipt.artifacts,
-                            })
-                        }),
-                    );
-                    let terminal_reason = mission
-                        .as_ref()
-                        .and_then(|mission| mission.terminal_reason.as_deref());
-                    let recommended_action = match terminal_reason {
-                        Some("server_shutdown" | "orphan_no_runner") => "resume_once",
-                        Some("auth_error") => "disable_provider_and_reroute",
-                        Some("rate_limited" | "capacity_limited") => "reroute_or_queue",
-                        Some("watchdog_stalled" | "cancelled") => "inspect_artifacts",
-                        _ if status == MissionStatus::Interrupted => "reconcile_then_resume",
-                        _ if status == MissionStatus::Failed => "classify_failure",
-                        _ if status == MissionStatus::AwaitingUser => "inspect_result",
-                        _ => "notify",
-                    };
-                    // Resolve workspace_name from the registry (the store row
-                    // usually leaves it null), so the payload is self-contained.
-                    let workspace_name = match mission.as_ref() {
-                        Some(m) => match m.workspace_name.clone() {
-                            Some(name) => Some(name),
-                            None => workspaces.get(m.workspace_id).await.map(|ws| ws.name),
-                        },
-                        None => None,
-                    };
-                    let body = serde_json::json!({
-                        // Idempotency / ordering (P#6): consumers dedupe on
-                        // `event_id` and may order by `sequence`.
-                        "event_id": event_id,
-                        "sequence": seq,
-                        "mission_id": mission_id,
-                        "old_status": old_status,
-                        "status": status,
-                        // Event-type mirror of `status` so consumers with
-                        // route-level event filters (e.g. the Hermes webhook
-                        // platform reads `payload.type`) can drop unwanted
-                        // transitions like `acknowledged` before spawning an
-                        // agent run.
-                        "type": status,
-                        "title": title,
-                        "short_description": mission
-                            .as_ref()
-                            .and_then(|m| m.short_description.clone()),
-                        "workspace_id": mission.as_ref().map(|m| m.workspace_id),
-                        "workspace_name": workspace_name,
-                        "backend": mission.as_ref().map(|m| m.backend.clone()),
-                        "terminal_reason": terminal_reason,
-                        "resumable": matches!(status, MissionStatus::Interrupted | MissionStatus::Failed | MissionStatus::Blocked),
-                        "recommended_action": recommended_action,
-                        "execution": run.as_ref().map(|run| serde_json::json!({
-                            "run_id": run.run_id,
-                            "generation": run.generation,
-                            "state": run.execution_state,
-                            "heartbeat_at": run.heartbeat_at,
-                            "scope_unit": run.scope_unit,
-                        })),
-                        "remote_jobs": remote_jobs,
-                        "updated_at": mission.as_ref().map(|m| m.updated_at.clone()),
-                        // When the status itself last changed (P#5) — the most
-                        // relevant staleness anchor for a status-change webhook.
-                        "last_status_change_at": mission
-                            .as_ref()
-                            .and_then(|m| m.activity.last_status_change_at.clone()),
-                        // Project tagging so Paloma can route by project/track/
-                        // intent/PR instead of parsing titles.
-                        "project": project.and_then(|p| p.project.clone()),
-                        "track": project.and_then(|p| p.track.clone()),
-                        "intent": project.and_then(|p| p.intent.clone()),
-                        "github_pr": project.and_then(|p| p.github_pr.clone()),
-                        "tags": project.map(|p| p.tags.clone()).unwrap_or_default(),
-                        // Creation provenance. Without these, a status webhook
-                        // lands in an isolated consumer session with no way
-                        // back to the conversation that started the mission —
-                        // results then sit acknowledged and unreported. The
-                        // consumer routes the completion into `origin_session`.
-                        //
-                        // TRUST: `origin_session` is a routing HINT, not
-                        // authority. It is declared by the creating client and
-                        // the MCP transport carries no per-call session
-                        // context to verify it against, so a delivery handler
-                        // MUST confirm the target conversation actually
-                        // references this mission_id before delivering there,
-                        // and fall back to its default notification path
-                        // otherwise.
-                        "origin": mission.as_ref().and_then(|m| m.origin.clone()),
-                        "origin_session": mission
-                            .as_ref()
-                            .and_then(|m| m.origin_session_id.clone()),
-                        // Track state so a watchdog can tell "intentionally
-                        // waiting (CI/review/external)" from "no worker = stuck".
-                        "desired_state": project.and_then(|p| p.desired_state.clone()),
-                        "next_check_at": project.and_then(|p| p.next_check_at.clone()),
-                        // For awaiting_user, whether the agent needs a decision
-                        // or is just waiting to be acked/merged.
-                        "awaiting_kind": mission
-                            .as_ref()
-                            .and_then(|m| m.awaiting_kind)
-                            .map(|k| k.as_str()),
-                    });
-
-                    // Serialize once so the signature is computed over the
-                    // exact bytes sent (consumers verify HMAC over the raw
-                    // body, e.g. the Hermes webhook platform's GitHub-style
-                    // `X-Hub-Signature-256` check).
-                    let payload = match serde_json::to_vec(&body) {
-                        Ok(bytes) => bytes,
-                        Err(err) => {
-                            tracing::warn!(
-                                mission_id = %mission_id,
-                                "Failed to serialize Paloma webhook payload: {}",
-                                err
-                            );
-                            return;
-                        }
-                    };
-                    let signature = secret.as_ref().and_then(|secret| {
-                        use hmac::{Hmac, Mac};
-                        let mut mac =
-                            Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes()).ok()?;
-                        mac.update(&payload);
-                        Some(format!(
-                            "sha256={}",
-                            hex::encode(mac.finalize().into_bytes())
-                        ))
-                    });
-
-                    // At-least-once: retry transient failures with the SAME
-                    // event_id so the consumer can dedupe. Bounded so a dead
-                    // endpoint can't pile up tasks.
-                    const MAX_ATTEMPTS: u32 = 3;
-                    for attempt in 1..=MAX_ATTEMPTS {
-                        let mut request = http
-                            .post(&url)
-                            .header(reqwest::header::CONTENT_TYPE, "application/json")
-                            .body(payload.clone());
-                        if let Some(signature) = signature.as_deref() {
-                            request = request.header("X-Hub-Signature-256", signature);
-                        }
-                        match request.send().await {
-                            Ok(resp) if resp.status().is_success() => break,
-                            Ok(resp) => {
-                                tracing::warn!(
-                                    mission_id = %mission_id,
-                                    webhook_url = %url,
-                                    attempt,
-                                    status = %resp.status(),
-                                    "Paloma webhook returned non-success status"
-                                );
-                            }
-                            Err(err) => {
-                                tracing::warn!(
-                                    mission_id = %mission_id,
-                                    webhook_url = %url,
-                                    attempt,
-                                    "Failed to forward Paloma mission status webhook: {}",
-                                    err
-                                );
-                            }
-                        }
-                        if attempt < MAX_ATTEMPTS {
-                            tokio::time::sleep(std::time::Duration::from_millis(
-                                250 * attempt as u64,
-                            ))
-                            .await;
-                        }
-                    }
-                });
+                if !webhook_forwardable_status(status) {
+                    markers.lock().await.set(mission_id, status);
+                    continue;
+                }
+                if !in_flight.lock().await.insert((mission_id, status)) {
+                    continue;
+                }
+                forward(mission_id, status, old_status);
             }
             Ok(_) => {}
             Err(broadcast::error::RecvError::Lagged(dropped)) => {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -71,6 +71,7 @@ pub mod telegram;
 pub mod types;
 pub mod usage_optimize;
 pub mod validation;
+pub mod webhook_markers;
 pub mod workspaces;
 
 pub use routes::serve;

--- a/src/api/webhook_markers.rs
+++ b/src/api/webhook_markers.rs
@@ -1,0 +1,189 @@
+//! Durable "this status was forwarded" markers for the mission webhook.
+//!
+//! The forwarder's dedupe map used to live in memory, which left two windows
+//! where a transition could be lost for good (2026-08-06 analysis of mission
+//! `45e54e0b`, whose completed status never reached its waiting conversation):
+//!
+//! * a restart blanked the map, so anything that transitioned while the
+//!   service was down was "adopted" silently and never forwarded;
+//! * the marker was recorded when the event was *observed*, not when the POST
+//!   *succeeded* — an unreachable consumer meant the event was considered
+//!   delivered after three failed attempts.
+//!
+//! A marker here means "this status has been fully processed": for
+//! non-forwardable statuses that is trivially true on observation, for
+//! forwardable ones it is written only after a successful POST. Divergence
+//! between a mission's current status and its marker is therefore exactly the
+//! set of undelivered transitions, regardless of how they were missed —
+//! broadcast lag, a writer that never broadcast, a restart, or a consumer
+//! outage. The reconcile sweep retries them until they land.
+//!
+//! Storage is one small JSON file under the working directory (the same home
+//! as the remote-job ledger), written atomically via tmp+rename. The file is
+//! tiny — one entry per mission ever seen — and rewritten at most once per
+//! processed transition.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use super::control::MissionStatus;
+
+const FILE_NAME: &str = "webhook_forward_markers.json";
+
+#[derive(Debug)]
+pub struct MarkerStore {
+    path: PathBuf,
+    markers: HashMap<Uuid, MissionStatus>,
+    /// Whether the backing file existed at load time. Its absence is how the
+    /// forwarder distinguishes "first boot with this feature" (adopt current
+    /// history without forwarding it) from "restart" (markers are authority).
+    pub loaded_from_disk: bool,
+}
+
+impl MarkerStore {
+    pub fn load(working_dir: &Path) -> Self {
+        let path = working_dir.join(FILE_NAME);
+        let (markers, loaded_from_disk) = match std::fs::read_to_string(&path) {
+            Ok(raw) => match serde_json::from_str::<HashMap<String, serde_json::Value>>(&raw) {
+                Ok(parsed) => {
+                    let markers = parsed
+                        .into_iter()
+                        .filter_map(|(id, status)| {
+                            Some((
+                                Uuid::parse_str(&id).ok()?,
+                                serde_json::from_value::<MissionStatus>(status).ok()?,
+                            ))
+                        })
+                        .collect();
+                    (markers, true)
+                }
+                Err(error) => {
+                    // A corrupt file must not brick forwarding; treat it as
+                    // first boot. The cost is one silent re-adoption pass,
+                    // never a replay storm (adoption forwards nothing).
+                    tracing::warn!(
+                        path = %path.display(),
+                        %error,
+                        "webhook marker file unreadable; re-adopting current state"
+                    );
+                    (HashMap::new(), false)
+                }
+            },
+            Err(_) => (HashMap::new(), false),
+        };
+        Self {
+            path,
+            markers,
+            loaded_from_disk,
+        }
+    }
+
+    pub fn get(&self, mission_id: Uuid) -> Option<MissionStatus> {
+        self.markers.get(&mission_id).copied()
+    }
+
+    /// Record and persist. Failure to persist is logged, never fatal: the
+    /// in-memory marker still dedupes this process, and the worst outcome of
+    /// a lost write is one duplicate forward after a restart — the recoverable
+    /// direction (consumers carry `mission_id` + status and tolerate repeats;
+    /// a *dropped* wake-up is what they cannot recover from).
+    pub fn set(&mut self, mission_id: Uuid, status: MissionStatus) {
+        if self.markers.insert(mission_id, status) == Some(status) {
+            return;
+        }
+        self.save();
+    }
+
+    fn save(&self) {
+        let serializable: HashMap<String, &MissionStatus> = self
+            .markers
+            .iter()
+            .map(|(id, status)| (id.to_string(), status))
+            .collect();
+        let Ok(raw) = serde_json::to_string(&serializable) else {
+            return;
+        };
+        let tmp = self.path.with_extension("json.tmp");
+        let result = std::fs::write(&tmp, raw).and_then(|_| std::fs::rename(&tmp, &self.path));
+        if let Err(error) = result {
+            tracing::warn!(
+                path = %self.path.display(),
+                %error,
+                "failed to persist webhook forward markers"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn a_first_boot_has_no_disk_state() {
+        let d = dir();
+        let store = MarkerStore::load(d.path());
+        assert!(!store.loaded_from_disk);
+        assert_eq!(store.get(Uuid::new_v4()), None);
+    }
+
+    /// The property the whole change exists for: markers survive a restart.
+    #[test]
+    fn markers_survive_a_reload() {
+        let d = dir();
+        let mission = Uuid::new_v4();
+        let mut store = MarkerStore::load(d.path());
+        store.set(mission, MissionStatus::Acknowledged);
+
+        let reloaded = MarkerStore::load(d.path());
+        assert!(reloaded.loaded_from_disk);
+        assert_eq!(reloaded.get(mission), Some(MissionStatus::Acknowledged));
+    }
+
+    #[test]
+    fn an_unchanged_set_does_not_rewrite_the_file() {
+        let d = dir();
+        let mission = Uuid::new_v4();
+        let mut store = MarkerStore::load(d.path());
+        store.set(mission, MissionStatus::Active);
+        let mtime = |p: &Path| std::fs::metadata(p).unwrap().modified().unwrap();
+        let path = d.path().join(FILE_NAME);
+        let before = mtime(&path);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        store.set(mission, MissionStatus::Active);
+        assert_eq!(mtime(&path), before, "idempotent set must not rewrite");
+    }
+
+    /// A corrupt file is first boot, not a crash: adoption forwards nothing,
+    /// so the failure direction is one silent pass, never a replay storm.
+    #[test]
+    fn a_corrupt_file_reads_as_first_boot() {
+        let d = dir();
+        std::fs::write(d.path().join(FILE_NAME), "{not json").unwrap();
+        let store = MarkerStore::load(d.path());
+        assert!(!store.loaded_from_disk);
+    }
+
+    #[test]
+    fn unknown_statuses_in_the_file_are_skipped_not_fatal() {
+        let d = dir();
+        let known = Uuid::new_v4();
+        std::fs::write(
+            d.path().join(FILE_NAME),
+            format!(
+                "{{\"{known}\": \"acknowledged\", \"{}\": \"status_from_the_future\"}}",
+                Uuid::new_v4()
+            ),
+        )
+        .unwrap();
+        let store = MarkerStore::load(d.path());
+        assert!(store.loaded_from_disk);
+        assert_eq!(store.get(known), Some(MissionStatus::Acknowledged));
+    }
+}


### PR DESCRIPTION
## Closes the two loss windows #755 named

#755's reconcile sweep fixed the *detection* of missed transitions, but its dedupe record was still in-memory and observation-time. That left exactly two ways to lose a wake-up for good, both requiring a transition to land *during* an outage:

1. **Restart**: the map came up empty, so anything that transitioned while the service was down was adopted silently — never forwarded.
2. **Consumer outage**: the marker was recorded when the event was *observed*; three failed POSTs later, the event counted as delivered.

## The rule

A marker now means **"this status has been fully processed"**, and it lives on disk (`webhook_forward_markers.json`, tmp+rename):

- non-forwardable statuses: recorded on observation (nothing to deliver; recording keeps re-entry detection exact — A → B → A must forward A again);
- forwardable statuses: recorded **only after a successful POST**.

Divergence between a mission's current status and its marker is therefore *exactly* the set of undelivered transitions — however they were missed: broadcast lag, a writer that never broadcasts, a restart, or Hermes being down at the wrong moment. The 60-second sweep retries them until they land.

Consequences worth naming:

- **The sweep's 15-minute recency window is gone.** It existed to protect an amnesiac map from replaying history; the durable marker is now the authority, so a divergence is actionable at any age. That is the lossless-across-outages property itself.
- **First boot adopts, never replays**: with no marker file, current history (up to 5 000 missions) is marked as processed without forwarding — enabling this cannot flood conversations with settled missions.
- **An in-flight set** keeps the broadcast arm and the sweep from double-sending a transition whose POST is still running.
- **Failure direction of a lost marker write**: one duplicate forward after a restart. Consumers carry `mission_id` and tolerate repeats; a *dropped* wake-up is what they cannot recover from.

`MissionStatus` gains `Hash` for the in-flight set.

## Tests

5 in the new module — the one the change exists for is `markers_survive_a_reload`; `a_corrupt_file_reads_as_first_boot` pins that corruption degrades to a silent adoption pass, never a replay storm. Full `cargo test --lib`: **1726 passed**. Clippy clean.

## Provenance note

An intermediate push of this branch briefly carried merge-conflict markers from a stash mishap; it was amended and force-pushed within minutes. CI on the current head is the one that counts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission webhook delivery semantics and persistence; mis-handled first boot or marker corruption could duplicate or delay Paloma/Hermes wake-ups, though design favors duplicate over dropped events.
> 
> **Overview**
> Replaces the Paloma mission-status webhook forwarder’s **in-memory dedupe map** with a **durable `MarkerStore`** (`webhook_forward_markers.json`, atomic tmp+rename). A marker means the status is **fully processed**: non-forwardable statuses are recorded on observation; **forwardable ones only after a successful HTTP POST**, so failed retries stay eligible for the 60s reconcile sweep.
> 
> On **first boot** (no marker file), the forwarder **adopts** up to 5,000 current mission statuses without forwarding, avoiding a one-time flood of settled missions. The sweep **drops the 15-minute recency window**—store vs marker divergence is retried at any age—and uses an **in-flight** `(mission_id, status)` set so broadcast and sweep don’t double-send. `MissionStatus` gains **`Hash`** for that set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84da231e15f04120c8697db7d768943d95da936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->