### PR TITLE
Guard contract: terminal_evidence from detector to webhook

### DIFF
--- a/docs/HERMES_ORCHESTRATION.md
+++ b/docs/HERMES_ORCHESTRATION.md
@@ -238,6 +238,37 @@ believed an `acknowledged` mission could not be woken. It could.
 
 ---
 
+## The guard contract
+
+Every kill-switch in the stack — watchdogs, loop detectors, auth preflights,
+circuit breakers — obeys three rules, each paid for by an incident where a
+guard fired and the agent downstream **invented a cause** ("transport bug",
+"GitHub is disabled here", "the pool needs 12 logins re-provisioned"):
+
+1. **Evidence, not a verdict.** The guard names what it *observed* — the
+   repeated substring, the selectors probed and the page they were probed on,
+   the measured idle time — in its message, its logs, and the mission's
+   `terminal_evidence` field, which rides the completion webhook next to
+   `terminal_reason`.
+2. **A guard that cannot check says so.** Silence reads as "checked, nothing
+   found".
+3. **The work survives the verdict.** Partial output is preserved below the
+   notice, never replaced by it.
+
+Compliance at the time of writing:
+
+| guard | evidence | says-when-blind | preserves work |
+|---|---|---|---|
+| cron idle watchdog (600s) | ✓ `last_activity` | ✓ | n/a |
+| degenerate-stream detector | ✓ repeated substring | n/a | ✓ since the adjacency fix |
+| chatgpt_ui auth preflight | ✓ probed selectors + URL | ✓ fails closed loudly | n/a |
+| MCP circuit breaker | ✓ triggering error class (denylist) | ✓ | n/a |
+| skill-body guard | ✓ | ✓ warns with the skill name | n/a |
+| webhook forwarder | ✓ marker divergence is the evidence | ✓ reconcile log | ✓ durable markers |
+
+For agents, the mirror rule lives in `controllers-policy`: a `terminal_reason`
+without evidence is missing data to report — never an invitation to guess.
+
 ## Known limitations
 
 **Two stores hold the project↔conversation link.** Hermes `projects.db` follows

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -497,7 +497,17 @@ async def verify_authentication(page) -> None:
         if await nav_evidence.nth(index).is_visible():
             emit("diagnostic", message="stage=account_confirmed_via_nav")
             return
-    raise PermissionError("authenticated account control not found")
+    # Guard contract: name what was probed and where. Without this, the
+    # 2026-08-06 false positive read as "login required" and the dispatching
+    # agent asked the operator to re-provision 12 accounts that were fine.
+    raise PermissionError(
+        "authenticated account control not found: no visible match for "
+        "accounts-profile-button / account / profile aria-labels, nor for the "
+        f"Library/Scheduled nav, on {page.url!r} (title {await page.title()!r}). "
+        "If ChatGPT's UI was redesigned again, the selector lists in "
+        "verify_authentication need the new evidence — the session cookie may "
+        "still be perfectly valid."
+    )
 
 
 async def establish_resumed_chat(page, conversation_path: str, message: str) -> int:

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -738,6 +738,7 @@ impl Agent for OpenCodeAgent {
                 "session_id": session.id,
             })),
             terminal_reason: Some(TerminalReason::TurnComplete),
+            terminal_evidence: None,
         }
     }
 }
@@ -825,6 +826,7 @@ impl OpenCodeAgent {
                 "session_id": session_id,
             })),
             terminal_reason: Some(TerminalReason::TurnComplete),
+            terminal_evidence: None,
         }
     }
 }

--- a/src/agents/types.rs
+++ b/src/agents/types.rs
@@ -189,6 +189,11 @@ pub struct AgentResult {
 
     /// Reason why execution terminated (if not successful completion)
     pub terminal_reason: Option<TerminalReason>,
+
+    /// What the terminating guard OBSERVED (the repeated substring, the
+    /// missing selector, the measured timeout). Guard contract, 2026-08-06:
+    /// a reason without evidence is how downstream agents invent causes.
+    pub terminal_evidence: Option<String>,
 }
 
 impl AgentResult {
@@ -203,6 +208,7 @@ impl AgentResult {
             model_used: None,
             data: None,
             terminal_reason: None,
+            terminal_evidence: None,
         }
     }
 
@@ -217,6 +223,7 @@ impl AgentResult {
             model_used: None,
             data: None,
             terminal_reason: None,
+            terminal_evidence: None,
         }
     }
 
