### PR TITLE
Ingestor: [SILENT] deliveries advance freshness without becoming headlines

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -141,7 +141,7 @@ fn ingest_deliveries(
         // synthetic `ctrl:…` descriptor is recorded then, so the delivery's
         // headline and session still reach the timeline — that is what the
         // overview builds `latest_update` from. `observations` drives `wait`.
-        let headline = Some(delivery.headline.as_str()).filter(|h| !h.is_empty());
+        let headline = Some(delivery.headline.trim()).filter(|h| !h.is_empty());
         let session = Some(delivery.session_id.as_str()).filter(|s| !s.is_empty());
         let descriptor = delivery.state.clone().unwrap_or_else(|| {
             format!(
@@ -149,14 +149,24 @@ fn ingest_deliveries(
                 delivery.mode.as_deref().unwrap_or("report")
             )
         });
-        let observations =
-            match projects.record_state(slug, &descriptor, headline, &delivery.at, session) {
-                Ok(observations) => observations,
-                Err(error) => {
-                    tracing::warn!("state ingest: {slug}: {error}");
-                    1
-                }
-            };
+        // `[SILENT]` is the controllers-policy convention for "nothing to
+        // report". It must advance freshness (a quiet tick is proof of life),
+        // but it must never become the headline the card shows — fold it onto
+        // the previous state event so `latest_update` keeps surfacing the last
+        // meaningful headline with the fresh timestamp.
+        let recorded = match headline {
+            Some("[SILENT]") | None => {
+                projects.record_silent_observation(slug, &descriptor, &delivery.at, session)
+            }
+            Some(_) => projects.record_state(slug, &descriptor, headline, &delivery.at, session),
+        };
+        let observations = match recorded {
+            Ok(observations) => observations,
+            Err(error) => {
+                tracing::warn!("state ingest: {slug}: {error}");
+                1
+            }
+        };
         // Project the controller's `[CTRL: … mode=… ]` mode onto the
         // project record — independent of the descriptor, so a
         // CTRL-only delivery still updates the mode column. Idempotent
@@ -1978,6 +1988,64 @@ mod tests {
             update.state, None,
             "the synthetic ctrl descriptor is not a state"
         );
+    }
+
+    /// A `[SILENT]` tick after a real report must advance freshness without
+    /// stealing the headline: the card keeps the last meaningful headline,
+    /// stamped with the silent delivery's (fresher) time. Observed live on
+    /// verity-lido, where cards showed the literal string "[SILENT]".
+    #[test]
+    fn a_silent_delivery_keeps_the_previous_headline_but_advances_freshness() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        let real = "[Cron delivery: Verity]\nCertify #2240 merged\n\
+                    [CTRL: verity | mode=active | wait=0 | next=x]";
+        let quiet = "[Cron delivery: Verity]\n[SILENT]\n\
+                     [CTRL: verity | mode=active | wait=1 | next=x]";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            // Newest-first, as read_deliveries returns them.
+            vec![
+                parse_delivery("sess-2", 1_754_003_600.0, quiet),
+                parse_delivery("sess-1", 1_754_000_000.0, real),
+            ],
+        );
+
+        let latest = store.latest_states().expect("latest");
+        let event = latest.get("verity").expect("state event recorded");
+        let update = store_update("verity", event, None, None);
+        assert_eq!(
+            update.headline, "Certify #2240 merged",
+            "the [SILENT] tick must not replace the last meaningful headline"
+        );
+        assert_eq!(
+            update.at,
+            parse_delivery("sess-2", 1_754_003_600.0, quiet).at,
+            "freshness must advance to the silent delivery's time"
+        );
+        assert_eq!(event.observations, 2, "the quiet tick is still counted");
+    }
+
+    /// A controller whose very first delivery is `[SILENT]` must not put the
+    /// literal marker on the card: the event lands with no headline at all.
+    #[test]
+    fn a_silent_first_delivery_records_no_garbage_headline() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        let quiet = "[Cron delivery: Lido]\n[SILENT]\n\
+                     [CTRL: lido | mode=active | wait=0 | next=x]";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            vec![parse_delivery("sess-1", 1_754_000_000.0, quiet)],
+        );
+
+        let latest = store.latest_states().expect("latest");
+        let event = latest.get("lido").expect("freshness is still recorded");
+        assert_eq!(event.headline, None, "no [SILENT] garbage headline");
+        let update = store_update("lido", event, None, None);
+        assert_eq!(update.headline, "");
     }
 
     /// The serialized shape of a store-built latest_update is the one every

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -371,6 +371,67 @@ impl ProjectsStore {
         Ok(1)
     }
 
