### PR TITLE
Ingestor resolves aliases and auto-upserts the project roster (phase 3)

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -74,6 +74,12 @@ pub fn spawn_state_ingestor(state: Arc<AppState>) {
                     continue;
                 }
             };
+            // The routing key a controller emits (`lido`) and the roster slug
+            // (`lido-audit`) don't always coincide; resolve through the same
+            // alias map the overview uses so state and mode land on one row.
+            let aliases = hermes_projects_dir()
+                .map(|dir| read_alias_map(&dir))
+                .unwrap_or_default();
             // read_deliveries returns newest-first; replay oldest-first so a
             // run of the same state lands as one extended row rather than
             // being rejected as out-of-order.
@@ -81,11 +87,21 @@ pub fn spawn_state_ingestor(state: Arc<AppState>) {
                 // Both are required: the routing key says which project the
                 // row belongs to, the descriptor says what to record. A
                 // delivery carrying only a key has reported no state.
-                let (Some(slug), Some(descriptor)) =
+                let (Some(raw_key), Some(descriptor)) =
                     (delivery.signature.as_deref(), delivery.state.as_deref())
                 else {
                     continue;
                 };
+                let canonical = resolve_alias(&aliases, raw_key);
+                let slug = canonical.as_str();
+                // Auto-upsert the roster from routed deliveries: a slug that
+                // reports state is a real project. This is how projects.db
+                // becomes the complete authoritative list without a manual
+                // seed of every project — done in the background ingestor, not
+                // on a GET. Cheap when the row already exists (COALESCE upsert).
+                if let Err(error) = state.projects.upsert_project(slug, None, None, None, None) {
+                    tracing::warn!("state ingest upsert: {slug}: {error}");
+                }
                 let headline = Some(delivery.headline.as_str()).filter(|h| !h.is_empty());
                 let observations =
                     match state


### PR DESCRIPTION
Phase 3 core: make projects.db the self-completing authoritative roster, and fix the lido mode=None case.

**Alias resolution** — a controller emits `[CTRL: lido | …]` while the roster slug is `lido-audit`, so the mode projection landed on a slug with no row (lido-audit stayed `mode=None`). The ingestor now resolves the same `routes.json` alias map the overview uses before recording state/mode.

**Auto-upsert** — the ingestor now upserts any routed slug (post-alias): a slug that reports state is a real project, so `projects.db` fills itself from the deliveries it already reads (background task, not on a GET). This is what lets the DB become the complete authoritative list without hand-seeding every project.

Both idempotent (COALESCE upsert; mode projection takes `wait` from the observation count), so the 60s overlapping replay is a no-op.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable project roster and mode projection in a background writer; behavior is intended to be idempotent but misconfigured aliases or unexpected slugs could create or update wrong rows.
> 
> **Overview**
> The background Hermes delivery **state ingestor** now maps controller routing keys through the same `routes.json` alias table as the projects overview before writing timeline state and projecting `mode`, so keys like `lido` land on roster slugs such as `lido-audit` instead of orphan rows with `mode=None`.
> 
> On each routed delivery it also **auto-upserts** a minimal project row in `projects.db` (COALESCE upsert, background only—not on GET), so any slug that reports state becomes part of the authoritative roster without manual seeding. Alias resolution and upsert run ahead of `record_state` and `project_mode_from_signal`, which remain idempotent under the existing 60s replay overlap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4d86840681537f14b9df61bef3b114d0f427e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->