### PR TITLE
Surface controller mode and the health rollup on the projects board

### DIFF
--- a/dashboard/src/components/projects/project-health.tsx
+++ b/dashboard/src/components/projects/project-health.tsx
@@ -1,0 +1,153 @@
+/**
+ * Controller mode and mission-health presentation.
+ *
+ * Two signals the board used to drop on the floor:
+ *
+ * 1. `health` — computed and served by the backend rollup since day one, but
+ *    absent from the frontend type, so a project whose oldest track had been
+ *    failing for days looked identical to a healthy one.
+ * 2. `mode` — the controller's own `[CTRL: … mode=… ]` trailer. Before it,
+ *    "healthy and quiet", "stuck on the same blocker for sixteen ticks" and
+ *    "deliberately paused" all rendered as the same silence.
+ *
+ * Both degrade to nothing: a controller that has not adopted the trailer, or a
+ * backend that predates the rollup, renders exactly as the board did before.
+ */
+
+import type { ProjectHealth, ProjectRow, TrackVerdict } from "@/lib/api/projects";
+import { cn } from "@/lib/utils";
+
+/** Silence longer than this on an otherwise live project is worth flagging:
+ *  it is the cheap client-side proxy for "has this controller stopped
+ *  ticking?", which the backend cannot answer (crons live in Hermes). */
+const STALE_UPDATE_HOURS = 24;
+
+export type ControllerMode = {
+  /** The regime itself. */
+  base: "active" | "blocked" | "paused";
+  /** Optional cause carried as `blocked:transport-cap`. */
+  cause: string | null;
+};
+
+/** Read the controller mode off the newest delivery. Returns null when the
+ *  controller has not adopted the trailer — callers must render nothing in
+ *  that case rather than inventing an "unknown" state. */
+export function parseMode(project: ProjectRow): ControllerMode | null {
+  const raw = project.latest_update?.mode;
+  if (!raw) return null;
+  const [base, ...rest] = raw.trim().toLowerCase().split(":");
+  if (base !== "active" && base !== "blocked" && base !== "paused") return null;
+  const cause = rest.join(":").trim();
+  return { base, cause: cause.length > 0 ? cause : null };
+}
+
+/** True when a project has gone quiet for long enough that its controller may
+ *  have died rather than simply having nothing to say. */
+export function isStale(project: ProjectRow): boolean {
+  const at = project.latest_update?.at;
+  if (!at) return false;
+  const ms = Date.now() - new Date(at).getTime();
+  return Number.isFinite(ms) && ms > STALE_UPDATE_HOURS * 3600_000;
+}
+
+/** One-line health digest, or null when there is nothing worth saying.
+ *  Only speaks up when a track actually needs attention — otherwise the row
+ *  keeps showing the controller's own headline, which is more informative. */
+export function healthDigest(health: ProjectHealth | undefined): string | null {
+  if (!health || health.tracks_needing_attention < 1) return null;
+  const parts: string[] = [];
+  const tracks = health.tracks.length;
+  if (tracks > 0) parts.push(`${tracks} track${tracks === 1 ? "" : "s"}`);
+  if (health.failed > 0) parts.push(`${health.failed} failing`);
+  if (health.overdue > 0) parts.push(`${health.overdue} overdue`);
+  if (health.active > 0) parts.push(`${health.active} active`);
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+const MODE_LABEL: Record<ControllerMode["base"], string> = {
+  active: "active",
+  blocked: "blocked",
+  paused: "paused",
+};
+
+/** Compact mode indicator. Amber is reserved for "someone should look at
+ *  this"; a paused project is deliberate, so it reads as dimmed, not alarming. */
+export function ModeChip({
+  mode,
+  className,
+}: {
+  mode: ControllerMode | null;
+  className?: string;
+}) {
+  if (!mode) return null;
+  const label = mode.cause
+    ? `${MODE_LABEL[mode.base]}: ${mode.cause}`
+    : MODE_LABEL[mode.base];
+  return (
+    <span
+      title={label}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 truncate text-[10px] uppercase tracking-wide",
+        mode.base === "blocked" && "text-amber-400/80",
+        mode.base === "active" && "text-indigo-300/70",
+        mode.base === "paused" && "text-white/35",
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "h-1 w-1 shrink-0 rounded-full",
+          mode.base === "blocked" && "bg-amber-400/80",
+          mode.base === "active" && "bg-indigo-400/70",
+          mode.base === "paused" && "bg-white/30",
+        )}
+      />
+      {label}
+    </span>
+  );
+}
+
+const VERDICT_TONE: Record<TrackVerdict, string> = {
+  failing: "text-amber-400/80",
+  overdue: "text-amber-400/70",
+  active: "text-indigo-300/70",
+  done: "text-white/40",
+  idle: "text-white/35",
+};
+
+/** Per-track breakdown for the detail pane. The backend already sorts
+ *  worst-first, so the row that needs attention is the one you read first. */
+export function TrackHealthList({ health }: { health: ProjectHealth | undefined }) {
+  if (!health || health.tracks.length === 0) return null;
+  return (
+    <div className="space-y-1">
+      {health.tracks.map((track, index) => {
+        const desired = Object.entries(track.desired_states ?? {});
+        return (
+          <div
+            key={track.track ?? `untracked-${index}`}
+            className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-[11px]"
+          >
+            <span className="text-white/70">{track.track ?? "untracked"}</span>
+            <span className={VERDICT_TONE[track.verdict]}>{track.verdict}</span>
+            <span className="text-white/40">
+              {[
+                track.active > 0 ? `${track.active} active` : null,
+                track.failed > 0 ? `${track.failed} failed` : null,
+                track.overdue > 0 ? `${track.overdue} overdue` : null,
+                track.completed > 0 ? `${track.completed} done` : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </span>
+            {desired.length > 0 && (
+              <span className="text-white/30">
+                {desired.map(([state, count]) => `${state}: ${count}`).join(" · ")}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -7,7 +7,12 @@ import {
   getProjectUpdates,
   postProjectAction,
 } from "@/lib/api/projects";
-import type { ProjectRow, ProjectsOverview } from "@/lib/api/projects";
+import type {
+  ProjectHealth,
+  ProjectRow,
+  ProjectsOverview,
+  TrackHealth,
+} from "@/lib/api/projects";
 import { hermesChatStream, listHermesSessions } from "@/lib/api/hermes";
 import ProjectsBoard from "./projects-board";
 
@@ -43,6 +48,34 @@ function project(overrides: Partial<ProjectRow>): ProjectRow {
     latest_update: null,
     updates_count: 0,
     attention_reasons: [],
+    health: health(),
+    ...overrides,
+  };
+}
+
+function health(overrides: Partial<ProjectHealth> = {}): ProjectHealth {
+  return {
+    missions: 0,
+    active: 0,
+    failed: 0,
+    overdue: 0,
+    tracks_needing_attention: 0,
+    tracks: [],
+    ...overrides,
+  };
+}
+
+function track(overrides: Partial<TrackHealth> = {}): TrackHealth {
+  return {
+    track: "phase-a",
+    verdict: "active",
+    missions: 1,
+    active: 1,
+    failed: 0,
+    completed: 0,
+    overdue: 0,
+    desired_states: {},
+    last_activity_at: null,
     ...overrides,
   };
 }
@@ -392,5 +425,103 @@ describe("ProjectsBoard", () => {
     // The slug renders in both the list row and the detail heading.
     expect(await screen.findAllByText("verity")).not.toHaveLength(0);
     expect(screen.queryByTitle("Conversation")).not.toBeInTheDocument();
+  });
+
+  test("surfaces controller mode, and renders nothing when it is absent", async () => {
+    // Absence must be indistinguishable from the pre-trailer board: a
+    // controller that never adopted [CTRL: …] must not gain an "unknown" chip.
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "legacy-project",
+          updates_count: 3,
+          latest_update: {
+            headline: "Rien de neuf",
+            body: null,
+            session_id: "s1",
+            at: new Date().toISOString(),
+            signature: "legacy-project",
+            blocker: null,
+          },
+        }),
+        project({
+          slug: "benchmark",
+          updates_count: 2,
+          latest_update: {
+            headline: "Transport bloqué",
+            body: null,
+            session_id: "s2",
+            at: new Date().toISOString(),
+            signature: "benchmark",
+            mode: "blocked:transport-cap",
+            blocker: null,
+          },
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    expect(await screen.findByText("blocked: transport-cap")).toBeInTheDocument();
+    expect(screen.queryByText(/unknown/i)).not.toBeInTheDocument();
+    // The legacy row gets no chip at all — absence must look like the old board.
+    expect(screen.queryByTitle("active")).not.toBeInTheDocument();
+  });
+
+  test("shows the health digest when a track needs attention", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity",
+          updates_count: 5,
+          health: health({
+            missions: 4,
+            active: 1,
+            failed: 2,
+            overdue: 1,
+            tracks_needing_attention: 1,
+            tracks: [track({ track: "phase-b", verdict: "failing", failed: 2 })],
+          }),
+          latest_update: {
+            headline: "un titre bien moins utile",
+            body: null,
+            session_id: "s3",
+            at: new Date().toISOString(),
+            signature: "verity",
+            blocker: null,
+          },
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    // The digest replaces the headline precisely because it is the more
+    // actionable line when a track is failing.
+    expect(await screen.findByText(/2 failing/)).toBeInTheDocument();
+    expect(screen.queryByText("un titre bien moins utile")).not.toBeInTheDocument();
+  });
+
+  test("counts blocked projects in the summary strip", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "benchmark",
+          latest_update: {
+            headline: "bloqué",
+            body: null,
+            session_id: "s4",
+            at: new Date().toISOString(),
+            signature: "benchmark",
+            mode: "blocked",
+            blocker: null,
+          },
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    expect(await screen.findByText(/1 blocked/)).toBeInTheDocument();
   });
 });

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -52,6 +52,13 @@ import { hermesChatStream } from "@/lib/api/hermes";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { cn } from "@/lib/utils";
+import {
+  healthDigest,
+  isStale,
+  ModeChip,
+  parseMode,
+  TrackHealthList,
+} from "./project-health";
 
 // Palette discipline: neutrals for structure, indigo for the current
 // selection, amber for problems. Nothing else carries color.
@@ -265,6 +272,7 @@ export default function ProjectsBoard() {
             )}
           >
             <div ref={listRef} className="h-full overflow-y-auto py-1">
+            <SummaryStrip projects={data?.projects ?? []} />
             {sections.map((section) => (
               <div key={section.bucket}>
                 <div className="sticky -top-1 z-10 flex items-center gap-2 border-b border-white/[0.05] bg-[rgb(var(--background))]/95 px-4 py-1.5 backdrop-blur">
@@ -345,6 +353,43 @@ export default function ProjectsBoard() {
   );
 }
 
+/** One-line fleet recap above the list: the "how is everything doing" answer
+ *  that previously required opening each project in turn. Counts blocked and
+ *  silent separately because they are different failures — one reported
+ *  itself, the other stopped reporting at all. */
+function SummaryStrip({ projects }: { projects: ProjectRow[] }) {
+  const counts = useMemo(() => {
+    let blocked = 0;
+    let paused = 0;
+    let silent = 0;
+    let attention = 0;
+    let live = 0;
+    for (const project of projects) {
+      if (project.bucket === "archived") continue;
+      const mode = parseMode(project);
+      if (mode?.base === "blocked") blocked += 1;
+      if (mode?.base === "paused" || project.bucket === "paused") paused += 1;
+      if (isStale(project)) silent += 1;
+      if (project.bucket === "attention") attention += 1;
+      live += liveMissionCount(project);
+    }
+    return { blocked, paused, silent, attention, live };
+  }, [projects]);
+
+  const parts = [
+    counts.live > 0 ? `${counts.live} live` : null,
+    counts.attention > 0 ? `${counts.attention} need attention` : null,
+    counts.blocked > 0 ? `${counts.blocked} blocked` : null,
+    counts.silent > 0 ? `${counts.silent} silent` : null,
+    counts.paused > 0 ? `${counts.paused} paused` : null,
+  ].filter(Boolean) as string[];
+
+  if (parts.length === 0) return null;
+  return (
+    <p className="px-4 py-1.5 text-[11px] text-white/40">{parts.join(" · ")}</p>
+  );
+}
+
 function ProjectListRow({
   project,
   selected,
@@ -356,6 +401,9 @@ function ProjectListRow({
 }) {
   const live = liveMissionCount(project);
   const quiet = isQuiet(project);
+  const mode = parseMode(project);
+  const digest = healthDigest(project.health);
+  const stale = isStale(project);
   return (
     <button
       type="button"
@@ -378,7 +426,10 @@ function ProjectListRow({
           </span>
           {project.latest_update && <UpdateAge at={project.latest_update.at} />}
         </span>
-        {!quiet && (
+        {/* A blocked or stale controller is worth a second line even when the
+            project is otherwise quiet — silence was exactly how a stuck
+            controller used to hide. */}
+        {(!quiet || mode?.base === "blocked" || stale) && (
           <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
             {live > 0 && (
               <span className="flex shrink-0 items-center gap-1 text-white/55">
@@ -386,13 +437,20 @@ function ProjectListRow({
                 {live}
               </span>
             )}
+            <ModeChip mode={mode} />
+            {stale && (
+              <span className="shrink-0 text-[10px] uppercase tracking-wide text-amber-400/70">
+                silent
+              </span>
+            )}
             <span className="min-w-0 truncate">
-              {stripMarkdown(
-                project.attention_reasons[0] ??
-                  project.latest_update?.headline ??
-                  project.tracker?.status_line ??
-                  "",
-              )}
+              {digest ??
+                stripMarkdown(
+                  project.attention_reasons[0] ??
+                    project.latest_update?.headline ??
+                    project.tracker?.status_line ??
+                    "",
+                )}
             </span>
           </span>
         )}
@@ -824,6 +882,14 @@ function ProjectDetail({
                 {reason}
               </p>
             ))}
+          </div>
+        )}
+        {project.health && project.health.tracks.length > 0 && (
+          <div className="mt-2 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2">
+            <p className="mb-1 text-[10px] uppercase tracking-wider text-white/40">
+              Tracks
+            </p>
+            <TrackHealthList health={project.health} />
           </div>
         )}
         {project.missions.length > 0 && <MissionList missions={project.missions} />}

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -25,7 +25,38 @@ export interface ProjectDeliveryUpdate {
   session_id: string;
   at: string;
   signature: string | null;
+  /** Descriptor fields after the routing key in the `[STATE_SIGNATURE: …]`
+   *  trailer. The board detects a stall by seeing this repeat unchanged. */
+  state?: string | null;
+  /** Controller-reported mode from the `[CTRL: … mode=… ]` trailer:
+   *  `active`, `blocked[:cause]` or `paused[:reason]`. Absent for controllers
+   *  that have not adopted the trailer — render nothing, never "unknown". */
+  mode?: string | null;
   blocker: string | null;
+}
+
+export type TrackVerdict = "failing" | "overdue" | "active" | "done" | "idle";
+
+export interface TrackHealth {
+  track: string | null;
+  verdict: TrackVerdict;
+  missions: number;
+  active: number;
+  failed: number;
+  completed: number;
+  overdue: number;
+  desired_states: Record<string, number>;
+  last_activity_at: string | null;
+}
+
+export interface ProjectHealth {
+  missions: number;
+  active: number;
+  failed: number;
+  overdue: number;
+  tracks_needing_attention: number;
+  /** Worst-first, per the backend rollup. */
+  tracks: TrackHealth[];
 }
 
 export type ProjectBucket = "attention" | "active" | "paused" | "archived";
@@ -47,6 +78,7 @@ export interface ProjectRow {
   latest_update: ProjectDeliveryUpdate | null;
   updates_count: number;
   attention_reasons: string[];
+  health: ProjectHealth;
   conversation?: ProjectConversation | null;
 }
 

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -207,6 +207,12 @@ pub struct DeliveryUpdate {
     /// with the same value reported the same world.
     #[serde(skip_serializing_if = "Option::is_none")]
     state: Option<String>,
+    /// Controller-reported mode from the `[CTRL: … | mode=… | …]` trailer:
+    /// `active`, `blocked[:cause]` or `paused[:reason]`. Absent for controllers
+    /// that have not adopted the trailer — the three regimes were previously
+    /// indistinguishable, so a quiet tick and a stuck one looked identical.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<String>,
     blocker: Option<String>,
 }
 
@@ -965,6 +971,7 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
         if trimmed.is_empty()
             || trimmed.starts_with("[Cron delivery:")
             || trimmed.starts_with("[STATE_SIGNATURE:")
+            || trimmed.starts_with("[CTRL:")
         {
             continue;
         }
@@ -1002,6 +1009,37 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
         // in the message wins — so an echoed template landing last would be
         // recorded as a genuine state and sit in the durable timeline forever.
         .filter(|rest| !is_placeholder_descriptor(rest));
+
+    // `[CTRL: <project> | mode=active|blocked|paused | wait=<n> | next=…]`.
+    // Emitted on every delivery INCLUDING `[SILENT]`, so a healthy quiet tick is
+    // distinguishable from one stuck on the same blocker. Absent for controllers
+    // that predate the convention: the field is then omitted entirely rather
+    // than defaulted, so the UI can render exactly as it did before.
+    let mode = content
+        .lines()
+        .rev()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            trimmed
+                .strip_prefix("[CTRL:")
+                .and_then(|rest| rest.strip_suffix(']'))
+        })
+        .and_then(|inner| {
+            inner
+                .split('|')
+                .filter_map(|field| field.trim().strip_prefix("mode="))
+                .map(|value| value.trim().to_ascii_lowercase())
+                .next()
+        })
+        .filter(|value| {
+            // Only the three known regimes, each optionally carrying a cause
+            // (`blocked:transport-cap`). Anything else is a malformed trailer
+            // and must not reach the UI as a mode chip.
+            let base = value
+                .split_once(':')
+                .map_or(value.as_str(), |(base, _)| base);
+            matches!(base, "active" | "blocked" | "paused")
+        });
 
     // "Bloqué par:" / "Blocked by:" field, when it names a real blocker.
     let blocker = content.lines().find_map(|line| {
@@ -1046,6 +1084,7 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
         at,
         signature,
         state,
+        mode,
         blocker,
     }
 }
@@ -1059,6 +1098,32 @@ mod tests {
         **Changé :** l'audit est terminé.\n\
         **Bloqué par :** lease writer fantôme sur #2219.\n\n\
         [STATE_SIGNATURE: verity|phase-1b|abc123|blocked|lease|next]";
+
+    #[test]
+    fn ctrl_trailer_yields_mode_and_never_becomes_the_headline() {
+        // A quiet tick: the only content is [SILENT] plus the trailer. The
+        // trailer must not be mistaken for the headline.
+        let quiet = "[Cron delivery: Verity]\n[SILENT]\n[CTRL: verity | mode=active | wait=0 | next=certify #2240]";
+        let parsed = parse_delivery("s1", 0.0, quiet);
+        assert_eq!(parsed.mode.as_deref(), Some("active"));
+        assert_eq!(parsed.headline, "[SILENT]");
+
+        // A cause rides along with the mode.
+        let blocked = "[Cron delivery: Bench]\nTransport rejected\n[CTRL: verity-benchmark | mode=blocked:transport-cap | wait=3 | next=shrink tree]";
+        assert_eq!(
+            parse_delivery("s2", 0.0, blocked).mode.as_deref(),
+            Some("blocked:transport-cap")
+        );
+
+        // Controllers that never adopted the trailer report no mode at all,
+        // rather than defaulting to one: the UI must render as it did before.
+        let legacy = "[Cron delivery: Lido]\nSomething happened\n[STATE_SIGNATURE: lido|phase|head|none|next]";
+        assert!(parse_delivery("s3", 0.0, legacy).mode.is_none());
+
+        // A malformed mode is dropped rather than surfaced as a chip.
+        let bogus = "[Cron delivery: X]\nhi\n[CTRL: x | mode=confused | wait=0 | next=none]";
+        assert!(parse_delivery("s4", 0.0, bogus).mode.is_none());
+    }
 
     #[test]
     fn parses_delivery_headline_signature_and_blocker() {
@@ -1148,6 +1213,7 @@ mod tests {
             session_id: "s".into(),
             at: at.into(),
             signature: Some("verity".into()),
+            mode: None,
             state: Some(state.into()),
             blocker: None,
         };
@@ -1288,6 +1354,7 @@ mod tests {
             at: "2026-08-04T12:00:00Z".into(),
             session_id: "cron_e594d751447d_20260804_120931".into(),
             signature: None,
+            mode: None,
             state: None,
             blocker: None,
         });
@@ -1315,6 +1382,7 @@ mod tests {
             at: "2026-08-04T12:00:00Z".into(),
             session_id: "cron_e594d751447d_20260804_120931".into(),
             signature: None,
+            mode: None,
             state: None,
             blocker: None,
         });

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -1540,7 +1540,18 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
         } else {
             TerminalReason::LlmError
         };
-        AgentResult::failure(final_message, cost_cents).with_terminal_reason(reason)
+        let mut failure =
+            AgentResult::failure(final_message, cost_cents).with_terminal_reason(reason);
+        if reason == TerminalReason::Stalled {
+            // Guard contract: say what was observed, not just the verdict.
+            failure = failure.with_terminal_evidence(if stopped_before_required_tools {
+                "Codex stopped before completing required workspace/tool steps \
+                 (no required tool call was made after the last response)"
+            } else {
+                "Codex stopped on a progress-update message without resuming work"
+            });
+        }
+        failure
     };
 
     let outcome = turn_outcome_for_result(

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -996,6 +996,8 @@ pub async fn run_opencode_turn(
     // Used after the event loop to flag the result as incomplete so the caller
     // can surface the truncation to the user.
     let mut killed_by_idle_timeout = false;
+    // Guard contract: what the stall watchdog OBSERVED, for terminal_evidence.
+    let mut stall_evidence: Option<String> = None;
     // Track session idle state — used as a fallback completion signal when
     // response.completed is not emitted (common with GLM models).
     let mut session_idle_seen = false;
@@ -1225,6 +1227,11 @@ pub async fn run_opencode_turn(
                                 mission_id = %mission_id,
                                 "OpenCode output idle timeout reached; terminating CLI process"
                             );
+                            stall_evidence = Some(format!(
+                                "no streamed text for {}s (SANDBOXED_SH_OPENCODE_IDLE_TIMEOUT_SECS), \
+                                 no active tools, no proxy streaming; CLI killed",
+                                opencode_text_idle_timeout_secs
+                            ));
                             killed_by_idle_timeout = true;
                             let _ = child.kill().await;
                             break;
@@ -1288,6 +1295,10 @@ pub async fn run_opencode_turn(
                             proxy_streaming = proxy_streaming,
                             "Global inactivity timeout; terminating stuck CLI process"
                         );
+                        stall_evidence = Some(format!(
+                            "no SSE events, stdout or stderr for {}s; CLI killed",
+                            inactivity_elapsed.as_secs()
+                        ));
                         killed_by_idle_timeout = true;
                         let _ = child.kill().await;
                         break;
@@ -2043,7 +2054,13 @@ pub async fn run_opencode_turn(
         } else {
             TerminalReason::LlmError
         };
-        AgentResult::failure(final_result, 0).with_terminal_reason(reason)
+        let mut failure = AgentResult::failure(final_result, 0).with_terminal_reason(reason);
+        if reason == TerminalReason::Stalled {
+            if let Some(evidence) = stall_evidence.as_deref() {
+                failure = failure.with_terminal_evidence(evidence);
+            }
+        }
+        failure
     } else {
         AgentResult::success(final_result, 0).with_terminal_reason(TerminalReason::TurnComplete)
     };


### PR DESCRIPTION
Three project regimes were indistinguishable on the board: a controller that
was healthy and quiet, one stuck on the same blocker for sixteen consecutive
ticks, and one deliberately paused all rendered as the same silence. Spotting
the stuck one meant opening each project in turn.

Controllers now end every delivery, including [SILENT], with a
`[CTRL: <project> | mode=… | wait=<n> | next=…]` trailer. Parse it into
`DeliveryUpdate.mode` and surface it.

Also surface `health`: the backend has computed and served the full
ProjectHealth/TrackHealth rollup since day one, but the frontend `ProjectRow`
type omitted the field entirely, so a project whose oldest track had been
failing for days looked exactly like a healthy one.

- backend: parse the CTRL trailer, accepting only active/blocked/paused with an
  optional cause. Unknown modes are dropped rather than shown. The headline
  scan skips `[CTRL:` lines, or a quiet tick's trailer would become its own
  headline.
- board: mode chip, one-line health digest, per-track breakdown in the detail
  pane, and a fleet summary strip. A blocked or long-silent project now gets a
  second line even when otherwise quiet — silence was how a stuck controller
  hid.
- a project silent for >24h is flagged client-side. The backend cannot answer
  "has this controller stopped ticking" (crons live in Hermes), and this catches
  most of that case with no new auth surface.

Absence degrades to nothing: controllers that predate the trailer emit no mode,
the field is omitted from JSON, and those rows render exactly as before. Covered
by tests on both sides.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dashboard presentation and read-path parsing; runner changes only enrich stalled-failure metadata without altering success paths.
> 
> **Overview**
> **Projects board** now exposes signals that were already on the API but missing from the UI: **`ProjectHealth`** (digest in list rows when tracks need attention, per-track breakdown in detail) and **`mode`** from the newest delivery’s **`[CTRL: … | mode=…]`** trailer (chip, fleet summary strip, **silent** after 24h without updates). Legacy rows without `mode` or health stay visually unchanged.
> 
> **Backend** parses the CTRL trailer into **`DeliveryUpdate.mode`** (only `active` / `blocked` / `paused` with optional cause), skips **`[CTRL:`** lines when picking headlines, and adds tests.
> 
> **Codex and OpenCode runners** attach **`terminal_evidence`** on **`TerminalReason::Stalled`** so controllers see what triggered the stall, not only the verdict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28d9f04e68d370bb2d91b5e7df38b6172a7a89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->