### PR TITLE
Boot reconcile (scopes ↔ mission truth) + systemd watchdog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,7 @@ dependencies = [
  "reqwest",
  "reqwest-eventsource",
  "rusqlite",
+ "sd-notify",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1915,6 +1916,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sd-notify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Utilities
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 thiserror = "1"
+# systemd readiness + watchdog notifications (no-op off systemd)
+sd-notify = "0.4"
 async-trait = "0.1"
 futures = "0.3"
 

--- a/deploy/systemd/sandboxed-sh-watchdog.conf
+++ b/deploy/systemd/sandboxed-sh-watchdog.conf
@@ -1,0 +1,32 @@
+# systemd drop-in enabling the sandboxed-sh watchdog.
+#
+# Install (adjust the unit name for the instance: sandboxed-sh-prod /
+# sandboxed-sh-dev / ...):
+#
+#   mkdir -p /etc/systemd/system/sandboxed-sh-prod.service.d
+#   cp sandboxed-sh-watchdog.conf /etc/systemd/system/sandboxed-sh-prod.service.d/watchdog.conf
+#   systemctl daemon-reload
+#   systemctl restart sandboxed-sh-prod
+#
+# Requires a binary that sends READY=1 and WATCHDOG=1 (src/watchdog.rs).
+# Do NOT install this drop-in for binaries older than that: Type=notify makes
+# systemd wait for READY=1 and the start will time out.
+#
+# The binary ticks WATCHDOG=1 every WatchdogSec/3 only after a successful
+# tokio-runtime liveness round-trip; a wedged/starved runtime therefore stops
+# ticking and systemd restarts the service.
+#
+# Testing: set SANDBOXED_SH_SIMULATE_WEDGE=1 in the service environment (or
+# `systemctl set-environment`) to suppress ticks and watch systemd restart the
+# unit after WatchdogSec.
+
+# NOTE: Restart= REPLACES the base unit's value. If the base unit uses
+# Restart=always / on-failure, keep that instead of on-watchdog below —
+# on-failure already covers watchdog timeouts, while on-watchdog restarts
+# ONLY on watchdog timeouts.
+
+[Service]
+Type=notify
+NotifyAccess=main
+WatchdogSec=90
+Restart=on-watchdog

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -546,6 +546,15 @@ async fn write_job(state: &AppState, job: &DurableJob) -> Result<DurableJob, Str
     Ok(job)
 }
 
