### PR TITLE
docs: how to run an autonomous project controller

### DIFF
--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -1,0 +1,144 @@
+# Piloter un projet en autonomie
+
+Mode d'emploi des contrôleurs autonomes. Un contrôleur, c'est un cron Hermes qui
+se réveille toutes les N minutes, charge le skill `controllers-policy`, et fait
+avancer **un** projet : il dispatche des missions, merge des PRs, met à jour son
+tracker, et te livre un rapport.
+
+## Créer un contrôleur
+
+Trois choses, dans cet ordre.
+
+**1. Un prompt court.** Uniquement *objectif + gates spécifiques au projet*.
+N'y écris pas de règles d'autonomie, de format de rapport, ni de seuils
+d'escalade : le skill les porte, et il est rechargé à chaque tick.
+
+```
+Contrôleur <nom>. Objectif : <ce qu'il doit faire aboutir>, projet `<slug>`.
+
+Gates du projet :
+- <la branche autorisée, ce qu'il ne faut jamais toucher, les invariants>
+- Autonomie, format de livraison, trailer `[CTRL: ...]`, escalade et questions
+  d'installation sont régis par le skill controllers-policy.
+```
+
+**2. Attacher le skill.**
+
+```bash
+hermes cron create --name "<nom>" --every 30m \
+  --skill controllers-policy --deliver project:<slug> --prompt "$(cat prompt.txt)"
+```
+
+`--deliver project:<slug>` est important : la livraison suit le projet, pas une
+session qui peut être compactée ou abandonnée. `--deliver origin` gèle la cible
+sur la session de création — à éviter pour tout ce qui doit durer.
+
+**3. Répondre une fois à ses cinq questions.** Au premier tick, le contrôleur te
+demande : périmètre, autorité de merge, plafond de budget, ce qui doit le mettre
+en pause, et ce qui mérite une livraison. Tes réponses sont écrites dans son
+tracker sous un bloc `GRANT:` — elles survivent ainsi à toute réécriture de
+prompt. Il ne les redemandera pas.
+
+## Ce qu'il fait sans demander
+
+Par défaut il **agit** : dispatche, merge une PR verte et dans le périmètre,
+tranche une décision défendable et te dit laquelle et pourquoi. Il ne demande
+pas la permission.
+
+**Trois choses seulement l'arrêtent** : détruire une donnée irrécupérable,
+dépenser hors du budget de sa campagne, ou toucher un dépôt hors périmètre.
+Tout le reste lui appartient.
+
+Corollaire important : « je m'en remets à l'autre contrôleur » est un blocage
+déguisé. S'il décline une tâche parce qu'elle « appartient » à quelqu'un
+d'autre, il doit vérifier que ce propriétaire est *réellement vivant* dessus
+(une mission qui tourne, une PR qui a bougé). Sinon le travail est sans
+propriétaire — et le travail sans propriétaire est le sien.
+
+## L'arrêter
+
+Une seule formulation compte :
+
+```
+PAUSED(reason=<pourquoi>; resume=<condition vérifiable par une machine>)
+```
+
+Toute formulation plus molle (« report only », « ne dispatche pas », « X est le
+contrôleur actif ») est traitée comme une dérive de prompt : il agira quand même
+et te le signalera pour que tu confirmes ou convertisses en `PAUSED(...)`.
+
+Écris le `resume=` de façon qu'il puisse le vérifier lui-même
+(« le périphérique FTDI réapparaît sur spark-de79 ») plutôt que « quand Thomas
+confirme ». **Quand la condition est remplie, il lève la pause tout seul** et
+reprend — y compris si tu l'as confirmé en conversation. Une pause qui survit à
+sa propre condition de reprise est un défaut, et c'est à lui de la corriger.
+
+## Lire son état
+
+Chaque livraison, **y compris les `[SILENT]`**, se termine par :
+
+```
+[CTRL: <projet> | mode=active|blocked|paused | wait=<ticks> | next=<prochaine action>]
+```
+
+- `mode=active` — il travaille. Un tick sain et muet, c'est `[SILENT]` + ce trailer.
+- `mode=blocked` — il bute sur quelque chose d'externe. `wait=` dit depuis combien
+  de ticks.
+- `mode=paused` — dormant volontairement.
+
+Avant, ces trois régimes te parvenaient tous sous la forme d'un `[SILENT]`
+indistinct : impossible de séparer « rien à dire » de « coincé depuis seize
+ticks ». Maintenant `grep 'mode=blocked'` suffit, et le board les affiche.
+
+**Rien ne peut rester coincé en silence.** Au bout de 3 ticks sur la même cause,
+il doit vérifier que la dépendance est encore vivante, tenter un contournement
+borné, et livrer un rapport non silencieux. À 6 ticks, il escalade avec une
+question précise.
+
+## Le board
+
+`http://localhost:3001/` — la liste de gauche affiche par projet : le mode, le
+nombre de missions vives, un digest de santé (`3 tracks · 1 failing · 2 overdue`)
+et un repère `silent` si plus rien n'est arrivé depuis 24 h. Le bandeau du haut
+récapitule la flotte (`4 live · 1 blocked · 1 paused`). Le panneau de détail
+ajoute le découpage par track, pire d'abord.
+
+Un projet sans trailer `[CTRL:]` s'affiche exactement comme avant — l'absence
+n'invente jamais un état.
+
+## Surveiller les budgets
+
+Un cron a un budget `repeat` et **s'auto-désarme quand il est épuisé**, même si
+sa campagne tourne encore. À vérifier de temps en temps :
+
+```bash
+hermes cron list          # colonne repeat + enabled
+hermes cron edit <id> --repeat <n>   # relever le plafond
+hermes cron resume <id>              # réarmer
+```
+
+## Diagnostiquer
+
+```bash
+# état de tous les contrôleurs
+hermes cron list
+
+# forcer un tick et voir ce qu'il fait
+hermes cron run <id>
+
+# le dernier rapport d'un projet, trailer compris
+grep -o '\[CTRL:[^]]*\]' <(hermes chat --resume <session> --last)
+```
+
+Si un contrôleur ticque `ok` mais que rien ne bouge, la question à poser est
+*quel est son mode*. `active` sans mission créée pendant deux ticks est un défaut
+qu'il doit signaler lui-même ; `blocked` avec un `wait=` qui grimpe veut dire que
+le contournement a échoué et que l'escalade arrive.
+
+## Références
+
+- Le contrat complet : `skills/controllers-policy/SKILL.md` sur agent-core.
+- Les doctrines d'autonomie, avec les incidents qui les ont produites :
+  `references/autonomy-playbook.md`.
+- Les questions d'installation et le bloc `GRANT:` :
+  `references/controller-setup-questions.md`.


