### PR TITLE
dashboard/ios: strip [CTRL:] control trailers at human render (D2)

### DIFF
--- a/dashboard/src/app/control/hermes-session-adapter.ts
+++ b/dashboard/src/app/control/hermes-session-adapter.ts
@@ -1,6 +1,6 @@
 import type { HermesMessage } from "@/lib/api";
 import type { HermesGatewayEvent } from "@/lib/hermes-gateway";
-import { stripStateSignature } from "@/lib/hermes-state-signature";
+import { stripHermesControlTrailers } from "@/lib/hermes-state-signature";
 import type { ChatItem } from "./events-reducer";
 
 /**
@@ -60,11 +60,10 @@ export function hermesHistoryToItems(messages: HermesMessage[]): ChatItem[] {
       message.id == null ? localId("hh") : `hermes-msg-${String(message.id)}`;
     const timestamp = parseTimestamp(message.timestamp);
     const rawContent = (message.content ?? "").trim();
-    // STATE_SIGNATURE trailers are controller routing metadata, not prose:
-    // strip them from conversational rows. Tool results keep the raw text —
-    // a tool output that legitimately ends with a signature (e.g. reading
-    // the tracker page) must not be truncated.
-    const content = stripStateSignature(rawContent).trim();
+    // Controller trailers are control-plane metadata, not prose: strip them
+    // from conversational rows. Tool results keep the raw text — a tool
+    // output that legitimately ends with a trailer must not be truncated.
+    const content = stripHermesControlTrailers(rawContent).trim();
 
     if (message.role === "user") {
       if (content) {
@@ -276,7 +275,7 @@ export class HermesLiveTranscript {
 
   private finalizeAssistant(finalText?: string) {
     this.finalizeThinking();
-    const text = stripStateSignature(finalText ?? this.streamText).trim();
+    const text = stripHermesControlTrailers(finalText ?? this.streamText).trim();
     const streamId = this.streamItemId;
     this.streamItemId = null;
     this.streamText = "";

--- a/dashboard/src/components/hermes/hermes-thread.tsx
+++ b/dashboard/src/components/hermes/hermes-thread.tsx
@@ -24,7 +24,7 @@ import {
   type HermesSession,
 } from "@/lib/api";
 import { LazyMarkdownContent } from "@/components/markdown-content";
-import { stripStateSignature } from "@/lib/hermes-state-signature";
+import { stripHermesControlTrailers } from "@/lib/hermes-state-signature";
 import { cn } from "@/lib/utils";
 
 /** One rendered row in the Hermes transcript. Tool/thinking rows are built
@@ -53,8 +53,8 @@ function persistedRows(messages: HermesMessage[]): ChatItem[] {
         ? localId("hist")
         : `persisted-${String(message.id)}`;
     if (message.role === "user" || message.role === "assistant") {
-      // STATE_SIGNATURE trailers are controller routing metadata, not prose.
-      const content = stripStateSignature(message.content ?? "").trim();
+      // Controller trailers are control-plane metadata, not prose.
+      const content = stripHermesControlTrailers(message.content ?? "").trim();
       if (content) rows.push({ id, role: message.role, content });
     } else if (message.role === "tool") {
       rows.push({
@@ -350,10 +350,10 @@ export function HermesThread({ className }: { className?: string }) {
           },
           onCompleted: (rawFinalContent) => {
             if (stale() || !rawFinalContent.trim()) return;
-            // The deltas may have streamed a STATE_SIGNATURE trailer into the
-            // bubble; the authoritative patch below erases it. A signature-only
-            // turn patches the bubble to empty rather than leaving metadata.
-            const finalContent = stripStateSignature(rawFinalContent).trim();
+            // Deltas may have streamed a control trailer into the bubble; the
+            // authoritative patch below erases it. A metadata-only turn patches
+            // the bubble to empty rather than leaving protocol details visible.
+            const finalContent = stripHermesControlTrailers(rawFinalContent).trim();
             if (!streamAssistantIdRef.current && !finalContent) return;
             // Authoritative turn text: replace the streamed bubble (deltas can
             // be lossy) or append if the turn produced no deltas.

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -1160,7 +1160,11 @@ function bodyWithoutHeadline(body: string, headline: string): string {
     .slice(index)
     .filter((line) => {
       const trimmed = line.trim();
-      return trimmed !== "[SILENT]" && !trimmed.startsWith("[STATE_SIGNATURE:");
+      return (
+        trimmed !== "[SILENT]" &&
+        !trimmed.startsWith("[STATE_SIGNATURE:") &&
+        !trimmed.startsWith("[CTRL:")
+      );
     })
     .join("\n");
 }

--- a/dashboard/src/lib/hermes-state-signature.test.ts
+++ b/dashboard/src/lib/hermes-state-signature.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractStateSignatureKey,
   stateSignatureKeyFromMessages,
+  stripHermesControlTrailers,
   stripStateSignature,
 } from "./hermes-state-signature";
 
@@ -18,6 +19,26 @@ describe("stripStateSignature", () => {
   it("removes stacked trailing signatures", () => {
     const body = `Done.\n\n[STATE_SIGNATURE: a|b]\n[STATE_SIGNATURE: c|d]\n`;
     expect(stripStateSignature(body)).toBe("Done.");
+  });
+
+  it("removes a trailing CTRL status trailer", () => {
+    const body =
+      "Formal repair is active.\n\n[CTRL: lean-silicon | mode=active | wait=0 | next=repair reachability]";
+    expect(stripHermesControlTrailers(body)).toBe("Formal repair is active.");
+  });
+
+  it("removes mixed control trailers in either order", () => {
+    expect(
+      stripHermesControlTrailers(`Done.\n${SIGNATURE}\n[CTRL: lean-silicon | mode=active]`),
+    ).toBe("Done.");
+    expect(
+      stripHermesControlTrailers(`Done.\n[CTRL: lean-silicon | mode=active]\n${SIGNATURE}`),
+    ).toBe("Done.");
+  });
+
+  it("leaves CTRL metadata quoted mid-message intact", () => {
+    const body = "The old format was [CTRL: project | mode=active] in reports.";
+    expect(stripHermesControlTrailers(body)).toBe(body);
   });
 
   it("leaves a signature quoted mid-message intact", () => {

--- a/dashboard/src/lib/hermes-state-signature.ts
+++ b/dashboard/src/lib/hermes-state-signature.ts
@@ -1,8 +1,9 @@
 /**
- * Hermes controller sessions (crons especially) end their replies with a
- * machine-readable trailer the projects board uses for routing:
+ * Hermes controller sessions (crons especially) can end their replies with
+ * machine-readable trailers the projects board uses for routing and health:
  *
  *   [STATE_SIGNATURE: lean-silicon|phase-c-bridges|7a1c0aab/…|external-ci-wait]
+ *   [CTRL: lean-silicon | mode=active | wait=0 | next=certify]
  *
  * The first field is the controller's routing key (project slug). The trailer
  * is control-plane metadata, not prose — transcripts shown to a human must
@@ -11,21 +12,25 @@
  * cron_bef…").
  */
 
