### PR TITLE
Add Daybreak Blue Codex support

### DIFF
--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -886,6 +886,14 @@ fn default_providers_config() -> ProvidersConfig {
                         ),
                     },
                     ProviderModel {
+                        id: "gpt-daybreak-blue-latest".to_string(),
+                        name: "Daybreak Blue".to_string(),
+                        description: Some(
+                            "Frontier model for approved defensive cybersecurity work; requires Daybreak access"
+                                .to_string(),
+                        ),
+                    },
+                    ProviderModel {
                         id: "gpt-5.6-terra".to_string(),
                         name: "GPT-5.6 Terra".to_string(),
                         description: Some(
@@ -2604,22 +2612,7 @@ pub async fn list_backend_model_options(
     // a new slug starts working as soon as the backend recognizes it
     // — there is no hard dependency on the CLI's embedded catalog
     // being up-to-date.
-    let codex_filter: &dyn Fn(&str) -> bool = &|id: &str| {
-        id.contains("codex")
-            || matches!(
-                id,
-                "gpt-5.5"
-                    | "gpt-5.6"
-                    | "gpt-5.6-sol"
-                    | "gpt-5.6-terra"
-                    | "gpt-5.6-luna"
-                    | "gpt-5.5-pro"
-                    | "gpt-5.4"
-                    | "gpt-5.4-pro"
-                    | "gpt-5.4-mini"
-                    | "gpt-5.4-nano"
-            )
-    };
+    let codex_filter: &dyn Fn(&str) -> bool = &|id: &str| is_codex_backend_model_id(id);
     push_options("codex", Some(&["openai"]), false, Some(codex_filter));
     push_options("gemini", Some(&["google"]), false, None);
     push_options("opencode", None, true, None);
@@ -2888,6 +2881,24 @@ fn reject_known_unsupported_codex_model(model_id: &str) -> Result<(), String> {
         );
     }
     Ok(())
+}
+
+fn is_codex_backend_model_id(model_id: &str) -> bool {
+    model_id.contains("codex")
+        || matches!(
+            model_id,
+            "gpt-daybreak-blue-latest"
+                | "gpt-5.5"
+                | "gpt-5.6"
+                | "gpt-5.6-sol"
+                | "gpt-5.6-terra"
+                | "gpt-5.6-luna"
+                | "gpt-5.5-pro"
+                | "gpt-5.4"
+                | "gpt-5.4-pro"
+                | "gpt-5.4-mini"
+                | "gpt-5.4-nano"
+        )
 }
 
 fn is_grok_backend_model_id(model_id: &str) -> bool {
@@ -3162,6 +3173,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         for id in [
+            "gpt-daybreak-blue-latest",
             "gpt-5.6",
             "gpt-5.6-sol",
             "gpt-5.6-terra",
@@ -3182,6 +3194,12 @@ mod tests {
                 "bare/non-API slug should not be exposed: {invalid_id}"
             );
         }
+    }
+
+    #[test]
+    fn codex_catalog_accepts_daybreak_blue() {
+        assert!(is_codex_backend_model_id("gpt-daybreak-blue-latest"));
+        assert!(!is_codex_backend_model_id("gpt-daybreak-red-latest"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- add the verified `gpt-daybreak-blue-latest` slug to the OpenAI subscription catalog
- expose Daybreak Blue through the Codex backend model filter
- document that the model requires approved Daybreak access
- add regression coverage for catalog inclusion and Codex filtering

## Why

The connected `ben@starknet.id` ChatGPT OAuth account advertises Daybreak Blue through Codex's live model catalog. Raw overrides already reached the model, but Sandboxed.sh did not offer it as a first-class selectable Codex model.

## Validation

- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test api::providers::tests` (23 passed, 1 intentionally ignored)
- production smoke mission confirmed account pinning and model resolution; inference reached OpenAI but was rate-limited by the shared organization TPM pool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and picker-only changes in `providers.rs`; no auth, dispatch, or data-path changes beyond exposing an existing API slug.
> 
> **Overview**
> Adds **`gpt-daybreak-blue-latest`** (Daybreak Blue) as a first-class OpenAI subscription model in the default catalog, with copy that it is for approved defensive cybersecurity work and requires Daybreak access.
> 
> The Codex backend picker now treats that slug like the other explicit GPT-5 family IDs: the inline filter is replaced by shared **`is_codex_backend_model_id`**, which includes Daybreak Blue while still excluding unrelated slugs (e.g. `gpt-daybreak-red-latest`).
> 
> Tests cover default OpenAI catalog inclusion and Codex filter acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4261a8ceefd021d24f41f2cfbf0b77f84d7e45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->