### PR TITLE
dashboard: fix remote-nodes-panel import (lib/api.ts shadows lib/api/)

### DIFF
--- a/dashboard/src/components/remote-nodes-panel.tsx
+++ b/dashboard/src/components/remote-nodes-panel.tsx
@@ -13,7 +13,7 @@
 import { useState } from 'react';
 import useSWR from 'swr';
 import { Network, ShieldOff, ShieldCheck } from 'lucide-react';
-import { getRemoteNodes, setNodeCordon } from '@/lib/api';
+import { getRemoteNodes, setNodeCordon } from '@/lib/api/nodes';
 import { cn } from '@/lib/utils';
 
 export function RemoteNodesPanel() {


### PR DESCRIPTION
PR #779 imported from @/lib/api which resolves to the legacy lib/api.ts shim, not the lib/api/ barrel — Turbopack build broke on master. Import @/lib/api/nodes directly. vitest + next build verified locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-path change with no behavior or API surface changes; low blast radius.
> 
> **Overview**
> Fixes a **Turbopack build failure** on master by changing how `RemoteNodesPanel` loads its API helpers.
> 
> `getRemoteNodes` and `setNodeCordon` are now imported from **`@/lib/api/nodes`** instead of **`@/lib/api`**. The `@/lib/api` alias was resolving to the legacy **`lib/api.ts`** shim rather than the **`lib/api/`** barrel, so the remote-node exports were not available at build time even though they live under `lib/api/nodes.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9367f94684b85b602500dd4637f49a08fac7c8e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->