### PR TITLE
Campaign uniqueness guard (409) + node cordon

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -705,3 +705,34 @@ retuned live from the dashboard **Resources** panel (or
 CPU property is also what makes systemd delegate the `cpu` controller into
 `missions.slice` — without it, a per-scope `CPUQuota` is silently unenforced.
 See the "Resource isolation" section in `CLAUDE.md` for the architecture.
+
+## Pausing / Resuming the DGX Spark (node cordon)
+
+To take the Spark (or any remote node) out of rotation without deleting its
+config — e.g. to reclaim it for inference or maintenance:
+
+```bash
+# Cordon: node stays listed and probed, but automatic placement
+# (remote_node_id: "auto") skips it. Persisted in
+# .sandboxed-sh/node_state.json, survives restarts.
+curl -X POST -H "Authorization: Bearer $JWT" \
+  http://localhost:3001/api/nodes/dgx-spark/cordon
+
+# Verify: GET /api/remote-nodes shows the node with "cordoned": true, and
+# controllers consulting get_compute_fleet see the same flag.
+curl -s -H "Authorization: Bearer $JWT" \
+  http://localhost:3001/api/remote-nodes | jq '.nodes[] | {id, status, cordoned}'
+
+# Optionally stop the Spark offload lane too (build offload is a separate
+# lane from the remote-node fleet). On the DGX:
+ssh dgx-spark 'systemctl stop spark-arbiter'
+
+# Resume: restart the arbiter and uncordon.
+ssh dgx-spark 'systemctl start spark-arbiter'
+curl -X POST -H "Authorization: Bearer $JWT" \
+  http://localhost:3001/api/nodes/dgx-spark/uncordon
+```
+
+The dashboard **Workspaces** page has the same toggle per node in the
+"Remote Nodes" panel (cordon badge + Cordon/Uncordon button). A cordoned node
+shows up in `place_auto` exclusion reports as `cordoned by operator`.

--- a/dashboard/src/app/workspaces/page.tsx
+++ b/dashboard/src/app/workspaces/page.tsx
@@ -46,6 +46,7 @@ import { useToast } from '@/components/toast';
 import { ConfigCodeEditor } from '@/components/config-code-editor';
 import { EnvVarsEditor, type EnvRow, toEnvRows, envRowsToMap, getEncryptedKeys } from '@/components/env-vars-editor';
 import { WorkspaceResources } from '@/components/workspace-resources';
+import { RemoteNodesPanel } from '@/components/remote-nodes-panel';
 
 // The nil UUID represents the default "host" workspace which cannot be deleted
 const DEFAULT_WORKSPACE_ID = '00000000-0000-0000-0000-000000000000';
@@ -544,6 +545,9 @@ export default function WorkspacesPage() {
           ))}
         </div>
       )}