+    /// Record a `[SILENT]` (or headline-less) delivery for `slug` at `at`.
+    ///
+    /// `[SILENT]` is the controllers-policy convention for "nothing to
+    /// report": the observation must advance freshness (so the controller is
+    /// not flagged silent — that is the point of emitting it), but it must
+    /// never become the headline the board shows. So instead of opening a new
+    /// state event, the newest event is extended — last_seen_at/observations
+    /// move forward while signature and headline stay what the last meaningful
+    /// delivery said, like a repeated-signature fold. Only when no event
+    /// exists at all is one created, with `descriptor` and no headline.
+    ///
+    /// Idempotent on `at`, same as [`Self::record_state`]. Returns the
+    /// resulting observation count.
+    pub fn record_silent_observation(
+        &self,
+        slug: &str,
+        descriptor: &str,
+        at: &str,
+        session_id: Option<&str>,
+    ) -> Result<u32, String> {
+        let connection = self.lock()?;
+        let current: Option<(String, String, u32)> = connection
+            .query_row(
+                "SELECT first_seen_at, last_seen_at, observations \
+                 FROM project_state_events WHERE slug = ?1 \
+                 ORDER BY last_seen_at DESC LIMIT 1",
+                params![slug],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .map_err(|e| e.to_string())?;
+
+        if let Some((first_seen_at, last_seen_at, observations)) = current {
+            // Already counted, or older than what we have: nothing to do.
+            if at <= last_seen_at.as_str() {
+                return Ok(observations);
+            }
+            connection
+                .execute(
+                    "UPDATE project_state_events \
+                     SET last_seen_at = ?1, observations = observations + 1, \
+                         session_id = COALESCE(?4, session_id) \
+                     WHERE slug = ?2 AND first_seen_at = ?3",
+                    params![at, slug, first_seen_at, session_id],
+                )
+                .map_err(|e| e.to_string())?;
+            return Ok(observations + 1);
+        }
+
+        connection
+            .execute(
+                "INSERT INTO project_state_events \
+                   (slug, signature, headline, first_seen_at, last_seen_at, observations, session_id) \
+                 VALUES (?1, ?2, NULL, ?3, ?3, 1, ?4) \
+                 ON CONFLICT(slug, first_seen_at) DO NOTHING",
+                params![slug, descriptor, at, session_id],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(1)
+    }
+
     /// A project's state history, newest first.
     pub fn state_timeline(&self, slug: &str, limit: usize) -> Result<Vec<ProjectState>, String> {
         let connection = self.lock()?;


### PR DESCRIPTION
Controllers deliver [SILENT] per policy; the ingestor recorded the literal string as the card headline. Silent/empty deliveries now extend the newest state event's freshness/observations (so the controller isn't flagged silent — the marker's purpose) while latest_update keeps the last meaningful headline at the fresher timestamp.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized ingest/store behavior for silent or empty headlines; mode projection unchanged and covered by new tests.
> 
> **Overview**
> Fixes project board cards showing the literal **`[SILENT]`** string when controllers emit policy “nothing to report” ticks.
> 
> The state ingestor now **trims** delivery headlines and routes **`[SILENT]`** or empty headlines through new **`record_silent_observation`** instead of **`record_state`**. That path **extends** the newest timeline row (`last_seen_at`, `observations`, `session_id`) while **keeping** the prior signature and headline, so **`latest_update`** stays meaningful but timestamps stay fresh. If there is no prior event, it inserts one **without** a headline.
> 
> Tests cover silent ticks after a real report, a silent-first delivery, and the existing repeated CTRL-only silent behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f101b5d4c251c298bf87df107ae39a749593e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->