### PR TITLE
Fix flaky capacity-boundary test under a loaded CI runner

### DIFF
--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -683,12 +683,17 @@ mod tests {
         )
         .await
         .expect("job accepted");
-        for _ in 0..20 {
-            if state.runner.active_count() == 1 {
-                break;
+        // Wait for the async job's process to actually register as active. A
+        // 200ms budget raced with process startup under a heavily parallel test
+        // runner (the scheduled CI run flaked here); match the 5s budget the
+        // terminal-state wait below already uses. Breaks immediately once up.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.runner.active_count() != 1 {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        })
+        .await
+        .expect("async job should register as active");
         assert_eq!(state.runner.active_count(), 1);
 
         let execute_claims = LeaseClaims {


### PR DESCRIPTION
The scheduled CI run on master went red on `execute_and_async_jobs_share_the_same_capacity_boundary` while every push run stayed green — a timing flake, not a regression.

The test waited only 200ms (20×10ms) for the async job's shell process to register as active before asserting `active_count == 1`. Under the more heavily parallel scheduled runner, process startup exceeded that budget. Fix aligns it with the 5s timeout the test's own terminal-state wait already uses; it still breaks the instant the process is up, so the fast path is unchanged. (The sibling test `execute_rejects_concurrent_work_when_shared_capacity_is_full` was already de-flaked the same way — see its comment.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing change with no production behavior impact.
> 
> **Overview**
> Fixes a flaky integration test in `execute_and_async_jobs_share_the_same_capacity_boundary` that asserted shared capacity between async jobs and `/execute` was already full.
> 
> The test used to poll `runner.active_count()` for at most **20×10ms (~200ms)** after submitting a long-running async job. On a heavily loaded scheduled CI runner, the child process sometimes registered as active after that window, so the test could proceed while capacity was still free and fail unpredictably.
> 
> The wait is now wrapped in **`tokio::time::timeout` with a 5s ceiling**, matching the terminal-state poll later in the same test. The loop still exits as soon as `active_count == 1`, so fast machines are unchanged; slow startup only gets more time before the explicit `"async job should register as active"` failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911f96bd4bf5bded045e1d950259db26e380ce3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->