### PR DESCRIPTION
Companion to #761. Documents the controller contract now carried by the `controllers-policy` skill: minimal prompts, `PAUSED(reason=…; resume=…)` as the only recognised stop, the `[CTRL: …]` trailer the board parses, stall escalation, and the repeat-budget gotcha that silently disarms a controller mid-campaign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds **`docs/CONTROLLERS.md`**, a French operator guide for Hermes autonomous project controllers (companion to the `controllers-policy` skill work in #761).
> 
> It documents **how to spin one up**: a minimal prompt (objective + project gates only), `hermes cron create` with `--skill controllers-policy` and **`--deliver project:<slug>`** (not `origin`), and the one-time answers to five setup questions stored in a **`GRANT:`** block on the tracker.
> 
> It spells out **runtime behavior**: default act-without-asking, the three hard stop conditions, **`PAUSED(reason=…; resume=…)`** as the only recognized pause, and the **`[CTRL: …]`** trailer (`mode`, `wait`, `next`) on every delivery including `[SILENT]`, plus stall escalation at 3/6 ticks.
> 
> Also covers **the local board** (`localhost:3001`), **cron `repeat` budget** self-disarm, and **CLI diagnostics** (`hermes cron list/run`, grepping the trailer), with pointers to the skill and reference docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8c7387d65aabe66a8057b015cf9b478c6305d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->