### PR TITLE
Ingest controller mode into the project record (phase 2)

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -87,12 +87,37 @@ pub fn spawn_state_ingestor(state: Arc<AppState>) {
                     continue;
                 };
                 let headline = Some(delivery.headline.as_str()).filter(|h| !h.is_empty());
-                if let Err(error) =
-                    state
+                let observations =
+                    match state
                         .projects
                         .record_state(slug, descriptor, headline, &delivery.at)
-                {
-                    tracing::warn!("state ingest: {slug}: {error}");
+                    {
+                        Ok(observations) => observations,
+                        Err(error) => {
+                            tracing::warn!("state ingest: {slug}: {error}");
+                            continue;
+                        }
+                    };
+                // Project the controller's `[CTRL: … mode=… ]` mode onto the
+                // project record so the board reads a column, not a parsed
+                // trailer, and a live surface can key off it. Idempotent on
+                // replay: `wait` comes from the timeline's observation count
+                // (how many times this exact state repeated), not a per-call
+                // increment, so re-ingesting the same delivery is a no-op.
+                // No-ops for a slug with no project row — the roster is not
+                // fabricated from a routed trailer.
+                if let Some(mode) = delivery.mode.as_deref() {
+                    let base = mode.split_once(':').map_or(mode, |(base, _)| base);
+                    let blocker = mode.split_once(':').map(|(_, cause)| cause);
+                    if let Err(error) = state.projects.project_mode_from_signal(
+                        slug,
+                        base,
+                        observations.saturating_sub(1) as i64,
+                        None,
+                        blocker,
+                    ) {
+                        tracing::warn!("state ingest mode: {slug}: {error}");
+                    }
                 }
             }
         }

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -515,6 +515,32 @@ impl ProjectsStore {
         Ok(())
     }
 
+    /// Project the mode onto an existing project record from the delivery
+    /// ingestor. Unlike `set_mode`, this is **idempotent** (it does not count
+    /// ticks — `wait` is passed in from the state timeline's observation count)
+    /// so the ingestor replaying the same delivery every cycle is harmless. It
+    /// silently no-ops for an unknown slug: the ingestor must not fabricate a
+    /// project from a routed trailer.
+    pub fn project_mode_from_signal(
+        &self,
+        slug: &str,
+        mode: &str,
+        wait: i64,
+        next_action: Option<&str>,
+        blocker: Option<&str>,
+    ) -> Result<(), String> {
+        let now = Utc::now().to_rfc3339();
+        let connection = self.lock()?;
+        connection
+            .execute(
+                "UPDATE projects SET mode = ?2, wait_ticks = ?3, next_action = ?4, \
+                 blocker = ?5, updated_at = ?6 WHERE slug = ?1",
+                params![slug, mode, wait, next_action, blocker, now],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
     /// Set the operator-facing status (active/paused/archived).
     pub fn set_status(&self, slug: &str, status: &str) -> Result<(), String> {
         let now = Utc::now().to_rfc3339();
@@ -1074,6 +1100,32 @@ mod tests {
     fn set_mode_on_unknown_project_errors() {
         let store = ProjectsStore::open_in_memory().expect("store");
         assert!(store.set_mode("ghost", "active", None, None).is_err());
+    }
+
+    #[test]
+    fn mode_projection_is_idempotent_and_never_fabricates() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        // No project row: the ingestor must not create one from a trailer.
+        store
+            .project_mode_from_signal("ghost", "active", 0, None, None)
+            .expect("no-op, not an error");
+        assert!(store.get_project("ghost").expect("read").is_none());
+
+        store
+            .upsert_project("bench", None, None, None, None)
+            .expect("seed");
+        // Replaying the same signal twice does not inflate wait — it is passed
+        // in, not incremented, so overlapping ingest cycles are harmless.
+        store
+            .project_mode_from_signal("bench", "blocked", 2, None, Some("transport-cap"))
+            .expect("m1");
+        store
+            .project_mode_from_signal("bench", "blocked", 2, None, Some("transport-cap"))
+            .expect("m2 replay");
+        let p = store.get_project("bench").expect("read").expect("present");
+        assert_eq!(p.mode.as_deref(), Some("blocked"));
+        assert_eq!(p.wait_ticks, 2);
+        assert_eq!(p.blocker.as_deref(), Some("transport-cap"));
     }
 
     #[test]


### PR DESCRIPTION
Phase 2 of the projects plan: make the project's `mode` a reliable DB column.

Phase 1 (#767) gave controllers `update_project_status`, but a soft skill instruction isn't adopted the same tick it lands — a fired verity tick loaded the skill yet made no call, leaving `projects.mode` null. Instead of waiting on agent adoption, derive the mode from the `[CTRL: … mode=… ]` trailer controllers already emit reliably (parsed into `delivery.mode` in #763).

The state ingestor now projects that mode onto the project row via `project_mode_from_signal` — **idempotent** (`wait` comes from the timeline's observation count, not a per-call increment, so re-ingesting the same delivery each 60s cycle is a no-op) and **never fabricates** a roster row for an unknown slug. `blocked:cause` splits its cause into the `blocker` column. The explicit MCP path stays for richer writes. Covered by an idempotency + no-fabrication test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Background ingest now writes project mode/blocker/wait_ticks from delivery trailers; behavior is scoped to existing rows and designed for idempotent replay, but it can overwrite MCP-written mode if both paths run on the same project.
> 
> **Overview**
> **Phase 2** keeps `projects.mode` (and related columns) in sync with what controllers already emit in `[CTRL: … | mode=…]` on cron deliveries, instead of relying on agents to call the explicit status API every tick.
> 
> After each successful `record_state` in the **state ingestor**, deliveries that include `mode` now call **`project_mode_from_signal`**: the base mode is stored (`active` / `blocked` / `paused`), `blocked:cause` maps the suffix into **`blocker`**, and **`wait_ticks`** is set from the state timeline’s observation count (`observations - 1`) so the 60s overlap replay does not keep incrementing. Unknown slugs are left alone—no roster row is created from a routed trailer.
> 
> The store adds **`project_mode_from_signal`**, which differs from **`set_mode`** by writing the supplied `wait` directly (no per-call tick math) and succeeding with zero rows updated for missing projects. A unit test covers idempotent replay and the no-fabrication rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebfef99273c4b74de38978b8dc81d7079a6a871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->