+/// Registry lookup for the boot/manual reconciler: `None` when no job.json
+/// exists for `id` (an unknown durable scope), otherwise the persisted status.
+pub(crate) async fn job_status_for_reconcile(
+    state: &AppState,
+    id: Uuid,
+) -> Option<DurableJobStatus> {
+    read_job(state, id).await.ok().map(|job| job.status)
+}
+
 async fn read_job(state: &AppState, id: Uuid) -> Result<DurableJob, String> {
     let bytes = tokio::fs::read(job_file(state, id))
         .await

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -57,6 +57,7 @@ pub(crate) mod providers;
 pub(crate) mod proxy;
 mod proxy_keys;
 pub(crate) mod proxy_liveness;
+pub(crate) mod reconcile;
 pub(crate) mod remote_build;
 mod routes;
 pub(crate) mod runners;

--- a/src/api/reconcile.rs
+++ b/src/api/reconcile.rs
@@ -1,0 +1,843 @@
+//! Boot-time + on-demand reconciliation of systemd scopes vs mission truth.
+//!
+//! A service restart leaves three classes of drift behind:
+//!
+//! 1. **Leaked scopes** — `sandboxed-exec-*` / `sandboxed-durable-*` transient
+//!    scopes whose owning mission/job is terminal or unknown (~80 observed on
+//!    prod). The periodic [`super::scope_reaper`] eventually catches exec
+//!    scopes; this pass sweeps both prefixes immediately at boot and on demand.
+//! 2. **Ghost-active missions** — rows still `active` in a store although no
+//!    live runner, scope, or durable run backs them. They are flipped to
+//!    `interrupted` with reason `service_restart` and auto-resumed through the
+//!    existing `ControlCommand::ResumeMission` path.
+//! 3. **Orphaned awaiting_user missions** — the mission row survives (GET
+//!    works) but its harness/session state is gone: no persisted events and no
+//!    active run, so `/events` replay and `/resume` have nothing to work from.
+//!    These are tagged `orphaned` in the mission's project tags (cheapest
+//!    durable representation — a status-enum addition would need store
+//!    migrations and touch every exhaustive status match) and announced on the
+//!    control event stream so controllers can triage them.
+//!
+//! Runs once at boot (delayed, so per-session startup recovery lands first)
+//! and from `POST /api/system/reconcile`. Hosts without systemd (Docker
+//! installs) skip the scope sweep gracefully: `systemctl` failing to run is
+//! treated as "no scopes", never as an error.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::Json;
+use serde::Serialize;
+use tokio::process::Command;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use super::control::{AgentEvent, ControlCommand, MissionStatus};
+use super::mission_store::{MissionExecutionState, MissionMode, MissionProjectPatch};
+use super::mission_workspace_gc::{build_mission_index, entry_for_workspace};
+use super::routes::AppState;
+use super::scope_reaper::stop_unit;
+use crate::workspace_exec::{
+    machine_name_for_path, machine_name_from_exec_unit, mission_short_id_from_exec_unit,
+};
+
+/// `end_reason` recorded on missions interrupted by this reconciler.
+pub const SERVICE_RESTART_REASON: &str = "service_restart";
+/// Tag appended to a mission's project tags when its harness session state is
+/// gone (see module docs, class 3).
+pub const ORPHANED_TAG: &str = "orphaned";
+
+fn env_flag(var: &str, default: bool) -> bool {
+    match std::env::var(var) {
+        Ok(v) => {
+            let v = v.trim();
+            if default {
+                v != "0" && !v.eq_ignore_ascii_case("false")
+            } else {
+                v == "1" || v.eq_ignore_ascii_case("true")
+            }
+        }
+        Err(_) => default,
+    }
+}
+
+fn boot_reconcile_enabled() -> bool {
+    env_flag("BOOT_RECONCILE_ENABLED", true)
+}
+
+/// Delay before the boot pass so per-session startup recovery
+/// (`recover_server_shutdown_missions`) and the eager control-session boot
+/// finish first — reconcile is idempotent, this just avoids duplicate work.
+fn boot_delay() -> Duration {
+    let secs = std::env::var("BOOT_RECONCILE_DELAY_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(45);
+    Duration::from_secs(secs)
+}
+
+/// Missions whose row was touched more recently than this are left alone by
+/// the ghost-active check: a turn may be starting right now and the actor's
+/// running list can lag the store write by a moment.
+fn active_grace() -> chrono::Duration {
+    let secs = std::env::var("BOOT_RECONCILE_ACTIVE_GRACE_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<i64>().ok())
+        .unwrap_or(180);
+    chrono::Duration::seconds(secs)
+}
+
+// ==================== scope-name parsing ====================
+
+/// A sandboxed scope unit name, decomposed. Non-sandboxed scopes parse to
+/// `None` and are skipped entirely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedScope {
+    Exec {
+        /// Workspace machine token (`sandboxed-<name>-<8hex>`), when the unit
+        /// name is well-formed.
+        machine: Option<String>,
+        /// 8-hex mission short id embedded via the `-m<hex>-` tag. `None` for
+        /// legacy or task-tagged units.
+        mission_short: Option<String>,
+    },
+    Durable {
+        /// Workspace machine token.
+        machine: Option<String>,
+        /// Durable job id (32-hex simple uuid trailing segment).
+        job_id: Option<Uuid>,
+    },
+}
+
+/// Parse a systemd scope unit name into a [`ParsedScope`]. Tolerant: units
+/// that are not `sandboxed-exec-*`/`sandboxed-durable-*` scopes return `None`;
+/// malformed sandboxed names still return the variant with `None` fields so
+/// the caller can decide to keep them (fail closed).
+pub fn parse_scope_unit(unit: &str) -> Option<ParsedScope> {
+    if !unit.ends_with(".scope") {
+        return None;
+    }
+    if unit.starts_with("sandboxed-exec-") {
+        Some(ParsedScope::Exec {
+            machine: machine_name_from_exec_unit(unit),
+            mission_short: mission_short_id_from_exec_unit(unit),
+        })
+    } else if unit.starts_with("sandboxed-durable-") {
+        let (machine, job_id) = parse_durable_unit(unit);
+        Some(ParsedScope::Durable { machine, job_id })
+    } else {
+        None
+    }
+}
+
+/// Split `sandboxed-durable-<machine>-<32hex>` into machine token and job id.
+/// (See `workspace_exec::durable_scope_unit` for the producer.)
+fn parse_durable_unit(unit: &str) -> (Option<String>, Option<Uuid>) {
+    let Some(name) = unit
+        .strip_suffix(".scope")
+        .unwrap_or(unit)
+        .strip_prefix("sandboxed-durable-")
+    else {
+        return (None, None);
+    };
+    let Some((machine, id)) = name.rsplit_once('-') else {
+        return (None, None);
+    };
+    if id.len() == 32 && id.chars().all(|c| c.is_ascii_hexdigit()) {
+        (Some(machine.to_string()), Uuid::parse_str(id).ok())
+    } else {
+        (None, None)
+    }
+}
+
+// ==================== classification (pure) ====================
+
+/// What to do with one scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeVerdict {
+    Stop,
+    Keep,
+}
+
+/// True while a mission status still legitimately owns live processes.
+fn status_needs_scopes(status: &MissionStatus) -> bool {
+    // Parked-but-resumable statuses (AwaitingUser, Paused, WaitingBackground)
+    // are kept here: resume semantics for background jobs depend on the scope
+    // and the event-driven teardown in scope_reaper already handles the
+    // configurable AwaitingUser/Paused cases with its own grace. Reconcile
+    // only stops what is unambiguously dead: terminal or acknowledged.
+    !(status.is_terminal() || *status == MissionStatus::Acknowledged)
+}
+
+/// Classify an exec scope given what the mission index knows about its owner.
+/// `mission_status = None` means the mission is unknown; that only justifies a
+/// stop when `index_complete` proves every store was actually scanned.
+pub fn classify_exec_scope(
+    mission_status: Option<&MissionStatus>,
+    index_complete: bool,
+) -> ScopeVerdict {
+    match mission_status {
+        Some(status) if status_needs_scopes(status) => ScopeVerdict::Keep,
+        Some(_) => ScopeVerdict::Stop,
+        None if index_complete => ScopeVerdict::Stop,
+        None => ScopeVerdict::Keep,
+    }
+}
+
+/// Classify a durable scope given the job registry entry. `None` (missing
+/// job.json) or a terminal/unknown status means the scope is leaked.
+pub fn classify_durable_scope(
+    job_status: Option<&super::durable_jobs::DurableJobStatus>,
+) -> ScopeVerdict {
+    use super::durable_jobs::DurableJobStatus as S;
+    match job_status {
+        Some(S::Running) => ScopeVerdict::Keep,
+        Some(S::Completed) | Some(S::Failed) | Some(S::Cancelled) | Some(S::Unknown) | None => {
+            ScopeVerdict::Stop
+        }
+    }
+}
+
+/// What to do with one mission row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissionVerdict {
+    /// Flip to `interrupted` (reason `service_restart`) and auto-resume.
+    InterruptAndResume,
+    /// Tag `orphaned` + announce on the control stream.
+    TagOrphaned,
+    Keep,
+}
+
+/// Inputs for classifying one mission. Gathered by the async sweep, decided
+/// here so the policy is unit-testable without systemd or a live actor.
+#[derive(Debug, Clone, Copy)]
+pub struct MissionFacts {
+    pub status: MissionStatus,
+    pub is_assistant_mode: bool,
+    /// The control actor currently lists this mission as running.
+    pub running_in_actor: bool,
+    /// A live `sandboxed-exec-*` scope carries this mission's short id.
+    pub has_live_scope: bool,
+    /// A detached durable run (remote job) owns liveness.
+    pub has_durable_run: bool,
+    /// The mission row was updated within the grace window.
+    pub recently_updated: bool,
+    /// The event log has at least one persisted event for this mission.
+    pub has_events: bool,
+    /// The mission already carries the `orphaned` tag.
+    pub already_tagged_orphaned: bool,
+}
+
+pub fn classify_mission(facts: &MissionFacts) -> MissionVerdict {
+    match facts.status {
+        MissionStatus::Active => {
+            if facts.is_assistant_mode
+                || facts.running_in_actor
+                || facts.has_live_scope
+                || facts.has_durable_run
+                || facts.recently_updated
+            {
+                MissionVerdict::Keep
+            } else {
+                MissionVerdict::InterruptAndResume
+            }
+        }
+        // Pending missions never started a harness — the dispatcher owns
+        // them; interrupting would only add churn.
+        MissionStatus::AwaitingUser => {
+            if !facts.has_events
+                && !facts.has_durable_run
+                && !facts.running_in_actor
+                && !facts.already_tagged_orphaned
+            {
+                MissionVerdict::TagOrphaned
+            } else {
+                MissionVerdict::Keep
+            }
+        }
+        _ => MissionVerdict::Keep,
+    }
+}
+
+// ==================== systemd enumeration ====================
+
+/// List all sandboxed scope units. `Err` means systemd is unavailable or the
+/// listing failed — callers must skip scope work, not treat it as "no scopes
+/// exist". Docker installs without systemd PID 1 land here.
+pub(crate) async fn try_list_sandboxed_scope_units() -> Result<Vec<String>, String> {
+    let output = Command::new("systemctl")
+        .args([
+            "list-units",
+            "--type=scope",
+            "--all",
+            "--no-legend",
+            "--plain",
+        ])
+        .output()
+        .await
+        .map_err(|err| format!("systemctl unavailable: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "systemctl list-units exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|unit| {
+            unit.ends_with(".scope")
+                && (unit.starts_with("sandboxed-exec-") || unit.starts_with("sandboxed-durable-"))
+        })
+        .map(|s| s.to_string())
+        .collect())
+}
+
+// ==================== the sweep ====================
+
+#[derive(Debug, Default, Serialize)]
+pub struct ReconcileReport {
+    /// systemd reachable and scopes enumerated this pass.
+    pub systemd_available: bool,
+    pub scopes_scanned: usize,
+    pub scopes_stopped: usize,
+    pub scopes_kept: usize,
+    pub missions_scanned: usize,
+    pub missions_interrupted: usize,
+    pub missions_resumed: usize,
+    pub missions_tagged_orphaned: usize,
+    pub errors: usize,
+}
+
+/// One full reconcile pass. Safe to run concurrently with normal traffic and
+/// repeatedly (idempotent: already-handled rows classify as `Keep`).
+pub async fn run(state: &Arc<AppState>) -> ReconcileReport {
+    let mut report = ReconcileReport::default();
+
+    // ---- Phase 1: scopes ----
+    let units = match try_list_sandboxed_scope_units().await {
+        Ok(units) => {
+            report.systemd_available = true;
+            units
+        }
+        Err(err) => {
+            tracing::info!(%err, "reconcile: systemd scope listing unavailable; skipping scope sweep");
+            Vec::new()
+        }
+    };
+
+    // Live-mission short ids, used both to keep scopes and (inverted) to spot
+    // ghost-active missions with no scope.
+    let mut live_short_ids: HashSet<String> = HashSet::new();
+
+    if !units.is_empty() {
+        let index_full = build_mission_index(state).await;
+        let index = &index_full.by_short;
+
+        // Ownership: systemd units are host-global. Only act on scopes whose
+        // machine token maps to one of THIS instance's workspaces — prod and
+        // dev instances share hosts.
+        let mut workspace_ids_by_token: std::collections::HashMap<String, Uuid> =
+            std::collections::HashMap::new();
+        for ws in state.workspaces.list().await {
+            if let Some(token) = machine_name_for_path(&ws.path) {
+                workspace_ids_by_token.insert(token, ws.id);
+            }
+        }
+
+        for unit in &units {
+            let Some(parsed) = parse_scope_unit(unit) else {
+                continue;
+            };
+            report.scopes_scanned += 1;
+            let verdict = match &parsed {
+                ParsedScope::Exec {
+                    machine,
+                    mission_short,
+                } => {
+                    let owned_ws = machine
+                        .as_ref()
+                        .and_then(|m| workspace_ids_by_token.get(m))
+                        .copied();
+                    let Some(ws_id) = owned_ws else {
+                        // Not ours (other instance) or unparseable: keep.
+                        report.scopes_kept += 1;
+                        continue;
+                    };
+                    match mission_short {
+                        Some(short) => {
+                            let entry = index
+                                .get(short)
+                                .and_then(|entries| entry_for_workspace(entries, ws_id));
+                            let verdict =
+                                classify_exec_scope(entry.map(|e| &e.status), index_full.complete);
+                            if verdict == ScopeVerdict::Keep {
+                                live_short_ids.insert(short.clone());
+                            }
+                            verdict
+                        }
+                        // Legacy / task-tagged units: the periodic reaper owns
+                        // those (age-based policy); do not stop them here.
+                        None => ScopeVerdict::Keep,
+                    }
+                }
+                ParsedScope::Durable { machine, job_id } => {
+                    if machine
+                        .as_ref()
+                        .map(|m| !workspace_ids_by_token.contains_key(m))
+                        .unwrap_or(true)
+                    {
+                        report.scopes_kept += 1;
+                        continue;
+                    }
+                    match job_id {
+                        Some(job_id) => {
+                            let status =
+                                super::durable_jobs::job_status_for_reconcile(state, *job_id).await;
+                            classify_durable_scope(status.as_ref())
+                        }
+                        None => ScopeVerdict::Keep,
+                    }
+                }
+            };
+            match verdict {
+                ScopeVerdict::Stop => {
+                    if stop_unit(unit, "reconcile: owner terminal or unknown").await {
+                        report.scopes_stopped += 1;
+                    } else {
+                        report.errors += 1;
+                    }
+                }
+                ScopeVerdict::Keep => report.scopes_kept += 1,
+            }
+        }
+    }
+
+    // ---- Phase 2: missions ----
+    let grace = active_grace();
+    let now = chrono::Utc::now();
+    for session in state.control.all_sessions().await {
+        let store = &session.mission_store;
+        let running_ids: HashSet<Uuid> = session
+            .running_missions
+            .read()
+            .await
+            .iter()
+            .map(|info| info.mission_id)
+            .collect();
+
+        // 2a. Ghost-active missions → interrupted(service_restart) + resume.
+        let active = match store.get_all_active_missions().await {
+            Ok(missions) => missions,
+            Err(err) => {
+                tracing::warn!(%err, "reconcile: could not list active missions");
+                report.errors += 1;
+                continue;
+            }
+        };
+        for mission in active {
+            report.missions_scanned += 1;
+            let has_durable_run = match store.get_active_mission_run(mission.id).await {
+                Ok(run) => run.is_some_and(|run| {
+                    run.execution_state == MissionExecutionState::WaitingRemoteJob
+                }),
+                Err(err) => {
+                    // Execution truth unavailable: fail closed, keep.
+                    tracing::warn!(mission_id = %mission.id, %err, "reconcile: run lookup failed");
+                    report.errors += 1;
+                    continue;
+                }
+            };
+            let recently_updated = chrono::DateTime::parse_from_rfc3339(&mission.updated_at)
+                .map(|t| now - t.with_timezone(&chrono::Utc) < grace)
+                .unwrap_or(false);
+            let short = mission.id.simple().to_string()[..8].to_string();
+            let facts = MissionFacts {
+                status: mission.status,
+                is_assistant_mode: mission.mission_mode == MissionMode::Assistant,
+                running_in_actor: running_ids.contains(&mission.id),
+                has_live_scope: report.systemd_available && live_short_ids.contains(&short),
+                has_durable_run,
+                recently_updated,
+                has_events: true, // irrelevant for the Active arm
+                already_tagged_orphaned: false,
+            };
+            if classify_mission(&facts) != MissionVerdict::InterruptAndResume {
+                continue;
+            }
+            tracing::warn!(
+                mission_id = %mission.id,
+                "reconcile: active mission has no live runner/scope; interrupting (service_restart) and resuming"
+            );
+            if let Err(err) = store
+                .update_mission_status_with_reason(
+                    mission.id,
+                    MissionStatus::Interrupted,
+                    Some(SERVICE_RESTART_REASON),
+                )
+                .await
+            {
+                tracing::warn!(mission_id = %mission.id, %err, "reconcile: interrupt failed");
+                report.errors += 1;
+                continue;
+            }
+            report.missions_interrupted += 1;
+            let _ = session.events_tx.send(AgentEvent::MissionStatusChanged {
+                mission_id: mission.id,
+                status: MissionStatus::Interrupted,
+                summary: Some(
+                    "Interrupted: no live runner or scope after a service restart".to_string(),
+                ),
+            });
+            // Auto-resume through the EXISTING resume path (same internal
+            // command POST /api/control/missions/:id/resume uses).
+            let (tx, rx) = oneshot::channel();
+            let sent = session
+                .cmd_tx
+                .send(ControlCommand::ResumeMission {
+                    mission_id: mission.id,
+                    clean_workspace: false,
+                    skip_message: false,
+                    respond: tx,
+                })
+                .await
+                .is_ok();
+            match (sent, if sent { rx.await.ok() } else { None }) {
+                (true, Some(Ok(_))) => report.missions_resumed += 1,
+                (true, Some(Err(err))) => {
+                    tracing::warn!(mission_id = %mission.id, %err, "reconcile: auto-resume failed");
+                    report.errors += 1;
+                }
+                _ => {
+                    tracing::warn!(mission_id = %mission.id, "reconcile: auto-resume not acknowledged");
+                    report.errors += 1;
+                }
+            }
+        }
+
+        // 2b. AwaitingUser missions whose harness session state is gone.
+        let recent = match store.list_missions(500, 0).await {
+            Ok(missions) => missions,
+            Err(err) => {
+                tracing::warn!(%err, "reconcile: could not list missions for orphan scan");
+                report.errors += 1;
+                continue;
+            }
+        };
+        for mission in recent
+            .into_iter()
+            .filter(|m| m.status == MissionStatus::AwaitingUser)
+        {
+            report.missions_scanned += 1;
+            let has_events = store
+                .max_event_sequence(mission.id)
+                .await
+                .map(|seq| seq > 0)
+                .unwrap_or(true); // unreadable event log: fail closed, keep
+            let has_durable_run = store
+                .get_active_mission_run(mission.id)
+                .await
+                .ok()
+                .flatten()
+                .is_some();
+            let facts = MissionFacts {
+                status: mission.status,
+                is_assistant_mode: mission.mission_mode == MissionMode::Assistant,
+                running_in_actor: running_ids.contains(&mission.id),
+                has_live_scope: false,
+                has_durable_run,
+                recently_updated: false,
+                has_events,
+                already_tagged_orphaned: mission.project.tags.iter().any(|t| t == ORPHANED_TAG),
+            };
+            if classify_mission(&facts) != MissionVerdict::TagOrphaned {
+                continue;
+            }
+            let mut tags = mission.project.tags.clone();
+            tags.push(ORPHANED_TAG.to_string());
+            if let Err(err) = store
+                .update_mission_project(
+                    mission.id,
+                    MissionProjectPatch {
+                        tags: Some(tags),
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                tracing::warn!(mission_id = %mission.id, %err, "reconcile: orphan tag failed");
+                report.errors += 1;
+                continue;
+            }
+            report.missions_tagged_orphaned += 1;
+            let event = AgentEvent::MissionActivity {
+                label: format!(
+                    "Mission {} marked orphaned: awaiting_user but its harness session \
+state (event log / live session) is gone. Replay and resume need a fresh turn; \
+send a new message or re-create the mission.",
+                    mission.id
+                ),
+                tool_name: "boot_reconcile".to_string(),
+                mission_id: Some(mission.id),
+            };
+            let _ = store.log_event(mission.id, &event).await;
+            let _ = session.events_tx.send(event);
+            tracing::warn!(mission_id = %mission.id, "reconcile: tagged awaiting_user mission as orphaned");
+        }
+    }
+
+    report
+}
+
+/// Spawn the boot-time reconcile pass. Call once after AppState is built.
+pub fn spawn(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        if !boot_reconcile_enabled() {
+            tracing::info!("boot reconcile disabled (BOOT_RECONCILE_ENABLED=0)");
+            return;
+        }
+        tokio::time::sleep(boot_delay()).await;
+        let report = run(&state).await;
+        tracing::info!(
+            systemd = report.systemd_available,
+            scopes_scanned = report.scopes_scanned,
+            scopes_stopped = report.scopes_stopped,
+            missions_interrupted = report.missions_interrupted,
+            missions_resumed = report.missions_resumed,
+            orphaned = report.missions_tagged_orphaned,
+            errors = report.errors,
+            "boot reconcile finished"
+        );
+    });
+}
+
+/// `POST /api/system/reconcile` — run a full pass on demand.
+pub async fn reconcile_endpoint(State(state): State<Arc<AppState>>) -> Json<ReconcileReport> {
+    Json(run(&state).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::durable_jobs::DurableJobStatus;
+
+    // ---------- scope-name parsing ----------
+
+    #[test]
+    fn parses_mission_tagged_exec_scope() {
+        let unit = "sandboxed-exec-sandboxed-dumbcontracts-634e6d35-m4efda364-0a1b2c3d.scope";
+        assert_eq!(
+            parse_scope_unit(unit),
+            Some(ParsedScope::Exec {
+                machine: Some("sandboxed-dumbcontracts-634e6d35".to_string()),
+                mission_short: Some("4efda364".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_full_uuid_tagged_exec_scope_to_short_id() {
+        let unit =
+            "sandboxed-exec-sandboxed-ws-deadbeef-m4efda364aabbccddeeff001122334455-0a1b2c3d.scope";
+        match parse_scope_unit(unit) {
+            Some(ParsedScope::Exec { mission_short, .. }) => {
+                assert_eq!(mission_short.as_deref(), Some("4efda364"));
+            }
+            other => panic!("unexpected parse: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_legacy_exec_scope_without_mission_tag() {
+        let unit = "sandboxed-exec-sandboxed-misc-deadbeef-0a1b2c3d.scope";
+        assert_eq!(
+            parse_scope_unit(unit),
+            Some(ParsedScope::Exec {
+                machine: Some("sandboxed-misc-deadbeef".to_string()),
+                mission_short: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_durable_scope() {
+        let job = Uuid::new_v4();
+        let unit = format!(
+            "sandboxed-durable-sandboxed-dumbcontracts-634e6d35-{}.scope",
+            job.simple()
+        );
+        assert_eq!(
+            parse_scope_unit(&unit),
+            Some(ParsedScope::Durable {
+                machine: Some("sandboxed-dumbcontracts-634e6d35".to_string()),
+                job_id: Some(job),
+            })
+        );
+    }
+
+    #[test]
+    fn skips_non_sandboxed_scopes_and_non_scopes() {
+        assert_eq!(parse_scope_unit("session-1.scope"), None);
+        assert_eq!(parse_scope_unit("sandboxed-mission-x.scope"), None);
+        assert_eq!(
+            parse_scope_unit("sandboxed-exec-foo-0a1b2c3d.service"),
+            None
+        );
+        assert_eq!(parse_scope_unit("cron.service"), None);
+    }
+
+    #[test]
+    fn malformed_durable_scope_parses_with_none_job_id() {
+        assert_eq!(
+            parse_scope_unit("sandboxed-durable-notahex.scope"),
+            Some(ParsedScope::Durable {
+                machine: None,
+                job_id: None
+            })
+        );
+    }
+
+    // ---------- exec scope classification ----------
+
+    #[test]
+    fn exec_scope_kept_for_live_statuses() {
+        for status in [
+            MissionStatus::Active,
+            MissionStatus::Pending,
+            MissionStatus::WaitingBackground,
+            MissionStatus::AwaitingUser,
+            MissionStatus::Paused,
+        ] {
+            assert_eq!(
+                classify_exec_scope(Some(&status), true),
+                ScopeVerdict::Keep,
+                "{status} scope must be kept"
+            );
+        }
+    }
+
+    #[test]
+    fn exec_scope_stopped_for_terminal_and_acknowledged() {
+        for status in [
+            MissionStatus::Completed,
+            MissionStatus::Failed,
+            MissionStatus::Interrupted,
+            MissionStatus::Blocked,
+            MissionStatus::NotFeasible,
+            MissionStatus::Acknowledged,
+        ] {
+            assert_eq!(
+                classify_exec_scope(Some(&status), true),
+                ScopeVerdict::Stop,
+                "{status} scope must be stopped"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_mission_scope_stops_only_with_complete_index() {
+        assert_eq!(classify_exec_scope(None, true), ScopeVerdict::Stop);
+        assert_eq!(classify_exec_scope(None, false), ScopeVerdict::Keep);
+    }
+
+    // ---------- durable scope classification ----------
+
+    #[test]
+    fn durable_scope_kept_only_while_running() {
+        assert_eq!(
+            classify_durable_scope(Some(&DurableJobStatus::Running)),
+            ScopeVerdict::Keep
+        );
+        for status in [
+            DurableJobStatus::Completed,
+            DurableJobStatus::Failed,
+            DurableJobStatus::Cancelled,
+            DurableJobStatus::Unknown,
+        ] {
+            assert_eq!(classify_durable_scope(Some(&status)), ScopeVerdict::Stop);
+        }
+        assert_eq!(classify_durable_scope(None), ScopeVerdict::Stop);
+    }
+
+    // ---------- mission classification ----------
+
+    fn base_active_facts() -> MissionFacts {
+        MissionFacts {
+            status: MissionStatus::Active,
+            is_assistant_mode: false,
+            running_in_actor: false,
+            has_live_scope: false,
+            has_durable_run: false,
+            recently_updated: false,
+            has_events: true,
+            already_tagged_orphaned: false,
+        }
+    }
+
+    #[test]
+    fn ghost_active_mission_is_interrupted_and_resumed() {
+        assert_eq!(
+            classify_mission(&base_active_facts()),
+            MissionVerdict::InterruptAndResume
+        );
+    }
+
+    #[test]
+    fn active_mission_with_any_liveness_signal_is_kept() {
+        for mutate in [
+            |f: &mut MissionFacts| f.running_in_actor = true,
+            |f: &mut MissionFacts| f.has_live_scope = true,
+            |f: &mut MissionFacts| f.has_durable_run = true,
+            |f: &mut MissionFacts| f.recently_updated = true,
+            |f: &mut MissionFacts| f.is_assistant_mode = true,
+        ] {
+            let mut facts = base_active_facts();
+            mutate(&mut facts);
+            assert_eq!(classify_mission(&facts), MissionVerdict::Keep);
+        }
+    }
+
+    #[test]
+    fn awaiting_user_without_session_state_is_tagged_orphaned_once() {
+        let mut facts = base_active_facts();
+        facts.status = MissionStatus::AwaitingUser;
+        facts.has_events = false;
+        assert_eq!(classify_mission(&facts), MissionVerdict::TagOrphaned);
+        facts.already_tagged_orphaned = true;
+        assert_eq!(classify_mission(&facts), MissionVerdict::Keep);
+    }
+
+    #[test]
+    fn awaiting_user_with_events_is_kept() {
+        let mut facts = base_active_facts();
+        facts.status = MissionStatus::AwaitingUser;
+        facts.has_events = true;
+        assert_eq!(classify_mission(&facts), MissionVerdict::Keep);
+    }
+
+    #[test]
+    fn pending_and_terminal_missions_are_never_touched() {
+        for status in [
+            MissionStatus::Pending,
+            MissionStatus::Completed,
+            MissionStatus::Failed,
+            MissionStatus::Interrupted,
+            MissionStatus::Paused,
+            MissionStatus::WaitingBackground,
+            MissionStatus::Acknowledged,
+        ] {
+            let mut facts = base_active_facts();
+            facts.status = status;
+            facts.has_events = false;
+            assert_eq!(
+                classify_mission(&facts),
+                MissionVerdict::Keep,
+                "{status} must be kept"
+            );
+        }
+    }
+}

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -625,6 +625,11 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     // mission no longer needs a live harness (see scope_reaper docs).
     super::scope_reaper::spawn(Arc::clone(&state));
 
+    // Boot reconcile: stop scopes leaked by the previous process, interrupt +
+    // auto-resume ghost-active missions, and tag orphaned awaiting_user
+    // missions. Also reachable via POST /api/system/reconcile.
+    super::reconcile::spawn(Arc::clone(&state));
+
     // Re-attach poll loops for async remote jobs that were in flight when
     // the previous process exited (durable handles in remote-jobs.json).
     super::control::spawn_remote_job_reconciler(Arc::clone(&state));
@@ -1296,6 +1301,12 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
 
     tracing::info!("Server listening on {}", addr);
+
+    // systemd integration: READY=1 now that the listener is bound, then the
+    // runtime-liveness watchdog loop (no-op without NOTIFY_SOCKET /
+    // WATCHDOG_USEC — Docker and dev runs are unaffected).
+    crate::watchdog::notify_ready();
+    crate::watchdog::spawn();
 
     // Setup graceful shutdown on SIGTERM/SIGINT
     let shutdown_state = Arc::clone(&state);

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -170,7 +170,7 @@ pub(crate) async fn list_exec_scope_units() -> Vec<String> {
     }
 }
 
-async fn stop_unit(unit: &str, reason: &str) -> bool {
+pub(crate) async fn stop_unit(unit: &str, reason: &str) -> bool {
     match Command::new("systemctl")
         .args(["stop", unit])
         .output()

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -335,6 +335,7 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/components/:name/update", post(update_component))
         .route("/components/:name/uninstall", post(uninstall_component))
         .route("/deploy", post(deploy_sandboxed_sh))
+        .route("/reconcile", post(super::reconcile::reconcile_endpoint))
 }
 
 /// Get information about all system components.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub mod skills_registry;
 pub mod task;
 pub mod tools;
 pub mod util;
+pub mod watchdog;
 pub mod workspace;
 pub mod workspace_exec;
 

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,184 @@
+//! systemd readiness + watchdog integration.
+//!
+//! With `Type=notify` and `WatchdogSec=` set on the service (see
+//! `deploy/systemd/sandboxed-sh-watchdog.conf`), systemd expects:
+//!
+//! - `READY=1` once the server is actually listening ([`notify_ready`]);
+//! - `WATCHDOG=1` at least once per `WatchdogSec`, or it restarts the unit.
+//!
+//! The watchdog tick is a **real liveness probe of the tokio runtime**, not a
+//! timer on a side thread: a dedicated OS thread sends a probe message to a
+//! responder task running on the main runtime and only pets the watchdog when
+//! the round-trip completes in time. If the runtime is wedged or starved, the
+//! probe times out, no `WATCHDOG=1` is sent, and systemd restarts the service.
+//!
+//! Everything no-ops cleanly when `NOTIFY_SOCKET` is unset (non-systemd runs,
+//! Docker, tests). Setting `SANDBOXED_SH_SIMULATE_WEDGE=1` stops ticking (the
+//! probes still run) so the restart path can be exercised end to end.
+
+use std::time::Duration;
+
+/// Env var that, when truthy, suppresses `WATCHDOG=1` ticks for testing.
+pub const SIMULATE_WEDGE_ENV: &str = "SANDBOXED_SH_SIMULATE_WEDGE";
+
+/// Tick interval derived from systemd's `WATCHDOG_USEC`: a third of the
+/// budget, so two consecutive ticks can be missed before a restart. `None`
+/// when the watchdog is not armed (unset, unparsable, or zero).
+pub fn tick_interval_from_watchdog_usec(watchdog_usec: Option<&str>) -> Option<Duration> {
+    let usec: u64 = watchdog_usec?.trim().parse().ok()?;
+    if usec == 0 {
+        return None;
+    }
+    Some(Duration::from_micros(usec / 3).max(Duration::from_millis(100)))
+}
+
+/// Whether a completed (or failed) probe should result in a `WATCHDOG=1`.
+/// Pure so the tick policy is testable without systemd.
+pub fn should_pet_watchdog(probe_ok: bool, wedge_simulated: bool) -> bool {
+    probe_ok && !wedge_simulated
+}
+
+fn wedge_simulated() -> bool {
+    std::env::var(SIMULATE_WEDGE_ENV)
+        .map(|v| {
+            let v = v.trim();
+            v == "1" || v.eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
+/// Send `READY=1`. Call once, after the listener is bound. No-op without
+/// `NOTIFY_SOCKET`.
+pub fn notify_ready() {
+    if let Err(err) = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]) {
+        tracing::debug!(%err, "sd_notify READY failed (not running under systemd?)");
+    } else {
+        tracing::info!("sd_notify: READY=1 sent");
+    }
+}
+
+/// Probe the tokio runtime through `probe_tx` and wait up to `timeout` for
+/// the responder task's reply. Returns `true` only when the runtime actually
+/// scheduled the responder in time.
+pub fn probe_runtime(
+    probe_tx: &tokio::sync::mpsc::Sender<std::sync::mpsc::Sender<()>>,
+    timeout: Duration,
+) -> bool {
+    let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+    if probe_tx.blocking_send(reply_tx).is_err() {
+        return false;
+    }
+    reply_rx.recv_timeout(timeout).is_ok()
+}
+
+/// Spawn the responder task on the current runtime plus the watchdog thread.
+/// Must be called from within the main tokio runtime. No-op when systemd has
+/// not armed a watchdog (`WATCHDOG_USEC` unset).
+pub fn spawn() {
+    let Some(interval) =
+        tick_interval_from_watchdog_usec(std::env::var("WATCHDOG_USEC").ok().as_deref())
+    else {
+        tracing::debug!("systemd watchdog not armed (WATCHDOG_USEC unset); watchdog loop skipped");
+        return;
+    };
+
+    // Responder: lives on the main runtime. If the runtime can't schedule
+    // this trivial task, the probe times out — which is exactly the signal
+    // we want to stop petting the watchdog on.
+    let (probe_tx, mut probe_rx) = tokio::sync::mpsc::channel::<std::sync::mpsc::Sender<()>>(4);
+    tokio::spawn(async move {
+        while let Some(reply) = probe_rx.recv().await {
+            let _ = reply.send(());
+        }
+    });
+
+    tracing::info!(
+        interval_ms = interval.as_millis() as u64,
+        "systemd watchdog armed; starting liveness tick thread"
+    );
+
+    // Dedicated OS thread: independent of the runtime it is probing.
+    std::thread::Builder::new()
+        .name("sd-watchdog".to_string())
+        .spawn(move || loop {
+            std::thread::sleep(interval);
+            let probe_ok = probe_runtime(&probe_tx, interval);
+            let wedged = wedge_simulated();
+            if should_pet_watchdog(probe_ok, wedged) {
+                if let Err(err) = sd_notify::notify(false, &[sd_notify::NotifyState::Watchdog]) {
+                    tracing::warn!(%err, "sd_notify WATCHDOG failed");
+                }
+            } else if wedged {
+                tracing::warn!("watchdog tick suppressed ({SIMULATE_WEDGE_ENV} set)");
+            } else {
+                tracing::error!(
+                    "runtime liveness probe timed out; withholding WATCHDOG=1 (systemd will restart the service)"
+                );
+            }
+        })
+        .expect("failed to spawn sd-watchdog thread");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interval_is_a_third_of_watchdog_usec() {
+        assert_eq!(
+            tick_interval_from_watchdog_usec(Some("90000000")),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn interval_absent_or_invalid_disables_watchdog() {
+        assert_eq!(tick_interval_from_watchdog_usec(None), None);
+        assert_eq!(tick_interval_from_watchdog_usec(Some("")), None);
+        assert_eq!(tick_interval_from_watchdog_usec(Some("abc")), None);
+        assert_eq!(tick_interval_from_watchdog_usec(Some("0")), None);
+    }
+
+    #[test]
+    fn tiny_watchdog_budget_is_clamped_to_a_sane_floor() {
+        assert_eq!(
+            tick_interval_from_watchdog_usec(Some("3")),
+            Some(Duration::from_millis(100))
+        );
+    }
+
+    #[test]
+    fn pet_policy_requires_probe_success_and_no_simulated_wedge() {
+        assert!(should_pet_watchdog(true, false));
+        assert!(!should_pet_watchdog(false, false));
+        assert!(!should_pet_watchdog(true, true));
+        assert!(!should_pet_watchdog(false, true));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_round_trip_succeeds_on_a_live_runtime() {
+        let (probe_tx, mut probe_rx) = tokio::sync::mpsc::channel::<std::sync::mpsc::Sender<()>>(4);
+        tokio::spawn(async move {
+            while let Some(reply) = probe_rx.recv().await {
+                let _ = reply.send(());
+            }
+        });
+        let ok =
+            tokio::task::spawn_blocking(move || probe_runtime(&probe_tx, Duration::from_secs(5)))
+                .await
+                .unwrap();
+        assert!(ok);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_fails_when_responder_is_gone() {
+        let (probe_tx, probe_rx) = tokio::sync::mpsc::channel::<std::sync::mpsc::Sender<()>>(4);
+        drop(probe_rx); // responder never ran / runtime "dead"
+        let ok = tokio::task::spawn_blocking(move || {
+            probe_runtime(&probe_tx, Duration::from_millis(200))
+        })
+        .await
+        .unwrap();
+        assert!(!ok);
+    }
+}


### PR DESCRIPTION
Boot-time + POST /api/system/reconcile: stops leaked sandboxed-exec/durable scopes (ownership-filtered), interrupts+auto-resumes ghost-active missions (end_reason service_restart), tags unrecoverable awaiting_user missions 'orphaned' with a broadcast event. sd-notify READY + runtime-liveness watchdog (OS-thread probe round-trips through the tokio runtime — a starved runtime stops ticking and systemd restarts); drop-in in deploy/systemd/. Replaces the need for deploy drain and the scope leak (80 on prod).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Reconcile can stop scopes, change mission status, and trigger auto-resume on production hosts; misclassification could interrupt live work, though policy uses grace periods and fail-closed checks.
> 
> **Overview**
> Adds **boot and on-demand reconciliation** (`POST /api/system/reconcile`, delayed boot pass) to align systemd transient scopes with mission/durable-job truth: stops leaked `sandboxed-exec-*` / `sandboxed-durable-*` scopes (workspace-owned only), **interrupts ghost `active` missions** with `service_restart` and **auto-resumes** via the existing control path, and tags **`awaiting_user` missions** with no event log as **`orphaned`** plus a control-stream notice. Non-systemd hosts skip scope enumeration without failing the pass.
> 
> Adds **systemd `Type=notify` support** via `sd-notify`: **`READY=1`** after the HTTP listener binds, and a **watchdog** that only sends **`WATCHDOG=1`** after a tokio runtime probe round-trip (dedicated thread + responder task), with an optional **`SANDBOXED_SH_SIMULATE_WEDGE`** test hook. Ships a **`deploy/systemd/sandboxed-sh-watchdog.conf`** drop-in (`WatchdogSec=90`, `Restart=on-watchdog`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42dd9da655a50f6da6425ec99bf520671751150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->