+
+      {/* Remote runner fleet: status + operator cordons (hidden when none configured) */}
+      <RemoteNodesPanel />
 
       {/* Workspace Details Modal */}
       {selectedWorkspace && (

--- a/dashboard/src/components/remote-nodes-panel.tsx
+++ b/dashboard/src/components/remote-nodes-panel.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+/**
+ * RemoteNodesPanel — fleet status + operator cordons.
+ *
+ * Lists configured remote runner nodes with their heartbeat status and lets
+ * the operator cordon/uncordon each one. A cordoned node stays listed and
+ * probed but is excluded from automatic placement (`remote_node_id: "auto"`)
+ * until uncordoned; controllers consulting `get_compute_fleet` see
+ * `cordoned: true`. Renders nothing when no remote nodes are configured.
+ */
+
+import { useState } from 'react';
+import useSWR from 'swr';
+import { Network, ShieldOff, ShieldCheck } from 'lucide-react';
+import { getRemoteNodes, setNodeCordon } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+export function RemoteNodesPanel() {
+  const { data, mutate } = useSWR('remote-nodes', getRemoteNodes, {
+    refreshInterval: 15000,
+    revalidateOnFocus: false,
+  });
+  const [busyNode, setBusyNode] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const nodes = data?.nodes ?? [];
+  if (nodes.length === 0) return null;
+
+  const toggle = async (name: string, cordoned: boolean) => {
+    setBusyNode(name);
+    setError(null);
+    try {
+      await setNodeCordon(name, cordoned);
+      await mutate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update cordon');
+    } finally {
+      setBusyNode(null);
+    }
+  };
+
+  return (
+    <div className="rounded-lg bg-white/[0.02] border border-white/[0.05] p-3">
+      <p className="text-xs text-white/60 font-medium flex items-center gap-1.5">
+        <Network className="h-3.5 w-3.5 text-white/40" />
+        Remote Nodes
+      </p>
+      <p className="text-[10px] text-white/30 mt-0.5">
+        Cordoned nodes stay listed but are excluded from automatic placement.
+      </p>
+
+      <div className="mt-2 space-y-1.5">
+        {nodes.map((node) => (
+          <div
+            key={node.id}
+            className="flex items-center justify-between gap-2 rounded-lg bg-black/20 border border-white/[0.04] px-2.5 py-1.5"
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <span
+                className={cn(
+                  'h-1.5 w-1.5 rounded-full shrink-0',
+                  node.status === 'online'
+                    ? 'bg-emerald-400/80'
+                    : node.status === 'degraded'
+                    ? 'bg-amber-400/80'
+                    : 'bg-white/20'
+                )}
+              />
+              <span className="text-xs font-mono text-white/80 truncate">{node.id}</span>
+              {node.cordoned && (
+                <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20">
+                  cordoned
+                </span>
+              )}
+              {node.labels.length > 0 && (
+                <span className="text-[10px] text-white/30 truncate max-sm:hidden">
+                  {node.labels.join(', ')}
+                </span>
+              )}
+            </div>
+            <button
+              onClick={() => toggle(node.id, !node.cordoned)}
+              disabled={busyNode === node.id}
+              className={cn(
+                'shrink-0 flex items-center gap-1 rounded-lg px-2 py-1 text-[10px] font-medium transition-colors',
+                busyNode === node.id
+                  ? 'bg-white/[0.04] border border-white/[0.06] text-white/30 cursor-wait'
+                  : node.cordoned
+                  ? 'bg-indigo-500/15 border border-indigo-500/25 text-indigo-200 hover:bg-indigo-500/25'
+                  : 'bg-amber-500/10 border border-amber-500/20 text-amber-300 hover:bg-amber-500/20'
+              )}
+              title={
+                node.cordoned
+                  ? 'Allow automatic placement on this node again'
+                  : 'Exclude this node from automatic placement'
+              }
+            >
+              {node.cordoned ? (
+                <ShieldCheck className="h-3 w-3" />
+              ) : (
+                <ShieldOff className="h-3 w-3" />
+              )}
+              {busyNode === node.id ? 'Updating…' : node.cordoned ? 'Uncordon' : 'Cordon'}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {error && <p className="text-[10px] text-red-300/80 mt-1.5">{error}</p>}
+    </div>
+  );
+}

--- a/dashboard/src/lib/api/index.ts
+++ b/dashboard/src/lib/api/index.ts
@@ -282,3 +282,12 @@ export {
   listAlerts,
   getHermesMissionControl,
 } from "./hermes";
+
+// Remote runner nodes (fleet + cordons)
+export {
+  type RemoteNodeView,
+  type RemoteNodesResponse,
+  type NodeCordonResponse,
+  getRemoteNodes,
+  setNodeCordon,
+} from "./nodes";

--- a/dashboard/src/lib/api/nodes.ts
+++ b/dashboard/src/lib/api/nodes.ts
@@ -1,0 +1,59 @@
+/**
+ * Remote runner nodes API — fleet status + operator cordons.
+ *
+ * A cordoned node keeps heartbeating and stays listed in the fleet, but is
+ * excluded from automatic placement until uncordoned. The cordon set is
+ * persisted server-side (`.sandboxed-sh/node_state.json`) so it survives
+ * restarts.
+ */
+
+import { apiGet, apiPost } from "./core";
+
+export interface RemoteNodeView {
+  id: string;
+  base_url: string;
+  token_env: string;
+  status: "online" | "degraded" | "offline" | "unknown" | string;
+  labels: string[];
+  version: string | null;
+  capacity_total: number | null;
+  capacity_available: number | null;
+  active_jobs: number | null;
+  queued_jobs: number | null;
+  cpu_total: number | null;
+  mem_total_bytes: number | null;
+  mem_available_bytes: number | null;
+  disk_total_bytes: number | null;
+  disk_available_bytes: number | null;
+  last_seen: string | null;
+  error: string | null;
+  /** Operator-cordoned: listed but excluded from automatic placement. */
+  cordoned: boolean;
+}
+
+export interface RemoteNodesResponse {
+  enabled: boolean;
+  nodes: RemoteNodeView[];
+}
+
+export async function getRemoteNodes(): Promise<RemoteNodesResponse> {
+  return apiGet("/api/remote-nodes", "Failed to fetch remote nodes");
+}
+
+export interface NodeCordonResponse {
+  node: string;
+  cordoned: boolean;
+  changed: boolean;
+}
+
+export async function setNodeCordon(
+  name: string,
+  cordoned: boolean
+): Promise<NodeCordonResponse> {
+  const action = cordoned ? "cordon" : "uncordon";
+  return apiPost(
+    `/api/nodes/${encodeURIComponent(name)}/${action}`,
+    {},
+    `Failed to ${action} node`
+  );
+}

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -791,6 +791,93 @@ everything is truly done, report completion and stop."
 }
 
 #[cfg(test)]
+mod campaign_guard_tests {
+    use super::*;
+
+    async fn mk_campaign(store: &Arc<dyn MissionStore>, project: &str) -> Uuid {
+        let mission = store
+            .create_mission(Some("campaign"), None, None, None, None, None, None)
+            .await
+            .expect("create");
+        store
+            .update_mission_project(
+                mission.id,
+                mission_store::MissionProjectPatch {
+                    project: Some(Some(project.to_string())),
+                    track: Some(Some("campaign".to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+        mission.id
+    }
+
+    #[tokio::test]
+    async fn second_campaign_is_blocked_until_the_first_terminates() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        // No campaign yet: the slot is free (first create would succeed).
+        assert!(find_open_campaign_mission(&store, "verity").await.is_none());
+
+        let first = mk_campaign(&store, "verity").await;
+        // Second create for the same project sees the open campaign → 409.
+        let existing = find_open_campaign_mission(&store, "verity")
+            .await
+            .expect("open campaign found");
+        assert_eq!(existing.id, first);
+        // A different project is unaffected.
+        assert!(find_open_campaign_mission(&store, "other").await.is_none());
+
+        // Every listed non-terminal status holds the slot.
+        for status in [
+            MissionStatus::Active,
+            MissionStatus::AwaitingUser,
+            MissionStatus::WaitingBackground,
+            MissionStatus::Paused,
+        ] {
+            store
+                .update_mission_status(first, status)
+                .await
+                .expect("status");
+            assert!(
+                find_open_campaign_mission(&store, "verity").await.is_some(),
+                "{status} should hold the campaign slot"
+            );
+        }
+
+        // Once the first completes, a new campaign is allowed.
+        store
+            .update_mission_status(first, MissionStatus::Completed)
+            .await
+            .expect("status");
+        assert!(find_open_campaign_mission(&store, "verity").await.is_none());
+        let second = mk_campaign(&store, "verity").await;
+        assert_ne!(first, second);
+        assert_eq!(
+            find_open_campaign_mission(&store, "verity")
+                .await
+                .expect("new open campaign")
+                .id,
+            second
+        );
+    }
+
+    #[test]
+    fn terminal_and_archived_statuses_do_not_hold_the_slot() {
+        for status in [
+            MissionStatus::Completed,
+            MissionStatus::Failed,
+            MissionStatus::Interrupted,
+            MissionStatus::Blocked,
+            MissionStatus::NotFeasible,
+            MissionStatus::Acknowledged,
+        ] {
+            assert!(!campaign_slot_held_by(status), "{status}");
+        }
+    }
+}
+
+#[cfg(test)]
 mod stall_guard_tests {
     use super::*;
 
@@ -7519,6 +7606,46 @@ async fn find_recent_identical_mission(
     })
 }
 
+/// Whether a mission in this status holds its project's single campaign slot.
+///
+/// Campaign missions are long-running per-project drivers; two of them racing
+/// on the same project duplicate work and fight over the same PRs. Anything
+/// that can still run (or be resumed) blocks a new campaign: `Pending`
+/// (created/queued), `Active`, `AwaitingUser`, `WaitingBackground`, and
+/// `Paused`. `Acknowledged` is archived and terminal-in-practice, so it does
+/// not hold the slot; a genuinely terminal status never does.
+fn campaign_slot_held_by(status: MissionStatus) -> bool {
+    matches!(
+        status,
+        MissionStatus::Pending
+            | MissionStatus::Active
+            | MissionStatus::AwaitingUser
+            | MissionStatus::WaitingBackground
+            | MissionStatus::Paused
+    )
+}
+
+/// Find a non-terminal `track == "campaign"` mission for `project`, if any.
+/// Scan errors return `None` (a duplicate campaign is recoverable; refusing a
+/// legitimate create is not) — same failure direction as the retry coalescer.
+async fn find_open_campaign_mission(
+    mission_store: &Arc<dyn MissionStore>,
+    project: &str,
+) -> Option<Mission> {
+    const PAGE: usize = 200;
+    let filter = crate::api::mission_store::MissionFilter {
+        project: Some(project.to_string()),
+        track: Some("campaign".to_string()),
+        ..Default::default()
+    };
+    mission_store
+        .list_missions_filtered(&filter, PAGE, 0)
+        .await
+        .ok()?
+        .into_iter()
+        .find(|mission| campaign_slot_held_by(mission.status))
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -7600,6 +7727,40 @@ pub async fn create_mission(
                 headers.insert("x-coalesced-with", value);
             }
             return Ok((headers, Json(existing)));
+        }
+    }
+
+    // Campaign uniqueness guard: at most one non-terminal campaign mission per
+    // project. Checked on the explicit request tags (project inherited from a
+    // bound conversation never carries track="campaign").
+    if let (Some(project), Some("campaign")) = (
+        req.project
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty()),
+        req.track
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty()),
+    ) {
+        let control_state = control_for_user(&state, &user).await;
+        if let Some(existing) =
+            find_open_campaign_mission(&control_state.mission_store, project).await
+        {
+            tracing::info!(
+                mission_id = %existing.id,
+                project = %project,
+                "create_mission rejected: a non-terminal campaign mission already \
+                 exists for this project"
+            );
+            return Err((
+                StatusCode::CONFLICT,
+                serde_json::json!({
+                    "error": "campaign_exists",
+                    "mission_id": existing.id.to_string(),
+                })
+                .to_string(),
+            ));
         }
     }
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -558,6 +558,11 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         projects,
     });
 
+    // Persisted node state (operator cordons) survives restarts.
+    state
+        .fleet
+        .load_node_state(config.working_dir.join(".sandboxed-sh/node_state.json"));
+
     super::validation::spawn_outbox_forwarder(Arc::clone(&state));
     super::projects_overview::spawn_state_ingestor(Arc::clone(&state));
 
@@ -748,6 +753,8 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     let protected_routes = Router::new()
         .route("/api/stats", get(get_stats))
         .route("/api/remote-nodes", get(list_remote_nodes))
+        .route("/api/nodes/:name/cordon", post(cordon_remote_node))
+        .route("/api/nodes/:name/uncordon", post(uncordon_remote_node))
         .route("/api/ai/usage/summary", get(get_ai_usage_summary))
         .route("/api/task", post(create_task))
         .route("/api/task/:id", get(get_task))
@@ -1517,10 +1524,9 @@ async fn list_remote_nodes(
             crate::remote_node::probe_node(&state.fleet, &client, node).await;
         }
         let cached = state.fleet.get(&node.id);
-        nodes.push(crate::remote_node::RemoteNodeView::from_cache(
-            node,
-            cached.as_ref(),
-        ));
+        let mut view = crate::remote_node::RemoteNodeView::from_cache(node, cached.as_ref());
+        view.cordoned = state.fleet.is_cordoned(&node.id);
+        nodes.push(view);
     }
     // The Spark offload lane is separate from the remote-node fleet; expose
     // it alongside so `get_compute_fleet` consumers (Hermes, controllers) see
