### PR TITLE
Add Meta Muse (muse-spark) as a first-class provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,3 +273,7 @@ JWT_TTL_DAYS=30
 # HERMES_DASHBOARD_SESSION_TOKEN=
 # HERMES_DASHBOARD_PORT=9119
 # HERMES_DASHBOARD_WS_URL=ws://127.0.0.1:9119/api/ws
+
+# Meta Muse (api.meta.ai) — picked up as the muse provider's key when no
+# provider row exists (ProviderType::env_var_name fallback).
+# META_MODEL_API_KEY=

--- a/dashboard/src/components/ui/add-provider-modal.tsx
+++ b/dashboard/src/components/ui/add-provider-modal.tsx
@@ -29,6 +29,7 @@ const providerIcons: Record<string, string> = {
   zai: '⚡',
   xai: '𝕏',
   minimax: 'M',
+  muse: '🎭',
   kimi: '🌙',
   custom: '🔧',
 };

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -25,6 +25,7 @@ export type AIProviderType =
   | "perplexity"
   | "zai"
   | "minimax"
+  | "muse"
   | "github-copilot"
   | "kimi"
   | "custom";

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -105,6 +105,8 @@ pub enum ProviderType {
     Zai,
     Minimax,
     Kimi,
+    /// Meta's Muse model family (api.meta.ai, OpenAI-compatible).
+    Muse,
     Custom,
 }
 
@@ -128,6 +130,7 @@ impl ProviderType {
             Self::GithubCopilot => "GitHub Copilot",
             Self::Zai => "Z.AI",
             Self::Minimax => "Minimax",
+            Self::Muse => "Meta Muse",
             Self::Kimi => "Kimi",
             Self::Custom => "Custom",
         }
@@ -152,6 +155,7 @@ impl ProviderType {
             Self::GithubCopilot => "github-copilot",
             Self::Zai => "zai",
             Self::Minimax => "minimax",
+            Self::Muse => "muse",
             Self::Kimi => "kimi",
             Self::Custom => "custom",
         }
@@ -177,6 +181,7 @@ impl ProviderType {
             "github-copilot" => Some(Self::GithubCopilot),
             "zai" => Some(Self::Zai),
             "minimax" => Some(Self::Minimax),
+            "muse" => Some(Self::Muse),
             "kimi" => Some(Self::Kimi),
             "custom" => Some(Self::Custom),
             _ => None,
@@ -202,6 +207,7 @@ impl ProviderType {
             Self::GithubCopilot => None, // Uses OAuth
             Self::Zai => Some("ZHIPU_API_KEY"),
             Self::Minimax => Some("MINIMAX_API_KEY"),
+            Self::Muse => Some("META_MODEL_API_KEY"),
             Self::Kimi => None, // OAuth-only (Kimi Code subscription)
             Self::Custom => None,
         }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -6471,6 +6471,12 @@ async fn list_provider_types() -> Json<Vec<ProviderTypeInfo>> {
             env_var: Some("MINIMAX_API_KEY".to_string()),
         },
         ProviderTypeInfo {
+            id: "muse".to_string(),
+            name: "Meta Muse".to_string(),
+            uses_oauth: false,
+            env_var: Some("META_MODEL_API_KEY".to_string()),
+        },
+        ProviderTypeInfo {
             id: "deep-infra".to_string(),
             name: "DeepInfra".to_string(),
             uses_oauth: false,
@@ -6834,6 +6840,20 @@ async fn check_provider_health(
                 "https://api.minimax.io/v1/chat/completions",
                 serde_json::json!({
                     "model": "MiniMax-M3",
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 1
+                }),
+                format!("Bearer {}", key),
+            )
+        }
+        ProviderType::Muse => {
+            let key = api_key_opt
+                .as_ref()
+                .ok_or((StatusCode::BAD_REQUEST, "No API key".to_string()))?;
+            (
+                "https://api.meta.ai/v1/chat/completions",
+                serde_json::json!({
+                    "model": "muse-spark-1.2",
                     "messages": [{"role": "user", "content": "test"}],
                     "max_tokens": 1
                 }),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4887,6 +4887,12 @@ pub(crate) fn detect_opencode_provider_auth(
             configured_providers.insert("cerebras".to_string());
         }
     }
+    if let Ok(value) = std::env::var("META_MODEL_API_KEY") {
+        if !value.trim().is_empty() {
+            has_other = true;
+            configured_providers.insert("muse".to_string());
+        }
+    }
 
     if let Some(app_dir) = app_working_dir {
         if let Some(auth) = build_opencode_auth_from_ai_providers(app_dir) {
@@ -5329,6 +5335,27 @@ pub(crate) fn ensure_opencode_provider_for_model(
                 },
                 "options": {
                     "baseURL": base_url
+                }
+            }))
+        }
+        "muse" => {
+            // Unlike minimax/xai, "muse" is not in OpenCode's built-in
+            // provider registry, so the key must be referenced explicitly.
+            // `{env:META_MODEL_API_KEY}` is expanded by OpenCode from the
+            // mission process env, which apply_opencode_auth_env populates
+            // from the provider store / server env (enum-driven via
+            // ProviderType::env_var_name).
+            let base_url = std::env::var("MUSE_BASE_URL")
+                .unwrap_or_else(|_| "https://api.meta.ai/v1".to_string());
+            Some(serde_json::json!({
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "Meta Muse",
+                "models": {
+                    model_id: { "name": model_id }
+                },
+                "options": {
+                    "baseURL": base_url,
+                    "apiKey": "{env:META_MODEL_API_KEY}"
                 }
             }))
         }
