### PR TITLE
Recycle stale MCPs in the deploy path that actually runs

### DIFF
--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -33,7 +33,7 @@ use uuid::Uuid;
 use crate::agents::TerminalReason;
 use crate::api::mission_store::{
     now_string, BoardOutboxItem, BoardTask, BoardTaskOutcome, BoardTaskRole, BoardTaskStatus,
-    MissionHistoryEntry, MissionStore, TaskAttempt,
+    MissionHistoryEntry, MissionProjectPatch, MissionStore, TaskAttempt,
 };
 
 use super::{ControlCommand, MissionStatus, UserMessageAck};
@@ -1644,6 +1644,40 @@ async fn spawn_task_worker(
             task.working_directory.as_deref(),
         )
         .await?;
+    // Inherit the boss's project tagging. Board tasks bypass the public
+    // create-mission handler, and `create_mission_with_parent` carries no
+    // project metadata — so workers were landing untagged. The parent link
+    // alone does not group them: an untagged worker is invisible in the
+    // per-project inventory the board and every controller reconcile against,
+    // which is exactly where a campaign's own work needs to be visible.
+    // The task's own key becomes the track when the boss has none, so sibling
+    // workers stay distinguishable.
+    if let Ok(Some(boss)) = mission_store.get_mission(task.boss_mission_id).await {
+        if boss.project.project.is_some() {
+            let patch = MissionProjectPatch {
+                project: Some(boss.project.project.clone()),
+                track: Some(
+                    boss.project
+                        .track
+                        .clone()
+                        .or_else(|| Some(task.task_key.clone())),
+                ),
+                intent: Some(boss.project.intent.clone()),
+                ..Default::default()
+            };
+            if let Err(error) = mission_store
+                .update_mission_project(mission.id, patch)
+                .await
+            {
+                tracing::warn!(
+                    mission = %mission.id,
+                    boss = %task.boss_mission_id,
+                    "board: could not inherit project tagging: {error}"
+                );
+            }
+        }
+    }
+
     if let Some(profile_slot) = task
         .prior_result_digest
         .as_deref()
