### PR TITLE
CI: iOS build job (xcodegen drift check + compile)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -23,6 +23,9 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Pinned so CI and local regeneration produce byte-identical pbxproj output.
+  # The committed project.pbxproj must be regenerated with exactly this version.
+  XCODEGEN_VERSION: 2.46.0
 
 jobs:
   ios-build:
@@ -38,15 +41,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install xcodegen
-        run: brew install xcodegen
+      - name: Install xcodegen (pinned)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o "${RUNNER_TEMP}/xcodegen.zip" \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
+          unzip -oq "${RUNNER_TEMP}/xcodegen.zip" -d "${RUNNER_TEMP}"
+          "${RUNNER_TEMP}/xcodegen/bin/xcodegen" --version
 
       - name: Regenerate Xcode project and check for drift
         run: |
           set -euo pipefail
-          xcodegen generate
+          "${RUNNER_TEMP}/xcodegen/bin/xcodegen" generate
           if ! git diff --exit-code SandboxedDashboard.xcodeproj/project.pbxproj; then
-            echo "::error title=pbxproj drift::project.pbxproj is out of date. Run 'xcodegen generate' in ios_dashboard/ and commit the result."
+            echo "::error title=pbxproj drift::project.pbxproj is out of date. Regenerate with xcodegen ${XCODEGEN_VERSION} ('xcodegen generate' in ios_dashboard/) and commit the result."
             exit 1
           fi
 

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,60 @@
+name: iOS Build
+
+# Path-gated like android-apk.yml so unrelated PRs don't pay the macOS-runner
+# cost. This exists because the committed pbxproj once silently missed new
+# views for days: we verify the project is regenerated and that it compiles.
+on:
+  push:
+    branches: [master, main, "release/*"]
+    paths:
+      - ".github/workflows/ios-build.yml"
+      - "ios_dashboard/**"
+  pull_request:
+    branches: [master, main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/ios-build.yml"
+      - "ios_dashboard/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  ios-build:
+    name: iOS Build
+    # macos-15 ships Xcode 16 (project.yml xcodeVersion 16, iOS deployment
+    # target 18) — older images lack the iOS 18 SDK.
+    runs-on: macos-15
+    # Skip CI on draft PRs unless explicitly requested
+    if: github.event.pull_request.draft == false || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    defaults:
+      run:
+        working-directory: ios_dashboard
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Regenerate Xcode project and check for drift
+        run: |
+          set -euo pipefail
+          xcodegen generate
+          if ! git diff --exit-code SandboxedDashboard.xcodeproj/project.pbxproj; then
+            echo "::error title=pbxproj drift::project.pbxproj is out of date. Run 'xcodegen generate' in ios_dashboard/ and commit the result."
+            exit 1
+          fi
+
+      - name: Build (compile-only, no signing)
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project SandboxedDashboard.xcodeproj \
+            -scheme SandboxedDashboard \
+            -destination "generic/platform=iOS" \
+            CODE_SIGNING_ALLOWED=NO

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -487,7 +487,6 @@
 				};
 			};
 			buildConfigurationList = 210E554B4D49DD6F4EE7F3FD /* Build configuration list for PBXProject "SandboxedDashboard" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -497,6 +496,7 @@
 			mainGroup = 9402FD943158ED3148A81A0C;
 			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 057719CAD3366030137C44B3 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/ios_dashboard/SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift
@@ -61,7 +61,7 @@ final class ControlPerformanceDiagnostics {
         return try operation()
     }
 
-    func measureAsync<T>(
+    func measureAsync<T: Sendable>(
         _ name: StaticString,
         detail: String = "",
         count: Int? = nil,


### PR DESCRIPTION
Path-gated macOS-15 workflow on ios_dashboard/** changes: xcodegen generate must produce no pbxproj drift (the trap that shipped a non-compiling app), then xcodebuild compile-only, no signing/simulator. Non-required until proven stable (repo has no aggregator; android-apk.yml pattern followed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and generated project metadata plus a narrow generics constraint; no runtime product behavior changes beyond compile-time conformance.
> 
> **Overview**
> Adds a **path-gated** GitHub Actions workflow (`.github/workflows/ios-build.yml`) for `ios_dashboard/**`, mirroring the Android APK pattern so unrelated PRs avoid macOS runner cost.
> 
> On **macos-15**, CI installs **pinned XcodeGen 2.46.0**, runs `xcodegen generate`, and **fails if `project.pbxproj` drifts** from the committed file—addressing cases where stale pbxproj shipped a non-compiling app. It then runs **`xcodebuild` compile-only** (`CODE_SIGNING_ALLOWED=NO`, generic iOS destination). Draft PRs are skipped unless push/dispatch.
> 
> The committed **`project.pbxproj`** is refreshed for XcodeGen output (e.g. `productRefGroup` wiring, removal of `compatibilityVersion`). **`ControlPerformanceDiagnostics.measureAsync`** gains a **`T: Sendable`** bound, likely for Swift 6 strict concurrency under the new compile gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25940270d8a0bec4c8c4b56748d8d3435678faff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->