### PR TITLE
docs: document multi-controller coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ system together:
 | Concept | What it is | Where it lives |
 |---|---|---|
 | **Project** | The durable unit of work (an audit, a paper, a benchmark). First-class object with a mode (`active` / `blocked` / `paused`), an autonomy **grant** (merge authority, budget, parallelism), **tracks**, and open **decisions**. | `projects.db` on the sandboxed.sh host, served at `/api/projects/*` |
-| **Controller** | A coordinator cron that wakes on a schedule, reads its control conversation + GitHub + the project state, and dispatches work. It drives exactly one project and reports back with structured status trailers. | Coordinator (e.g. a Hermes cron with the project MCP tools) |
-| **Conversation** *(control session)* | The durable Hermes chat thread; the one bound to a project is its **control conversation** — where you (or the controller) talk — where you (or the controller) talk. Continuations roll over, so it's addressed by route, not a frozen ID. | Coordinator, binding stored in `projects.db` |
+| **Controller** | A coordinator cron that wakes on a schedule, reads its control conversation + GitHub + the project state, and dispatches work. Each controller owns its project(s) and reports structured status trailers; it can also launch missions on *another* project when it depends on that project's output (see [Coordination between controllers](docs/CONTROLLERS.md#coordination-between-controllers)). | Coordinator (e.g. a Hermes cron with the project MCP tools) |
+| **Conversation** *(control session)* | The durable Hermes chat thread; the one bound to a project is its **control conversation** — where you (or the controller) talk. Continuations roll over, so it's addressed by route, not a frozen ID. | Coordinator, binding stored in `projects.db` |
 | **Mission** | One unit of autonomous execution: an agent in an isolated workspace/container running a harness (Claude Code, Codex, …) that writes code, runs builds, opens PRs. Tagged with `project`/`track`. | sandboxed.sh workspaces |
 
 ```

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -135,6 +135,46 @@ Si un contrôleur ticque `ok` mais que rien ne bouge, la question à poser est
 qu'il doit signaler lui-même ; `blocked` avec un `wait=` qui grimpe veut dire que
 le contournement a échoué et que l'escalade arrive.
 
+## Coordination between controllers
+
+Plusieurs contrôleurs tournent en parallèle, un (ou plusieurs) par projet, chacun
+sur sa propre session de contrôle. Ils **ne se parlent pas directement** (pas de
+chat session-à-session). La coordination est **décentralisée**, par trois canaux :
+
+1. **Le substrat git (producteur / consommateur).** Un projet qui *produit* (ex.
+   Verity merge ses features de langage dans son repo) et un projet qui *consomme*
+   (ex. Lido re-pin sa dépendance sur le HEAD de Verity) se coordonnent en lisant
+   l'état git de l'autre. Le consommateur observe le repo du producteur et re-pin
+   quand il avance — aucune tâche explicite à s'envoyer.
+2. **Lancement de missions cross-projet.** Une session de contrôle peut
+   `start_mission` sur un *autre* projet quand elle a besoin de son output : la
+   mission porte alors l'`origin_session_id` du demandeur mais le `project` tag de
+   la cible. C'est ainsi qu'un contrôleur ajoute une tâche au périmètre d'un autre.
+3. **La DB de missions partagée.** Tous les contrôleurs voient toutes les missions
+   via les outils MCP (`list_missions`, `get_mission_health`, `list_projects`) —
+   visibilité mutuelle, pas de vue privée par contrôleur.
+
+**Évitement de conflit** (il n'y a pas de verrou global unique) :
+
+- **Propriété distincte** : chaque projet a son périmètre ; le pont
+  « consommer X » est un projet dédié (ex. `verity-lido`), pas une intrusion dans
+  le projet producteur.
+- **Verrou de campagne** : une seconde mission de campagne sur le même projet est
+  refusée (`409`) tant que la première n'est pas terminée — empêche le doublon.
+- **Gates de soundness / revue exact-head** : sur les repos formels, aucun merge
+  ne passe sans sa revue exact-head (receipts rejouables, head exact, zéro
+  `sorry`/`admit`), ce qui rattrape un travail concurrent divergent au merge.
+
+**Coordinateur central optionnel — le fleet-orchestrator.** Un daemon (état dans
+`~/.hermes/fleet/state.json`) peut, quand il tourne, ajouter une garde
+*anti-sur-souscription* (signal `OVER_SUBSCRIPTION` quand plus de missions actives
+que `max_parallel_missions`) et une dédup des signaux au-dessus des canaux
+ci-dessus. **Il est optionnel** : sans lui, la coordination reste correcte
+(canaux 1–3 + verrous), mais il n'y a plus de garde centrale de dédup/débit — à
+forte charge, surveiller le travail redondant (plusieurs sessions lançant des
+missions sur le même projet) via `list_active_missions`. Vérifier qu'il tourne :
+`daemon_last_seen` dans `state.json` doit être récent.
+
 ## Références
 
 - Le contrat complet : `skills/controllers-policy/SKILL.md` sur agent-core.


### PR DESCRIPTION
Audited the prod coordination model (prompted by 'how do the Verity and Lido controllers coordinate / avoid conflict?'). The docs only described single-controller ops and said a controller drives 'exactly one project'. Adds a **Coordination between controllers** section to `docs/CONTROLLERS.md`: the 3 decentralized channels (git producer/consumer re-pin, cross-project mission launch, shared mission DB), the conflict-avoidance (distinct ownership, campaign 409 lock, exact-head soundness gates), and the **optional fleet-orchestrator daemon** (over-subscription guard) + how to check it's live. Corrects the README controller row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 57d57a1eaed728e0b775df91285720a0dc0f45f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->