### PR TITLE
providers: add Grok 4.6 (xAI) support (D4)

### DIFF
--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -96,6 +96,7 @@ const OPENROUTER_SEED_MODEL_IDS: &[&str] = &[
 /// backend only offers canonical IDs documented for Grok Build. Actual access
 /// remains account/region-dependent and is diagnosed by the CLI at runtime.
 const GROK_CLI_TEXT_MODEL_IDS: &[&str] = &[
+    "grok-4.6",
     "grok-4.5",
     "grok-build-0.1",
     "grok-4.3",
@@ -1035,9 +1036,19 @@ fn default_providers_config() -> ProvidersConfig {
                 description: "Grok models via xAI API key".to_string(),
                 models: vec![
                     ProviderModel {
+                        id: "grok-4.6".to_string(),
+                        name: "Grok 4.6".to_string(),
+                        description: Some("Latest flagship Grok model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "grok-4.6-latest".to_string(),
+                        name: "Grok 4.6 (Latest)".to_string(),
+                        description: Some("Rolling alias for Grok 4.6".to_string()),
+                    },
+                    ProviderModel {
                         id: "grok-4.5".to_string(),
                         name: "Grok 4.5".to_string(),
-                        description: Some("Latest flagship Grok model".to_string()),
+                        description: Some("Previous flagship Grok model".to_string()),
                     },
                     ProviderModel {
                         id: "grok-4.5-latest".to_string(),

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -262,6 +262,13 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         pricing: pricing(75, 300, None, None),
     },
     PricingEntry {
+        // grok-4.6 list price not yet published separately; mirrors grok-4.5
+        // ($2/$6 per Mtok, $0.5 cached) until xAI publishes it.
+        canonical: "grok-4.6",
+        aliases: &["grok-4.6", "grok-4.6-latest"],
+        pricing: pricing(2_000, 6_000, None, Some(500)),
+    },
+    PricingEntry {
         canonical: "grok-4.5",
         aliases: &["grok-4.5", "grok-4.5-latest", "grok-build-latest"],
         pricing: pricing(2_000, 6_000, None, Some(500)),
@@ -618,6 +625,8 @@ mod tests {
         assert_eq!(normalize_model("gemini-3-pro-preview"), "gemini-3-pro");
         assert_eq!(normalize_model("grok-4-fast-reasoning"), "grok-4-fast");
         assert_eq!(normalize_model("xAI/Grok Inference"), "grok-4-fast");
+        assert_eq!(normalize_model("xai/grok-4.6"), "grok-4.6");
+        assert_eq!(normalize_model("xai/grok-4.6-latest"), "grok-4.6");
         assert_eq!(normalize_model("xai/grok-4.5"), "grok-4.5");
         assert_eq!(normalize_model("xai/grok-4.5-latest"), "grok-4.5");
         assert_eq!(normalize_model("xai/grok-build-latest"), "grok-4.5");
@@ -660,6 +669,8 @@ mod tests {
         assert!(pricing_for_model("gemini-3-flash-preview").is_some());
         assert!(pricing_for_model("grok-4-fast").is_some());
         assert!(pricing_for_model("xAI/Grok Inference").is_some());
+        assert!(pricing_for_model("xai/grok-4.6").is_some());
+        assert!(pricing_for_model("xai/grok-4.6-latest").is_some());
         assert!(pricing_for_model("xai/grok-4.5").is_some());
         assert!(pricing_for_model("grok-build").is_some());
         assert!(pricing_for_model("glm-5").is_some());


### PR DESCRIPTION
Add grok-4.6 as the new flagship Grok model.

- `cost.rs`: PricingEntry (canonical grok-4.6 + grok-4.6-latest alias), mirrors grok-4.5 list price until xAI publishes; normalize/pricing tests (12 green).
- `providers.rs`: static xAI catalog entry (grok-4.6 + rolling -latest) + native Grok CLI model list.
- Proxy routing + dynamic /v1/models fetch already handle `xai/grok-4.6` generically (no change needed).

`cargo check` clean, `cargo fmt --all` applied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and cost-table additions only; no routing or auth changes. Estimated pricing may diverge slightly from xAI’s eventual published rates until updated.
> 
> **Overview**
> Introduces **Grok 4.6** as the current flagship xAI model across provider metadata and billing helpers.
> 
> In `providers.rs`, **`grok-4.6`** is added to the native Grok CLI text-model allowlist, and the default xAI catalog gains **`grok-4.6`** plus **`grok-4.6-latest`**; Grok 4.5 is relabeled as the previous flagship.
> 
> In `cost.rs`, a new **`PricingEntry`** maps `grok-4.6` and `grok-4.6-latest` to Grok 4.5 rates ($2/$6 per Mtok, $0.5 cached) with a note that this is provisional. Tests cover normalization and pricing lookup for the new IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369482e1fdaaf0c8cd2864c973e706bc6041f1ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->