@@ -1549,6 +1555,54 @@ async fn list_remote_nodes(
             enabled_workspaces: spark_workspaces,
         },
     })
+}
+
+/// Cordon a remote node: keep probing and listing it, but exclude it from
+/// automatic placement until uncordoned. Persisted in
+/// `.sandboxed-sh/node_state.json` so it survives restarts.
+async fn cordon_remote_node(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    set_remote_node_cordon(&state, &name, true)
+}
+
+/// Undo a cordon: the node becomes eligible for automatic placement again.
+async fn uncordon_remote_node(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    set_remote_node_cordon(&state, &name, false)
+}
+
+fn set_remote_node_cordon(
+    state: &AppState,
+    name: &str,
+    cordoned: bool,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    // Only configured nodes can be (un)cordoned: a typo'd name silently
+    // persisted would look like a successful cordon of the real node.
+    if !state
+        .config
+        .remote_nodes
+        .nodes
+        .iter()
+        .any(|node| node.id == name)
+    {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("unknown remote node '{name}'"),
+        ));
+    }
+    let changed = state
+        .fleet
+        .set_cordoned(name, cordoned)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    Ok(Json(serde_json::json!({
+        "node": name,
+        "cordoned": cordoned,
+        "changed": changed,
+    })))
 }
 
 /// Optional query parameters for the stats endpoint.

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -83,6 +83,20 @@ pub fn status_after_probe(previous_misses: u32, probe_ok: bool) -> (RemoteNodeSt
 pub struct FleetMonitor {
     statuses: RwLock<HashMap<String, CachedNodeStatus>>,
     recent: RwLock<VecDeque<DispatchOutcome>>,
+    /// Node ids an operator has cordoned: still probed and listed, but
+    /// excluded from automatic placement until uncordoned. Persisted to
+    /// `state_path` (see [`NodeStateFile`]) so a cordon survives restarts.
+    cordoned: RwLock<std::collections::HashSet<String>>,
+    /// Where the cordon set is persisted (`.sandboxed-sh/node_state.json`
+    /// under the working dir). `None` in tests / until startup wiring runs.
+    state_path: RwLock<Option<std::path::PathBuf>>,
+}
+
+/// On-disk shape of `.sandboxed-sh/node_state.json`.
+#[derive(Debug, Default, Serialize, serde::Deserialize)]
+struct NodeStateFile {
+    #[serde(default)]
+    cordoned: Vec<String>,
 }
 
 impl Default for FleetMonitor {
@@ -96,7 +110,66 @@ impl FleetMonitor {
         Self {
             statuses: RwLock::new(HashMap::new()),
             recent: RwLock::new(VecDeque::new()),
+            cordoned: RwLock::new(std::collections::HashSet::new()),
+            state_path: RwLock::new(None),
         }
+    }
+
+    /// Load the persisted cordon set from `path` and remember the path for
+    /// later writes. Missing or unreadable files start with an empty set (a
+    /// lost cordon is recoverable; refusing to start is not).
+    pub fn load_node_state(&self, path: std::path::PathBuf) {
+        let loaded: NodeStateFile = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|text| serde_json::from_str(&text).ok())
+            .unwrap_or_default();
+        {
+            let mut cordoned = self.cordoned.write().unwrap_or_else(|e| e.into_inner());
+            *cordoned = loaded.cordoned.into_iter().collect();
+        }
+        let mut state_path = self.state_path.write().unwrap_or_else(|e| e.into_inner());
+        *state_path = Some(path);
+    }
+
+    pub fn is_cordoned(&self, node_id: &str) -> bool {
+        self.cordoned
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(node_id)
+    }
+
+    /// Cordon (`true`) or uncordon (`false`) a node and persist the set.
+    /// Returns whether the set changed.
+    pub fn set_cordoned(&self, node_id: &str, cordoned: bool) -> Result<bool, String> {
+        let snapshot: Vec<String> = {
+            let mut set = self.cordoned.write().unwrap_or_else(|e| e.into_inner());
+            let changed = if cordoned {
+                set.insert(node_id.to_string())
+            } else {
+                set.remove(node_id)
+            };
+            if !changed {
+                return Ok(false);
+            }
+            let mut nodes: Vec<String> = set.iter().cloned().collect();
+            nodes.sort();
+            nodes
+        };
+        let path = self
+            .state_path
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        if let Some(path) = path {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("create {}: {e}", parent.display()))?;
+            }
+            let body = serde_json::to_string_pretty(&NodeStateFile { cordoned: snapshot })
+                .map_err(|e| e.to_string())?;
+            std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))?;
+        }
+        Ok(true)
     }
 
     /// Record a successful heartbeat probe.