@@ -294,6 +301,12 @@ impl AgentResult {
     /// Add terminal reason to the result.
     pub fn with_terminal_reason(mut self, reason: TerminalReason) -> Self {
         self.terminal_reason = Some(reason);
+        self
+    }
+
+    /// Attach what the terminating guard observed.
+    pub fn with_terminal_evidence(mut self, evidence: impl Into<String>) -> Self {
+        self.terminal_evidence = Some(evidence.into());
         self
     }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -6275,6 +6275,7 @@ pub async fn get_mission_digest(
         "status": mission.status,
         "awaiting_kind": mission.awaiting_kind.map(|k| k.as_str()),
         "terminal_reason": mission.terminal_reason,
+        "terminal_evidence": mission.terminal_evidence,
         "short_description": mission.short_description,
         "terminal_verdict": terminal_verdict,
         "backend": mission.backend,
@@ -12856,6 +12857,12 @@ async fn paloma_webhook_forwarder_loop(
                 "workspace_name": workspace_name,
                 "backend": mission.as_ref().map(|m| m.backend.clone()),
                 "terminal_reason": terminal_reason,
+                // What the terminating guard OBSERVED. Without it, consumers
+                // invent causes: "transport bug", "GitHub is disabled",
+                // "pool needs re-provisioning" — all measured this week.
+                "terminal_evidence": mission
+                    .as_ref()
+                    .and_then(|mission| mission.terminal_evidence.as_deref()),
                 "resumable": matches!(status, MissionStatus::Interrupted | MissionStatus::Failed | MissionStatus::Blocked),
                 "recommended_action": recommended_action,
                 "execution": run.as_ref().map(|run| serde_json::json!({
@@ -14799,6 +14806,8 @@ async fn maybe_finalize_terminal_mission(
     events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
     mission_id: Uuid,
     terminal_reason: Option<TerminalReason>,
+    // What the terminating guard observed, from AgentResult::terminal_evidence.
+    terminal_evidence: Option<&str>,
     completion_confidence: Option<crate::agents::CompletionConfidence>,
     complete_turn_without_follow_up: bool,
     // The just-completed turn's assistant output, if available. Used to classify
@@ -14926,6 +14935,16 @@ async fn maybe_finalize_terminal_mission(
                 None
             };
 
+            if let Some(evidence) = terminal_evidence.filter(|e| !e.trim().is_empty()) {
+                // Best-effort by contract: failing to record evidence must
+                // never turn into failing to terminate.
+                if let Err(e) = mission_store
+                    .set_terminal_evidence(mission_id, evidence)
+                    .await
+                {
+                    tracing::warn!(mission_id = %mission_id, "failed to record terminal evidence: {e}");
+                }
+            }
             if let Err(e) = mission_store
                 .update_mission_status_with_reason(
                     mission_id,
@@ -18885,6 +18904,7 @@ async fn control_actor_loop(
                                     &events_tx,
                                     mission_id,
                                     agent_result.terminal_reason,
+                                    agent_result.terminal_evidence.as_deref(),
                                     Some(completion_evidence.completion_confidence),
                                     false,
                                     Some(agent_result.output.as_str()),
@@ -19149,6 +19169,7 @@ async fn control_actor_loop(
                                 &events_tx,
                                 mission_id,
                                 completed_terminal_reason,
+                                None,
                                 completed_completion_confidence,
                                 true,
                                 Some(completed_agent_output.as_str()),
@@ -19793,6 +19814,7 @@ async fn control_actor_loop(
                                         &events_tx,
                                         *mission_id,
                                         result.terminal_reason,
+                                        result.terminal_evidence.as_deref(),
                                         Some(completion_evidence.completion_confidence),
                                         true,
                                         Some(result.output.as_str()),
@@ -28492,6 +28514,7 @@ And the report:
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),
@@ -28531,6 +28554,7 @@ And the report:
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),
@@ -28585,6 +28609,7 @@ And the report:
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),
@@ -28636,6 +28661,7 @@ And the report:
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),
@@ -28687,6 +28713,7 @@ And the report:
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),
@@ -28738,6 +28765,7 @@ And the report:
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),
@@ -28873,6 +28901,7 @@ And the report:
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),
@@ -29733,6 +29762,7 @@ Investigate <service/> failures.
             mission.id,
             Some(TerminalReason::LlmError),
             None,
+            None,
             false,
             None,
             "shutdown race test",
@@ -29768,6 +29798,7 @@ Investigate <service/> failures.
             &events_tx,
             mission.id,
             Some(TerminalReason::Completed),
+            None,
             Some(crate::agents::CompletionConfidence::Low),
             true,
             None,

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -8526,12 +8526,26 @@ pub(crate) fn text_buffer_stream_looks_degenerate(
     min_substring_len: usize,
     min_repeats: usize,
 ) -> bool {
+    degenerate_repeated_substring(accumulated, window_chars, min_substring_len, min_repeats)
+        .is_some()
+}
+
+/// The substring that makes the stream look degenerate, if any — the guard's
+/// EVIDENCE. Returning it (rather than a bare bool) is what lets the runner
+/// record what actually tripped the kill, so a downstream agent reads a fact
+/// instead of inventing a transport bug (mission 7fb8970f, 2026-08-06).
+pub(crate) fn degenerate_repeated_substring(
+    accumulated: &str,
+    window_chars: usize,
+    min_substring_len: usize,
+    min_repeats: usize,
+) -> Option<String> {
     if min_substring_len == 0 || min_repeats < 2 || window_chars == 0 {
-        return false;
+        return None;
     }
     let chars: Vec<char> = accumulated.chars().collect();
     if chars.len() < min_substring_len.saturating_mul(min_repeats) {
-        return false;
+        return None;
     }
     let window_end = chars.len();
     let window_start = window_end.saturating_sub(window_chars);
@@ -8595,7 +8609,7 @@ pub(crate) fn text_buffer_stream_looks_degenerate(
                         "degenerate-stream detector matched; this substring is \
                          what tripped it"
                     );
-                    return true;
+                    return Some(needle);
                 }
                 // Non-overlapping, as the comment above has always claimed:
                 // advancing by one char let a periodic needle count its own
@@ -8605,7 +8619,7 @@ pub(crate) fn text_buffer_stream_looks_degenerate(
             }
         }
     }
-    false
+    None
 }
 
 /// Count distinct "substantive" words in `s`: tokens that are at least 4
@@ -12283,6 +12297,19 @@ mod tests {
     /// mid-way through its final report because a 17-guarantee table repeats
     /// long row scaffolding. Legitimate structure repeats are SEPARATED by
     /// distinct content; a degenerate loop is back to back.
+    /// Guard contract: the detector must surrender its evidence, not a bool.
+    #[test]
+    fn degenerate_detector_names_the_repeated_substring() {
+        let phrase = "Yielding pending your choice between the three options. ";
+        let s = phrase.repeat(50);
+        let needle = super::degenerate_repeated_substring(&s, 4096, 40, 3)
+            .expect("a 50x adjacent repeat must be caught");
+        assert!(
+            phrase.contains(&needle) || needle.contains(phrase.trim_end()),
+            "the evidence must be the actual repeated text, got {needle:?}"
+        );
+    }
+
     #[test]
     fn degenerate_detector_spares_a_structured_report() {
         let mut s = String::from("## Hypothesis report\n### Sources verified\n");

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -314,6 +314,7 @@ impl MissionStore for FileMissionStore {
             desktop_sessions: Vec::new(),
             session_id: Some(Uuid::new_v4().to_string()),
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id,
             working_directory: working_directory.map(|s| s.to_string()),
             mission_mode: super::MissionMode::default(),
@@ -350,6 +351,15 @@ impl MissionStore for FileMissionStore {
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String> {
         self.update_mission_status_with_reason(id, status, None)
             .await
+    }
+
+    async fn set_terminal_evidence(&self, id: Uuid, evidence: &str) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission not found: {id}"))?;
+        mission.terminal_evidence = Some(evidence.chars().take(2000).collect());
+        Ok(())
     }
 
     async fn update_mission_status_with_reason(

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -316,6 +316,7 @@ impl MissionStore for InMemoryMissionStore {
             desktop_sessions: Vec::new(),
             session_id: Some(Uuid::new_v4().to_string()),
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id,
             working_directory: working_directory.map(|s| s.to_string()),
             mission_mode: super::MissionMode::default(),
@@ -351,6 +352,15 @@ impl MissionStore for InMemoryMissionStore {
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String> {
         self.update_mission_status_with_reason(id, status, None)
             .await
+    }
+
+    async fn set_terminal_evidence(&self, id: Uuid, evidence: &str) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission not found: {id}"))?;
+        mission.terminal_evidence = Some(evidence.chars().take(2000).collect());
+        Ok(())
     }
 
     async fn update_mission_status_with_reason(

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -433,6 +433,13 @@ pub struct Mission {
     /// Why the mission terminated (for failed/completed missions)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_reason: Option<String>,
+    /// What the guard that terminated the mission OBSERVED — the repeated
+    /// substring, the missing selector, the measured timeout. The guard
+    /// contract (2026-08-06): a terminal_reason without evidence is how a
+    /// downstream agent ends up inventing a cause ("transport bug",
+    /// "GitHub is disabled") instead of reporting a fact.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_evidence: Option<String>,
     /// Parent mission ID (for orchestrated worker missions)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_mission_id: Option<Uuid>,
@@ -2083,6 +2090,14 @@ pub trait MissionStore: Send + Sync {
         status: MissionStatus,
         terminal_reason: Option<&str>,
     ) -> Result<(), String>;
+
+    /// Attach what the terminating guard observed. Additive and best-effort:
+    /// stores that predate the column simply keep None, and a failure to
+    /// record evidence must never turn into a failure to terminate.
+    async fn set_terminal_evidence(&self, id: Uuid, evidence: &str) -> Result<(), String> {
+        let _ = (id, evidence);
+        Ok(())
+    }
 
     /// Update mission conversation history.
     async fn update_mission_history(
@@ -4074,6 +4089,7 @@ mod tests {
             desktop_sessions: Vec::new(),
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::default(),

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2401,6 +2401,22 @@ impl SqliteMissionStore {
             }
         }
 
+        // Guard-evidence side table (2026-08-06). A separate table, NOT a
+        // missions column: every mission SELECT here maps columns by
+        // position, and widening those projections risks the exact
+        // fall-back-to-memory failure the migration comments above warn
+        // about. Non-fatal like the indexes.
+        if let Err(e) = conn.execute(
+            "CREATE TABLE IF NOT EXISTS mission_terminal_evidence (
+                mission_id TEXT PRIMARY KEY,
+                evidence TEXT NOT NULL,
+                recorded_at TEXT NOT NULL
+            )",
+            [],
+        ) {
+            tracing::warn!("creating mission_terminal_evidence skipped: {}", e);
+        }
+
         Ok(())
     }
 
@@ -2694,6 +2710,7 @@ fn row_to_mission(row: &rusqlite::Row<'_>) -> rusqlite::Result<Mission> {
             .unwrap_or_default(),
         session_id,
         terminal_reason,
+        terminal_evidence: None,
         parent_mission_id: row
             .get::<_, Option<String>>(22)?
             .and_then(|s| Uuid::parse_str(&s).ok()),
@@ -3090,6 +3107,25 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn set_terminal_evidence(&self, id: Uuid, evidence: &str) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let id_str = id.to_string();
+        let evidence = evidence.chars().take(2000).collect::<String>();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO mission_terminal_evidence (mission_id, evidence, recorded_at)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(mission_id) DO UPDATE SET evidence = ?2, recorded_at = ?3",
+                params![id_str, evidence, now_string()],
+            )
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn get_mission(&self, id: Uuid) -> Result<Option<Mission>, String> {
         let conn = self.conn.clone();
         let id_str = id.to_string();
@@ -3154,6 +3190,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                         session_id,
                         terminal_reason,
+                        terminal_evidence: None,
                         parent_mission_id: row.get::<_, Option<String>>(22)?.and_then(|s| Uuid::parse_str(&s).ok()),
                         working_directory: row.get(23)?,
                         mission_mode: row.get::<_, Option<String>>(24)?
@@ -3216,6 +3253,16 @@ impl MissionStore for SqliteMissionStore {
                     .map_err(|e| e.to_string())?;
 
                 m.history = history;
+                // Guard evidence lives in its own side table (see
+                // run_migrations); the single-mission read is the one path
+                // that carries it — list projections stay lean.
+                m.terminal_evidence = conn
+                    .query_row(
+                        "SELECT evidence FROM mission_terminal_evidence WHERE mission_id = ?1",
+                        params![&id_str],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .ok();
                 Ok(Some(m))
             } else {
                 Ok(None)
@@ -3599,6 +3646,7 @@ impl MissionStore for SqliteMissionStore {
             desktop_sessions: Vec::new(),
             session_id: Some(session_id.clone()),
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id,
             working_directory: working_directory.map(|s| s.to_string()),
             mission_mode: MissionMode::default(),
@@ -3696,6 +3744,7 @@ impl MissionStore for SqliteMissionStore {
                         desktop_sessions: Vec::new(),
                         session_id: row.get(18)?,
                         terminal_reason: row.get(19)?,
+                        terminal_evidence: None,
                         parent_mission_id: row.get::<_, Option<String>>(20)?.and_then(|s| Uuid::parse_str(&s).ok()),
                         working_directory: row.get(21)?,
                         mission_mode: row.get::<_, Option<String>>(22)?
@@ -4635,6 +4684,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                         session_id: None, // Not needed for stale mission checks
                         terminal_reason: None,
+                        terminal_evidence: None,
                         parent_mission_id: None,
                         working_directory: None,
                         mission_mode: MissionMode::default(),
@@ -4714,6 +4764,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                         session_id: None,
                         terminal_reason: None,
+                        terminal_evidence: None,
                         parent_mission_id: None,
                         working_directory: None,
                         mission_mode: row
@@ -4853,6 +4904,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                         session_id: None,
                         terminal_reason: None,
+                        terminal_evidence: None,
                         parent_mission_id: None,
                         working_directory: None,
                         mission_mode: row
@@ -7370,6 +7422,7 @@ impl MissionStore for SqliteMissionStore {
                         desktop_sessions: vec![],
                         session_id: None,
                         terminal_reason: None,
+                        terminal_evidence: None,
                         parent_mission_id: None,
                         working_directory: None,
                         mission_mode: serde_json::from_value(serde_json::Value::String(mode_str))

--- a/src/api/paloma/mission_card.rs
+++ b/src/api/paloma/mission_card.rs
@@ -289,6 +289,7 @@ mod tests {
             desktop_sessions: vec![],
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::Task,

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -1598,6 +1598,7 @@ pub fn run_claudecode_turn<'a>(
                 .unwrap_or(4096);
         let mut first_text_delta_at: Option<Instant> = None;
         let mut degenerate_stage_triggered: bool = false;
+        let mut degenerate_evidence: Option<String> = None;
 
         let mut saw_non_init_event = false;
         let startup_timeout = Duration::from_secs(
@@ -2005,14 +2006,18 @@ pub fn run_claudecode_turn<'a>(
                                                                 .cloned()
                                                                 .collect::<Vec<_>>()
                                                                 .join("");
-                                                            if streaming_for >= degenerate_min_duration
-                                                                && text_buffer_stream_looks_degenerate(
-                                                                    &total_acc,
-                                                                    degenerate_window_chars,
-                                                                    degenerate_min_substring_len,
-                                                                    degenerate_min_repeats,
-                                                                )
-                                                            {
+                                                            let degenerate_needle =
+                                                                if streaming_for >= degenerate_min_duration {
+                                                                    crate::api::mission_runner::degenerate_repeated_substring(
+                                                                        &total_acc,
+                                                                        degenerate_window_chars,
+                                                                        degenerate_min_substring_len,
+                                                                        degenerate_min_repeats,
+                                                                    )
+                                                                } else {
+                                                                    None
+                                                                };
+                                                            if let Some(needle) = degenerate_needle {
                                                                 tracing::warn!(
                                                                     mission_id = %mission_id,
                                                                     streaming_for_secs = streaming_for.as_secs(),
@@ -2023,6 +2028,7 @@ pub fn run_claudecode_turn<'a>(
                                                                     "Claude Code stream looks degenerate (same substring repeated); killing CLI"
                                                                 );
                                                                 degenerate_stage_triggered = true;
+                                                                degenerate_evidence = Some(needle);
                                                                 pty.kill();
                                                                 reader_handle.abort();
                                                                 break;
@@ -2621,9 +2627,18 @@ pub fn run_claudecode_turn<'a>(
                 // Keep the partial output. The previous message claimed it
                 // was "preserved" while overwriting it — mission 7fb8970f
                 // lost five minutes of verified findings to that word.
+                let evidence_line = degenerate_evidence
+                    .as_deref()
+                    .map(|needle| {
+                        format!(
+                            "\nRepeated substring (the guard's evidence): {:?}",
+                            needle.chars().take(120).collect::<String>()
+                        )
+                    })
+                    .unwrap_or_default();
                 let notice = format!(
-                    "Claude Code entered a degenerate output loop (the same short string was repeated many times in the streamed response) and the turn was cut short to avoid a runaway 50-minute bill — see mission ab260b2e for the canonical example.\n\nThe model never produced a terminal result event. Partial output ({} chars) is preserved below; resend your last message to try again.",
-                    partial_chars
+                    "Claude Code entered a degenerate output loop (the same short string was repeated many times in the streamed response) and the turn was cut short to avoid a runaway 50-minute bill — see mission ab260b2e for the canonical example.{}\n\nThe model never produced a terminal result event. Partial output ({} chars) is preserved below; resend your last message to try again.",
+                    evidence_line, partial_chars
                 );
                 final_result = if final_result.trim().is_empty() {
                     notice
@@ -2785,7 +2800,15 @@ pub fn run_claudecode_turn<'a>(
             } else {
                 TerminalReason::LlmError
             };
-            AgentResult::failure(final_result, cost_cents).with_terminal_reason(reason)
+            let mut failure =
+                AgentResult::failure(final_result, cost_cents).with_terminal_reason(reason);
+            if let Some(needle) = degenerate_evidence.as_deref() {
+                failure = failure.with_terminal_evidence(format!(
+                    "repeated substring: {:?}",
+                    needle.chars().take(200).collect::<String>()
+                ));
+            }
+            failure
         } else if is_success_path_rate_limited_error(&final_result) {
             // Claude Code sometimes surfaces subscription quota exhaustion as a
             // normal assistant message (e.g. "You've hit your limit · resets

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -6837,6 +6837,7 @@ mod tests {
             desktop_sessions: vec![],
             session_id: None,
             terminal_reason: None,
+            terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
             mission_mode: MissionMode::Task,


### PR DESCRIPTION
## The pattern this closes

Five guards fired this week; five times the downstream agent **invented a cause**, because the verdict travelled without its evidence:

| guard fired | what the agent concluded | reality |
|---|---|---|
| degenerate-loop detector | "transport bug with claude-fable-5", lane frozen | detector false-positive on a review table |
| `github_enabled` read | "I cannot dispatch missions" | a dashboard login flag |
| chatgpt_ui auth preflight | "pool systemically broken, re-provision 12 logins" | one renamed selector; 12 valid cookies |
| MCP connect failure | "I have no Notion tools" (improvised workaround) | 89s cold-cache handshake vs 60s timeout |
| webhook forwarder gap | operator noticed before any instrument | lossy broadcast, non-broadcasting writers |

## The contract

**Evidence, not a verdict** — and it travels the whole chain:

```
detector                    → returns its needle (degenerate_repeated_substring)
AgentResult                 → terminal_evidence alongside terminal_reason
maybe_finalize_terminal_mission → persists it (best-effort: failing to record
                              evidence must never turn into failing to terminate)
MissionStore                → set_terminal_evidence; sqlite keeps a SIDE TABLE —
                              not a missions column, because every mission SELECT
                              maps columns by position and widening those
                              projections risks the fall-back-to-memory failure
                              the migration comments warn about
get_mission                 → enriched; list projections stay lean
completion webhook          → "terminal_evidence" next to terminal_reason and
                              recommended_action
```

Plus the audit items shipped here: the chatgpt_ui preflight now names the selectors it probed and the page it probed them on ("the session cookie may still be perfectly valid" — the sentence that would have saved yesterday's diagnosis); the degenerate notice names the repeated substring in the user-facing message, not only the logs.

`docs/HERMES_ORCHESTRATION.md` gains the contract and a compliance table for the six standing guards.

## Tests

`degenerate_detector_names_the_repeated_substring` pins that the evidence is the actual repeated text, not a paraphrase. Full `cargo test --lib`: **1729 passed**. Clippy clean.

## What follows (same goal, next commits)

The one-line mirror rule in `controllers-policy` on the Hermes side: *a `terminal_reason` without evidence is missing data to report, never an invitation to guess.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission finalization, persistence (new SQLite table), and webhook payloads; behavior is mostly additive and best-effort, but incorrect evidence wiring could mislead operators on terminal missions.
> 
> **Overview**
> Introduces a **guard contract** so kill-switches ship *what they observed*, not just a verdict. `docs/HERMES_ORCHESTRATION.md` documents the three rules and a compliance table for standing guards.
> 
> **`terminal_evidence`** is added on `AgentResult` and `Mission`, persisted via `MissionStore::set_terminal_evidence` (SQLite uses a side table; file/memory stores inline), exposed on mission GET and completion webhooks beside `terminal_reason`, and recorded best-effort in `maybe_finalize_terminal_mission` so a storage failure cannot block termination.
> 
> The **degenerate-stream** path is wired end-to-end: `degenerate_repeated_substring` returns the repeated needle; the Claude Code runner attaches it to the user notice and `AgentResult::terminal_evidence` on `InfiniteLoop` failures.
> 
> **ChatGPT UI** auth preflight errors now list probed selectors, page URL, and title so a selector rename is not misread as “re-provision the pool.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b018b814b4086de64a31d7b526a0825f86eb9e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->