### PR TITLE
control events: no-cursor default returns the newest page, not the oldest

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10869,9 +10869,15 @@ pub async fn get_mission_events(
             .await
             .map_err(internal_error)?
     } else {
+        // No cursor: default to the NEWEST `limit` events (the tail), returned
+        // ascending within the page — i.e. behave as `before_seq=MAX`. "Latest
+        // activity" is the overwhelmingly common need (dashboards, debugging a
+        // live mission), so paging from the oldest row by default is a footgun.
+        // Callers that genuinely want a forward replay from the start pass
+        // `since_seq=0` explicitly, which is handled above and is unaffected.
         control
             .mission_store
-            .get_events(mission_id, types.as_deref(), query.limit, None)
+            .get_events_before(mission_id, i64::MAX, types.as_deref(), query.limit)
             .await
             .map_err(internal_error)?
     };

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -15378,6 +15378,67 @@ mod tests {
         );
     }
 
+    // The `GET /events` handler routes a cursor-less request to
+    // `get_events_before(i64::MAX)` so the default page is the NEWEST `limit`
+    // events (the tail), ascending — not the oldest rows. This locks in that
+    // contract and the X-Max-Sequence value the handler reports alongside it.
+    #[tokio::test]
+    async fn no_cursor_default_returns_newest_page_ascending() {
+        use crate::api::control::AgentEvent;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("default page"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+
+        for i in 0..10 {
+            store
+                .log_event(
+                    mission.id,
+                    &AgentEvent::UserMessage {
+                        id: Uuid::new_v4(),
+                        content: format!("msg {i}"),
+                        queued: false,
+                        mission_id: Some(mission.id),
+                        source: None,
+                    },
+                )
+                .await
+                .expect("log user message");
+        }
+
+        // No-cursor + limit=3 must yield the newest three (8, 9, 10) ASC,
+        // exactly what the handler now emits for `?limit=3` with no cursor.
+        let newest = store
+            .get_events_before(mission.id, i64::MAX, None, Some(3))
+            .await
+            .expect("get newest page");
+        assert_eq!(
+            newest.iter().map(|e| e.sequence).collect::<Vec<_>>(),
+            vec![8, 9, 10],
+            "no-cursor default should return the tail, not the oldest rows"
+        );
+
+        // X-Max-Sequence reflects the true tail regardless of the page limit.
+        let max = store.max_event_sequence(mission.id).await.expect("max seq");
+        assert_eq!(max, 10);
+
+        // Explicit forward replay (`since_seq=0`) still pages from the start —
+        // this path is untouched by the default change.
+        let from_start = store
+            .get_events_since(mission.id, 0, None, Some(3))
+            .await
+            .expect("get_events_since zero");
+        assert_eq!(
+            from_start.iter().map(|e| e.sequence).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
     #[tokio::test]
     async fn max_event_sequence_is_zero_for_mission_with_no_events() {
         let temp_dir = tempfile::tempdir().expect("temp dir");

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -754,9 +754,10 @@ fn mission_events_path(
     } else if let Some(since_seq) = since_seq {
         path.push_str(&format!("&since_seq={since_seq}"));
     } else {
-        // The public events endpoint intentionally starts at the oldest row
-        // when no cursor is supplied. Hermes uses this bounded tool for live
-        // reconciliation, so its useful default is the newest page.
+        // The events endpoint already defaults to the newest page when no
+        // cursor is supplied, but Hermes uses this bounded tool for live
+        // reconciliation, so we pin the tail explicitly to stay robust against
+        // any future change to the server-side default.
         path.push_str(&format!("&before_seq={}", i64::MAX));
     }
     path


### PR DESCRIPTION
GET /missions/:id/events?limit=N with no cursor returned sequences 1..N (oldest) — a footgun that misdiagnoses live missions as wedged. No-cursor now returns the newest N (before_seq=MAX semantics); since_seq/before_seq unchanged. Full caller audit: none relied on oldest-default; dashboard fallback + worker peek improve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API behavior change for any client that relied on cursor-less requests returning the oldest page; explicit cursors are unaffected but unaudited callers may see different data.
> 
> **Overview**
> **Cursor-less `GET /missions/:id/events?limit=N` now returns the newest N events** (ascending within the page), matching `before_seq=i64::MAX`, instead of sequences 1..N from the start. That fixes dashboards and live debugging that assumed “latest activity” when no `since_seq` / `before_seq` was sent.
> 
> **`since_seq` and explicit `before_seq` are unchanged.** Full replay from the beginning still uses `since_seq=0`.
> 
> A **SQLite store test** documents the tail-default contract and that `since_seq=0` still pages from the start. **Hermes `assistant_mcp`** only updates comments: it already sends `before_seq=MAX` when no cursor is given, now described as defense in depth against a future server default change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b52285675b06976b72d6cef23b776816b60699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->