### PR TITLE
Route deliveries by the CTRL trailer when the routing trailer is absent

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -991,12 +991,28 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
             .strip_prefix("[STATE_SIGNATURE:")
             .and_then(|rest| rest.strip_suffix(']'))
     });
+    let ctrl = content.lines().rev().find_map(|line| {
+        let trimmed = line.trim();
+        trimmed
+            .strip_prefix("[CTRL:")
+            .and_then(|rest| rest.strip_suffix(']'))
+    });
     let signature = trailer
         .and_then(|inner| inner.split('|').next())
         .map(|key| key.trim().to_string())
         // Reject template placeholders like `<project>` and anything that
         // isn't a plain routing key.
-        .filter(|key| is_plain_key(key));
+        .filter(|key| is_plain_key(key))
+        // Fall back to the `[CTRL: <project> | …]` trailer's own first field.
+        // Requiring a controller to emit two separate trailers to be routed is
+        // a rule it will eventually forget, and the failure is silent: the
+        // report simply never reaches its project row. The mode trailer already
+        // names the project, so accept it rather than lose the delivery.
+        .or_else(|| {
+            ctrl.and_then(|inner| inner.split('|').next())
+                .map(|key| key.trim().to_string())
+                .filter(|key| is_plain_key(key))
+        });
     // The state descriptor: the trailer minus its routing key. Empty when the
     // controller emitted a key and nothing else, which is not a state.
     let state = trailer
@@ -1015,15 +1031,7 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
     // distinguishable from one stuck on the same blocker. Absent for controllers
     // that predate the convention: the field is then omitted entirely rather
     // than defaulted, so the UI can render exactly as it did before.
-    let mode = content
-        .lines()
-        .rev()
-        .find_map(|line| {
-            let trimmed = line.trim();
-            trimmed
-                .strip_prefix("[CTRL:")
-                .and_then(|rest| rest.strip_suffix(']'))
-        })
+    let mode = ctrl
         .and_then(|inner| {
             inner
                 .split('|')
@@ -1119,6 +1127,23 @@ mod tests {
         // rather than defaulting to one: the UI must render as it did before.
         let legacy = "[Cron delivery: Lido]\nSomething happened\n[STATE_SIGNATURE: lido|phase|head|none|next]";
         assert!(parse_delivery("s3", 0.0, legacy).mode.is_none());
+
+        // The CTRL trailer alone routes the delivery: requiring two separate
+        // trailers is a rule a controller eventually forgets, and the failure
+        // is silent — the report never reaches its project row.
+        let ctrl_only =
+            "[Cron delivery: Verity]\nDid a thing\n[CTRL: verity | mode=active | wait=0 | next=x]";
+        assert_eq!(
+            parse_delivery("s5", 0.0, ctrl_only).signature.as_deref(),
+            Some("verity")
+        );
+
+        // When both are present the explicit routing trailer still wins.
+        let both = "[Cron delivery: X]\nhi\n[CTRL: ctrl-key | mode=active | wait=0 | next=x]\n[STATE_SIGNATURE: sig-key|a|b|c|d]";
+        assert_eq!(
+            parse_delivery("s6", 0.0, both).signature.as_deref(),
+            Some("sig-key")
+        );
 
         // A malformed mode is dropped rather than surfaced as a chip.
         let bogus = "[Cron delivery: X]\nhi\n[CTRL: x | mode=confused | wait=0 | next=none]";


### PR DESCRIPTION
Follow-up to #761, fixing a silent routing regression I introduced when trimming the controller prompts.

The minimal prompts no longer emit `[STATE_SIGNATURE: …]`, so deliveries carrying `[CTRL: verity | mode=active | …]` landed in `unrouted_updates` — project rows kept showing stale deliveries and no mode reached the board.

Requiring two separate trailers for routing is a rule controllers forget silently. The CTRL trailer already names the project, so it now serves as the routing key when no explicit routing trailer is present; an explicit `[STATE_SIGNATURE:]` still wins where both appear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to delivery trailer parsing and board routing; no auth, persistence, or API contract changes beyond fixing previously unrouted updates.
> 
> **Overview**
> Fixes **silent mis-routing** of Hermes cron deliveries that only include a `[CTRL: …]` trailer (common after slimmer controller prompts dropped `[STATE_SIGNATURE: …]`).
> 
> In `parse_delivery`, the **routing key** (`signature`) now falls back to the first field of the `[CTRL:]` trailer when no valid `[STATE_SIGNATURE:]` key is present; **`[STATE_SIGNATURE:]` still wins** when both trailers exist. **`mode`** parsing reuses the same parsed `ctrl` block instead of scanning the message again.
> 
> Tests cover CTRL-only routing and explicit precedence when both trailers are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1fb61c710efd26f862b0b91b8d82535f881c68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->