@@ -5803,6 +5830,7 @@ pub(crate) fn sync_opencode_auth_to_workspace(
         "zai",
         "cerebras",
         "minimax",
+        "muse",
     ];
     if let (Some(src_dir), Some(dest_dir)) =
         (host_opencode_provider_auth_dir(), provider_auth_dir.clone())

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -64,6 +64,7 @@ pub const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] = &[
     "cerebras",
     "zai",
     "minimax",
+    "muse",
     "kimi",
 ];
 
@@ -1190,6 +1191,27 @@ fn default_providers_config() -> ProvidersConfig {
                 description: "Kimi Code via Moonshot OAuth (device login)".to_string(),
                 models: kimi_fallback_models(),
             },
+            Provider {
+                id: "muse".to_string(),
+                name: "Meta Muse".to_string(),
+                billing: "api_key".to_string(),
+                description: "Meta's Muse family via api.meta.ai (OpenAI-compatible)".to_string(),
+                // Verified live against /models on 2026-08-06; the catalog
+                // refresh overwrites this with the fetched list when the key
+                // is present.
+                models: vec![
+                    ProviderModel {
+                        id: "muse-spark-1.2".to_string(),
+                        name: "Muse Spark 1.2".to_string(),
+                        description: Some("Fast reasoning model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "muse-spark-1.1".to_string(),
+                        name: "Muse Spark 1.1".to_string(),
+                        description: None,
+                    },
+                ],
+            },
         ],
     }
 }
