### PR TITLE
Degenerate-loop detector: require adjacency, count whole occurrences, keep the partial

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -8569,12 +8569,39 @@ pub(crate) fn text_buffer_stream_looks_degenerate(
             }
             let mut count = 0usize;
             let mut idx = 0usize;
+            let mut last_end: Option<usize> = None;
             while let Some(found) = find_subslice(window, &needle, idx) {
-                count += 1;
+                // A degenerate loop is ADJACENT: the model emits the same
+                // string back to back. A structured report legitimately
+                // repeats 40+ char scaffolding — measured 2026-08-06, mission
+                // 7fb8970f was killed mid-way through a 17-guarantee review
+                // table whose rows shared long prefixes — but those repeats
+                // are separated by distinct content. Only count a repeat when
+                // it starts within one needle-length of the previous match's
+                // end; anything farther apart is prose that happens to rhyme.
+                let adjacent = match last_end {
+                    None => true,
+                    Some(end) => found <= end.saturating_add(len),
+                };
+                if adjacent {
+                    count += 1;
+                } else {
+                    count = 1;
+                }
                 if count >= min_repeats {
+                    tracing::warn!(
+                        repeated_substring = %needle.chars().take(120).collect::<String>(),
+                        repeats = count,
+                        "degenerate-stream detector matched; this substring is \
+                         what tripped it"
+                    );
                     return true;
                 }
-                idx = found + 1;
+                // Non-overlapping, as the comment above has always claimed:
+                // advancing by one char let a periodic needle count its own
+                // overlaps and inflate the tally.
+                idx = found + len;
+                last_end = Some(found + len);
             }
         }
     }
