### PR TITLE
test: confirmed project delete revalidates the overview

### DIFF
--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -249,6 +249,34 @@ describe("ProjectsBoard", () => {
     );
   });
 
+  test("confirmed delete revalidates the overview and the row disappears", async () => {
+    // First load shows the project; the post-delete revalidation returns an
+    // overview without it, so the row must leave the triage list.
+    mockedOverview
+      .mockResolvedValueOnce(
+        overview([project({ slug: "verity" }), project({ slug: "beal" })]),
+      )
+      .mockResolvedValue(overview([project({ slug: "beal" })]));
+    mockedAction.mockResolvedValue(undefined);
+
+    renderBoard();
+
+    fireEvent.click(await screen.findByRole("button", { name: /verity/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /Delete/ }));
+    expect(mockedAction).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/ }));
+
+    await waitFor(() =>
+      expect(mockedAction).toHaveBeenCalledWith("verity", "delete"),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /verity/ }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /beal/ })).toBeInTheDocument();
+  });
+
   test("reply composer streams into the update's origin session", async () => {
     mockedOverview.mockResolvedValue(overview([project({ slug: "verity" })]));
     mockedUpdates.mockResolvedValue({


### PR DESCRIPTION
Web delete already existed (detail-pane Trash with two-click confirm). Adds the missing coverage: confirm gates the call and the row disappears after revalidation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior modifications.
> 
> **Overview**
> Adds integration coverage for **ProjectsBoard** project delete beyond the existing two-click confirm test.
> 
> The new case stubs `getProjectsOverview` so the first fetch returns **verity** and **beal**, then a post-delete revalidation returns only **beal**. After confirm, it asserts `postProjectAction("verity", "delete")` runs and the **verity** triage row is gone while **beal** remains—locking in the SWR `projects-overview` refresh behavior the UI already relies on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58f3dce95ac80b550c7f3e5ea48cf5f2bca5f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->