### PR TITLE
Stall guards surrender their evidence

### DIFF
--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -1540,7 +1540,18 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
         } else {
             TerminalReason::LlmError
         };
-        AgentResult::failure(final_message, cost_cents).with_terminal_reason(reason)
+        let mut failure =
+            AgentResult::failure(final_message, cost_cents).with_terminal_reason(reason);
+        if reason == TerminalReason::Stalled {
+            // Guard contract: say what was observed, not just the verdict.
+            failure = failure.with_terminal_evidence(if stopped_before_required_tools {
+                "Codex stopped before completing required workspace/tool steps \
+                 (no required tool call was made after the last response)"
+            } else {
+                "Codex stopped on a progress-update message without resuming work"
+            });
+        }
+        failure
     };
 
     let outcome = turn_outcome_for_result(

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -996,6 +996,8 @@ pub async fn run_opencode_turn(
     // Used after the event loop to flag the result as incomplete so the caller
     // can surface the truncation to the user.
     let mut killed_by_idle_timeout = false;
+    // Guard contract: what the stall watchdog OBSERVED, for terminal_evidence.
+    let mut stall_evidence: Option<String> = None;
     // Track session idle state — used as a fallback completion signal when
     // response.completed is not emitted (common with GLM models).
     let mut session_idle_seen = false;
@@ -1225,6 +1227,11 @@ pub async fn run_opencode_turn(
                                 mission_id = %mission_id,
                                 "OpenCode output idle timeout reached; terminating CLI process"
                             );
+                            stall_evidence = Some(format!(
+                                "no streamed text for {}s (SANDBOXED_SH_OPENCODE_IDLE_TIMEOUT_SECS), \
+                                 no active tools, no proxy streaming; CLI killed",
+                                opencode_text_idle_timeout_secs
+                            ));
                             killed_by_idle_timeout = true;
                             let _ = child.kill().await;
                             break;
@@ -1288,6 +1295,10 @@ pub async fn run_opencode_turn(
                             proxy_streaming = proxy_streaming,
                             "Global inactivity timeout; terminating stuck CLI process"
                         );
+                        stall_evidence = Some(format!(
+                            "no SSE events, stdout or stderr for {}s; CLI killed",
+                            inactivity_elapsed.as_secs()
+                        ));
                         killed_by_idle_timeout = true;
                         let _ = child.kill().await;
                         break;
@@ -2043,7 +2054,13 @@ pub async fn run_opencode_turn(
         } else {
             TerminalReason::LlmError
         };
-        AgentResult::failure(final_result, 0).with_terminal_reason(reason)
+        let mut failure = AgentResult::failure(final_result, 0).with_terminal_reason(reason);
+        if reason == TerminalReason::Stalled {
+            if let Some(evidence) = stall_evidence.as_deref() {
+                failure = failure.with_terminal_evidence(evidence);
+            }
+        }
+        failure
     } else {
         AgentResult::success(final_result, 0).with_terminal_reason(TerminalReason::TurnComplete)
     };


### PR DESCRIPTION
## Found by the contract's own first live exercise

Tonight's supervision pass hit the first real `terminal_evidence` read since #758 shipped:

```
Lido PR #47 integration mission → reason: stalled | evidence: None
```

The evidence chain works (the callback marker proved delivery; the Lido pilot self-diagnosed from mission events) — but the **mission-stall watchdogs** were never wired to it, so the field shipped empty on exactly the failure mode it was built for. `stalled` without measurement is the bare-verdict pattern again.

## The change

**opencode runner** — both kill sites record what was measured:

- text-idle: `"no streamed text for {N}s (SANDBOXED_SH_OPENCODE_IDLE_TIMEOUT_SECS), no active tools, no proxy streaming; CLI killed"`
- global inactivity: `"no SSE events, stdout or stderr for {N}s; CLI killed"` — with the *elapsed* seconds, not the configured ones.

**codex runner** — the two stall classifications name their observation: stopped before required workspace/tool steps, or stopped on a progress-update message without resuming.

Evidence rides `AgentResult::terminal_evidence` → store → completion webhook (all shipped in #758), so the pilot receiving the callback reasons from a measurement instead of the word `stalled`.

## Tests

`cargo test --lib`: **1729 passed**. Clippy clean. No new tests: the sites are inline in process-management loops that the existing runner tests already cover for classification; the evidence strings are compile-checked format arms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to failure metadata on existing stall paths; no auth, persistence schema, or classification logic changes beyond attaching evidence strings.
> 
> **Overview**
> **Stall watchdogs now attach `terminal_evidence` on `TerminalReason::Stalled` failures**, so completion webhooks and pilots get measurements instead of a bare `stalled` verdict.
> 
> In the **OpenCode** runner, both idle-kill paths record what was observed before killing the CLI: text-idle stalls (no streamed text for N seconds, no tools, no proxy streaming) and global inactivity (no SSE/stdout/stderr for elapsed seconds). Those strings are set at kill time and passed through `AgentResult::with_terminal_evidence`.
> 
> In the **Codex** runner, the two existing stall classifications each get a fixed evidence message: stopped before required tool/workspace steps, or stopped on a progress-update without resuming work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e062cb39f0783f96a2e1d3fb9393fc1df3a8a54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->