@@ -2063,6 +2085,16 @@ async fn fetch_model_catalog(
             provider_id: "minimax",
             base_url: "https://api.minimax.io/v1",
             prefix_filters: vec!["MiniMax-"],
+            models_query: None,
+            sort_results_by_id: true,
+            allow_unauthenticated: false,
+            max_models: None,
+        },
+        FetchTarget {
+            provider_type: ProviderType::Muse,
+            provider_id: "muse",
+            base_url: "https://api.meta.ai/v1",
+            prefix_filters: vec!["muse-"],
             models_query: None,
             sort_results_by_id: true,
             allow_unauthenticated: false,

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -152,6 +152,7 @@ fn default_base_url(provider_type: ProviderType) -> Option<&'static str> {
         ProviderType::Cerebras => Some("https://api.cerebras.ai/v1"),
         ProviderType::Zai => Some("https://api.z.ai/api/coding/paas/v4"),
         ProviderType::Minimax => Some("https://api.minimax.io/v1"),
+        ProviderType::Muse => Some("https://api.meta.ai/v1"),
         ProviderType::DeepInfra => Some("https://api.deepinfra.com/v1/openai"),
         ProviderType::Groq => Some("https://api.groq.com/openai/v1"),
         ProviderType::OpenRouter => Some("https://openrouter.ai/api/v1"),

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1746,6 +1746,8 @@ fn infer_provider_for_model(model: &str) -> Option<String> {
         Some("zai".to_string())
     } else if m.contains("minimax") || m.contains("abab") {
         Some("minimax".to_string())
+    } else if m.contains("muse") {
+        Some("muse".to_string())
     } else if m.contains("mistral") || m.contains("codestral") {
         Some("mistral".to_string())
     } else if m.contains("llama") && m.contains("groq") {

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -686,6 +686,17 @@ pub async fn run_opencode_turn(
 
     if let Some(auth) = opencode_auth.as_ref() {
         let providers = apply_opencode_auth_env(auth, &mut env);
+        // Server-env fallback for Muse: the key may live only in
+        // META_MODEL_API_KEY on the service (no provider row), and the
+        // opencode provider block references {env:META_MODEL_API_KEY}.
+        // Without this, a store-less deployment silently loses the key.
+        if !env.contains_key("META_MODEL_API_KEY") {
+            if let Ok(value) = std::env::var("META_MODEL_API_KEY") {
+                if !value.trim().is_empty() {
+                    env.insert("META_MODEL_API_KEY".to_string(), value);
+                }
+            }
+        }
         if !providers.is_empty() {
             tracing::info!(
                 mission_id = %mission_id,

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -353,6 +353,21 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         aliases: &["minimax-m3"],
         pricing: pricing(600, 2_400, Some(375), Some(60)),
     },
+    // Meta Muse (api.meta.ai). TODO: replace with published per-token prices —
+    // none were available at integration time (2026-08-06); zero entries here
+    // would be SILENT zero-cost accounting, so this placeholder uses
+    // MiniMax-M3-class rates as a conservative stand-in and must be corrected
+    // when Meta publishes pricing.
+    PricingEntry {
+        canonical: "muse-spark-1.2",
+        aliases: &["muse-spark-1.2", "muse-spark"],
+        pricing: pricing(600, 2_400, None, None),
+    },
+    PricingEntry {
+        canonical: "muse-spark-1.1",
+        aliases: &["muse-spark-1.1"],
+        pricing: pricing(600, 2_400, None, None),
+    },
     PricingEntry {
         canonical: "minimax-m2.7-highspeed",
         aliases: &["minimax-m2.7-highspeed", "minimax-m2-7-highspeed"],

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -887,6 +887,10 @@ impl ModelChainStore {
                         provider_id: "zai".to_string(),
                         model_id: "glm-5.2".to_string(),
                     },
+                    ChainEntry {
+                        provider_id: "muse".to_string(),
+                        model_id: "muse-spark-1.2".to_string(),
+                    },
                 ],
                 is_default: true,
                 strip_thinking: false,
@@ -925,6 +929,22 @@ impl ModelChainStore {
                     chain.entries.swap(0, 1);
                     migrated = true;
                     tracing::info!("Reordered builtin/smart to lead with MiniMax");
+                }
+                // 2026-08-06: append Meta Muse as a tail fallback to already-
+                // persisted chains. Appending (never inserting) preserves the
+                // operator's configured priority — prod runs a kimi-first
+                // custom order that the stock migrations deliberately skip.
+                if !chain
+                    .entries
+                    .iter()
+                    .any(|entry| entry.provider_id == "muse")
+                {
+                    chain.entries.push(ChainEntry {
+                        provider_id: "muse".to_string(),
+                        model_id: "muse-spark-1.2".to_string(),
+                    });
+                    migrated = true;
+                    tracing::info!("Appended muse/muse-spark-1.2 to builtin/smart");
                 }
                 if migrated {
                     chain.updated_at = now;
@@ -1621,6 +1641,9 @@ mod tests {
                 // glm-5.1 is migrated to glm-5.2 by ensure_default_chain.
                 ("zai".to_string(), "glm-5.2".to_string()),
                 ("cerebras".to_string(), "zai-glm-4.7".to_string()),
+                // The 2026-08-06 migration appends Meta Muse as a tail
+                // fallback to persisted chains, never reordering them.
+                ("muse".to_string(), "muse-spark-1.2".to_string()),
             ]
         );
 


### PR DESCRIPTION
## What

Meta's Muse family via **api.meta.ai** (OpenAI-compatible), key from `META_MODEL_API_KEY`. Verified live before any hardcoding:

```
GET  /v1/models           → muse-spark-1.2, muse-spark-1.1
POST /v1/chat/completions → round-trips (reasoning model; usage reports reasoning_tokens)
```

## Why first-class rather than a Custom row

The Custom path works today but: the key would sit in plaintext in `ai_providers.json` (no env pickup — `env_var_name()` is enum-only), the health test answers "configured" without probing, no catalog fetch, and the opencode mission env has **no generic passthrough** — `apply_opencode_auth_env` maps known `ProviderType`s only. The enum variant buys all four.

## The wiring (per the approved plan)

- **Enum + proxy**: `ProviderType::Muse`, four arms, `default_base_url` (compile-enforced).
- **Health**: a real 1-token probe against `chat/completions` — per the guard contract, never "configured" without evidence.
- **Catalog**: `/models` FetchTarget + static fallback (selectable even when the fetch fails).
- **Router**: appended at the **tail** of `builtin/smart`, and a migration that *appends, never reorders* — prod runs a kimi-first custom order that stock migrations deliberately leave alone; inserting anywhere else would silently change routing priority.
- **OpenCode missions**: dedicated arm (`muse` is not in OpenCode's built-in registry, so `options.apiKey = {env:META_MODEL_API_KEY}` is explicit), plus env-detection, auth-file copy list, and a server-env fallback into the mission process env for store-less deployments.
- **Cost**: placeholder MiniMax-class rates with a loud TODO — absent entries would be **silent zero-cost accounting**, the worse failure.
- Dashboard type + icon, `.env.example` doc.

## Naming collision, checked

A Custom provider named `spark` (DGX vLLM) already exists. No conflict: chain entries are provider-qualified (`muse/muse-spark-1.2` vs `spark/…`), and no Custom account named "Muse" exists for the enum to shadow.

## Tests

`cargo test --lib`: **1729 passed** (the chain-migration test's expectation gains the appended tail — that is the migration working). Clippy clean.

## Deploy notes (done alongside the merge)

`META_MODEL_API_KEY` added to `/etc/open_agent/open_agent.env` from the Bitwarden project (fallback #3 in `get_api_key_for_provider` — no store row needed), then the standard detached deploy. End-to-end verification: provider listed, health probe green, catalog refresh shows both models, `builtin/smart` resolve counts muse with credentials, and a live opencode mission on `muse/muse-spark-1.2` answers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider routing, fallback-chain migrations, and mission env/auth for a new upstream API; cost accounting uses placeholder rates until Meta publishes pricing.
> 
> **Overview**
> Adds **Meta Muse** (`api.meta.ai`, OpenAI-compatible) as a first-class provider keyed by `META_MODEL_API_KEY`, instead of relying on a Custom provider row.
> 
> **Backend & routing:** New `ProviderType::Muse` with proxy base URL, a real 1-token health probe, live `/models` catalog fetch (plus static fallbacks), model-id inference for `muse`, and placeholder cost rates for `muse-spark-*` (documented TODO so usage is not silently zero).
> 
> **Missions & OpenCode:** Muse gets an explicit OpenCode provider block (`{env:META_MODEL_API_KEY}`, optional `MUSE_BASE_URL`), env-based “configured” detection, auth-file copy, and a server-env fallback when no dashboard provider row exists.
> 
> **Fallback chains:** `builtin/smart` gains Muse at the **tail**; a migration **appends** `muse/muse-spark-1.2` to existing chains without reordering operator priorities.
> 
> **Dashboard:** `muse` in provider types and add-provider UI (🎭 icon). `.env.example` documents `META_MODEL_API_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22f167ca8c666d601be3ea8daa4b2877fd791dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->