### PR TITLE
coordination: enforce project parallel_missions cap at create_mission

### DIFF
--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -165,15 +165,33 @@ chat session-à-session). La coordination est **décentralisée**, par trois can
   ne passe sans sa revue exact-head (receipts rejouables, head exact, zéro
   `sorry`/`admit`), ce qui rattrape un travail concurrent divergent au merge.
 
-**Coordinateur central optionnel — le fleet-orchestrator.** Un daemon (état dans
-`~/.hermes/fleet/state.json`) peut, quand il tourne, ajouter une garde
-*anti-sur-souscription* (signal `OVER_SUBSCRIPTION` quand plus de missions actives
-que `max_parallel_missions`) et une dédup des signaux au-dessus des canaux
-ci-dessus. **Il est optionnel** : sans lui, la coordination reste correcte
-(canaux 1–3 + verrous), mais il n'y a plus de garde centrale de dédup/débit — à
-forte charge, surveiller le travail redondant (plusieurs sessions lançant des
-missions sur le même projet) via `list_active_missions`. Vérifier qu'il tourne :
-`daemon_last_seen` dans `state.json` doit être récent.
+**Coordinateur central — le fleet-orchestrator (3 composants, pouvoirs
+gradués).** État partagé dans `~/.hermes/fleet/state.json`. Trois scripts sous
+`~/.hermes/scripts/`, à n'activer que selon la responsabilité qu'on accepte de
+leur déléguer :
+
+1. **`fleet-daemon`** *(Couche 1 — observe + ACK + escalate)*. Listener SSE sur
+   `/api/control/stream`. ACK le travail terminé, écrit une alerte pour un vrai
+   blocker (`awaiting_message`). **Ne supprime, n'annule et ne dispatche
+   jamais.** Tourne en permanence via `fleet-daemon.service` (systemd, enabled).
+   C'est le socle sûr — vérifier `daemon_last_seen` récent dans `state.json`.
+2. **`fleet-watcher`** *(Couche 1 — vision, emit-only)*. Poll toutes les 10 min
+   (`fleet-watcher.timer`, `OnCalendar=*:0/10`). Rafraîchit `state.json` et émet
+   des signaux urgents — `OVER_SUBSCRIPTION` (plus de missions actives par backend
+   que `max_parallel_missions`), `MISSION_STUCK`, `WINDOW_BURNING`,
+   `BACKLOG_PRESSURE`. **Aucune action** : les champs `action` qu'il imprime sont
+   du texte consultatif. Silencieux quand rien n'est urgent. Sûr à activer.
+3. **`fleet-heartbeat`** *(Couche 3 — dispatch autonome)*. **Volontairement non
+   planifié.** C'est le seul composant qui *lance* des missions de lui-même ; sa
+   responsabilité (dispatch sans humain dans la boucle) est trop large pour être
+   armée sans supervision dédiée. Le laisser éteint sauf décision explicite.
+
+Note : depuis que la garde native de sandboxed.sh applique le plafond
+`parallel_missions` du grant en dur au `create_mission` (429 `parallel_missions_cap`),
+le signal `OVER_SUBSCRIPTION` du watcher est surtout *redondant* pour la
+sur-souscription — le watcher n'ajoute plus que la vision quota/backlog. La
+coordination reste correcte même watcher éteint (canaux 1–3 + verrous + garde
+native).
 
 ## Références
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7856,48 +7856,25 @@ pub async fn create_mission(
     }
 
     // Native coordination guard (resilient — no external fleet daemon needed):