@@ -468,15 +541,41 @@ impl FleetMonitor {
         requirements: &[String],
         reservations: &HashMap<String, u32>,
     ) -> Result<String, PlacementError> {
+        let (nodes, mut cordoned_reasons) = self.partition_cordoned(&settings.nodes);
         let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
         select_node_auto_with_reservations(
-            &settings.nodes,
+            &nodes,
             &statuses,
             requirements,
             env_gb_bytes("REMOTE_NODE_MIN_DISK_GB", DEFAULT_MIN_DISK_GB),
             env_gb_bytes("REMOTE_NODE_MIN_MEM_GB", DEFAULT_MIN_MEM_GB),
             reservations,
         )
+        .map_err(|mut error| {
+            cordoned_reasons.append(&mut error.reasons);
+            PlacementError {
+                reasons: cordoned_reasons,
+            }
+        })
+    }
+
+    /// Split configured nodes into placeable ones and `(id, reason)` entries
+    /// for cordoned nodes, so exclusion reports still name every node.
+    fn partition_cordoned(
+        &self,
+        nodes: &[RemoteNodeConfig],
+    ) -> (Vec<RemoteNodeConfig>, Vec<(String, String)>) {
+        let cordoned = self.cordoned.read().unwrap_or_else(|e| e.into_inner());
+        let mut placeable = Vec::new();
+        let mut reasons = Vec::new();
+        for node in nodes {
+            if cordoned.contains(&node.id) {
+                reasons.push((node.id.clone(), "cordoned by operator".to_string()));
+            } else {
+                placeable.push(node.clone());
+            }
+        }
+        (placeable, reasons)
     }
 
     /// Like [`Self::place_auto_with_reservations`], with an explicit disk