@@ -12251,6 +12278,44 @@ mod tests {
     // before the model hit max_tokens. The detector should fire on a loop
     // large enough to matter, and NOT fire on a normal response that
     // happens to contain repeated short strings (e.g. "yes, yes, yes").
+
+    /// The 7fb8970f incident (2026-08-06): a Fable 5 review was killed
+    /// mid-way through its final report because a 17-guarantee table repeats
+    /// long row scaffolding. Legitimate structure repeats are SEPARATED by
+    /// distinct content; a degenerate loop is back to back.
+    #[test]
+    fn degenerate_detector_spares_a_structured_report() {
+        let mut s = String::from("## Hypothesis report\n### Sources verified\n");
+        for i in 0..17 {
+            s.push_str(&format!(
+                "| P-GUARANTEE-{i} | verified against the PR head checkout \
+                 | Source/Correspondence{i}.lean lines {}..{} | detailed note \
+                 about branch conditions and revert paths for case {i} |\n",
+                i * 40,
+                i * 40 + 39
+            ));
+        }
+        assert!(
+            !text_buffer_stream_looks_degenerate(&s, 4096, 40, 3),
+            "a review table with distinct data between repeated scaffolding \
+             is a report, not a loop"
+        );
+    }
+
+    /// Non-overlap regression: a periodic phrase must be counted by whole
+    /// occurrences, not by every one-char offset of itself.
+    #[test]
+    fn degenerate_detector_counts_whole_occurrences_only() {
+        // Two adjacent copies of a 56-char phrase: below min_repeats=3, so it
+        // must NOT fire — the old `found + 1` overlap walk could inflate a
+        // periodic needle past the threshold.
+        let phrase = "Yielding pending your choice between the three options. ";
+        let s = phrase.repeat(2);
+        assert!(
+            !text_buffer_stream_looks_degenerate(&s, 4096, 40, 3),
+            "two copies are two, not three"
+        );
+    }
 
     #[test]
     fn degenerate_detector_flags_long_repeated_phrase() {

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -2618,10 +2618,18 @@ pub fn run_claudecode_turn<'a>(
                     "Claude Code stream looked degenerate; killed CLI and treating as degenerate-stream failure"
                 );
                 let partial_chars = final_result.chars().count();
-                final_result = format!(
-                    "Claude Code entered a degenerate output loop (the same short string was repeated many times in the streamed response) and the turn was cut short to avoid a runaway 50-minute bill — see mission ab260b2e for the canonical example.\n\nThe model never produced a terminal result event. Partial output ({} chars) was preserved; resend your last message to try again.",
+                // Keep the partial output. The previous message claimed it
+                // was "preserved" while overwriting it — mission 7fb8970f
+                // lost five minutes of verified findings to that word.
+                let notice = format!(
+                    "Claude Code entered a degenerate output loop (the same short string was repeated many times in the streamed response) and the turn was cut short to avoid a runaway 50-minute bill — see mission ab260b2e for the canonical example.\n\nThe model never produced a terminal result event. Partial output ({} chars) is preserved below; resend your last message to try again.",
                     partial_chars
                 );
+                final_result = if final_result.trim().is_empty() {
+                    notice
+                } else {
+                    format!("{notice}\n\n--- partial output ---\n{final_result}")
+                };
             } else if !saw_non_init_event {
                 transport_failure_stage = Some(ClaudeTransportFailureStage::Startup);
                 tracing::warn!(


### PR DESCRIPTION
## The incident

Mission `7fb8970f` (Fable 5 guarantee review, `claudecode` + `claude-fable-5`): five minutes of correct agentic work, then — while streaming its **final report** — killed with `terminal_reason=infinite_loop`:

```
13:30–13:32  tool calls executing normally (bytecode checks, SVG grep)
13:35:25     text_delta: "All data gathered. Here is the structured report.
              ## Fable 5 hypothesis report  ### Sources verified …"
13:35:29     "Claude Code entered a degenerate output loop … Partial output
              (46 chars) was preserved"
```

The dispatching agent concluded *"problème de transport Claude Code avec claude-fable-5"* and froze its Fable lane after two failures. The transport was fine; the **detector** was the failure.

## Three compounding defects

**1. It never said what repeated.** The `warn!` logged thresholds but not the needle — so true degeneration versus false positive was undecidable from logs, and the agent guessed "transport bug". It now logs the offending substring. Same rule as everything else this week: a guard that cannot say what it saw produces invented causes.

**2. "Non-overlapping" wasn't.** The scan advanced by `found + 1`, so a periodic needle counted its own overlaps. Now advances by the needle length — the comment has always claimed this.

**3. No adjacency requirement — the actual killer.** A 17-guarantee review table repeats 40+ char row scaffolding (`| verified against the PR head checkout |`) with **distinct data between repeats**. The sliding 4096-char window sees 3 occurrences and fires. But a *degenerate* loop emits the same string **back to back** — that is its defining shape (the `ab260b2e` canonical case is a phrase repeated adjacently for 50 minutes). Repeats now only count when the next match starts within one needle-length of the previous match's end; distance resets the count.

**Plus one falsehood fixed:** *"Partial output (N chars) was preserved"* — while `final_result = format!(...)` overwrote it. The partial is now actually kept below the notice. `7fb8970f` lost five minutes of verified findings to that word.

## Tests

7 in the detector suite (2 new): `degenerate_detector_spares_a_structured_report` rebuilds the incident's table shape and pins it as NOT degenerate; `degenerate_detector_counts_whole_occurrences_only` pins the overlap regression. The pre-existing true-positive test (`flags_long_repeated_phrase`, 50 adjacent copies) still passes — adjacency is exactly its shape.

Full `cargo test --lib`: 1728 passed. Clippy clean.

## For the frozen Fable lane

Once deployed, the lane can be retried as-is: the prompt was never the problem, and if it trips again the log will name the repeated substring instead of leaving the agent to guess.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live mission-runner kill logic and Claude turn finalization; behavior is well-tested but mis-tuning could miss true loops or still false-positive on edge cases.
> 
> **Overview**
> Fixes false kills of legitimate long reports (e.g. repeated table row scaffolding) and stops discarding streamed text when the degenerate-stream guard fires.
> 
> **Degenerate-stream detector** (`text_buffer_stream_looks_degenerate`): repeats only increment when the next match is **adjacent** (within one needle-length of the prior match); separated repeats reset the count. The scan now advances by **needle length** so periodic phrases are not over-counted via overlaps. On a match it **logs the repeated substring** for debugging.
> 
> **Claude Code runner**: when a turn is cut for degenerate output, the user notice is prepended and **partial `final_result` is kept** under a separator instead of replacing the buffer.
> 
> Two unit tests cover structured-report non-detection and whole-occurrence counting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e1e3ea4c813709d8c270bd01841dadd7671bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->