### PR TITLE
fix(watchdog): never silently auto-kill operator/controller-launched missions

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -205,6 +205,19 @@ async fn pop_next_runnable_control_queue(
 /// CancelMission re-check to keep the two views of "stalled" consistent.
 pub(crate) const STUCK_SECONDS: u64 = 900;
 
+/// The effective stall threshold, overridable at runtime via
+/// `MISSION_STUCK_SECONDS` (clamped to >= 30s so a typo can't make the
+/// watchdog trigger-happy). An ops lever to widen the window for tracks that
+/// legitimately go quiet between tool calls (long scans/builds) without a
+/// redeploy.
+pub(crate) fn stuck_seconds() -> u64 {
+    std::env::var("MISSION_STUCK_SECONDS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&v| v >= 30)
+        .unwrap_or(STUCK_SECONDS)
+}
+
 /// Grace period after the user first opens an `AwaitingUser` mission before
 /// the ack-promotion tick auto-archives it to `Acknowledged` (Finished).
 /// Resets whenever the user sends a new message (status returns to Active and

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -236,7 +236,7 @@ pub(crate) async fn cleanup_stale_active_missions_once(
                 if cmd_tx
                     .send(ControlCommand::CancelMission {
                         mission_id: mission.id,
-                        min_idle: Some(std::time::Duration::from_secs(STUCK_SECONDS)),
+                        min_idle: Some(std::time::Duration::from_secs(stuck_seconds())),
                         respond: tx,
                     })
                     .await
@@ -337,7 +337,7 @@ pub(crate) async fn ack_promotion_loop(
 }
 
 fn inactivity_is_cancellable(seconds_since_activity: u64, tool_call_in_flight: bool) -> bool {
-    seconds_since_activity >= STUCK_SECONDS
+    seconds_since_activity >= stuck_seconds()
         && (!tool_call_in_flight || seconds_since_activity >= TOOL_CALL_STALL_GRACE_SECS)
 }
 
@@ -459,7 +459,7 @@ pub(crate) async fn stuck_mission_watchdog_loop(
         // threshold. Cancel via the actor (clean shutdown) and mark
         // the row Interrupted.
         for info in &running_list {
-            if info.seconds_since_activity < STUCK_SECONDS {
+            if info.seconds_since_activity < stuck_seconds() {
                 continue;
             }
             let is_chatgpt_ui = info.backend_id.as_deref() == Some("chatgpt_ui");
@@ -517,6 +517,27 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 );
                 continue;
             }
+            // Never silently auto-kill a mission an operator/controller launched
+            // through a control session (`origin == "hermes"` with an
+            // `origin_session_id`). A slow scan/build looks idle but is the
+            // operator's work; killing it out from under a "launch these
+            // missions" request is exactly the confusion we're removing. Skip
+            // the kill and log — Phase 1 routes a rich alert to the owning
+            // controller session so a human/controller can decide, and Phase 2b
+            // will re-narrow this to operator-vs-cron. Dashboard/API-direct
+            // missions (`origin == None`) keep the watchdog protection.
+            if let Ok(Some(mission)) = mission_store.get_mission(info.mission_id).await {
+                if mission.origin.as_deref() == Some("hermes")
+                    && mission.origin_session_id.is_some()
+                {
+                    tracing::warn!(
+                        mission_id = %info.mission_id,
+                        seconds_since_activity = info.seconds_since_activity,
+                        "Stuck-mission watchdog: control-session-launched mission idle past threshold — NOT auto-killing (operator/controller owns it)"
+                    );
+                    continue;
+                }
+            }
             tracing::warn!(
                 "Stuck-mission watchdog: cancelling {} after {}s of inactivity",
                 info.mission_id,
@@ -526,7 +547,7 @@ pub(crate) async fn stuck_mission_watchdog_loop(
             let cancelled = if cmd_tx
                 .send(ControlCommand::CancelMission {
                     mission_id: info.mission_id,
-                    min_idle: Some(std::time::Duration::from_secs(STUCK_SECONDS)),
+                    min_idle: Some(std::time::Duration::from_secs(stuck_seconds())),
                     respond: cancel_tx,
                 })
                 .await


### PR DESCRIPTION
**Phase 0a — the urgent bleeding-stopper.**

The stuck-mission watchdog (`supervision.rs`) cancelled any mission inactive ≥ `STUCK_SECONDS` (900s), no exemption for operator-launched work → a slow scan/build the operator asked for got `force_killed_after_cancel_timeout`. Root cause of 'scanner tué par un cron/superviseur'.

- **Exempt control-session-launched missions** (`origin=="hermes"` + `origin_session_id`, via a single `get_mission` lookup) from the silent auto-kill; log instead. Dashboard/API-direct missions keep protection.
- **`MISSION_STUCK_SECONDS`** env override (clamped ≥30s) — ops lever, no redeploy.

Follow-ups (in the plan): Phase 1 routes a rich alert to the owning controller session; Phase 2b re-narrows operator-vs-cron. `cargo build` + inactivity tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission supervision behavior (who gets auto-cancelled and when), which can leave long-idle control-session missions running but avoids killing legitimate operator work; env override misconfiguration could delay kills on other missions.
> 
> **Overview**
> **Phase 0a** stops the stuck-mission watchdog from **silently auto-killing** missions launched through a control session (`origin == "hermes"` with `origin_session_id`). Those runs can look idle during long scans or builds but are operator-owned; the watchdog now **logs and skips** cancellation while dashboard/API-direct missions keep the same protection.
> 
> All stall checks and `CancelMission` `min_idle` values that used the fixed **900s** constant now call **`stuck_seconds()`**, which honors **`MISSION_STUCK_SECONDS`** at runtime (parsed, clamped to **≥ 30s**, default unchanged) so ops can widen the window without redeploying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aad0741e7261d67b21ef48fbe159db7d0404d92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->