@@ -510,9 +609,10 @@ impl FleetMonitor {
         reservations: &HashMap<String, u32>,
         disk_reservations: &HashMap<String, u64>,
     ) -> Result<String, PlacementError> {
+        let (nodes, mut cordoned_reasons) = self.partition_cordoned(&settings.nodes);
         let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
         select_node_auto_with_protocol_and_resource_reservations(
-            &settings.nodes,
+            &nodes,
             &statuses,
             requirements,
             min_disk_bytes,
@@ -521,6 +621,12 @@ impl FleetMonitor {
             reservations,
             disk_reservations,
         )
+        .map_err(|mut error| {
+            cordoned_reasons.append(&mut error.reasons);
+            PlacementError {
+                reasons: cordoned_reasons,
+            }
+        })
     }
 }
 
@@ -561,6 +667,9 @@ pub struct RemoteNodeView {
     pub lean_runtime_ready: Option<bool>,
     pub last_seen: Option<DateTime<Utc>>,
     pub error: Option<String>,
+    /// Operator-cordoned: still probed and listed, but excluded from
+    /// automatic placement until uncordoned.
+    pub cordoned: bool,
 }
 
 impl RemoteNodeView {
@@ -599,6 +708,7 @@ impl RemoteNodeView {
             lean_runtime_ready: heartbeat.and_then(|h| h.lean_runtime_ready),
             last_seen: cached.and_then(|c| c.last_seen),
             error: cached.and_then(|c| c.last_error.clone()),
+            cordoned: false,
         }
     }
 }
