### PR TITLE
Taxonomy alignment + web/iOS unread parity + roster metadata on overview rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ building in isolation. Four concepts tie the system together:
 |---|---|---|
 | **Project** | The durable unit of work (an audit, a paper, a benchmark). First-class object with a mode (`active` / `blocked` / `paused`), an autonomy **grant** (merge authority, budget, parallelism), **tracks**, and open **decisions**. | `projects.db` on the sandboxed.sh host, served at `/api/projects/*` |
 | **Controller** | A coordinator cron that wakes on a schedule, reads its control conversation + GitHub + the project state, and dispatches work. It drives exactly one project and reports back with structured status trailers. | Coordinator (e.g. a Hermes cron with the project MCP tools) |
-| **Session** | The durable control conversation bound to a project — where you (or the controller) talk. Continuations roll over, so it's addressed by route, not a frozen ID. | Coordinator, binding stored in `projects.db` |
+| **Conversation** *(control session)* | The durable Hermes chat thread; the one bound to a project is its **control conversation** — where you (or the controller) talk — where you (or the controller) talk. Continuations roll over, so it's addressed by route, not a frozen ID. | Coordinator, binding stored in `projects.db` |
 | **Mission** | One unit of autonomous execution: an agent in an isolated workspace/container running a harness (Claude Code, Codex, …) that writes code, runs builds, opens PRs. Tagged with `project`/`track`. | sandboxed.sh workspaces |
 
 ```
@@ -85,13 +85,14 @@ instead of free text; a state ingestor also folds controller status trailers
 from deliveries into the project record, so the roster stays current even for
 text-only updates.
 
-**Rule of thumb:** *decide/coordinate → the assistant; build/execute in
-isolation → a sandboxed mission.* In-conversation subagents are for quick
+**Rule of thumb:** *a controller drives a project through its control
+conversation by dispatching missions.* Decide/coordinate → the assistant;
+build/execute in isolation → a sandboxed mission. In-conversation subagents are for quick
 reasoning and decomposition; anything needing a real filesystem, git, builds,
 or a PR gets dispatched as a mission.
 
 The same project roster is rendered by three surfaces: the web dashboard's
-board (`/`), the Hermes desktop board plugin, and the iOS app's Projects tab.
+board (`/`), the desktop Projects board, and the iOS app's Projects tab.
 
 ---
 

--- a/dashboard/src/app/history/page.tsx
+++ b/dashboard/src/app/history/page.tsx
@@ -206,9 +206,9 @@ export default function HistoryPage() {
     <div className="p-6">
       {/* Header */}
       <div className="mb-6">
-        <h1 className="text-xl font-semibold text-white">Agents</h1>
+        <h1 className="text-xl font-semibold text-white">Missions</h1>
         <p className="mt-1 text-sm text-white/50">
-          Mission history and agent tree visualization
+          Mission history and subagent tree visualization
         </p>
       </div>
 

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -14,7 +14,10 @@ import type {
   TrackHealth,
 } from "@/lib/api/projects";
 import { hermesChatStream, listHermesSessions } from "@/lib/api/hermes";
-import ProjectsBoard from "./projects-board";
+import ProjectsBoard, {
+  unreadCountFor,
+  type ProjectLastSeen,
+} from "./projects-board";
 
 vi.mock("@/lib/api/projects", () => ({
   getProjectsOverview: vi.fn(),
@@ -198,7 +201,7 @@ describe("ProjectsBoard", () => {
     await waitFor(() => expect(mockedUpdates).toHaveBeenCalledWith("beal", 50));
     // First update is expanded by default: body + origin session visible.
     expect(
-      await screen.findByText(/Origin session: sess-42/),
+      await screen.findByText(/Origin conversation: sess-42/),
     ).toBeInTheDocument();
   });
 
@@ -523,5 +526,56 @@ describe("ProjectsBoard", () => {
     renderBoard();
 
     expect(await screen.findByText(/1 blocked/)).toBeInTheDocument();
+  });
+});
+
+describe("unreadCountFor", () => {
+  const seen = (
+    updates_count: number,
+    latest_at: string | null = null,
+  ): ProjectLastSeen => ({ updates_count, latest_at });
+
+  const proj = (updates_count: number, at: string | null) => ({
+    updates_count,
+    latest_update: at
+      ? {
+          headline: "h",
+          body: null,
+          session_id: "s",
+          at,
+          signature: "sig",
+          mode: null,
+          blocker: null,
+        }
+      : null,
+  });
+
+  test("never-opened project counts every update", () => {
+    expect(unreadCountFor(proj(7, "2026-08-08T00:00:00Z"), undefined)).toBe(7);
+  });
+
+  test("delta since last seen", () => {
+    expect(unreadCountFor(proj(7, null), seen(4))).toBe(3);
+  });
+
+  test("caught up means zero", () => {
+    const at = "2026-08-08T00:00:00Z";
+    expect(unreadCountFor(proj(4, at), seen(4, at))).toBe(0);
+  });
+
+  test("flat count with a newer latest_update still shows one", () => {
+    // The updates window is rolling: the count can stay flat while newer
+    // deliveries replace older ones.
+    expect(
+      unreadCountFor(
+        proj(4, "2026-08-08T12:00:00Z"),
+        seen(4, "2026-08-08T00:00:00Z"),
+      ),
+    ).toBe(1);
+  });
+
+  test("count shrinking (server-side trim) does not go negative", () => {
+    const at = "2026-08-08T00:00:00Z";
+    expect(unreadCountFor(proj(2, at), seen(10, at))).toBe(0);
   });
 });

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -119,6 +119,71 @@ function stripMarkdown(text: string): string {
     .trim();
 }
 
+// ── Unread tracking ─────────────────────────────────────────────────────────
+// Client-side only: the backend has no per-user read state, so "seen" lives in
+// localStorage keyed by project slug. Opening a project in the detail pane
+// records its current updates_count / latest_update.at; the badge is the delta.
+
+const LAST_SEEN_STORAGE_KEY = "projects-board.last-seen.v1";
+
+export type ProjectLastSeen = {
+  updates_count: number;
+  latest_at: string | null;
+};
+
+function loadLastSeen(): Record<string, ProjectLastSeen> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    const result: Record<string, ProjectLastSeen> = {};
+    for (const [slug, value] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (!value || typeof value !== "object") continue;
+      const entry = value as Partial<ProjectLastSeen>;
+      if (typeof entry.updates_count !== "number") continue;
+      result[slug] = {
+        updates_count: entry.updates_count,
+        latest_at: typeof entry.latest_at === "string" ? entry.latest_at : null,
+      };
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function persistLastSeen(map: Record<string, ProjectLastSeen>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // Storage full or unavailable — the badge just won't persist.
+  }
+}
+
+/** New deliveries since the project was last opened. Exported for tests. */
+export function unreadCountFor(
+  project: Pick<ProjectRow, "updates_count" | "latest_update">,
+  seen: ProjectLastSeen | undefined,
+): number {
+  if (!seen) return Math.max(0, project.updates_count);
+  const delta = project.updates_count - seen.updates_count;
+  if (delta > 0) return delta;
+  // The rolling updates window can keep the count flat while newer deliveries
+  // replace older ones — a fresher latest_update.at still means "something new".
+  const latest = project.latest_update?.at ?? null;
+  if (!latest) return 0;
+  if (!seen.latest_at) return 1;
+  const latestMs = new Date(latest).getTime();
+  const seenMs = new Date(seen.latest_at).getTime();
+  if (Number.isNaN(latestMs) || Number.isNaN(seenMs)) return 0;
+  return latestMs > seenMs ? 1 : 0;
+}
+
 /** A project with no missions and no updates is a quiet tracker file. */
 function isQuiet(project: ProjectRow): boolean {
   return project.missions.length === 0 && project.updates_count === 0;
@@ -134,6 +199,13 @@ export default function ProjectsBoard() {
   const [filter, setFilter] = useState("");
   const [mobileDetail, setMobileDetail] = useState(false);
   const listRef = useRef<HTMLDivElement | null>(null);
+
+  // Loaded in an effect (not the initial state) so the server render and the
+  // first client render agree — localStorage only exists on the client.
+  const [lastSeen, setLastSeen] = useState<Record<string, ProjectLastSeen>>({});
+  useEffect(() => {
+    setLastSeen(loadLastSeen());
+  }, []);
 
   const sections = useMemo(() => {
     const projects = data?.projects ?? [];
@@ -160,6 +232,33 @@ export default function ProjectsBoard() {
 
   const selected =
     flatList.find((p) => p.slug === selectedSlug) ?? flatList[0] ?? null;
+
+  // Opening a project (it is showing in the detail pane) marks it seen.
+  const selectedUpdatesCount = selected?.updates_count;
+  const selectedLatestAt = selected?.latest_update?.at ?? null;
+  useEffect(() => {
+    if (!selected) return;
+    setLastSeen((prev) => {
+      const entry = prev[selected.slug];
+      if (
+        entry &&
+        entry.updates_count === selected.updates_count &&
+        entry.latest_at === (selected.latest_update?.at ?? null)
+      ) {
+        return prev;
+      }
+      const next = {
+        ...prev,
+        [selected.slug]: {
+          updates_count: selected.updates_count,
+          latest_at: selected.latest_update?.at ?? null,
+        },
+      };
+      persistLastSeen(next);
+      return next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected?.slug, selectedUpdatesCount, selectedLatestAt]);
 
   const select = useCallback((slug: string, viaPointer = false) => {
     setSelectedSlug(slug);
@@ -296,6 +395,11 @@ export default function ProjectsBoard() {
                     key={project.slug}
                     project={project}
                     selected={selected?.slug === project.slug}
+                    unread={
+                      selected?.slug === project.slug
+                        ? 0
+                        : unreadCountFor(project, lastSeen[project.slug])
+                    }
                     onSelect={() => select(project.slug, true)}
                   />
                 ))}
@@ -393,10 +497,13 @@ function SummaryStrip({ projects }: { projects: ProjectRow[] }) {
 function ProjectListRow({
   project,
   selected,
+  unread,
   onSelect,
 }: {
   project: ProjectRow;
   selected: boolean;
+  /** New deliveries since this project was last opened; 0 hides the badge. */
+  unread: number;
   onSelect: () => void;
 }) {
   const live = liveMissionCount(project);
@@ -424,7 +531,19 @@ function ProjectListRow({
           >
             {project.slug}
           </span>
-          {project.latest_update && <UpdateAge at={project.latest_update.at} />}
+          <span className="flex shrink-0 items-center gap-1.5">
+            {unread > 0 && (
+              <span
+                title={`${unread > 9 ? "9+" : unread} new update${unread === 1 ? "" : "s"}`}
+                className="rounded-full bg-indigo-500/20 px-1.5 py-px text-[10px] font-semibold tabular-nums text-indigo-200"
+              >
+                {unread > 9 ? "9+" : unread}
+              </span>
+            )}
+            {project.latest_update && (
+              <UpdateAge at={project.latest_update.at} />
+            )}
+          </span>
         </span>
         {/* A blocked or stale controller is worth a second line even when the
             project is otherwise quiet — silence was exactly how a stuck
@@ -625,7 +744,7 @@ function ProjectActions({ project }: { project: ProjectRow }) {
         <ActionButton
           icon={Link2}
           label="Bind…"
-          title="Choose the conversation this project reports into. Until one is declared, the link above follows whichever session sent the last update — for a cron-driven project that is a per-tick session which has already ended."
+          title="Choose the conversation this project reports into. Until one is declared, the link above follows whichever conversation sent the last update — for a cron-driven project that is a per-tick conversation which has already ended."
           busy={busy === "bind"}
           onClick={openPicker}
         />
@@ -688,7 +807,7 @@ function ProjectActions({ project }: { project: ProjectRow }) {
         <ActionButton
           icon={Unlink}
           label="Unbind"
-          title="Stop declaring a control conversation for this project. The link falls back to whichever session sent the last update."
+          title="Stop declaring a control conversation for this project. The link falls back to whichever conversation sent the last update."
           busy={busy === "bind"}
           onClick={unbindConversation}
         />
@@ -778,7 +897,7 @@ function ReplyComposer({ sessionId }: { sessionId: string }) {
               void send();
             }
           }}
-          placeholder={`Reply in session ${sessionId.slice(0, 14)}…`}
+          placeholder={`Reply in conversation ${sessionId.slice(0, 14)}…`}
           rows={message.includes("\n") ? 3 : 1}
           className="min-h-[32px] flex-1 resize-none rounded-lg border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/80 placeholder:text-white/25 focus:border-indigo-400/40 focus:outline-none"
         />
@@ -812,7 +931,7 @@ function ReplyComposer({ sessionId }: { sessionId: string }) {
           )}
           {replyDone && reply !== "" && (
             <p className="mt-1.5 text-[10px] text-white/30">
-              Reply from session {sessionId.slice(0, 14)}
+              Reply from conversation {sessionId.slice(0, 14)}
             </p>
           )}
         </div>
@@ -1077,7 +1196,7 @@ function UpdateEntry({
               content={bodyWithoutHeadline(update.body, update.headline)}
             />
             <p className="mt-2 text-[11px] text-white/30">
-              Origin session: {update.session_id}
+              Origin conversation: {update.session_id}
             </p>
           </div>
         )}

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -211,7 +211,11 @@ export default function ProjectsBoard() {
     const projects = data?.projects ?? [];
     const query = filter.trim().toLowerCase();
     const filtered = query
-      ? projects.filter((p) => p.slug.toLowerCase().includes(query))
+      ? projects.filter(
+          (p) =>
+            p.slug.toLowerCase().includes(query) ||
+            (p.title ?? "").toLowerCase().includes(query),
+        )
       : projects;
     return SECTIONS.map((section) => ({
       ...section,
@@ -529,7 +533,7 @@ function ProjectListRow({
               quiet ? "text-white/45" : "text-white/85",
             )}
           >
-            {project.slug}
+            {project.title || project.slug}
           </span>
           <span className="flex shrink-0 items-center gap-1.5">
             {unread > 0 && (
@@ -967,8 +971,11 @@ function ProjectDetail({
           >
             <ArrowLeft className="h-4 w-4" />
           </button>
-          <h2 className="min-w-0 truncate text-base font-semibold text-white/90">
-            {project.slug}
+          <h2
+            title={project.title ? project.slug : undefined}
+            className="min-w-0 truncate text-base font-semibold text-white/90"
+          >
+            {project.title || project.slug}
           </h2>
           {section && (
             <span className="flex shrink-0 items-center gap-1.5 rounded-full border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[10px] font-medium text-white/45">

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -72,6 +72,10 @@ export interface ProjectConversation {
 
 export interface ProjectRow {
   slug: string;
+  /** Roster title, when set — shown instead of the raw slug. */
+  title?: string | null;
+  /** The controller's declared next step, from the roster record. */
+  next_action?: string | null;
   bucket: ProjectBucket;
   tracker: ProjectTracker | null;
   missions: ProjectMissionChip[];

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		110C67FF7A62B86FB7AD4CD0 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD2C112534D498211B26C38 /* NetworkMonitor.swift */; };
 		13C5370F22B2BDFF2C337A0E /* AskSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F800962F5A1EFD8380ADE25C /* AskSheet.swift */; };
 		1750DD5DC204F7506E885D83 /* WorkspacesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384691169D9EC024B03AA57F /* WorkspacesView.swift */; };
+		1B5E3776BE1C79D6CDB50228 /* ProjectsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4015786D778B76973EA06D5 /* ProjectsView.swift */; };
 		20629DBCC7F1A2D09E435D75 /* BoardTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B805F407A9145CA937B3917 /* BoardTask.swift */; };
 		277C491E1B1B5E9673DF1CD8 /* MessageBubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EF1D3FCDDC536A1D824359 /* MessageBubbles.swift */; };
 		2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */; };
@@ -59,6 +60,7 @@
 		B12C86DF039026D6FFFD2B52 /* HermesConversationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F0AD1E30FB3F3BC08A39FB /* HermesConversationUITests.swift */; };
 		B2C28CDD378203A229D62B9B /* PhosphorIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17889CB07B4A4285DD87C30 /* PhosphorIcon.swift */; };
 		B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */; };
+		B5F362452171D8F33FE32B9F /* ProjectDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B668E3312C606018F59C5835 /* ProjectDetailView.swift */; };
 		B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370F364BA05D1236D9B630AB /* ChatMessage.swift */; };
 		BAA09895377937393FF864A7 /* Mission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6DBBABC4AE0FD4368A185C /* Mission.swift */; };
 		BFD7D29C1F46E9F130A05F34 /* BackendAgentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6993AD59CA0D7392AAACDC2 /* BackendAgentService.swift */; };
@@ -145,6 +147,7 @@
 		ADBAC1664CAF3CD9DCCDB8B4 /* WorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceState.swift; sourceTree = "<group>"; };
 		AED7C0B17601881E8725F04D /* MissionSwitcherSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionSwitcherSheet.swift; sourceTree = "<group>"; };
 		AF933753B68F0B468D9F3864 /* TaskBoardViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBoardViews.swift; sourceTree = "<group>"; };
+		B668E3312C606018F59C5835 /* ProjectDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDetailView.swift; sourceTree = "<group>"; };
 		B920E504080EAEEA7CFD5201 /* ToolUIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIModels.swift; sourceTree = "<group>"; };
 		C0E02066E781D088A194C232 /* ControlPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPerformanceDiagnostics.swift; sourceTree = "<group>"; };
 		C433FADB27AED6165D3EE2E4 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
@@ -154,6 +157,7 @@
 		D17889CB07B4A4285DD87C30 /* PhosphorIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhosphorIcon.swift; sourceTree = "<group>"; };
 		D1EF1D3FCDDC536A1D824359 /* MessageBubbles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbles.swift; sourceTree = "<group>"; };
 		D2E4AC8C92D9F496B8152B8F /* ControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlView.swift; sourceTree = "<group>"; };
+		D4015786D778B76973EA06D5 /* ProjectsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsView.swift; sourceTree = "<group>"; };
 		D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButton.swift; sourceTree = "<group>"; };
 		D9E023EEFFFA9B1092B66006 /* ANSIParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIParser.swift; sourceTree = "<group>"; };
 		E387E6A01D00EAD668074CCC /* WorkerBuckets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerBuckets.swift; sourceTree = "<group>"; };
@@ -215,6 +219,7 @@
 				39B9469E602F8BD41799B337 /* FidoApproval */,
 				04136BE3D92AE400B09C5462 /* Files */,
 				DA63D97B804AFD44A1D1BFF3 /* History */,
+				94D2FAB173218E36F440F6B8 /* Projects */,
 				D104E1B7D32CBCD873A2C0EA /* Settings */,
 				A2D731F9852E4B1A58365B5D /* Terminal */,
 				9018DD0662733D22A4BADF1E /* Workspaces */,
@@ -300,6 +305,15 @@
 				69E84F6BBDAEC47870846B46 /* SandboxedDashboardUITests */,
 				057719CAD3366030137C44B3 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		94D2FAB173218E36F440F6B8 /* Projects */ = {
+			isa = PBXGroup;
+			children = (
+				B668E3312C606018F59C5835 /* ProjectDetailView.swift */,
+				D4015786D778B76973EA06D5 /* ProjectsView.swift */,
+			);
+			path = Projects;
 			sourceTree = "<group>";
 		};
 		A2D731F9852E4B1A58365B5D /* Terminal */ = {
@@ -549,6 +563,8 @@
 				D0646F9EE2D2E984F0446C57 /* NewMissionSheet.swift in Sources */,
 				B2C28CDD378203A229D62B9B /* PhosphorIcon.swift in Sources */,
 				6EC32F7CE8BFDB84428DFF4A /* Project.swift in Sources */,
+				B5F362452171D8F33FE32B9F /* ProjectDetailView.swift in Sources */,
+				1B5E3776BE1C79D6CDB50228 /* ProjectsView.swift in Sources */,
 				51E9D9F51934DFC8EAD58CDC /* QueueSheet.swift in Sources */,
 				95B7AB5DBEB42E107EBE06FB /* RunningMissionsBar.swift in Sources */,
 				6846AB79778CDF4CC216B7D1 /* SandboxedDashboardApp.swift in Sources */,

--- a/ios_dashboard/SandboxedDashboard/Models/Project.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Project.swift
@@ -396,12 +396,12 @@ enum ProjectUnread {
         return latest > previous ? 1 : 0
     }
 
-    private static let isoWithFractional: ISO8601DateFormatter = {
+    private nonisolated(unsafe) static let isoWithFractional: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f
     }()
-    private static let iso = ISO8601DateFormatter()
+    private nonisolated(unsafe) static let iso = ISO8601DateFormatter()
 
     static func parseDate(_ raw: String) -> Date? {
         isoWithFractional.date(from: raw) ?? iso.date(from: raw)
@@ -410,7 +410,7 @@ enum ProjectUnread {
 
 /// Client-side "seen" state for the projects board, persisted in UserDefaults
 /// keyed by project slug — the backend has no per-user read state.
-final class ProjectUnreadStore {
+final class ProjectUnreadStore: @unchecked Sendable {
     static let shared = ProjectUnreadStore()
 
     private let defaults: UserDefaults

--- a/ios_dashboard/SandboxedDashboard/Models/Project.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Project.swift
@@ -10,6 +10,10 @@ struct ProjectSummary: Codable, Identifiable, Hashable {
     var id: String { slug }
 
     let slug: String
+    /// Roster title, when set — shown instead of the raw slug.
+    let title: String?
+    /// The controller's declared next step, from the roster record.
+    let nextAction: String?
     /// `attention` | `active` | `paused` | anything else the server adds.
     let bucket: String
     let attentionReasons: [String]
@@ -17,11 +21,12 @@ struct ProjectSummary: Codable, Identifiable, Hashable {
     let health: ProjectHealth?
     let conversation: ProjectConversation?
     let latestUpdate: ProjectUpdate?
-    /// Live missions grouped under this project — the "agents" of the fleet.
+    /// Live missions grouped under this project.
     let missions: [ProjectMissionChip]
 
     enum CodingKeys: String, CodingKey {
-        case slug, bucket, health, conversation, missions
+        case slug, title, bucket, health, conversation, missions
+        case nextAction = "next_action"
         case attentionReasons = "attention_reasons"
         case updatesCount = "updates_count"
         case latestUpdate = "latest_update"
@@ -30,6 +35,8 @@ struct ProjectSummary: Codable, Identifiable, Hashable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         slug = try container.decode(String.self, forKey: .slug)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        nextAction = try container.decodeIfPresent(String.self, forKey: .nextAction)
         bucket = try container.decodeIfPresent(String.self, forKey: .bucket) ?? "active"
         attentionReasons = try container.decodeIfPresent([String].self, forKey: .attentionReasons) ?? []
         updatesCount = try container.decodeIfPresent(Int.self, forKey: .updatesCount) ?? 0
@@ -37,6 +44,13 @@ struct ProjectSummary: Codable, Identifiable, Hashable {
         conversation = try container.decodeIfPresent(ProjectConversation.self, forKey: .conversation)
         latestUpdate = try container.decodeIfPresent(ProjectUpdate.self, forKey: .latestUpdate)
         missions = try container.decodeIfPresent([ProjectMissionChip].self, forKey: .missions) ?? []
+    }
+
+    /// What to render as the project's name: the roster title when one was
+    /// set, the slug otherwise.
+    var displayName: String {
+        if let title, !title.isEmpty { return title }
+        return slug
     }
 
     /// The controller-reported mode from the latest delivery: `active`,
@@ -351,5 +365,85 @@ struct ProjectState: Codable, Hashable, Identifiable {
         case signature, headline, observations
         case firstSeenAt = "first_seen_at"
         case lastSeenAt = "last_seen_at"
+    }
+}
+
+// MARK: - Unread tracking
+
+/// What the user had seen of a project the last time they opened its detail:
+/// the delivery count and the newest delivery timestamp at that moment.
+struct ProjectLastSeen: Codable, Equatable {
+    let updatesCount: Int
+    let latestAt: String?
+}
+
+/// New deliveries since a project was last opened. Pure so it is testable;
+/// mirrors the web board's `unreadCountFor`.
+///
+/// - Never opened → every update is unread.
+/// - Count grew → the delta.
+/// - Count flat but `latest_update.at` newer → at least 1 (the updates window
+///   is rolling: newer deliveries can replace older ones without moving the
+///   count).
+enum ProjectUnread {
+    static func count(updatesCount: Int, latestAt: String?, seen: ProjectLastSeen?) -> Int {
+        guard let seen else { return max(0, updatesCount) }
+        let delta = updatesCount - seen.updatesCount
+        if delta > 0 { return delta }
+        guard let latestAt else { return 0 }
+        guard let seenAt = seen.latestAt else { return 1 }
+        guard let latest = parseDate(latestAt), let previous = parseDate(seenAt) else { return 0 }
+        return latest > previous ? 1 : 0
+    }
+
+    private static let isoWithFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let iso = ISO8601DateFormatter()
+
+    static func parseDate(_ raw: String) -> Date? {
+        isoWithFractional.date(from: raw) ?? iso.date(from: raw)
+    }
+}
+
+/// Client-side "seen" state for the projects board, persisted in UserDefaults
+/// keyed by project slug — the backend has no per-user read state.
+final class ProjectUnreadStore {
+    static let shared = ProjectUnreadStore()
+
+    private let defaults: UserDefaults
+    private let storageKey = "projects.lastSeen.v1"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func unreadCount(for project: ProjectSummary) -> Int {
+        ProjectUnread.count(
+            updatesCount: project.updatesCount,
+            latestAt: project.latestUpdate?.at,
+            seen: lastSeen()[project.slug]
+        )
+    }
+
+    /// Opening the project detail marks everything current as seen.
+    func markSeen(_ project: ProjectSummary) {
+        var map = lastSeen()
+        map[project.slug] = ProjectLastSeen(
+            updatesCount: project.updatesCount,
+            latestAt: project.latestUpdate?.at
+        )
+        if let data = try? JSONEncoder().encode(map) {
+            defaults.set(data, forKey: storageKey)
+        }
+    }
+
+    private func lastSeen() -> [String: ProjectLastSeen] {
+        guard let data = defaults.data(forKey: storageKey),
+              let map = try? JSONDecoder().decode([String: ProjectLastSeen].self, from: data)
+        else { return [:] }
+        return map
     }
 }

--- a/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectDetailView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectDetailView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 /// One project in full: the controller-reported state, the cron controller that
-/// drives it, its bound Hermes session (tap to open it in Control), the
-/// autonomy grant, tracks, live mission-agents, and any open decisions.
+/// drives it, its bound control conversation (tap to open it in Control), the
+/// autonomy grant, tracks, live missions, and any open decisions.
 ///
-/// This is where "which controller drives this project, and which session is it
-/// tied to" is answered — the link the switcher never surfaced.
+/// This is where "which controller drives this project, and which conversation
+/// is it tied to" is answered — the link the switcher never surfaced.
 struct ProjectDetailView: View {
     let slug: String
     /// The overview row we came from, used as an instant fallback while the
@@ -38,9 +38,14 @@ struct ProjectDetailView: View {
             .padding(16)
         }
         .background(Theme.backgroundPrimary)
-        .navigationTitle(record?.displayTitle ?? slug)
+        .navigationTitle(record?.displayTitle ?? summary?.displayName ?? slug)
         .navigationBarTitleDisplayMode(.inline)
-        .task { await load() }
+        .task {
+            await load()
+            // Opening the detail marks the project's deliveries as seen — the
+            // list badge is the delta since this moment.
+            if let summary { ProjectUnreadStore.shared.markSeen(summary) }
+        }
         .refreshable { await load() }
     }
 
@@ -52,7 +57,7 @@ struct ProjectDetailView: View {
         GlassCard {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
-                    Text(record?.displayTitle ?? slug)
+                    Text(record?.displayTitle ?? summary?.displayName ?? slug)
                         .font(.system(size: 18, weight: .bold))
                         .foregroundStyle(Theme.textPrimary)
                     if let mode = record?.controllerMode ?? summary?.mode {
@@ -79,7 +84,7 @@ struct ProjectDetailView: View {
         }
     }
 
-    // MARK: controller + bound session
+    // MARK: controller + control conversation
 
     private var controllerSection: some View {
         GlassCard {
@@ -141,14 +146,14 @@ struct ProjectDetailView: View {
             || g.pauseReason != nil || g.resumeCondition != nil
     }
 
-    // MARK: missions (the agents)
+    // MARK: missions
 
     @ViewBuilder private var missionsSection: some View {
         let missions = summary?.missions ?? []
         if !missions.isEmpty {
             GlassCard {
                 VStack(alignment: .leading, spacing: 8) {
-                    sectionTitle("Agents", icon: "cpu")
+                    sectionTitle("Missions", icon: "cpu")
                     ForEach(missions) { m in
                         HStack(spacing: 8) {
                             Circle()

--- a/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectsView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Projects/ProjectsView.swift
@@ -1,16 +1,21 @@
 import SwiftUI
 
 /// The projects surface: every sandboxed.sh project as a card showing its
-/// controller-reported mode, its live mission-agents, and — through the detail
-/// view — the controller that drives it and the session bound to it.
+/// controller-reported mode, its live missions, and — through the detail
+/// view — the controller that drives it and the control conversation bound
+/// to it.
 ///
 /// Unlike the mission-switcher's project rows, this does NOT hide projects
-/// without a bound session: a paused or freshly-seeded project is still a
-/// project worth seeing.
+/// without a bound conversation: a paused or freshly-seeded project is still
+/// a project worth seeing.
 struct ProjectsView: View {
     private let api = APIService.shared
+    private let unreadStore = ProjectUnreadStore.shared
 
     @State private var projects: [ProjectSummary] = []
+    /// Unread deliveries per slug, recomputed on load and whenever the list
+    /// reappears (coming back from a detail view clears that project's badge).
+    @State private var unread: [String: Int] = [:]
     @State private var isLoading = true
     @State private var loadError: String?
 
@@ -72,7 +77,7 @@ struct ProjectsView: View {
                     NavigationLink {
                         ProjectDetailView(slug: project.slug, summary: project)
                     } label: {
-                        ProjectCard(project: project)
+                        ProjectCard(project: project, unread: unread[project.slug] ?? 0)
                     }
                     .buttonStyle(.plain)
                 }
@@ -80,6 +85,14 @@ struct ProjectsView: View {
             .padding(16)
         }
         .background(Theme.backgroundPrimary)
+        .onAppear { refreshUnread() }
+    }
+
+    private func refreshUnread() {
+        unread = Dictionary(
+            projects.map { ($0.slug, unreadStore.unreadCount(for: $0)) },
+            uniquingKeysWith: { first, _ in first }
+        )
     }
 
     private func load() async {
@@ -88,22 +101,26 @@ struct ProjectsView: View {
         do {
             projects = try await api.listProjects()
             loadError = nil
+            refreshUnread()
         } catch {
             loadError = error.localizedDescription
         }
     }
 }
 
-/// One project as a card: title/slug, mode chip, live-agent count, and the
-/// single most useful line (attention reason, blocker, or headline).
+/// One project as a card: title/slug, mode chip, live-mission count, unread
+/// deliveries, and the single most useful line (attention reason, blocker,
+/// or headline).
 struct ProjectCard: View {
     let project: ProjectSummary
+    /// New deliveries since the project was last opened; 0 hides the badge.
+    var unread: Int = 0
 
     var body: some View {
         GlassCard {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
-                    Text(project.slug)
+                    Text(project.displayName)
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
@@ -111,6 +128,15 @@ struct ProjectCard: View {
                         ModeChipView(mode: mode)
                     }
                     Spacer(minLength: 4)
+                    if unread > 0 {
+                        Text(unread > 9 ? "9+" : "\(unread)")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(Theme.accent)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Theme.accent.opacity(0.15), in: Capsule())
+                            .accessibilityLabel("\(unread > 9 ? "9 or more" : "\(unread)") new updates")
+                    }
                     if !project.liveMissions.isEmpty {
                         Label("\(project.liveMissions.count)", systemImage: "circle.fill")
                             .labelStyle(.titleAndIcon)

--- a/ios_dashboard/SandboxedDashboardTests/ProjectTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ProjectTests.swift
@@ -219,3 +219,107 @@ final class MissionProjectMetadataTests: XCTestCase {
         XCTAssertNil(try mission(project: nil, track: "orphan-track").projectLabel)
     }
 }
+
+/// Roster metadata on the overview row: title replaces the slug on cards,
+/// next_action is only rendered when present.
+final class ProjectRosterMetadataTests: XCTestCase {
+    func testTitleAndNextActionDecodeAndDisplayNamePrefersTitle() throws {
+        let project = try JSONDecoder().decode(
+            ProjectSummary.self,
+            from: Data(
+                """
+                {
+                  "slug": "verity", "bucket": "active",
+                  "title": "Verity 4.31 convergence",
+                  "next_action": "certify #2240"
+                }
+                """.utf8
+            )
+        )
+        XCTAssertEqual(project.title, "Verity 4.31 convergence")
+        XCTAssertEqual(project.nextAction, "certify #2240")
+        XCTAssertEqual(project.displayName, "Verity 4.31 convergence")
+    }
+
+    func testDisplayNameFallsBackToSlug() throws {
+        let project = try JSONDecoder().decode(
+            ProjectSummary.self,
+            from: Data(#"{ "slug": "lido", "bucket": "active" }"#.utf8)
+        )
+        XCTAssertNil(project.title)
+        XCTAssertNil(project.nextAction)
+        XCTAssertEqual(project.displayName, "lido")
+    }
+}
+
+/// The unread badge: new deliveries since the project detail was last opened.
+final class ProjectUnreadTests: XCTestCase {
+    private func seen(_ count: Int, at: String? = nil) -> ProjectLastSeen {
+        ProjectLastSeen(updatesCount: count, latestAt: at)
+    }
+
+    func testNeverOpenedCountsEveryUpdate() {
+        XCTAssertEqual(ProjectUnread.count(updatesCount: 7, latestAt: "2026-08-08T00:00:00Z", seen: nil), 7)
+    }
+
+    func testDeltaSinceLastSeen() {
+        XCTAssertEqual(ProjectUnread.count(updatesCount: 7, latestAt: nil, seen: seen(4)), 3)
+    }
+
+    func testCaughtUpIsZero() {
+        let at = "2026-08-08T00:00:00Z"
+        XCTAssertEqual(ProjectUnread.count(updatesCount: 4, latestAt: at, seen: seen(4, at: at)), 0)
+    }
+
+    /// The updates window is rolling: the count can stay flat while newer
+    /// deliveries replace older ones — a fresher timestamp still means unread.
+    func testFlatCountWithNewerTimestampShowsOne() {
+        XCTAssertEqual(
+            ProjectUnread.count(
+                updatesCount: 4,
+                latestAt: "2026-08-08T12:00:00Z",
+                seen: seen(4, at: "2026-08-08T00:00:00Z")
+            ),
+            1
+        )
+    }
+
+    func testShrunkenCountDoesNotGoNegative() {
+        let at = "2026-08-08T00:00:00Z"
+        XCTAssertEqual(ProjectUnread.count(updatesCount: 2, latestAt: at, seen: seen(10, at: at)), 0)
+    }
+
+    func testFractionalSecondTimestampsParse() {
+        XCTAssertEqual(
+            ProjectUnread.count(
+                updatesCount: 4,
+                latestAt: "2026-08-08T12:00:00.500Z",
+                seen: seen(4, at: "2026-08-08T12:00:00.100Z")
+            ),
+            1
+        )
+    }
+
+    func testStoreRoundTripAndMarkSeen() throws {
+        let suite = "ProjectUnreadTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = ProjectUnreadStore(defaults: defaults)
+
+        let project = try JSONDecoder().decode(
+            ProjectSummary.self,
+            from: Data(
+                """
+                {
+                  "slug": "verity", "bucket": "active", "updates_count": 5,
+                  "latest_update": { "headline": "h", "at": "2026-08-08T00:00:00Z" }
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(store.unreadCount(for: project), 5)
+        store.markSeen(project)
+        XCTAssertEqual(store.unreadCount(for: project), 0)
+    }
+}

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -498,6 +498,13 @@ pub struct DeliveryUpdate {
 #[derive(Debug, Serialize)]
 struct ProjectRow {
     slug: String,
+    /// The roster project's title, when one was set — surfaces render it
+    /// instead of the raw slug.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    /// The controller's declared next step, from the roster record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_action: Option<String>,
     bucket: &'static str,
     tracker: Option<TrackerInfo>,
     missions: Vec<MissionChip>,
@@ -638,8 +645,11 @@ pub async fn projects_overview(
             continue;
         }
         let slug = record.slug.clone();
-        rows.entry(slug.clone())
+        let builder = rows
+            .entry(slug.clone())
             .or_insert_with(|| ProjectRowBuilder::new(slug));
+        builder.title = record.title;
+        builder.next_action = record.next_action;
     }
     let mut unrouted: Vec<DeliveryUpdate> = Vec::new();
     for delivery in deliveries {
@@ -723,6 +733,9 @@ pub async fn project_updates(
 
 struct ProjectRowBuilder {
     slug: String,
+    /// Roster title/next-action, attached when the slug has a roster record.
+    title: Option<String>,
+    next_action: Option<String>,
     tracker: Option<TrackerInfo>,
     missions: Vec<MissionChip>,
     /// Health inputs, accumulated alongside the display chips.
@@ -737,6 +750,8 @@ impl ProjectRowBuilder {
     fn new(slug: String) -> Self {
         Self {
             slug,
+            title: None,
+            next_action: None,
             tracker: None,
             missions: Vec::new(),
             health_inputs: Vec::new(),
@@ -892,6 +907,8 @@ impl ProjectRowBuilder {
 
         ProjectRow {
             slug: self.slug,
+            title: self.title,
+            next_action: self.next_action,
             bucket,
             tracker: self.tracker,
             missions: self.missions,
@@ -1710,5 +1727,31 @@ mod tests {
         let conversation = row.conversation.expect("conversation");
         assert_eq!(conversation.source, "latest_update");
         assert_eq!(conversation.bound_at, None);
+    }
+
+    /// Roster metadata rides on the row: the title replaces the slug on cards
+    /// and the palette; next_action renders on attention cards. Both are
+    /// optional and absent from the JSON when unset.
+    #[test]
+    fn roster_title_and_next_action_ride_on_the_row() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder.title = Some("Verity 4.31 convergence".to_string());
+        builder.next_action = Some("certify #2240".to_string());
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert_eq!(row.title.as_deref(), Some("Verity 4.31 convergence"));
+        assert_eq!(row.next_action.as_deref(), Some("certify #2240"));
+
+        let bare = ProjectRowBuilder::new("lido".to_string()).finish(
+            &[],
+            None,
+            None,
+            "2026-08-04T12:00:00Z",
+        );
+        let json = serde_json::to_value(&bare).expect("serialize");
+        assert!(json.get("title").is_none(), "unset title is omitted");
+        assert!(
+            json.get("next_action").is_none(),
+            "unset next_action is omitted"
+        );
     }
 }


### PR DESCRIPTION
README: Session→Conversation (control session), desktop Projects board wording, merged rule-of-thumb. Dashboard: conversation/missions vocabulary, unread badges per project (localStorage last-seen vs updates_count/latest_update.at). API: ProjectRow gains optional title + next_action from the roster. iOS: same vocabulary, displayName, ProjectUnreadStore + badges. Note: iOS XCTest cases verified via a standalone swiftc harness locally (CoreSimulator version drift blocks simulator runs until a reboot); assertions all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI copy, client-only unread state, and additive optional API fields; no auth or breaking contract changes.
> 
> **Overview**
> Aligns **Session → Conversation** (control session) across README, web projects board, history page, and iOS; renames **Agents → Missions** where the UI meant mission/subagent work.
> 
> **API:** `/api/projects/overview` rows now include optional **`title`** and **`next_action`** from the roster (omitted when unset).
> 
> **Web projects board:** Client-side **unread badges** via `localStorage` last-seen (`updates_count` + `latest_update.at`), including the rolling-window case where count stays flat but the timestamp moves. List/detail show **title** over slug; filter matches title. Tests cover `unreadCountFor`.
> 
> **iOS:** Same vocabulary, **`displayName`**, **`ProjectUnreadStore`** + badges on cards; detail marks seen on open. Xcode project wires **ProjectsView** / **ProjectDetailView**. Unit tests for roster metadata and unread logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17fbba77231b3147bc00089024740c3e0788c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->