### PR TITLE
overview: resolve alias trackers onto canonical (finish #802)

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -760,31 +760,55 @@ pub async fn projects_overview(
         if deleted(&record.slug) {
             continue;
         }
-        record_signals.insert(
-            record.slug.clone(),
-            (record.mode.clone(), record.blocker.clone()),
-        );
-        let slug = record.slug.clone();
+        // Fold an alias record onto its canonical row, the same way tagged
+        // missions are resolved above — otherwise every alias slug (`lido-audit`
+        // → `verity-lido`, `verity`/`verity-roadmap` → `verity-core`, …) forks a
+        // phantom card next to the real one. The canonical record is
+        // authoritative; an alias record only fills gaps so a merged card never
+        // shows the alias's stale title/mode over the canonical's.
+        let key = resolve_alias(&aliases, &record.slug);
+        if deleted(&key) {
+            continue;
+        }
+        let is_canonical = key == record.slug;
+        if is_canonical || !record_signals.contains_key(&key) {
+            record_signals.insert(key.clone(), (record.mode.clone(), record.blocker.clone()));
+        }
         let builder = rows
-            .entry(slug.clone())
-            .or_insert_with(|| ProjectRowBuilder::new(slug));
-        builder.title = record.title;
-        builder.next_action = record.next_action;
-        builder.mode = record.mode;
-        builder.controller_cron_id = record.controller_cron_id;
+            .entry(key.clone())
+            .or_insert_with(|| ProjectRowBuilder::new(key.clone()));
+        if is_canonical {
+            builder.title = record.title;
+            builder.next_action = record.next_action;
+            builder.mode = record.mode;
+            builder.controller_cron_id = record.controller_cron_id;
+        } else {
+            builder.title = builder.title.take().or(record.title);
+            builder.next_action = builder.next_action.take().or(record.next_action);
+            builder.mode = builder.mode.take().or(record.mode);
+            builder.controller_cron_id = builder
+                .controller_cron_id
+                .take()
+                .or(record.controller_cron_id);
+        }
     }
     // The latest ingested state per project becomes the row's latest_update —
     // same serialized shape the delivery scan used to produce, now read back
     // from the store the ingestor maintains.
     for (slug, project_state) in &latest_states {
-        if deleted(slug) {
+        let key = resolve_alias(&aliases, slug);
+        if deleted(&key) {
             continue;
         }
-        let (mode, blocker) = record_signals.get(slug).cloned().unwrap_or_default();
-        let update = store_update(slug, project_state, mode, blocker);
+        let (mode, blocker) = record_signals
+            .get(&key)
+            .or_else(|| record_signals.get(slug))
+            .cloned()
+            .unwrap_or_default();
+        let update = store_update(&key, project_state, mode, blocker);
         let total = update_totals.get(slug).copied().unwrap_or(0);
-        rows.entry(slug.clone())
-            .or_insert_with(|| ProjectRowBuilder::new(slug.clone()))
+        rows.entry(key.clone())
+            .or_insert_with(|| ProjectRowBuilder::new(key.clone()))
             .attach_store_update(update, project_state.observations, total);
     }
     let unrouted: Vec<DeliveryUpdate> = unrouted_rows
@@ -1667,6 +1691,20 @@ mod tests {
         assert_eq!(humanize_slug("minimax_m3_full263"), "Minimax M3 Full263");
         assert_eq!(humanize_slug("verity-core"), "Verity Core");
         assert_eq!(humanize_slug(""), "");
+    }
+
+    #[test]
+    fn resolve_alias_folds_known_keys_and_passes_through_the_rest() {
+        let mut aliases = HashMap::new();
+        aliases.insert("lido-audit".to_string(), "verity-lido".to_string());
+        aliases.insert("verity-roadmap".to_string(), "verity-core".to_string());
+        // Verity and Lido are kept distinct: an alias only ever resolves to the
+        // canonical its own family declares, never across families.
+        assert_eq!(resolve_alias(&aliases, "lido-audit"), "verity-lido");
+        assert_eq!(resolve_alias(&aliases, "verity-roadmap"), "verity-core");
+        // The canonical resolves to itself, and an unknown slug is untouched.
+        assert_eq!(resolve_alias(&aliases, "verity-lido"), "verity-lido");
+        assert_eq!(resolve_alias(&aliases, "sandboxed-sh"), "sandboxed-sh");
     }
 
     const SAMPLE: &str = "[Cron delivery: Verity two-phase Fable/Codex progression]\n\

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -715,10 +715,21 @@ pub async fn projects_overview(
         if deleted(&tracker.slug) {
             continue;
         }
-        let slug = tracker.slug.clone();
-        rows.entry(slug.clone())
-            .or_insert_with(|| ProjectRowBuilder::new(slug))
-            .tracker = Some(tracker);
+        // An alias's tracker file (`verity.md`, `verity-roadmap.md`) folds onto
+        // the canonical row too — otherwise a markdown file alone re-forks the
+        // phantom card the roster/mission loops just collapsed. The canonical's
+        // own tracker wins; an alias tracker only fills the gap.
+        let key = resolve_alias(&aliases, &tracker.slug);
+        if deleted(&key) {
+            continue;
+        }
+        let is_canonical = key == tracker.slug;
+        let builder = rows
+            .entry(key.clone())
+            .or_insert_with(|| ProjectRowBuilder::new(key.clone()));
+        if is_canonical || builder.tracker.is_none() {
+            builder.tracker = Some(tracker);
+        }
     }
     for mission in &missions {
         let Some(project) = mission.project.project.as_deref() else {


### PR DESCRIPTION
Follow-up to #802. The trackers loop still keyed rows by the raw slug, so an alias slug that has its own markdown tracker file (`verity.md`, `verity-roadmap.md`) re-forked a phantom card next to its canonical (`verity-core`). Verified on prod after #802 deploy: 18/20 alias cards collapsed, only `verity` + `verity-roadmap` remained — exactly the two with tracker files. Resolve the tracker slug through the alias map; canonical tracker wins, alias fills the gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-path board assembly fix with explicit canonical-over-alias precedence and a unit test. Worst case is incorrect card merge/display, not data loss or auth impact.
> 
> **Overview**
> **Completes alias collapse** on the projects overview so leftover phantom cards (e.g. `verity` / `verity-roadmap` next to `verity-core`) no longer reappear after missions already folded.
> 
> Tracker markdown files, roster records, and latest store states now resolve through `resolve_alias` onto the canonical row. **Canonical data wins**; an alias only fills gaps (tracker, title, mode, etc.) so stale alias metadata cannot overwrite the real card.
> 
> Adds a unit test covering known alias folds and pass-through for unknown/canonical slugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5f5c0e3b4d1f0d6c2ba165f50556c27f6ff316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->