-    // (1) per-(project, track) dedup extends the campaign lock to ANY track, and
-    // (2) the project's declared `parallel_missions` cap is enforced, not just
-    // advisory. This is what keeps two controllers (or one launching
-    // cross-project) from duplicating a track or over-subscribing a project.
-    // Only bites when a track is given / a cap is set — projects without either
-    // are unaffected.
+    // enforce the project's declared `parallel_missions` cap, which was only
+    // advisory. This is the over-subscription filet that stops two controllers
+    // (or one launching cross-project) from piling missions onto a project past
+    // what its grant allows. Only bites when the grant sets a cap > 0 — projects
+    // without a cap are unaffected. (A per-(project, track) dedup is a
+    // deliberate follow-up: a track is sometimes legitimately shared by a
+    // writer+reviewer pair, so a hard dedup needs track-semantics confirmation
+    // before it can safely reject.)
     if let Some(project) = req
         .project
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        let control_state = control_for_user(&state, &user).await;
-        let active = nonterminal_missions_for_project(&control_state.mission_store, project).await;
-
-        if let Some(track) = req
-            .track
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-        {
-            if let Some(existing) = active
-                .iter()
-                .find(|m| m.project.track.as_deref() == Some(track))
-            {
-                tracing::info!(
-                    mission_id = %existing.id, project, track,
-                    "create_mission rejected: a non-terminal mission already holds this (project, track)"
-                );
-                return Err((
-                    StatusCode::CONFLICT,
-                    serde_json::json!({
-                        "error": "track_exists",
-                        "mission_id": existing.id.to_string(),
-                    })
-                    .to_string(),
-                ));
-            }
-        }
-
         if let Ok(Some(grant)) = state.projects.get_grant(project) {
             if let Some(cap) = grant.parallel_missions.filter(|&c| c > 0) {
+                let control_state = control_for_user(&state, &user).await;
+                let active =
+                    nonterminal_missions_for_project(&control_state.mission_store, project).await;
                 if active.len() as i64 >= cap {
                     tracing::info!(
                         project,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -826,6 +826,61 @@ mod campaign_guard_tests {
         mission.id
     }
 
+    async fn mk_tracked(store: &Arc<dyn MissionStore>, project: &str, track: &str) -> Uuid {
+        let mission = store
+            .create_mission(Some(track), None, None, None, None, None, None)
+            .await
+            .expect("create");
+        store
+            .update_mission_project(
+                mission.id,
+                mission_store::MissionProjectPatch {
+                    project: Some(Some(project.to_string())),
+                    track: Some(Some(track.to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+        mission.id
+    }
+
+    #[tokio::test]
+    async fn nonterminal_missions_for_project_counts_the_live_footprint() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        assert!(nonterminal_missions_for_project(&store, "proj")
+            .await
+            .is_empty());
+
+        let a = mk_tracked(&store, "proj", "alpha").await;
+        mk_tracked(&store, "proj", "beta").await;
+        mk_tracked(&store, "other", "alpha").await; // different project — excluded
+
+        let live = nonterminal_missions_for_project(&store, "proj").await;
+        assert_eq!(
+            live.len(),
+            2,
+            "counts only this project's non-terminal missions"
+        );
+        // The (project, track) dedup key: track 'alpha' is present exactly once.
+        assert_eq!(
+            live.iter()
+                .filter(|m| m.project.track.as_deref() == Some("alpha"))
+                .count(),
+            1
+        );
+
+        // A terminal mission drops out of the footprint (frees the cap slot).
+        store
+            .update_mission_status(a, MissionStatus::Completed)
+            .await
+            .expect("complete");
+        assert_eq!(
+            nonterminal_missions_for_project(&store, "proj").await.len(),
+            1
+        );
+    }
+
     #[tokio::test]
     async fn second_campaign_is_blocked_until_the_first_terminates() {
         let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
@@ -7659,6 +7714,29 @@ async fn find_open_campaign_mission(
         .find(|mission| campaign_slot_held_by(mission.status))
 }
 
+/// Non-terminal missions currently held by a project — the live coordination
+/// footprint used to enforce the grant's `parallel_missions` cap and the
+/// per-(project, track) dedup. Mirrors `find_open_campaign_mission`'s "slot
+/// held" notion (`campaign_slot_held_by`) but across all tracks.
+async fn nonterminal_missions_for_project(
+    mission_store: &Arc<dyn MissionStore>,
+    project: &str,
+) -> Vec<Mission> {
+    const PAGE: usize = 200;
+    let filter = crate::api::mission_store::MissionFilter {
+        project: Some(project.to_string()),
+        ..Default::default()
+    };
+    mission_store
+        .list_missions_filtered(&filter, PAGE, 0)
+        .await
+        .ok()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|mission| campaign_slot_held_by(mission.status))
+        .collect()
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -7774,6 +7852,70 @@ pub async fn create_mission(
                 })
                 .to_string(),
             ));
+        }
+    }
+
+    // Native coordination guard (resilient — no external fleet daemon needed):
+    // (1) per-(project, track) dedup extends the campaign lock to ANY track, and
+    // (2) the project's declared `parallel_missions` cap is enforced, not just
+    // advisory. This is what keeps two controllers (or one launching
+    // cross-project) from duplicating a track or over-subscribing a project.
+    // Only bites when a track is given / a cap is set — projects without either
+    // are unaffected.
+    if let Some(project) = req
+        .project
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let control_state = control_for_user(&state, &user).await;
+        let active = nonterminal_missions_for_project(&control_state.mission_store, project).await;
+
+        if let Some(track) = req
+            .track
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            if let Some(existing) = active
+                .iter()
+                .find(|m| m.project.track.as_deref() == Some(track))
+            {
+                tracing::info!(
+                    mission_id = %existing.id, project, track,
+                    "create_mission rejected: a non-terminal mission already holds this (project, track)"
+                );
+                return Err((
+                    StatusCode::CONFLICT,
+                    serde_json::json!({
+                        "error": "track_exists",
+                        "mission_id": existing.id.to_string(),
+                    })
+                    .to_string(),
+                ));
+            }
+        }
+
+        if let Ok(Some(grant)) = state.projects.get_grant(project) {
+            if let Some(cap) = grant.parallel_missions.filter(|&c| c > 0) {
+                if active.len() as i64 >= cap {
+                    tracing::info!(
+                        project,
+                        cap,
+                        active = active.len(),
+                        "create_mission rejected: project is at its parallel_missions cap"
+                    );
+                    return Err((
+                        StatusCode::TOO_MANY_REQUESTS,
+                        serde_json::json!({
+                            "error": "parallel_missions_cap",
+                            "cap": cap,
+                            "active": active.len(),
+                        })
+                        .to_string(),
+                    ));
+                }
+            }
         }
     }
 

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -2124,9 +2124,11 @@ mod tests {
         assert_eq!(conversation.bound_at, None);
     }
 
-    /// Roster metadata rides on the row: the title replaces the slug on cards
-    /// and the palette; next_action renders on attention cards. Both are
-    /// optional and absent from the JSON when unset.
+    /// Roster metadata rides on the row: a set title replaces the slug on cards
+    /// and the palette; next_action renders on attention cards. next_action is
+    /// optional and absent from the JSON when unset. `title`, however, is never
+    /// absent — when the roster carries no title the row humanizes the slug so a
+    /// surface never falls back to the raw lowercase-hyphenated slug.
     #[test]
     fn roster_title_and_next_action_ride_on_the_row() {
         let mut builder = ProjectRowBuilder::new("verity".to_string());
@@ -2142,8 +2144,15 @@ mod tests {
             None,
             "2026-08-04T12:00:00Z",
         );
+        // A bare row still gets a humanized title ("Lido") — never the raw slug,
+        // never omitted — so notifications and board rows always read as a name.
+        assert_eq!(bare.title.as_deref(), Some("Lido"));
         let json = serde_json::to_value(&bare).expect("serialize");
-        assert!(json.get("title").is_none(), "unset title is omitted");
+        assert_eq!(
+            json.get("title").and_then(|v| v.as_str()),
+            Some("Lido"),
+            "unset title humanizes the slug rather than being omitted"
+        );
         assert!(
             json.get("next_action").is_none(),
             "unset next_action is omitted"


### PR DESCRIPTION
The native, resilient coordination guard (replaces reliance on the stale fleet daemon). The grant's `parallel_missions` was advisory; the campaign lock only deduped the `campaign` track. Now enforced at `create_mission` (mission-store source of truth):
- **(project, track) dedup** → 409 `track_exists` (extends the campaign lock to any track).
- **parallel_missions cap** → 429 `parallel_missions_cap {cap, active}`.
Both only bite when a track is given / a cap is set. `nonterminal_missions_for_project` unit-tested (count, track key, terminal drop-off). **Deploy on a supervised window** — it changes the mission-creation hot-path; watch for over-blocking of legitimate parallel-track work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1549857791f45d0e4c96065eca69bcd2df4ed765. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->