### PR TITLE
iOS: Projects tab surfacing controller ↔ project ↔ session

### DIFF
--- a/ios_dashboard/SandboxedDashboard/ContentView.swift
+++ b/ios_dashboard/SandboxedDashboard/ContentView.swift
@@ -468,12 +468,14 @@ struct MainTabView: View {
     
     enum TabItem: String, CaseIterable {
         case control = "Control"
+        case projects = "Projects"
         case terminal = "Terminal"
         case files = "Files"
 
         var icon: String {
             switch self {
             case .control: return "message.fill"
+            case .projects: return "square.stack.3d.up.fill"
             case .terminal: return "terminal.fill"
             case .files: return "folder.fill"
             }
@@ -508,6 +510,8 @@ struct MainTabView: View {
         switch tab {
         case .control:
             ControlView()
+        case .projects:
+            ProjectsView()
         case .terminal:
             TerminalView()
         case .files:

--- a/ios_dashboard/SandboxedDashboard/Models/Project.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Project.swift
@@ -17,9 +17,11 @@ struct ProjectSummary: Codable, Identifiable, Hashable {
     let health: ProjectHealth?
     let conversation: ProjectConversation?
     let latestUpdate: ProjectUpdate?
+    /// Live missions grouped under this project — the "agents" of the fleet.
+    let missions: [ProjectMissionChip]
 
     enum CodingKeys: String, CodingKey {
-        case slug, bucket, health, conversation
+        case slug, bucket, health, conversation, missions
         case attentionReasons = "attention_reasons"
         case updatesCount = "updates_count"
         case latestUpdate = "latest_update"
@@ -34,6 +36,21 @@ struct ProjectSummary: Codable, Identifiable, Hashable {
         health = try container.decodeIfPresent(ProjectHealth.self, forKey: .health)
         conversation = try container.decodeIfPresent(ProjectConversation.self, forKey: .conversation)
         latestUpdate = try container.decodeIfPresent(ProjectUpdate.self, forKey: .latestUpdate)
+        missions = try container.decodeIfPresent([ProjectMissionChip].self, forKey: .missions) ?? []
+    }
+
+    /// The controller-reported mode from the latest delivery: `active`,
+    /// `blocked`, or `paused`. Nil when the controller hasn't reported one.
+    var mode: ControllerMode? { latestUpdate?.controllerMode }
+
+    /// Live missions worth showing as "working": active or awaiting the user.
+    var liveMissions: [ProjectMissionChip] {
+        missions.filter { $0.status == "active" || $0.status == "awaiting_user" }
+    }
+
+    /// Missions that need the operator — the attention rail.
+    var missionsNeedingAttention: [ProjectMissionChip] {
+        missions.filter { $0.status == "awaiting_user" }
     }
 
     /// The conversation to open, but only when it is a real declared binding.
@@ -68,6 +85,170 @@ struct ProjectUpdate: Codable, Hashable {
     let headline: String
     let at: String
     let blocker: String?
+    /// The `[CTRL: … mode=… ]` mode the controller reported: `active`,
+    /// `blocked[:cause]`, or `paused[:reason]`. Absent for controllers that
+    /// predate the trailer — render nothing rather than a guessed state.
+    let mode: String?
+
+    var controllerMode: ControllerMode? { ControllerMode(raw: mode) }
+}
+
+/// A controller's regime, parsed from the `mode` string (`blocked:transport-cap`
+/// splits into base + cause). Absent input yields nil — never an invented state.
+struct ControllerMode: Hashable {
+    enum Base: String { case active, blocked, paused }
+    let base: Base
+    let cause: String?
+
+    init?(raw: String?) {
+        guard let raw = raw?.trimmingCharacters(in: .whitespaces).lowercased(),
+              !raw.isEmpty else { return nil }
+        let parts = raw.split(separator: ":", maxSplits: 1).map(String.init)
+        guard let base = Base(rawValue: parts[0]) else { return nil }
+        self.base = base
+        self.cause = parts.count > 1 ? parts[1] : nil
+    }
+
+    var label: String { cause.map { "\(base.rawValue): \($0)" } ?? base.rawValue }
+}
+
+/// A live mission under a project, from the overview's `missions` chips.
+struct ProjectMissionChip: Codable, Hashable, Identifiable {
+    let id: String
+    let status: String
+    let title: String?
+    let updatedAt: String?
+    let githubPr: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, status, title
+        case updatedAt = "updated_at"
+        case githubPr = "github_pr"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString
+        status = try c.decodeIfPresent(String.self, forKey: .status) ?? "unknown"
+        title = try c.decodeIfPresent(String.self, forKey: .title)
+        updatedAt = try c.decodeIfPresent(String.self, forKey: .updatedAt)
+        githubPr = try c.decodeIfPresent(String.self, forKey: .githubPr)
+    }
+
+    var displayTitle: String { title ?? String(id.prefix(8)) }
+    var needsAttention: Bool { status == "awaiting_user" }
+}
+
+// MARK: - Project detail (`/api/projects/:slug`)
+
+/// The structured project object from `/api/projects/:slug`: record + grant +
+/// tracks + open decisions + bound conversation. Powers the project detail
+/// view, where the controller ↔ project ↔ sessions link is made visible.
+struct ProjectDetail: Codable, Hashable {
+    let project: ProjectRecord
+    let grant: ProjectGrant?
+    let tracks: [ProjectTrack]
+    let openDecisions: [ProjectDecision]
+    let conversation: ProjectConversation?
+
+    enum CodingKeys: String, CodingKey {
+        case project, grant, tracks, conversation
+        case openDecisions = "open_decisions"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        project = try c.decode(ProjectRecord.self, forKey: .project)
+        grant = try c.decodeIfPresent(ProjectGrant.self, forKey: .grant)
+        tracks = try c.decodeIfPresent([ProjectTrack].self, forKey: .tracks) ?? []
+        openDecisions = try c.decodeIfPresent([ProjectDecision].self, forKey: .openDecisions) ?? []
+        conversation = try c.decodeIfPresent(ProjectConversation.self, forKey: .conversation)
+    }
+
+    /// The bound control conversation — only when explicitly declared, not a
+    /// throwaway cron tick guessed from the latest delivery.
+    var boundSessionId: String? {
+        guard let conversation, conversation.source == "binding" else { return nil }
+        return conversation.sessionId
+    }
+}
+
+/// The authoritative project record.
+struct ProjectRecord: Codable, Hashable {
+    let slug: String
+    let title: String?
+    let objective: String?
+    let status: String
+    /// `active` | `blocked` | `paused` — the controller's regime.
+    let mode: String?
+    let waitTicks: Int
+    let nextAction: String?
+    let blocker: String?
+    /// Which cron controller drives this project. The controller ↔ project link.
+    let controllerCronId: String?
+    let repository: String?
+
+    enum CodingKeys: String, CodingKey {
+        case slug, title, objective, status, mode, blocker, repository
+        case waitTicks = "wait_ticks"
+        case nextAction = "next_action"
+        case controllerCronId = "controller_cron_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        slug = try c.decode(String.self, forKey: .slug)
+        title = try c.decodeIfPresent(String.self, forKey: .title)
+        objective = try c.decodeIfPresent(String.self, forKey: .objective)
+        status = try c.decodeIfPresent(String.self, forKey: .status) ?? "active"
+        mode = try c.decodeIfPresent(String.self, forKey: .mode)
+        waitTicks = try c.decodeIfPresent(Int.self, forKey: .waitTicks) ?? 0
+        nextAction = try c.decodeIfPresent(String.self, forKey: .nextAction)
+        blocker = try c.decodeIfPresent(String.self, forKey: .blocker)
+        controllerCronId = try c.decodeIfPresent(String.self, forKey: .controllerCronId)
+        repository = try c.decodeIfPresent(String.self, forKey: .repository)
+    }
+
+    var controllerMode: ControllerMode? { ControllerMode(raw: mode) }
+    var displayTitle: String { title ?? slug }
+}
+
+/// The autonomy grant.
+struct ProjectGrant: Codable, Hashable {
+    let mergeAuthority: String?
+    let budgetPerTick: String?
+    let pauseReason: String?
+    let resumeCondition: String?
+    let materialBar: String?
+
+    enum CodingKeys: String, CodingKey {
+        case mergeAuthority = "merge_authority"
+        case budgetPerTick = "budget_per_tick"
+        case pauseReason = "pause_reason"
+        case resumeCondition = "resume_condition"
+        case materialBar = "material_bar"
+    }
+}
+
+/// One workstream from the detail endpoint.
+struct ProjectTrack: Codable, Hashable, Identifiable {
+    var id: String { track }
+    let track: String
+    let desiredState: String?
+    let status: String?
+
+    enum CodingKeys: String, CodingKey {
+        case track, status
+        case desiredState = "desired_state"
+    }
+}
+
+/// An open question the controller batched for the operator.
+struct ProjectDecision: Codable, Hashable, Identifiable {
+    var id: String { at }
+    let at: String
+    let question: String
+    let rationale: String?
 }
 
 /// Per-track rollup. Mirrors the server's `ProjectHealth`.

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -280,6 +280,15 @@ final class APIService {
         return response.states
     }
 
+    /// One project's structured object: record (mode, next action, blocker),
+    /// autonomy grant, tracks, open decisions, and its bound control
+    /// conversation — which is where the controller ↔ project ↔ session link
+    /// is surfaced.
+    func getProject(slug: String) async throws -> ProjectDetail {
+        let encoded = slug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? slug
+        return try await get("/api/projects/\(encoded)")
+    }
+
     // MARK: - Mission task board
 
     /// Server-owned task board for a boss mission. Returns an empty board

--- a/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectDetailView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectDetailView.swift
@@ -1,0 +1,273 @@
+import SwiftUI
+
+/// One project in full: the controller-reported state, the cron controller that
+/// drives it, its bound Hermes session (tap to open it in Control), the
+/// autonomy grant, tracks, live mission-agents, and any open decisions.
+///
+/// This is where "which controller drives this project, and which session is it
+/// tied to" is answered — the link the switcher never surfaced.
+struct ProjectDetailView: View {
+    let slug: String
+    /// The overview row we came from, used as an instant fallback while the
+    /// detail loads (and for the live mission chips the detail endpoint omits).
+    let summary: ProjectSummary?
+
+    private let api = APIService.shared
+    private let nav = NavigationState.shared
+
+    @State private var detail: ProjectDetail?
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                controllerSection
+                if let next = record?.nextAction, !next.isEmpty {
+                    infoCard(title: "Next action", body: next, icon: "arrow.right.circle")
+                }
+                if let blocker = record?.blocker, !blocker.isEmpty {
+                    infoCard(title: "Blocked on", body: blocker, icon: "exclamationmark.triangle", tint: Theme.warning)
+                }
+                grantSection
+                missionsSection
+                tracksSection
+                decisionsSection
+            }
+            .padding(16)
+        }
+        .background(Theme.backgroundPrimary)
+        .navigationTitle(record?.displayTitle ?? slug)
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+        .refreshable { await load() }
+    }
+
+    private var record: ProjectRecord? { detail?.project }
+
+    // MARK: header
+
+    private var header: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Text(record?.displayTitle ?? slug)
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(Theme.textPrimary)
+                    if let mode = record?.controllerMode ?? summary?.mode {
+                        ModeChipView(mode: mode)
+                        if mode.base == .blocked, let wait = record?.waitTicks, wait > 0 {
+                            Text("· \(wait) tick\(wait == 1 ? "" : "s")")
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.textTertiary)
+                        }
+                    }
+                }
+                if let objective = record?.objective, !objective.isEmpty {
+                    Text(objective)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                if let repo = record?.repository, !repo.isEmpty {
+                    Label(repo, systemImage: "chevron.left.forwardslash.chevron.right")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: controller + bound session
+
+    private var controllerSection: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 10) {
+                sectionTitle("Controller", icon: "gearshape.2")
+                if let cron = record?.controllerCronId, !cron.isEmpty {
+                    labeledRow("Cron", value: cron, mono: true)
+                } else {
+                    Text("No controller drives this project.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.textTertiary)
+                }
+                if let session = detail?.boundSessionId ?? summary?.boundSessionId {
+                    Button {
+                        nav.openHermesSession(session)
+                    } label: {
+                        HStack {
+                            Label("Open control conversation", systemImage: "bubble.left.and.text.bubble.right")
+                                .font(.system(size: 13, weight: .medium))
+                            Spacer()
+                            Image(systemName: "chevron.right").font(.system(size: 11))
+                        }
+                        .foregroundStyle(Theme.accent)
+                    }
+                } else {
+                    Text("No control conversation bound.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: grant
+
+    @ViewBuilder private var grantSection: some View {
+        if let grant = detail?.grant, hasGrant(grant) {
+            GlassCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionTitle("Autonomy grant", icon: "checkmark.seal")
+                    if let m = grant.mergeAuthority { labeledRow("Merge", value: m) }
+                    if let b = grant.budgetPerTick { labeledRow("Budget", value: b) }
+                    if let bar = grant.materialBar { labeledRow("Material", value: bar) }
+                    if let reason = grant.pauseReason {
+                        labeledRow("Paused", value: reason, tint: Theme.warning)
+                    }
+                    if let resume = grant.resumeCondition {
+                        labeledRow("Resume when", value: resume)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func hasGrant(_ g: ProjectGrant) -> Bool {
+        g.mergeAuthority != nil || g.budgetPerTick != nil || g.materialBar != nil
+            || g.pauseReason != nil || g.resumeCondition != nil
+    }
+
+    // MARK: missions (the agents)
+
+    @ViewBuilder private var missionsSection: some View {
+        let missions = summary?.missions ?? []
+        if !missions.isEmpty {
+            GlassCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionTitle("Agents", icon: "cpu")
+                    ForEach(missions) { m in
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(missionColor(m.status))
+                                .frame(width: 6, height: 6)
+                            Text(m.displayTitle)
+                                .font(.system(size: 12))
+                                .foregroundStyle(Theme.textSecondary)
+                                .lineLimit(1)
+                            Spacer(minLength: 4)
+                            if m.needsAttention {
+                                Text("NEEDS YOU")
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundStyle(Theme.warning)
+                            }
+                            if let pr = m.githubPr {
+                                Text(pr).font(.system(size: 10)).foregroundStyle(Theme.textTertiary)
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func missionColor(_ status: String) -> Color {
+        switch status {
+        case "active": return Theme.accent
+        case "awaiting_user": return Theme.warning
+        case "failed", "interrupted": return Theme.error
+        default: return Theme.textMuted
+        }
+    }
+
+    // MARK: tracks
+
+    @ViewBuilder private var tracksSection: some View {
+        if let tracks = detail?.tracks, !tracks.isEmpty {
+            GlassCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionTitle("Tracks", icon: "point.3.connected.trianglepath.dotted")
+                    ForEach(tracks) { t in
+                        HStack {
+                            Text(t.track).font(.system(size: 12)).foregroundStyle(Theme.textSecondary)
+                            Spacer()
+                            if let status = t.status {
+                                Text(status).font(.system(size: 11)).foregroundStyle(Theme.textTertiary)
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    // MARK: decisions
+
+    @ViewBuilder private var decisionsSection: some View {
+        if let decisions = detail?.openDecisions, !decisions.isEmpty {
+            GlassCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionTitle("Open questions", icon: "questionmark.bubble")
+                    ForEach(decisions) { d in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(d.question).font(.system(size: 12)).foregroundStyle(Theme.textPrimary)
+                            if let r = d.rationale {
+                                Text(r).font(.system(size: 11)).foregroundStyle(Theme.textTertiary)
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    // MARK: helpers
+
+    private func sectionTitle(_ text: String, icon: String) -> some View {
+        Label(text, systemImage: icon)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(Theme.textTertiary)
+    }
+
+    private func labeledRow(_ label: String, value: String, mono: Bool = false, tint: Color? = nil) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(label)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(Theme.textTertiary)
+                .frame(width: 76, alignment: .leading)
+            Text(value)
+                .font(.system(size: 12, design: mono ? .monospaced : .default))
+                .foregroundStyle(tint ?? Theme.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func infoCard(title: String, body: String, icon: String, tint: Color? = nil) -> some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 6) {
+                sectionTitle(title, icon: icon)
+                Text(body)
+                    .font(.system(size: 13))
+                    .foregroundStyle(tint ?? Theme.textPrimary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            detail = try await api.getProject(slug: slug)
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectsView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectsView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+/// The projects surface: every sandboxed.sh project as a card showing its
+/// controller-reported mode, its live mission-agents, and — through the detail
+/// view — the controller that drives it and the session bound to it.
+///
+/// Unlike the mission-switcher's project rows, this does NOT hide projects
+/// without a bound session: a paused or freshly-seeded project is still a
+/// project worth seeing.
+struct ProjectsView: View {
+    private let api = APIService.shared
+
+    @State private var projects: [ProjectSummary] = []
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    var body: some View {
+        Group {
+            if isLoading && projects.isEmpty {
+                LoadingView()
+            } else if let loadError, projects.isEmpty {
+                ContentUnavailableView("Projects unavailable", systemImage: "square.stack.3d.up.slash", description: Text(loadError))
+            } else if projects.isEmpty {
+                ContentUnavailableView("No projects", systemImage: "square.stack.3d.up", description: Text("No sandboxed.sh projects on this backend."))
+            } else {
+                content
+            }
+        }
+        .navigationTitle("Projects")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+        .refreshable { await load() }
+    }
+
+    private var summaryLine: String {
+        let live = projects.reduce(0) { $0 + $1.liveMissions.count }
+        let blocked = projects.filter { $0.mode?.base == .blocked }.count
+        let attention = projects.filter { $0.needsAttention }.count
+        var parts: [String] = []
+        if live > 0 { parts.append("\(live) live") }
+        if attention > 0 { parts.append("\(attention) need attention") }
+        if blocked > 0 { parts.append("\(blocked) blocked") }
+        return parts.joined(separator: " · ")
+    }
+
+    private var sortedProjects: [ProjectSummary] {
+        // Attention first, then blocked, then the rest — the stuck one is what
+        // you open the app to find.
+        projects.sorted { a, b in
+            func rank(_ p: ProjectSummary) -> Int {
+                if p.needsAttention { return 0 }
+                if p.mode?.base == .blocked { return 1 }
+                if p.bucket == "paused" || p.mode?.base == .paused { return 3 }
+                return 2
+            }
+            let ra = rank(a), rb = rank(b)
+            return ra == rb ? a.slug < b.slug : ra < rb
+        }
+    }
+
+    private var content: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                if !summaryLine.isEmpty {
+                    Text(summaryLine)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.textTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 4)
+                }
+                ForEach(sortedProjects) { project in
+                    NavigationLink {
+                        ProjectDetailView(slug: project.slug, summary: project)
+                    } label: {
+                        ProjectCard(project: project)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(16)
+        }
+        .background(Theme.backgroundPrimary)
+    }
+
+    private func load() async {
+        if projects.isEmpty { isLoading = true }
+        defer { isLoading = false }
+        do {
+            projects = try await api.listProjects()
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+}
+
+/// One project as a card: title/slug, mode chip, live-agent count, and the
+/// single most useful line (attention reason, blocker, or headline).
+struct ProjectCard: View {
+    let project: ProjectSummary
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Text(project.slug)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+                    if let mode = project.mode {
+                        ModeChipView(mode: mode)
+                    }
+                    Spacer(minLength: 4)
+                    if !project.liveMissions.isEmpty {
+                        Label("\(project.liveMissions.count)", systemImage: "circle.fill")
+                            .labelStyle(.titleAndIcon)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(Theme.accent)
+                    }
+                }
+                let attention = project.missionsNeedingAttention.count
+                if attention > 0 {
+                    Label("\(attention) need you", systemImage: "exclamationmark.circle.fill")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(Theme.warning)
+                }
+                if let sub = subtitle {
+                    Text(sub)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var subtitle: String? {
+        if let blocker = project.latestUpdate?.blocker, !blocker.isEmpty {
+            return "Blocked: \(blocker)"
+        }
+        if let reason = project.attentionReasons.first { return reason }
+        return project.latestUpdate?.headline
+    }
+}
+
+/// The controller mode as a small colored chip. Amber = look at this; indigo =
+/// working; dim = deliberately paused.
+struct ModeChipView: View {
+    let mode: ControllerMode
+
+    private var color: Color {
+        switch mode.base {
+        case .blocked: return Theme.warning
+        case .active: return Theme.accent
+        case .paused: return Theme.textMuted
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Circle().fill(color).frame(width: 5, height: 5)
+            Text(mode.label.uppercased())
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(color.opacity(0.12), in: Capsule())
+    }
+}

--- a/ios_dashboard/SandboxedDashboardTests/ProjectTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ProjectTests.swift
@@ -128,6 +128,62 @@ final class ProjectTests: XCTestCase {
         XCTAssertEqual(state.observations, 34)
         XCTAssertEqual(state.id, "2026-08-04T10:00:00Z")
     }
+
+    func testDecodesModeAndMissionChipsOnTheSummary() throws {
+        let project = try decode(
+            """
+            {
+              "slug": "verity",
+              "bucket": "active",
+              "latest_update": {"headline": "moving", "at": "2026-08-07T10:00:00Z", "mode": "blocked:transport-cap"},
+              "missions": [
+                {"id": "m1", "status": "awaiting_user", "title": "Fix PR #2240"},
+                {"id": "m2", "status": "active", "title": "Certify head"}
+              ]
+            }
+            """
+        )
+        XCTAssertEqual(project.mode?.base, .blocked)
+        XCTAssertEqual(project.mode?.cause, "transport-cap")
+        XCTAssertEqual(project.mode?.label, "blocked: transport-cap")
+        XCTAssertEqual(project.liveMissions.count, 2)
+        XCTAssertEqual(project.missionsNeedingAttention.count, 1)
+    }
+
+    func testAbsentModeYieldsNilNotAGuess() throws {
+        let project = try decode(
+            #"{"slug": "legacy", "bucket": "active", "latest_update": {"headline": "x", "at": "2026-08-07T10:00:00Z"}}"#
+        )
+        XCTAssertNil(project.mode)
+    }
+
+    func testDecodesTheProjectDetailWithControllerAndGrant() throws {
+        let detail = try JSONDecoder().decode(
+            ProjectDetail.self,
+            from: Data(
+                """
+                {
+                  "project": {
+                    "slug": "verity", "title": "Verity", "objective": "prove it",
+                    "status": "active", "mode": "active", "wait_ticks": 0,
+                    "next_action": "certify #2240", "controller_cron_id": "e594d751447d",
+                    "repository": "lfglabs-dev/verity"
+                  },
+                  "grant": {"merge_authority": "full", "material_bar": "PR merged"},
+                  "tracks": [{"track": "phase-b", "desired_state": "proved", "status": "in-progress"}],
+                  "open_decisions": [{"at": "2026-08-07T10:00:00Z", "question": "merge #48?"}],
+                  "conversation": {"session_id": "20260806_231844_ff644f", "source": "binding"}
+                }
+                """.utf8)
+        )
+        XCTAssertEqual(detail.project.controllerCronId, "e594d751447d")
+        XCTAssertEqual(detail.project.controllerMode?.base, .active)
+        XCTAssertEqual(detail.grant?.mergeAuthority, "full")
+        XCTAssertEqual(detail.tracks.first?.track, "phase-b")
+        XCTAssertEqual(detail.openDecisions.first?.question, "merge #48?")
+        // A declared binding is offered as the session to open.
+        XCTAssertEqual(detail.boundSessionId, "20260806_231844_ff644f")
+    }
 }
 
 final class MissionProjectMetadataTests: XCTestCase {


### PR DESCRIPTION
Adds a Projects tab to the iOS dashboard that visualizes sandboxed.sh projects, the controller driving each one, and the control session bound to it. Part of the projects-as-first-class-objects rollout (projects.db + MCP project tools).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and API client changes with conservative session-binding rules; no auth or server behavior changes in this diff.
> 
> **Overview**
> Adds a **Projects** tab to the iOS dashboard so operators can browse sandboxed.sh projects without relying on the mission switcher, including projects that have no bound control session yet.
> 
> The overview lists project cards with **controller-reported mode** (parsed from `latest_update.mode`, with no guessed state when absent), **live mission “agent” chips**, and attention-oriented sorting. Tapping a card opens **project detail** via a new `getProject` API call, showing cron controller id, next action/blocker, autonomy grant, tracks, open decisions, and a button to **open the bound Hermes control conversation** in the Control tab (only when `conversation.source` is `binding`, not inferred cron sessions).
> 
> Models gain `ProjectMissionChip`, `ControllerMode`, and `ProjectDetail` / related record types; unit tests cover decoding for mode, missions, and detail payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a19393d599d8bc5b7aa0c0fd04275ec331ebb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->