### PR TITLE
Kimi proxy: route live OAuth over stale stored key + one-shot 401 refresh

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -786,6 +786,10 @@ pub(crate) async fn chat_completions_inner(
     let mut pending_fallback_events: Vec<crate::provider_health::FallbackEvent> = Vec::new();
 
     let chain_length = entries.len() as u32;
+    // Accounts whose Kimi OAuth token was already force-refreshed after a 401
+    // in this request — the retry is one-shot per account, never a loop.
+    let mut kimi_auth_refreshed: std::collections::HashSet<uuid::Uuid> =
+        std::collections::HashSet::new();
     for (entry_idx, entry) in entries.iter().enumerate() {
         // Non-builtin prefixes are custom providers referenced by their
         // sanitized name (e.g. "spark"); they all route as `Custom` through the
@@ -990,6 +994,15 @@ pub(crate) async fn chat_completions_inner(
                 extra.insert(header::USER_AGENT, HeaderValue::from_static("KimiCLI/1.5"));
             }
             (url, upstream_body, extra)
+        };
+
+        // Keep the exact request parts around for a one-shot resend when a
+        // Kimi 401 turns out to be a stale access token (see the auth-error
+        // handler below). `Bytes` clones are refcounted, so this is cheap.
+        let kimi_retry_parts = if provider_type == ProviderType::Kimi {
+            Some((url.clone(), upstream_body.clone(), extra_headers.clone()))
+        } else {
+            None
         };
 
         // Forward the request.
@@ -1764,6 +1777,91 @@ pub(crate) async fn chat_completions_inner(
 
         // Auth errors (401/403) — bad credentials, try next account
         if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+            // Kimi first gets ONE token refresh + resend before the account is
+            // cooled down: its access tokens only live ~300s, so an auth error
+            // usually means the routed Bearer went stale between the background
+            // refresh cycles rather than that the subscription is broken.
+            if should_attempt_kimi_auth_refresh(
+                provider_type,
+                kimi_auth_refreshed.insert(entry.account_id),
+            ) {
+                if let Some((retry_url, retry_body, retry_headers)) = kimi_retry_parts.clone() {
+                    match crate::api::ai_providers::refresh_store_account_oauth_locked(
+                        &state.ai_providers,
+                        entry.account_id,
+                        ProviderType::Kimi,
+                        "",
+                    )
+                    .await
+                    {
+                        Ok((fresh_token, _, _))
+                            if !fresh_token.trim().is_empty()
+                                && Some(fresh_token.as_str()) != entry.api_key.as_deref() =>
+                        {
+                            tracing::info!(
+                                provider = %entry.provider_id,
+                                account_id = %entry.account_id,
+                                "Kimi auth error with stale token — refreshed, retrying once"
+                            );
+                            let mut retry_req = state
+                                .http_client
+                                .post(&retry_url)
+                                .header("Content-Type", "application/json")
+                                .header("Authorization", format!("Bearer {}", fresh_token))
+                                .body(retry_body);
+                            for (name, value) in &retry_headers {
+                                retry_req = retry_req.header(name, value);
+                            }
+                            if !is_stream {
+                                retry_req = retry_req.timeout(std::time::Duration::from_secs(300));
+                            }
+                            match retry_req.send().await {
+                                // Only a successful retry rescues the entry;
+                                // any other status keeps the original
+                                // auth-error handling (cooldown + next entry)
+                                // so the chain still fails over.
+                                Ok(resp) if resp.status().is_success() => {
+                                    upstream_resp = resp;
+                                    status = upstream_resp.status();
+                                }
+                                Ok(resp) => {
+                                    tracing::warn!(
+                                        provider = %entry.provider_id,
+                                        account_id = %entry.account_id,
+                                        status = %resp.status(),
+                                        "Kimi retry with refreshed token still failed"
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        provider = %entry.provider_id,
+                                        account_id = %entry.account_id,
+                                        error = %e,
+                                        "Kimi retry with refreshed token failed to send"
+                                    );
+                                }
+                            }
+                        }
+                        Ok(_) => {
+                            // Token unchanged — the 401 wasn't staleness, a
+                            // retry with the same Bearer would fail again.
+                            tracing::debug!(
+                                account_id = %entry.account_id,
+                                "Kimi token refresh returned the same credential; not retrying"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                account_id = %entry.account_id,
+                                error = %e,
+                                "Kimi OAuth refresh after auth error failed"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
             let elapsed_ms = request_start.elapsed().as_millis() as u64;
             tracing::warn!(
                 provider = %entry.provider_id,
@@ -2313,6 +2411,20 @@ fn strip_thinking_blocks(messages: &mut [serde_json::Value]) {
             }));
         }
     }
+}
+
+/// Whether an upstream 401/403 should trigger a one-shot OAuth refresh +
+/// resend instead of immediately cooling the account down. Only Kimi qualifies
+/// (its Bearer is a ~300s OAuth access token, so staleness is the common
+/// cause), and only on the first auth error per account per request —
+/// `first_refresh_for_account` is the result of inserting the account into the
+/// per-request refreshed set, so a second 401 falls through to the normal
+/// cooldown path.
+fn should_attempt_kimi_auth_refresh(
+    provider_type: ProviderType,
+    first_refresh_for_account: bool,
+) -> bool {
+    provider_type == ProviderType::Kimi && first_refresh_for_account
 }
 
 /// Rewrite the model id and normalize sampling params for Kimi's coding endpoint.
@@ -5200,6 +5312,40 @@ mod tests {
         let e2 = parse_direct_model_entry("openai/codex-mini/latest").expect("known provider");
         assert_eq!(e2.provider_id, "openai");
         assert_eq!(e2.model_id, "codex-mini/latest");
+    }
+
+    #[test]
+    fn kimi_k3_routes_as_direct_passthrough_to_coding_endpoint() {
+        // `kimi/k3` (and any `kimi/<model>`) must resolve as a direct
+        // provider/model passthrough entry...
+        let e = parse_direct_model_entry("kimi/k3").expect("kimi is a known provider prefix");
+        assert_eq!(e.provider_id, "kimi");
+        assert_eq!(e.model_id, "k3");
+        let e = parse_direct_model_entry("kimi/k3-256k").expect("kimi is a known provider prefix");
+        assert_eq!(e.model_id, "k3-256k");
+        // ...aimed at the Kimi Code coding endpoint (OpenAI-compatible).
+        assert_eq!(
+            completions_url(ProviderType::Kimi, None).as_deref(),
+            Some("https://api.kimi.com/coding/v1/chat/completions")
+        );
+    }
+
+    #[test]
+    fn kimi_auth_refresh_is_one_shot_and_kimi_only() {
+        // First 401 on a Kimi account → refresh + retry once.
+        assert!(should_attempt_kimi_auth_refresh(ProviderType::Kimi, true));
+        // Second auth error for the same account in the same request → normal
+        // cooldown path, never a refresh loop.
+        assert!(!should_attempt_kimi_auth_refresh(ProviderType::Kimi, false));
+        // Other providers keep their existing 401 handling untouched.
+        assert!(!should_attempt_kimi_auth_refresh(
+            ProviderType::Anthropic,
+            true
+        ));
+        assert!(!should_attempt_kimi_auth_refresh(
+            ProviderType::OpenAI,
+            true
+        ));
     }
 
     #[test]

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -1333,26 +1333,19 @@ impl ModelChainStore {
                 // `api.openai.com/v1/chat/completions`; those accounts keep
                 // `api_key = None, has_oauth = true` and route through the
                 // CLI-proxy adapter instead.
-                let routed_api_key = account.api_key.clone().or_else(|| {
-                    if !matches!(
-                        provider_type,
-                        crate::ai_providers::ProviderType::Anthropic
-                            | crate::ai_providers::ProviderType::Kimi
-                    ) {
-                        return None;
-                    }
-                    if !oauth_is_fresh {
-                        return None;
-                    }
-                    account.oauth.as_ref().and_then(|oauth| {
-                        let token = oauth.access_token.trim();
-                        if token.is_empty() {
-                            None
-                        } else {
-                            Some(token.to_string())
-                        }
-                    })
-                });
+                let fresh_oauth_token = if oauth_is_fresh {
+                    account
+                        .oauth
+                        .as_ref()
+                        .map(|oauth| oauth.access_token.as_str())
+                } else {
+                    None
+                };
+                let (routed_api_key, credential_is_oauth_token) = preferred_store_credential(
+                    provider_type,
+                    account.api_key.as_deref(),
+                    fresh_oauth_token,
+                );
                 // `routed_api_key` is only populated for OpenAI/Anthropic
                 // OAuth (where we can forward the access token as a Bearer
                 // credential). Google OAuth is routed via `get_google_access_token`
@@ -1404,13 +1397,10 @@ impl ModelChainStore {
                 // attaching OAuth-only headers (Bearer + oauth beta) to an
                 // x-api-key request. Google still needs `has_oauth=true` to
                 // trigger its adapter regardless of store-token freshness.
-                let provider_oauth_is_proxy_routable = matches!(
-                    provider_type,
-                    crate::ai_providers::ProviderType::Anthropic
-                        | crate::ai_providers::ProviderType::Kimi
-                );
-                let credential_is_oauth_token =
-                    account.api_key.is_none() && oauth_is_fresh && provider_oauth_is_proxy_routable;
+                // `credential_is_oauth_token` comes from
+                // `preferred_store_credential` above so it always describes the
+                // credential actually routed (Kimi routes the live OAuth token
+                // even when a stale `api_key` snapshot is persisted).
                 let xai_oauth_cli_proxy_routable =
                     matches!(provider_type, crate::ai_providers::ProviderType::Xai)
                         && account.api_key.is_none()
@@ -1521,6 +1511,47 @@ impl ModelChainStore {
         }
 
         resolved
+    }
+}
+
+/// Pick the credential the proxy will forward for a store account, returning
+/// `(credential, credential_is_oauth_token)`.
+///
+/// Only Anthropic and Kimi chat endpoints accept the OAuth access token as a
+/// Bearer credential, so OAuth hoisting is limited to those types. Ordering
+/// differs per provider:
+/// - **Kimi**: the live OAuth token always wins. Kimi Code access tokens live
+///   ~300s and are refreshed in the background, so any `api_key` persisted in
+///   `ai_providers.json` is a stale snapshot of an old token — routing it
+///   produces deterministic 401s. The stored key is only a last-resort
+///   fallback when no fresh OAuth token exists.
+/// - **Anthropic** (and everything else): a real API key wins over OAuth, so
+///   the proxy sends `x-api-key`-style auth when the operator configured one.
+pub(crate) fn preferred_store_credential(
+    provider_type: crate::ai_providers::ProviderType,
+    api_key: Option<&str>,
+    fresh_oauth_access_token: Option<&str>,
+) -> (Option<String>, bool) {
+    use crate::ai_providers::ProviderType as PT;
+    let oauth_routable = matches!(provider_type, PT::Anthropic | PT::Kimi);
+    let oauth_token = fresh_oauth_access_token
+        .map(str::trim)
+        .filter(|t| !t.is_empty() && oauth_routable)
+        .map(str::to_string);
+    let stored_key = api_key
+        .map(str::trim)
+        .filter(|k| !k.is_empty())
+        .map(str::to_string);
+    if provider_type == PT::Kimi {
+        if let Some(token) = oauth_token {
+            return (Some(token), true);
+        }
+        return (stored_key, false);
+    }
+    match (stored_key, oauth_token) {
+        (Some(key), _) => (Some(key), false),
+        (None, Some(token)) => (Some(token), true),
+        (None, None) => (None, false),
     }
 }
 
@@ -2088,5 +2119,80 @@ mod tests {
             store_account_subscription_key(ProviderType::Anthropic, &acc),
             None
         );
+    }
+
+    #[test]
+    fn preferred_store_credential_kimi_prefers_live_oauth_over_stored_key() {
+        // Kimi: a persisted api_key is a stale snapshot of a ~300s OAuth
+        // token; the live token must win.
+        assert_eq!(
+            preferred_store_credential(
+                ProviderType::Kimi,
+                Some("stale-snapshot"),
+                Some("live-token")
+            ),
+            (Some("live-token".to_string()), true)
+        );
+        // Without a fresh token, the stored key remains a last-resort fallback.
+        assert_eq!(
+            preferred_store_credential(ProviderType::Kimi, Some("stale-snapshot"), None),
+            (Some("stale-snapshot".to_string()), false)
+        );
+        // Anthropic keeps key-first ordering.
+        assert_eq!(
+            preferred_store_credential(ProviderType::Anthropic, Some("sk-ant"), Some("oauth-at")),
+            (Some("sk-ant".to_string()), false)
+        );
+        assert_eq!(
+            preferred_store_credential(ProviderType::Anthropic, None, Some("oauth-at")),
+            (Some("oauth-at".to_string()), true)
+        );
+        // OAuth hoisting stays limited to Anthropic/Kimi — an xAI token must
+        // never be forwarded as an API key.
+        assert_eq!(
+            preferred_store_credential(ProviderType::Xai, None, Some("grok-oauth")),
+            (None, false)
+        );
+        // Whitespace-only credentials are treated as absent.
+        assert_eq!(
+            preferred_store_credential(ProviderType::Kimi, Some("  "), Some("  ")),
+            (None, false)
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_entries_kimi_routes_live_oauth_not_stale_api_key() {
+        let mut kimi = AIProvider::new(ProviderType::Kimi, "Kimi".to_string());
+        kimi.api_key = Some("stale-snapshot".to_string());
+        kimi.oauth = Some(OAuthCredentials {
+            access_token: "live-kimi-token".to_string(),
+            refresh_token: "kimi-rt".to_string(),
+            expires_at: future_ms(1),
+        });
+        kimi.status = ProviderStatus::Connected;
+        let store = store_with(vec![kimi]).await;
+        let chains = store_with_chain("unused", vec![]).await;
+        let tracker = ProviderHealthTracker::new();
+
+        let resolved = chains
+            .resolve_entries(
+                &[ChainEntry {
+                    provider_id: "kimi".to_string(),
+                    model_id: "k3".to_string(),
+                }],
+                &store,
+                &[],
+                &tracker,
+            )
+            .await;
+
+        assert_eq!(resolved.len(), 1, "kimi entry should resolve: {resolved:?}");
+        assert_eq!(
+            resolved[0].api_key.as_deref(),
+            Some("live-kimi-token"),
+            "must route the live OAuth token, never the persisted api_key snapshot"
+        );
+        assert!(resolved[0].has_oauth);
+        assert_eq!(resolved[0].model_id, "k3");
     }
 }


### PR DESCRIPTION
kimi/k3 was already a direct passthrough, but resolve_entries preferred the stale ~300s api_key snapshot from ai_providers.json over the live OAuth token → deterministic 401s. Kimi now always routes the live Bearer, and a Kimi 401/403 triggers one serialized OAuth refresh + identical resend before the normal cooldown/failover.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy auth routing and inline OAuth refresh on the hot request path for Kimi only; behavior is scoped with one-shot guards but mistakes could affect failover or credential selection.
> 
> **Overview**
> Fixes **Kimi** (`kimi/k3`) proxy auth by stopping chain resolution from preferring a stale `api_key` snapshot in `ai_providers.json` over the live ~300s OAuth Bearer, which caused predictable **401**s.
> 
> Introduces **`preferred_store_credential`**: for Kimi, a fresh OAuth access token always wins (stored key is fallback only); Anthropic and other providers keep **API key before OAuth**. Resolved entries now set **`has_oauth`** from the credential actually sent so OAuth-only headers are not applied to key-based requests.
> 
> On upstream **401/403** for Kimi, the proxy may **refresh OAuth once per account per request** via the locked store refresh path and **resend the same request** with the new token before the usual cooldown and chain failover. Non-success retries still follow normal auth-error handling.
> 
> Adds unit/integration tests for Kimi direct routing, credential preference, one-shot refresh gating, and `resolve_entries` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8551cb05fc7bd5c1efad62a82fa97e376509cf4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->