### PR TITLE
fix(projects): humanize a project's fallback name (no raw slugs in the UI)

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -894,6 +894,23 @@ fn store_update(
     }
 }
 
+/// Turn a slug into a readable fallback name: `ec-defensive-research` ->
+/// `Ec Defensive Research`. Used only when the roster carries no explicit
+/// title, so a raw slug never leaks into a notification or a board row.
+pub(crate) fn humanize_slug(slug: &str) -> String {
+    slug.split(['-', '_'])
+        .filter(|w| !w.is_empty())
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 struct ProjectRowBuilder {
     slug: String,
     /// Roster title/next-action, attached when the slug has a roster record.
@@ -1113,9 +1130,18 @@ impl ProjectRowBuilder {
                 })
         });
 
+        // Never let a surface fall back to the raw lowercase-hyphenated slug
+        // ("ec-security"): when the roster carries no title, present a
+        // humanized slug ("Ec Security") so notifications/board rows always
+        // read as a name. (A project's true display title still wins when set.)
+        let title = self
+            .title
+            .clone()
+            .or_else(|| Some(humanize_slug(&self.slug)));
+
         ProjectRow {
             slug: self.slug,
-            title: self.title,
+            title,
             next_action: self.next_action,
             bucket,
             board_override: forced.map(str::to_string),
@@ -1623,6 +1649,18 @@ fn parse_delivery(session_id: &str, timestamp: f64, content: &str) -> DeliveryUp
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn humanize_slug_makes_a_readable_name() {
+        assert_eq!(
+            humanize_slug("ec-defensive-research"),
+            "Ec Defensive Research"
+        );
+        assert_eq!(humanize_slug("coldcard"), "Coldcard");
+        assert_eq!(humanize_slug("minimax_m3_full263"), "Minimax M3 Full263");
+        assert_eq!(humanize_slug("verity-core"), "Verity Core");
+        assert_eq!(humanize_slug(""), "");
+    }
 
     const SAMPLE: &str = "[Cron delivery: Verity two-phase Fable/Codex progression]\n\
         Verity — BLOQUÉE PAR LE CONTROL PLANE\n\n\


### PR DESCRIPTION
**Phase 0b (code part).** When the roster carries no title, `ProjectRow.title` was None → every surface fell back to the raw slug (`ec-security`) instead of a name. Now presents a **humanized slug** (`Ec Defensive Research`) server-side; a real title still wins. Unit-tested.

The deeper 'wrong project name' (a mission tagged `ec-defensive-research` shown under the *Coldcard* project) is a **taxonomy/binding reconciliation** (data), tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c839a73e8a2df0e59c0d6274fe1c03094e40ed29. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->