-// A trailer at the very END of a message, tolerating trailing whitespace.
-// `[^\]]` (not `.`) so a signature spanning lines still matches.
-const TRAILING_SIGNATURE_RE = /\s*\[STATE_SIGNATURE:[^\]]*\]\s*$/;
+// A control-plane trailer at the very END of a message, tolerating trailing
+// whitespace. `[^\]]` (not `.`) allows a trailer spanning lines.
+const TRAILING_CONTROL_TRAILER_RE =
+  /\s*\[(?:STATE_SIGNATURE|CTRL):[^\]]*\]\s*$/;
 
 const SIGNATURE_KEY_RE = /\[STATE_SIGNATURE:\s*([^|\]]+)/g;
 
-/** Remove trailing `[STATE_SIGNATURE: …]` trailer(s) from a message body.
- * Only trailers are stripped — a signature quoted mid-text stays intact. */
-export function stripStateSignature(content: string): string {
+/** Remove trailing Hermes control-plane trailer(s) from a message body.
+ * Only trailers are stripped — metadata quoted mid-text stays intact. */
+export function stripHermesControlTrailers(content: string): string {
   let out = content;
-  while (TRAILING_SIGNATURE_RE.test(out)) {
-    out = out.replace(TRAILING_SIGNATURE_RE, "");
+  while (TRAILING_CONTROL_TRAILER_RE.test(out)) {
+    out = out.replace(TRAILING_CONTROL_TRAILER_RE, "");
   }
   return out;
 }
+
+/** Backward-compatible name for callers outside the dashboard bundle. */
+export const stripStateSignature = stripHermesControlTrailers;
 
 /** Routing key (first `|`-separated field) of the LAST state signature in a
  * body, or null when the body carries none. */

--- a/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/HermesConversationView.swift
@@ -470,7 +470,11 @@ struct HermesConversationView: View {
     /// Close the in-flight assistant bubble (if any) so later rows append after it.
     private func flushAssistantBubble() {
         finalizeThinking()
+        streamText = HermesTranscript.strippingControlTrailers(from: streamText)
         guard !streamText.isEmpty else {
+            if let streamId {
+                messages.removeAll { $0.id == streamId }
+            }
             streamId = nil
             return
         }
@@ -538,6 +542,18 @@ struct HermesConversationView: View {
 
 /// Maps persisted Hermes messages onto the shared `ChatMessage` model.
 enum HermesTranscript {
+    /// Hermes controller status/routing trailers are persisted with assistant
+    /// prose for the projects board, but are not part of the human transcript.
+    /// Strip only complete trailers at the end so quoted examples remain.
+    static func strippingControlTrailers(from content: String) -> String {
+        var output = content
+        let pattern = #"\s*\[(?:STATE_SIGNATURE|CTRL):[^\]]*\]\s*$"#
+        while let range = output.range(of: pattern, options: .regularExpression) {
+            output.removeSubrange(range)
+        }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     static func chatMessages(from history: [HermesMessage]) -> [ChatMessage] {
         var result: [ChatMessage] = []
         // Assistant tool_calls create the bubble; the later `tool` role message
@@ -556,6 +572,7 @@ enum HermesTranscript {
                         id: message.id, type: .user, content: content, timestamp: timestamp))
 
             case "assistant":
+                let visibleContent = strippingControlTrailers(from: content)
                 if let reasoning = message.reasoningText {
                     result.append(
                         ChatMessage(
@@ -566,14 +583,14 @@ enum HermesTranscript {
                         )
                     )
                 }
-                if !content.isEmpty {
+                if !visibleContent.isEmpty {
                     result.append(
                         ChatMessage(
                             id: message.id,
                             type: .assistant(
                                 success: true, costCents: 0, costSource: .unknown,
                                 model: nil, sharedFiles: nil),
-                            content: content,
+                            content: visibleContent,
                             timestamp: timestamp
                         )
                     )

--- a/ios_dashboard/SandboxedDashboardTests/HermesConversationTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/HermesConversationTests.swift
@@ -107,6 +107,30 @@ final class HermesConversationTests: XCTestCase {
         XCTAssertTrue(items.isEmpty)
     }
 
+    func testControllerTrailersAreHiddenFromAssistantHistory() {
+        let report = """
+            Formal repair is active.
+
+            [STATE_SIGNATURE: lean-silicon|formal|ff0f265b]
+            [CTRL: lean-silicon | mode=active | wait=0 | next=repair reachability]
+            """
+        let items = HermesTranscript.chatMessages(from: [
+            makeMessage(id: 1, role: "assistant", content: report)
+        ])
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].content, "Formal repair is active.")
+    }
+
+    func testQuotedControllerTrailerRemainsVisible() {
+        let prose = "The format is [CTRL: project | mode=active] in old reports."
+        let items = HermesTranscript.chatMessages(from: [
+            makeMessage(id: 1, role: "assistant", content: prose)
+        ])
+
+        XCTAssertEqual(items.first?.content, prose)
+    }
+
     func testToolResultIsFoldedIntoItsCall() throws {
         let history = [
             makeMessage(


### PR DESCRIPTION
Controller cron deliveries carry machine-readable trailers ([STATE_SIGNATURE: …], [CTRL: … | mode=… | next=…]) that the projects board ingests for routing/health but must never show to a human. The desktop/iOS conversation was rendering them verbatim (illegible flood).

- `hermes-state-signature.ts`: `stripStateSignature` -> `stripHermesControlTrailers` (now also strips trailing `[CTRL: …]`); back-compat alias + tests (13 green).
- render callers (hermes-thread, projects-board, hermes-session-adapter) use the new stripper.
- iOS `HermesConversationView.strippingControlTrailers()` mirror + empty-bubble removal + tests.

Raw transcript still reaches the ingestor; only complete END trailers stripped, quoted mid-text preserved. Part of the controller delivery-hygiene set (D1/D3 shipped to hermes gateway).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer filtering only; persisted messages and routing extraction are unchanged, with regression tests on both platforms.
> 
> **Overview**
> **Hides controller `[CTRL: …]` trailers** in human-facing Hermes transcripts alongside existing `[STATE_SIGNATURE: …]` handling, so cron/controller deliveries no longer show routing/health metadata in chat.
> 
> The shared helper in `hermes-state-signature.ts` is generalized to **`stripHermesControlTrailers`** (stacked end-of-message `[STATE_SIGNATURE:…]` and `[CTRL:…]` removed; mid-message quotes unchanged). **`stripStateSignature`** remains as an alias. Call sites move to the new name in **control** (`hermes-session-adapter`), **Hermes thread**, and **projects board** update bodies (line filter for `[CTRL:`).
> 
> **iOS** adds matching `HermesTranscript.strippingControlTrailers` for history and live flush, drops empty assistant bubbles after strip, with unit tests mirroring the web behavior.
> 
> **Tests** on the dashboard cover mixed trailer order and quoted `[CTRL:` preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec34147f2de882337bc0dd916fdc7f81e34f145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->