### PR TITLE
overview: keep newest state per canonical when collapsing aliases

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -806,11 +806,28 @@ pub async fn projects_overview(
     // The latest ingested state per project becomes the row's latest_update —
     // same serialized shape the delivery scan used to produce, now read back
     // from the store the ingestor maintains.
+    //
+    // Collapse alias slugs onto their canonical FIRST, keeping only the newest
+    // state per canonical (last_seen_at is an ISO8601 string, so it sorts
+    // chronologically). `attach_store_update` is last-writer-wins, so without
+    // this a stale alias state (e.g. `lido-srv3` @ 08-03) clobbers the
+    // canonical's fresh one (`verity-lido` @ 08-12) and the card's
+    // latest_update goes backwards in time — which reads as "no updates".
+    let mut newest_state: HashMap<String, (&String, &super::projects_store::ProjectState)> =
+        HashMap::new();
     for (slug, project_state) in &latest_states {
         let key = resolve_alias(&aliases, slug);
         if deleted(&key) {
             continue;
         }
+        match newest_state.get(&key) {
+            Some((_, existing)) if existing.last_seen_at >= project_state.last_seen_at => {}
+            _ => {
+                newest_state.insert(key, (slug, project_state));
+            }
+        }
+    }
+    for (key, (slug, project_state)) in newest_state {
         let (mode, blocker) = record_signals
             .get(&key)
             .or_else(|| record_signals.get(slug))


### PR DESCRIPTION
Regression from #802/#803: `latest_states` resolves several alias slugs onto one canonical, and `attach_store_update` is last-writer-wins, so a stale alias state (`lido-srv3` @ 08-03) clobbered the canonical's fresh one (`verity-lido` @ 08-12). The Lido card's latest_update went **backwards in time** → operator saw 'no updates' despite hourly controller deliveries. Pre-aggregate by canonical keeping max `last_seen_at`, attach once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches projects overview `latest_update` selection, which drives freshness and attention on the operator board. Change is small and read-path only, but wrong selection previously made active projects look stale.
> 
> **Overview**
> **Fixes a regression** where collapsing alias slugs onto a canonical project could push `latest_update` *backwards in time*.
> 
> `attach_store_update` is last-writer-wins, so a stale alias state (e.g. `lido-srv3`) could overwrite a fresher canonical one (e.g. `verity-lido`). The overview now **pre-aggregates by canonical**, keeping only the newest state by `last_seen_at`, then attaches once — so cards keep the true latest update instead of appearing idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c37100fcdf95f35f337351ca1db157029849b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->