### PR TITLE
docs(readme): frame sandboxed.sh as the mission-execution backend for an agent coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 <h1 align="center">sandboxed.sh</h1>
 
 <p align="center">
-  <strong>Self-hosted cloud orchestrator for AI coding agents</strong><br/>
-  Isolated Linux workspaces with Claude Code, OpenCode, Codex, Gemini, and Grok runtimes
+  <strong>Self-hosted mission-execution backend for autonomous AI agents</strong><br/>
+  Isolated Linux workspaces with Claude Code, OpenCode, Codex, Gemini, and Grok runtimes<br/>
+  <em>Driven over MCP by a coordinator like <a href="https://github.com/Th0rgal/hermes-agent">Hermes</a> — sandboxed.sh runs the missions</em>
 </p>
 
 <p align="center">
@@ -55,10 +56,16 @@ literature. Local inference, isolated containers, nothing leaves your machines.
 
 ## Architecture
 
-sandboxed.sh is the **execution half** of a two-part system. The other half is a
-coordinator (we use [Hermes](https://github.com/Th0rgal/hermes-agent), but any
-MCP-capable assistant works) that decides *what* to do; sandboxed.sh does the
-building in isolation. Four concepts tie the system together:
+sandboxed.sh is the **mission-execution backend** of a two-part system — the
+half an autonomous agent drives over MCP to actually *build* things in
+isolation. The other half is a **coordinator** that decides *what* to do and
+*when*: we run our own Hermes fork —
+[hermes-agent](https://github.com/Th0rgal/hermes-agent) (the Python gateway +
+CLI) and its bundled **hermes-desktop** Electron app (`apps/desktop/`) — but any
+MCP-capable assistant works. The agent never runs untrusted code itself; it
+hands each unit of work to sandboxed.sh, which runs it in a throwaway
+workspace/container and streams back structured results. Four concepts tie the
+system together:
 
 | Concept | What it is | Where it lives |
 |---|---|---|
@@ -125,7 +132,20 @@ board (`/`), the desktop Projects board, and the iOS app's Projects tab.
 
 ## Ecosystem
 
-sandboxed.sh orchestrates multiple AI coding agent runtimes:
+**The coordinator** — the agent that decides what to run and drives sandboxed.sh
+over MCP:
+
+- **[Hermes (our fork)](https://github.com/Th0rgal/hermes-agent)**: the
+  coordinator we run in production — a Python gateway + CLI plus the bundled
+  **hermes-desktop** Electron app (`apps/desktop/`). It owns the control
+  conversations, controller crons, and the project MCP tools (`start_mission`,
+  `link_mission_to_project`, …). Any MCP-capable assistant can take this role;
+  Hermes is the reference implementation. See its
+  [`FORK.md`](https://github.com/Th0rgal/hermes-agent/blob/main/FORK.md) for how
+  our changes are layered on upstream to stay easy to update.
+
+**The runtimes** — the coding agents sandboxed.sh executes inside isolated
+workspaces:
 
 - **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**: Anthropic's
   official coding agent with native skills support (`.claude/skills/`)


### PR DESCRIPTION
Makes the two-part-system role explicit in the README: sandboxed.sh is the **mission-execution backend** an autonomous agent drives over MCP to build in isolation; the coordinator (our [Hermes fork](https://github.com/Th0rgal/hermes-agent) + bundled **hermes-desktop**) decides what to run.

- Subtitle + Architecture intro now state the backend role and link the Hermes fork / hermes-desktop.
- New **Coordinator** block in Ecosystem links hermes-agent, hermes-desktop (`apps/desktop/`), and its `FORK.md`.

Docs-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits; no runtime, API, or security behavior changes.
> 
> **Overview**
> Reframes the README so **sandboxed.sh** is explicitly the **mission-execution backend** an autonomous coordinator drives over MCP, not a generic “cloud orchestrator.”
> 
> The hero subtitle and a new tagline call out MCP-driven missions and link **Hermes** as an example coordinator. The **Architecture** section expands the two-part split: coordinator vs backend, names the **hermes-agent** fork and **hermes-desktop** (`apps/desktop/`), and clarifies that the agent delegates untrusted work to throwaway workspaces while results stream back.
> 
> **Ecosystem** is reorganized into **The coordinator** (Hermes fork, desktop app, project MCP tools, `FORK.md`) and **The runtimes** (existing agent harness list unchanged in substance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dd499aadd7624c3a809f03c421cb642d3c32104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->