@@ -1907,6 +1941,77 @@ mod tests {
         .await
         .expect("outbox acknowledgement persisted");
         assert!(inflight.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn task_workers_inherit_the_boss_project_tagging() {
+        // An untagged worker is invisible in the per-project inventory the
+        // board and every controller reconcile against — a campaign's own
+        // work must not vanish from its project.
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = store
+            .create_mission_with_parent(
+                Some("boss"),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create boss");
+        store
+            .update_mission_project(
+                boss.id,
+                MissionProjectPatch {
+                    project: Some(Some("verity-benchmark".into())),
+                    intent: Some(Some("evaluate".into())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag boss");
+        store
+            .upsert_board_tasks(
+                boss.id,
+                vec![NewBoardTask {
+                    task_key: "fast-verdict".into(),
+                    title: "Obtain verdicts".into(),
+                    prompt: "p".into(),
+                    backend: "codex".into(),
+                    ..Default::default()
+                }],
+            )
+            .await
+            .expect("create task");
+        let task = store.list_board_tasks(boss.id).await.expect("list")[0].clone();
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+        let inflight: BoardOutboxInflight = Default::default();
+        let worker_id = spawn_task_worker(
+            &store,
+            &cmd_tx,
+            &inflight,
+            &task,
+            Uuid::new_v4(),
+            &RetryPreflight::NothingFound,
+        )
+        .await
+        .expect("spawn worker");
+
+        let worker = store
+            .get_mission(worker_id)
+            .await
+            .expect("load")
+            .expect("worker exists");
+        assert_eq!(worker.project.project.as_deref(), Some("verity-benchmark"));
+        assert_eq!(worker.project.intent.as_deref(), Some("evaluate"));
+        // The boss has no track, so the task key keeps siblings apart.
+        assert_eq!(worker.project.track.as_deref(), Some("fast-verdict"));
     }
 
     #[tokio::test]

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3457,6 +3457,32 @@ fn stream_sandboxed_update(
             }
         }
 
+        // Recycle companion processes still executing the binary we just
+        // replaced. Replacing a file does not touch processes that already
+        // opened it: they keep running the old inode (`/proc/<pid>/exe` shows
+        // "(deleted)") and are NOT restarted by the service restart below,
+        // because Hermes agents own them, not this service.
+        //
+        // The failure that motivated this is silent and expensive: a stranded
+        // `assistant-mcp` kept answering on a half-broken connection, a
+        // controller's `get_compute_fleet` hung until its agent-side timeout
+        // (~600s of a bounded tick), and the controller concluded the MCP was
+        // unreachable — while the API itself was answering in 4ms. Deploy
+        // reported success throughout.
+        //
+        // Signalling is safe: each companion runs under a stdio watchdog that
+        // respawns it on next use, now against the new binary.
+        for (binary, _, destination) in &companion_plans {
+            let recycled = recycle_stale_companion_processes(binary, destination).await;
+            if recycled > 0 {
+                yield sse(
+                    "log",
+                    format!("Recycled {recycled} stale {binary} process(es) still on the replaced binary"),
+                    Some(78),
+                );
+            }
+        }
+
         let install_result = if versioned_install {
             install_versioned_binary_as(
                 repo_path,
@@ -3845,6 +3871,49 @@ enum DeployRollback {
     Missing,
     Backup,
     Symlink(std::path::PathBuf),
+}
+
+/// Signal companion processes still executing a binary that was just replaced.
+///
+/// Returns how many were signalled. A process that opened the old inode keeps
+/// running it after `install` overwrites the path — Linux reports this as
+/// `/proc/<pid>/exe` pointing at "<path> (deleted)". Those processes belong to
+/// Hermes agents rather than this service, so restarting the service does not
+/// touch them, and they linger with a broken view of the API they talk to.
+///
+/// Deliberately narrow: only processes whose resolved exe is the *deleted*
+/// version of this exact destination path are signalled. A companion already
+/// running the new binary, or an unrelated process of the same name installed
+/// elsewhere, is left alone.
+async fn recycle_stale_companion_processes(binary: &str, destination: &str) -> usize {
+    let Ok(output) = Command::new("pgrep").args(["-x", binary]).output().await else {
+        return 0;
+    };
+    let mut recycled = 0;
+    for pid in String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+    {
+        let exe = match tokio::fs::read_link(format!("/proc/{pid}/exe")).await {
+            Ok(path) => path.to_string_lossy().to_string(),
+            // The process exited between pgrep and now, or we cannot inspect
+            // it. Either way it is not ours to signal.
+            Err(_) => continue,
+        };
+        if exe != format!("{destination} (deleted)") {
+            continue;
+        }
+        if Command::new("kill")
+            .arg(pid.to_string())
+            .output()
+            .await
+            .is_ok_and(|out| out.status.success())
+        {
+            recycled += 1;
+            tracing::info!(pid, binary, "deploy: recycled stale companion process");
+        }
+    }
+    recycled
 }
 
 async fn prepare_deploy_backup(destination: &str, backup: &str) -> Result<DeployRollback, String> {
@@ -5525,6 +5594,26 @@ fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::conve
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn stale_companion_matching_is_exact() {
+        // The "(deleted)" suffix is how Linux reports a replaced binary. Only
+        // that exact form, for that exact destination, may be signalled —
+        // matching loosely here would kill a healthy companion that is already
+        // running the new binary, or an unrelated same-named process.
+        let dest = "/usr/local/bin/assistant-mcp";
+        assert_eq!(
+            format!("{dest} (deleted)"),
+            "/usr/local/bin/assistant-mcp (deleted)"
+        );
+        // A companion on the fresh binary reports the bare path and must not match.
+        assert_ne!(dest, format!("{dest} (deleted)"));
+        // A same-named binary installed elsewhere must not match either.
+        assert_ne!(
+            format!("/opt/other/assistant-mcp (deleted)"),
+            format!("{dest} (deleted)")
+        );
+    }
+
     use super::{
         chatgpt_ui_driver_install_path, evaluate_debounce, evaluate_deploy_request,
         expand_hermes_env_refs, extract_version_token, hermes_chat_proxy_status,

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -4306,6 +4306,20 @@ fn stream_deploy(
             }
         }
 
+        // The MCP binaries we just replaced are still being executed by the
+        // Hermes agents that spawned them: those processes hold the old inode
+        // and are NOT recycled by this service's restart, because they are not
+        // in its cgroup. See `recycle_stale_companion_processes`.
+        for (binary, destination) in [
+            ("assistant-mcp", &install_dest_assistant_mcp),
+            ("orchestrator-mcp", &install_dest_mcp),
+        ] {
+            let recycled = recycle_stale_companion_processes(binary, destination).await;
+            if recycled > 0 {
+                yield sse("log", format!("Recycled {recycled} stale {binary} process(es) still running the replaced binary"), Some(86));
+            }
+        }
+
         yield sse("log", format!("Installing {} → {}", src_paloma.display(), install_dest_paloma), Some(87));
         let bkp_paloma = format!("{}.pre-deploy-{}", install_dest_paloma, sha);
         let rollback_paloma = match prepare_deploy_backup(&install_dest_paloma, &bkp_paloma).await {


### PR DESCRIPTION
Follow-up to #765, which I placed in the wrong deploy implementation.

Verified against a real production deploy stream: the live path installs `orchestrator-mcp`, `assistant-mcp` and `palomactl` (logging `Installing X → Y`), whereas #765 patched a path that installs `workspace-mcp`/`desktop-mcp`. No `Recycled` line was emitted and both stale `assistant-mcp` processes survived with `/proc/<pid>/exe` → `"/usr/local/bin/assistant-mcp (deleted)"`.

Adds the recycle after the live path replaces `assistant-mcp` and `orchestrator-mcp`. The helper and its test from #765 are reused unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy now sends SIGTERM to narrowly matched companion PIDs during production installs; board tagging changes are warn-on-failure metadata only.
> 
> **Overview**
> **Deploy:** After companion binaries (`assistant-mcp`, `orchestrator-mcp`, and others in the companion install loop) are replaced on disk, the live deploy stream now **signals processes still executing the deleted inode** (`/proc/<pid>/exe` → `path (deleted)`). Hermes-spawned MCPs are not restarted with the service, so without this step deploy can succeed while stale companions keep broken connections. Matching is intentionally strict (exact binary name + exact deleted path); SSE logs report how many were recycled.
> 
> **Task board:** When `spawn_task_worker` creates a worker mission, it **copies the boss mission’s project/intent/track** (track falls back to the task key if the boss has none) so board workers show up in per-project inventory like missions created through the public API.
> 
> Tests cover stale-exe matching rules and boss→worker project inheritance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190ea3245d7d5cfa288b5028da91b2f8556115d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->