### PR TITLE
Overview includes bare roster projects

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -625,6 +625,22 @@ pub async fn projects_overview(
             updated_at: mission.updated_at.clone(),
         });
     }
+    // Roster projects are rows in their own right: a project created and bound
+    // through the API (no tracker file, no tagged mission, no delivery yet)
+    // must still appear on every surface, or "create + bind" looks like a
+    // silent no-op from the board.
+    for record in state
+        .projects
+        .list_projects()
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?
+    {
+        if deleted(&record.slug) {
+            continue;
+        }
+        let slug = record.slug.clone();
+        rows.entry(slug.clone())
+            .or_insert_with(|| ProjectRowBuilder::new(slug));
+    }
     let mut unrouted: Vec<DeliveryUpdate> = Vec::new();
     for delivery in deliveries {
         let Some(signature_key) = delivery.signature.as_deref().map(str::to_string) else {


### PR DESCRIPTION
A project created via PUT /api/projects and bound to a conversation, but with no tracker file, tagged mission, or delivery yet, was silently absent from /api/projects/overview — so it never appeared on the web board, desktop missions-board, or iOS. Roster records now seed rows like every other source (still enrich-only, still honoring deleted overrides).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single read-path addition on the overview GET; behavior matches existing union/enrich-only assembly with no auth or persistence changes.
> 
> **Overview**
> **`/api/projects/overview`** now seeds board rows from **`projects.list_projects()`**, not only from Hermes trackers, mission `project` tags, and routed deliveries.
> 
> API-created projects (e.g. **`PUT /api/projects`** plus conversation bind) with no tracker file, tagged mission, or cron delivery were missing from the overview and therefore from the web board, desktop missions board, and iOS. Each roster slug still uses **`or_insert_with`** so existing rows are only enriched, and **`deleted`** board overrides are still honored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918a2fd654e10d00f5f492dc22b7fcb5d90f6c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->