@@ -802,6 +912,62 @@ mod tests {
     }
 
     const GIB: u64 = 1 << 30;
+
+    #[test]
+    fn cordoned_node_is_excluded_from_auto_placement_with_a_reason() {
+        let fleet = FleetMonitor::new();
+        // Two healthy nodes; "spark" is deliberately the more attractive one
+        // (more memory) so exclusion, not ranking, is what the test proves.
+        for (id, mem) in [("spark", 96), ("cpu1", 16)] {
+            let status = cached_online(id, &["lean"], 100, mem, 2, 0, 0);
+            fleet.record_heartbeat(id, status.last_heartbeat.unwrap());
+        }
+        let settings = RemoteNodeSettings {
+            enabled: true,
+            nodes: vec![node_config("spark"), node_config("cpu1")],
+        };
+        assert_eq!(fleet.place_auto(&settings, &[]).unwrap(), "spark");
+
+        assert!(fleet.set_cordoned("spark", true).unwrap());
+        assert!(fleet.is_cordoned("spark"));
+        assert_eq!(fleet.place_auto(&settings, &[]).unwrap(), "cpu1");
+
+        // With every node cordoned, the exclusion report names them.
+        assert!(fleet.set_cordoned("cpu1", true).unwrap());
+        let error = fleet.place_auto(&settings, &[]).unwrap_err();
+        assert!(error
+            .reasons
+            .iter()
+            .any(|(id, reason)| id == "spark" && reason.contains("cordoned")));
+
+        // Uncordon restores placement; repeat uncordon is a no-op.
+        assert!(fleet.set_cordoned("spark", false).unwrap());
+        assert!(!fleet.set_cordoned("spark", false).unwrap());
+        assert_eq!(fleet.place_auto(&settings, &[]).unwrap(), "spark");
+    }
+
+    #[test]
+    fn cordon_set_persists_via_node_state_file() {
+        let dir = std::env::temp_dir().join(format!("node-state-{}", Uuid::new_v4()));
+        let path = dir.join("node_state.json");
+
+        let fleet = FleetMonitor::new();
+        fleet.load_node_state(path.clone());
+        assert!(fleet.set_cordoned("dgx-spark", true).unwrap());
+
+        // A fresh monitor (restart) reads the same file back.
+        let reloaded = FleetMonitor::new();
+        reloaded.load_node_state(path.clone());
+        assert!(reloaded.is_cordoned("dgx-spark"));
+
+        // Uncordon persists too.
+        assert!(reloaded.set_cordoned("dgx-spark", false).unwrap());
+        let third = FleetMonitor::new();
+        third.load_node_state(path);
+        assert!(!third.is_cordoned("dgx-spark"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 
     #[test]
     fn place_auto_filters_by_status_labels_disk_mem_and_load() {


### PR DESCRIPTION
start_mission with track=campaign returns 409 campaign_exists while a non-terminal campaign mission holds the slot. Node cordon: persisted set in .sandboxed-sh/node_state.json, POST /api/nodes/:name/cordon|uncordon, auto-placement exclusion with 'cordoned by operator' reason, cordoned flag on /api/remote-nodes, dashboard toggle panel, DEBUGGING.md Spark pause/resume recipe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission creation semantics (new 409) and remote job placement; cordon state is file-persisted and operator-controlled, with no auth changes in this diff.
> 
> **Overview**
> Adds two operator-facing controls: **one active campaign per project** and **cordoned remote nodes** that stay in the fleet but skip auto-placement.
> 
> **Campaign uniqueness:** Creating a mission with `track=campaign` and a project now fails with **HTTP 409** and `campaign_exists` (including the existing `mission_id`) while another campaign for that project is in a non-terminal state (`Pending`, `Active`, `AwaitingUser`, `WaitingBackground`, `Paused`). Terminal/archived statuses free the slot. Unit tests cover slot holding and release.
> 
> **Node cordon:** `FleetMonitor` tracks a persisted cordon set in `.sandboxed-sh/node_state.json` (loaded at startup). `POST /api/nodes/:name/cordon` and `uncordon` update it (404 for unknown node ids). Auto-placement paths filter cordoned nodes and surface **`cordoned by operator`** in placement exclusion reports; `GET /api/remote-nodes` includes `cordoned` on each node view.
> 
> The dashboard **Workspaces** page adds a **Remote Nodes** panel (SWR + cordon/uncordon via new `dashboard/src/lib/api/nodes.ts`). **DEBUGGING.md** documents curl/SSH recipes for pausing DGX Spark (cordon vs optional `spark-arbiter` stop).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23f2b98957298aa20aaef4c1f9b8c18c7c84d93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->