### PR TITLE
projects: decision ledger + normalized autonomy level

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -287,12 +287,17 @@ pub async fn get_project(
     let grant = state.projects.get_grant(&slug).map_err(store_err)?;
     let tracks = state.projects.tracks(&slug).map_err(store_err)?;
     let decisions = state.projects.open_decisions(&slug).map_err(store_err)?;
+    let recent = state
+        .projects
+        .recent_decisions(&slug, 20)
+        .map_err(store_err)?;
     let conversation = state.projects.binding(&slug).map_err(store_err)?;
     Ok(Json(serde_json::json!({
         "project": project,
         "grant": grant,
         "tracks": tracks,
         "open_decisions": decisions,
+        "recent_decisions": recent,
         "conversation": conversation,
     })))
 }
@@ -419,7 +424,10 @@ pub struct SetGrantRequest {
     pub pause_reason: Option<String>,
     pub resume_condition: Option<String>,
     pub material_bar: Option<String>,
+    pub autonomy_level: Option<String>,
 }
+
+pub(crate) const AUTONOMY_LEVELS: [&str; 4] = ["observe", "propose", "act_reversible", "act_full"];
 
 /// `POST /api/projects/:slug/grant` — set the autonomy grant. The project must
 /// exist (the grant FK-references it).
@@ -439,6 +447,19 @@ pub async fn set_project_grant(
     {
         return Err((StatusCode::NOT_FOUND, format!("unknown project '{slug}'")));
     }
+    let autonomy_level = match req.autonomy_level.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(level) if AUTONOMY_LEVELS.contains(&level) => Some(level.to_string()),
+        Some(other) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "autonomy_level must be one of {} (got '{other}')",
+                    AUTONOMY_LEVELS.join(", ")
+                ),
+            ));
+        }
+    };
     state
         .projects
         .set_grant(
@@ -449,6 +470,7 @@ pub async fn set_project_grant(
             req.pause_reason.as_deref(),
             req.resume_condition.as_deref(),
             req.material_bar.as_deref(),
+            autonomy_level.as_deref(),
         )
         .map_err(store_err)?;
     let grant = state.projects.get_grant(&slug).map_err(store_err)?;
@@ -459,9 +481,80 @@ pub async fn set_project_grant(
 pub struct RecordDecisionRequest {
     pub question: String,
     pub rationale: Option<String>,
+    /// merge | dispatch | scope | budget | … (free-form label)
+    pub kind: Option<String>,
+    /// granted (autonomous act) | escalation (question for the owner).
+    /// Legacy callers omit it: default escalation.
+    pub authority: Option<String>,
+    /// decided | pending_user. Defaults follow the authority.
+    pub status: Option<String>,
+    /// Supporting links: {"pr_url": …, "mission_id": …}.
+    pub evidence: Option<serde_json::Value>,
 }
 
-/// `POST /api/projects/:slug/decision` — add to the pending-decision ledger.
+/// How a decision request lands in the ledger after the grant is applied.
+pub(crate) struct DecisionDisposition {
+    pub authority: String,
+    pub status: String,
+    /// Set when the grant downgraded a claimed autonomous act to an
+    /// escalation — surfaced to the caller so the controller learns.
+    pub coerced_reason: Option<String>,
+}
+
+/// The enforcement point shared by the HTTP endpoint and the delivery-trailer
+/// ingestor: a controller may only *record* an act as autonomous when its
+/// grant actually allows acting. `observe`/`propose` (or an unset level)
+/// coerce granted+decided into an owner escalation instead of failing, so a
+/// mis-calibrated controller degrades to asking rather than erroring.
+pub(crate) fn resolve_decision_disposition(
+    autonomy_level: Option<&str>,
+    authority: Option<&str>,
+    status: Option<&str>,
+) -> Result<DecisionDisposition, String> {
+    let authority = match authority.map(str::trim).filter(|a| !a.is_empty()) {
+        None => "escalation",
+        Some(a @ ("granted" | "escalation")) => a,
+        Some(other) => {
+            return Err(format!(
+                "authority must be granted or escalation (got '{other}')"
+            ))
+        }
+    };
+    let status = match status.map(str::trim).filter(|s| !s.is_empty()) {
+        None => {
+            if authority == "granted" {
+                "decided"
+            } else {
+                "pending_user"
+            }
+        }
+        Some(s @ ("decided" | "pending_user")) => s,
+        Some(other) => {
+            return Err(format!(
+                "status must be decided or pending_user (got '{other}')"
+            ));
+        }
+    };
+    if authority == "granted" && status == "decided" {
+        let may_act = matches!(autonomy_level, Some("act_reversible") | Some("act_full"));
+        if !may_act {
+            let level = autonomy_level.unwrap_or("unset");
+            return Ok(DecisionDisposition {
+                authority: "escalation".to_string(),
+                status: "pending_user".to_string(),
+                coerced_reason: Some(format!("autonomy_level={level}")),
+            });
+        }
+    }
+    Ok(DecisionDisposition {
+        authority: authority.to_string(),
+        status: status.to_string(),
+        coerced_reason: None,
+    })
+}
+
+/// `POST /api/projects/:slug/decision` — add to the decision ledger: an owner
+/// escalation, or (grant permitting) a declared autonomous act.
 pub async fn record_project_decision(
     State(state): State<Arc<AppState>>,
     AxumPath(slug): AxumPath<String>,
@@ -473,12 +566,77 @@ pub async fn record_project_decision(
     if req.question.trim().is_empty() {
         return Err((StatusCode::BAD_REQUEST, "question is required".to_string()));
     }
-    state
+    let grant = state.projects.get_grant(&slug).map_err(store_err)?;
+    let disposition = resolve_decision_disposition(
+        grant.as_ref().and_then(|g| g.autonomy_level.as_deref()),
+        req.authority.as_deref(),
+        req.status.as_deref(),
+    )
+    .map_err(|error| (StatusCode::BAD_REQUEST, error))?;
+    let decision = super::projects_store::NewDecision {
+        question: req.question.trim().to_string(),
+        rationale: req.rationale.clone(),
+        kind: req
+            .kind
+            .as_deref()
+            .map(str::trim)
+            .filter(|k| !k.is_empty())
+            .map(str::to_string),
+        authority: disposition.authority,
+        status: disposition.status,
+        evidence: req.evidence.clone(),
+    };
+    let at = state
         .projects
-        .record_decision(&slug, req.question.trim(), req.rationale.as_deref())
+        .record_decision(&slug, &decision)
         .map_err(store_err)?;
     let open = state.projects.open_decisions(&slug).map_err(store_err)?;
-    Ok(Json(serde_json::json!({ "open_decisions": open })))
+    Ok(Json(serde_json::json!({
+        "at": at,
+        "authority": decision.authority,
+        "status": decision.status,
+        "coerced": disposition.coerced_reason.is_some(),
+        "coerced_reason": disposition.coerced_reason,
+        "open_decisions": open,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AnswerDecisionRequest {
+    /// The decision's `at` key.
+    pub at: String,
+    pub answer: String,
+}
+
+/// `POST /api/projects/:slug/decision/answer` — resolve a pending escalation.
+/// Delivery of the answer into the control conversation is the caller's job
+/// (the board relay knows how to address the bound Hermes session); this
+/// endpoint owns only the ledger transition.
+pub async fn answer_project_decision(
+    State(state): State<Arc<AppState>>,
+    AxumPath(slug): AxumPath<String>,
+    Json(req): Json<AnswerDecisionRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if !is_plain_key(&slug) {
+        return Err(bad_slug());
+    }
+    if req.answer.trim().is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "answer is required".to_string()));
+    }
+    let answered = state
+        .projects
+        .answer_decision(&slug, &req.at, req.answer.trim())
+        .map_err(store_err)?;
+    if !answered {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("no pending decision at '{}' for '{slug}'", req.at),
+        ));
+    }
+    let open = state.projects.open_decisions(&slug).map_err(store_err)?;
+    Ok(Json(
+        serde_json::json!({ "ok": true, "open_decisions": open }),
+    ))
 }
 
 pub fn routes() -> Router<Arc<AppState>> {
@@ -498,6 +656,10 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route(
             "/:slug/decision",
             axum::routing::post(record_project_decision),
+        )
+        .route(
+            "/:slug/decision/answer",
+            axum::routing::post(answer_project_decision),
         )
         .route(
             "/:slug/conversation",
@@ -640,6 +802,14 @@ struct ProjectRow {
     missions: Vec<MissionChip>,
     latest_update: Option<DeliveryUpdate>,
     updates_count: usize,
+    /// The grant's normalized autonomy level (observe | propose |
+    /// act_reversible | act_full), surfaced on the row so the card can show it
+    /// without a detail fetch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    autonomy_level: Option<String>,
+    /// Decisions waiting on the owner (`status = pending_user`) — the card
+    /// badge and a standing attention reason.
+    pending_decisions: u32,
     attention_reasons: Vec<String>,
     /// Per-track rollup, worst-first. Answers "which track is stuck" without
     /// making the reader scan a list of 800 mission chips.
@@ -720,6 +890,14 @@ pub async fn projects_overview(
     let unrouted_rows = state
         .projects
         .unrouted(20)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    let autonomy_levels = state
+        .projects
+        .autonomy_levels()
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    let pending_decisions = state
+        .projects
+        .pending_decision_counts()
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
 
     // ── Assemble rows: union of tracker slugs, mission project tags, and
@@ -873,6 +1051,24 @@ pub async fn projects_overview(
         })
         .collect();
 
+    // Grant levels and pending-decision counts are keyed by the roster slug the
+    // controller wrote them under; fold them onto canonical rows like every
+    // other source (an alias never hides, only fills).
+    for (slug, level) in &autonomy_levels {
+        let key = resolve_alias(&aliases, slug);
+        if let Some(builder) = rows.get_mut(&key) {
+            if builder.autonomy_level.is_none() || key == *slug {
+                builder.autonomy_level = Some(level.clone());
+            }
+        }
+    }
+    for (slug, count) in &pending_decisions {
+        let key = resolve_alias(&aliases, slug);
+        if let Some(builder) = rows.get_mut(&key) {
+            builder.pending_decisions += count;
+        }
+    }
+
     let mut projects: Vec<ProjectRow> = rows
         .into_values()
         .map(|builder| {
@@ -1000,6 +1196,8 @@ struct ProjectRowBuilder {
     /// signal's input, read from the store's observation count.
     latest_observations: u32,
     updates_count: usize,
+    autonomy_level: Option<String>,
+    pending_decisions: u32,
 }
 
 impl ProjectRowBuilder {
@@ -1016,6 +1214,8 @@ impl ProjectRowBuilder {
             latest_update: None,
             latest_observations: 0,
             updates_count: 0,
+            autonomy_level: None,
+            pending_decisions: 0,
         }
     }
 
@@ -1071,6 +1271,14 @@ impl ProjectRowBuilder {
             attention.push(match awaiting_user {
                 1 => "1 mission awaiting user input".to_string(),
                 count => format!("{count} missions awaiting user input"),
+            });
+        }
+        // Same rule for ledger escalations: a pending_user decision is a
+        // question only the owner can answer, so freshness never silences it.
+        if self.pending_decisions > 0 {
+            attention.push(match self.pending_decisions {
+                1 => "1 decision awaiting you".to_string(),
+                count => format!("{count} decisions awaiting you"),
             });
         }
 
@@ -1306,6 +1514,8 @@ impl ProjectRowBuilder {
             missions: self.missions,
             latest_update: self.latest_update,
             updates_count: self.updates_count,
+            autonomy_level: self.autonomy_level,
+            pending_decisions: self.pending_decisions,
             attention_reasons: attention,
             health,
             conversation,
@@ -2046,6 +2256,55 @@ mod tests {
             .attention_reasons
             .iter()
             .any(|r| r.contains("3 consecutive")));
+    }
+
+    // ---- decision disposition (the autonomy enforcement point) ----
+
+    #[test]
+    fn an_unearned_autonomous_act_is_coerced_into_an_escalation() {
+        // No grant, observe, and propose all deny acting.
+        for level in [None, Some("observe"), Some("propose")] {
+            let d = resolve_decision_disposition(level, Some("granted"), Some("decided"))
+                .expect("valid");
+            assert_eq!(d.authority, "escalation");
+            assert_eq!(d.status, "pending_user");
+            assert!(d.coerced_reason.is_some(), "level {level:?} must coerce");
+        }
+        for level in ["act_reversible", "act_full"] {
+            let d = resolve_decision_disposition(Some(level), Some("granted"), Some("decided"))
+                .expect("valid");
+            assert_eq!(d.authority, "granted");
+            assert_eq!(d.status, "decided");
+            assert!(d.coerced_reason.is_none());
+        }
+    }
+
+    #[test]
+    fn legacy_decision_bodies_default_to_owner_escalations() {
+        // The pre-ledger callers send only question+rationale: no authority,
+        // no status. They must keep meaning "ask the owner".
+        let d = resolve_decision_disposition(Some("act_full"), None, None).expect("valid");
+        assert_eq!(d.authority, "escalation");
+        assert_eq!(d.status, "pending_user");
+        assert!(d.coerced_reason.is_none());
+
+        assert!(resolve_decision_disposition(None, Some("sovereign"), None).is_err());
+        assert!(resolve_decision_disposition(None, None, Some("expired")).is_err());
+    }
+
+    #[test]
+    fn pending_decisions_are_a_standing_attention_reason() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.pending_decisions = 2;
+        builder.autonomy_level = Some("propose".into());
+        let row = builder.finish(&[], None, None, "2026-08-04T20:00:00Z");
+        assert_eq!(row.bucket, "attention");
+        assert_eq!(row.pending_decisions, 2);
+        assert_eq!(row.autonomy_level.as_deref(), Some("propose"));
+        assert!(row
+            .attention_reasons
+            .iter()
+            .any(|r| r == "2 decisions awaiting you"));
     }
 
     #[test]

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -95,7 +95,8 @@ CREATE TABLE IF NOT EXISTS project_grant (
     pause_reason      TEXT,
     resume_condition  TEXT,        -- the structured, checkable resume gate
     material_bar      TEXT,
-    answered_at       TEXT
+    answered_at       TEXT,
+    autonomy_level    TEXT         -- observe | propose | act_reversible | act_full
 );
 
 -- One row per workstream. `desired_state` is what the track should reach;
@@ -109,18 +110,29 @@ CREATE TABLE IF NOT EXISTS project_tracks (
     PRIMARY KEY (slug, track)
 );
 
--- The pending-decision ledger: questions the controller batched for the owner,
--- requestable rather than buried in a markdown file.
+-- The decision ledger. Two kinds of rows share it: escalations (questions the
+-- controller batched for the owner, `authority = 'escalation'`) and autonomous
+-- acts the controller declared before doing (`authority = 'granted'`). The
+-- legacy `answered` flag is dual-written (1 for anything not pending) so an
+-- older binary's "open decisions" query never surfaces autonomous acts.
 CREATE TABLE IF NOT EXISTS project_decisions (
-    slug      TEXT NOT NULL,
-    at        TEXT NOT NULL,
-    question  TEXT NOT NULL,
-    rationale TEXT,
-    answered  INTEGER NOT NULL DEFAULT 0,
+    slug        TEXT NOT NULL,
+    at          TEXT NOT NULL,
+    question    TEXT NOT NULL,
+    rationale   TEXT,
+    answered    INTEGER NOT NULL DEFAULT 0,
+    kind        TEXT,                                    -- merge|dispatch|scope|budget|...
+    authority   TEXT NOT NULL DEFAULT 'escalation',      -- granted|escalation
+    status      TEXT,                                    -- decided|pending_user|answered|expired
+    answer      TEXT,
+    answered_at TEXT,
+    evidence    TEXT,                                    -- JSON: {pr_url, mission_id, ...}
     PRIMARY KEY (slug, at)
 );
 CREATE INDEX IF NOT EXISTS idx_project_decisions_open
     ON project_decisions(slug, answered);
+-- idx_project_decisions_status is created in initialize(), after the additive
+-- column migration guarantees `status` exists on legacy tables.
 "#;
 
 /// A project's control conversation and how we know about it.
@@ -174,19 +186,72 @@ impl ProjectsStore {
         connection.execute_batch(SCHEMA)?;
         // project_state_events.session_id (2026-08: the overview builds
         // latest_update from the store, so the delivery's session rides along).
-        let mut statement = connection.prepare("PRAGMA table_info(project_state_events)")?;
-        let has_session_id = statement
-            .query_map([], |row| row.get::<_, String>(1))?
-            .filter_map(Result::ok)
-            .any(|name| name == "session_id");
-        drop(statement);
-        if !has_session_id {
+        Self::ensure_column(
+            connection,
+            "project_state_events",
+            "session_id",
+            "session_id TEXT",
+        )?;
+        // 2026-08: the decision ledger grew authority/status/evidence, and the
+        // grant grew a normalized autonomy level.
+        Self::ensure_column(connection, "project_decisions", "kind", "kind TEXT")?;
+        Self::ensure_column(
+            connection,
+            "project_decisions",
+            "authority",
+            "authority TEXT NOT NULL DEFAULT 'escalation'",
+        )?;
+        let added_status =
+            Self::ensure_column(connection, "project_decisions", "status", "status TEXT")?;
+        Self::ensure_column(connection, "project_decisions", "answer", "answer TEXT")?;
+        Self::ensure_column(
+            connection,
+            "project_decisions",
+            "answered_at",
+            "answered_at TEXT",
+        )?;
+        Self::ensure_column(connection, "project_decisions", "evidence", "evidence TEXT")?;
+        Self::ensure_column(
+            connection,
+            "project_grant",
+            "autonomy_level",
+            "autonomy_level TEXT",
+        )?;
+        connection.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_project_decisions_status \
+             ON project_decisions(slug, status);",
+        )?;
+        if added_status {
+            // Legacy rows were all owner escalations: open ones become
+            // pending_user, resolved ones answered.
             connection.execute(
-                "ALTER TABLE project_state_events ADD COLUMN session_id TEXT",
+                "UPDATE project_decisions SET status = \
+                 CASE WHEN answered = 1 THEN 'answered' ELSE 'pending_user' END \
+                 WHERE status IS NULL",
                 [],
             )?;
         }
         Ok(())
+    }
+
+    /// Additive column migration; returns true when the column was added.
+    fn ensure_column(
+        connection: &Connection,
+        table: &str,
+        column: &str,
+        definition: &str,
+    ) -> rusqlite::Result<bool> {
+        let mut statement = connection.prepare(&format!("PRAGMA table_info({table})"))?;
+        let exists = statement
+            .query_map([], |row| row.get::<_, String>(1))?
+            .filter_map(Result::ok)
+            .any(|name| name == column);
+        drop(statement);
+        if exists {
+            return Ok(false);
+        }
+        connection.execute(&format!("ALTER TABLE {table} ADD COLUMN {definition}"), [])?;
+        Ok(true)
     }
 
     fn lock(&self) -> Result<MutexGuard<'_, Connection>, String> {
@@ -868,7 +933,7 @@ impl ProjectsStore {
         connection
             .query_row(
                 "SELECT merge_authority, budget_per_tick, parallel_missions, \
-                 pause_reason, resume_condition, material_bar, answered_at \
+                 pause_reason, resume_condition, material_bar, answered_at, autonomy_level \
                  FROM project_grant WHERE slug = ?1",
                 params![slug],
                 |row| {
@@ -880,6 +945,7 @@ impl ProjectsStore {
                         resume_condition: row.get(4)?,
                         material_bar: row.get(5)?,
                         answered_at: row.get(6)?,
+                        autonomy_level: row.get(7)?,
                     })
                 },
             )
@@ -897,6 +963,7 @@ impl ProjectsStore {
         pause_reason: Option<&str>,
         resume_condition: Option<&str>,
         material_bar: Option<&str>,
+        autonomy_level: Option<&str>,
     ) -> Result<(), String> {
         let now = Utc::now().to_rfc3339();
         let connection = self.lock()?;
@@ -904,8 +971,8 @@ impl ProjectsStore {
             .execute(
                 "INSERT INTO project_grant \
                    (slug, merge_authority, budget_per_tick, parallel_missions, \
-                    pause_reason, resume_condition, material_bar, answered_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
+                    pause_reason, resume_condition, material_bar, answered_at, autonomy_level) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) \
                  ON CONFLICT(slug) DO UPDATE SET \
                    merge_authority = COALESCE(excluded.merge_authority, project_grant.merge_authority), \
                    budget_per_tick = COALESCE(excluded.budget_per_tick, project_grant.budget_per_tick), \
@@ -913,7 +980,8 @@ impl ProjectsStore {
                    pause_reason = COALESCE(excluded.pause_reason, project_grant.pause_reason), \
                    resume_condition = COALESCE(excluded.resume_condition, project_grant.resume_condition), \
                    material_bar = COALESCE(excluded.material_bar, project_grant.material_bar), \
-                   answered_at = excluded.answered_at",
+                   answered_at = excluded.answered_at, \
+                   autonomy_level = COALESCE(excluded.autonomy_level, project_grant.autonomy_level)",
                 params![
                     slug,
                     merge_authority,
@@ -922,51 +990,157 @@ impl ProjectsStore {
                     pause_reason,
                     resume_condition,
                     material_bar,
-                    now
+                    now,
+                    autonomy_level
                 ],
             )
             .map_err(|e| e.to_string())?;
         Ok(())
     }
 
-    pub fn record_decision(
-        &self,
-        slug: &str,
-        question: &str,
-        rationale: Option<&str>,
-    ) -> Result<(), String> {
+    /// Record a decision and return its `at` key. The legacy `answered` flag is
+    /// dual-written: only `pending_user` rows count as open, so an older binary
+    /// reading `answered = 0` never surfaces autonomous acts.
+    pub fn record_decision(&self, slug: &str, decision: &NewDecision) -> Result<String, String> {
         let now = Utc::now().to_rfc3339();
+        let answered = i64::from(decision.status != "pending_user");
+        let evidence = decision.evidence.as_ref().map(|value| value.to_string());
         let connection = self.lock()?;
         connection
             .execute(
-                "INSERT OR REPLACE INTO project_decisions (slug, at, question, rationale, answered) \
-                 VALUES (?1, ?2, ?3, ?4, 0)",
-                params![slug, now, question, rationale],
+                "INSERT OR REPLACE INTO project_decisions \
+                   (slug, at, question, rationale, answered, kind, authority, status, evidence) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    slug,
+                    now,
+                    decision.question,
+                    decision.rationale,
+                    answered,
+                    decision.kind,
+                    decision.authority,
+                    decision.status,
+                    evidence
+                ],
             )
             .map_err(|e| e.to_string())?;
-        Ok(())
+        Ok(now)
+    }
+
+    /// Answer a pending escalation. Returns false when no pending decision
+    /// exists at that key (already answered, expired, or never recorded).
+    pub fn answer_decision(&self, slug: &str, at: &str, answer: &str) -> Result<bool, String> {
+        let now = Utc::now().to_rfc3339();
+        let connection = self.lock()?;
+        let changed = connection
+            .execute(
+                "UPDATE project_decisions \
+                 SET status = 'answered', answer = ?3, answered_at = ?4, answered = 1 \
+                 WHERE slug = ?1 AND at = ?2 AND status = 'pending_user'",
+                params![slug, at, answer, now],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(changed > 0)
     }
 
     pub fn open_decisions(&self, slug: &str) -> Result<Vec<ProjectDecision>, String> {
+        self.decisions_where(slug, "status = 'pending_user'", "ORDER BY at", None)
+    }
+
+    /// Newest-first autonomous acts (`status = 'decided'`) plus recently
+    /// answered escalations, for the "recent activity" panel.
+    pub fn recent_decisions(&self, slug: &str, limit: u32) -> Result<Vec<ProjectDecision>, String> {
+        self.decisions_where(
+            slug,
+            "status IN ('decided', 'answered')",
+            "ORDER BY at DESC",
+            Some(limit),
+        )
+    }
+
+    fn decisions_where(
+        &self,
+        slug: &str,
+        predicate: &str,
+        order: &str,
+        limit: Option<u32>,
+    ) -> Result<Vec<ProjectDecision>, String> {
+        let limit_clause = limit.map(|n| format!(" LIMIT {n}")).unwrap_or_default();
         let connection = self.lock()?;
         let mut statement = connection
-            .prepare(
-                "SELECT at, question, rationale FROM project_decisions \
-                 WHERE slug = ?1 AND answered = 0 ORDER BY at",
-            )
+            .prepare(&format!(
+                "SELECT at, question, rationale, kind, authority, status, answer, answered_at, evidence \
+                 FROM project_decisions WHERE slug = ?1 AND {predicate} {order}{limit_clause}",
+            ))
             .map_err(|e| e.to_string())?;
         let rows = statement
             .query_map(params![slug], |row| {
+                let evidence: Option<String> = row.get(8)?;
                 Ok(ProjectDecision {
                     at: row.get(0)?,
                     question: row.get(1)?,
                     rationale: row.get(2)?,
+                    kind: row.get(3)?,
+                    authority: row.get(4)?,
+                    status: row.get(5)?,
+                    answer: row.get(6)?,
+                    answered_at: row.get(7)?,
+                    evidence: evidence.and_then(|raw| serde_json::from_str(&raw).ok()),
                 })
             })
             .map_err(|e| e.to_string())?;
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| e.to_string())
     }
+
+    /// Bulk autonomy levels, one board render = one query.
+    pub fn autonomy_levels(&self) -> Result<HashMap<String, String>, String> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare(
+                "SELECT slug, autonomy_level FROM project_grant WHERE autonomy_level IS NOT NULL",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| e.to_string())?;
+        rows.collect::<Result<HashMap<_, _>, _>>()
+            .map_err(|e| e.to_string())
+    }
+
+    /// Count of decisions waiting on the owner, for the board row badge.
+    pub fn pending_decision_counts(&self) -> Result<HashMap<String, u32>, String> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare(
+                "SELECT slug, COUNT(*) FROM project_decisions \
+                 WHERE status = 'pending_user' GROUP BY slug",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+            })
+            .map_err(|e| e.to_string())?;
+        rows.collect::<Result<HashMap<_, _>, _>>()
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Input for [`ProjectsStore::record_decision`], already validated/coerced by
+/// the caller (see `resolve_decision_disposition` in `projects_overview`).
+#[derive(Debug, Clone)]
+pub struct NewDecision {
+    pub question: String,
+    pub rationale: Option<String>,
+    pub kind: Option<String>,
+    /// granted | escalation
+    pub authority: String,
+    /// decided | pending_user | answered | expired
+    pub status: String,
+    pub evidence: Option<serde_json::Value>,
 }
 
 /// One distinct state a project reported, with how long it stayed there.
@@ -1038,6 +1212,9 @@ pub struct ProjectGrant {
     pub material_bar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub answered_at: Option<String>,
+    /// observe | propose | act_reversible | act_full
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autonomy_level: Option<String>,
 }
 
 /// One workstream within a project.
@@ -1051,13 +1228,26 @@ pub struct ProjectTrack {
     pub updated_at: String,
 }
 
-/// An open question the controller batched for the owner.
+/// One ledger entry: an owner escalation or a declared autonomous act.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ProjectDecision {
     pub at: String,
     pub question: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rationale: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// granted | escalation
+    pub authority: String,
+    /// decided | pending_user | answered | expired
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answered_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<serde_json::Value>,
 }
 
 #[cfg(test)]
@@ -1426,11 +1616,17 @@ mod tests {
                 None,
                 None,
                 Some("only merged PRs"),
+                Some("act_reversible"),
             )
             .expect("grant");
         let g = store.get_grant("lido").expect("read").expect("present");
         assert_eq!(g.merge_authority.as_deref(), Some("review-first"));
         assert_eq!(g.parallel_missions, Some(3));
+        assert_eq!(g.autonomy_level.as_deref(), Some("act_reversible"));
+        assert_eq!(
+            store.autonomy_levels().expect("levels")["lido"],
+            "act_reversible"
+        );
 
         store
             .set_track("lido", "P-ETH-1", Some("proved"), Some("in-progress"))
@@ -1440,7 +1636,7 @@ mod tests {
         assert_eq!(tracks[0].track, "P-ETH-1");
 
         store
-            .record_decision("lido", "merge #48?", Some("blocks A.2"))
+            .record_decision("lido", &escalation("merge #48?", Some("blocks A.2")))
             .expect("dec");
         assert_eq!(store.open_decisions("lido").expect("open").len(), 1);
 
@@ -1561,6 +1757,105 @@ mod tests {
                 .as_deref(),
             Some("s1")
         );
+    }
+
+    // ---- decision ledger ----
+
+    fn escalation(question: &str, rationale: Option<&str>) -> NewDecision {
+        NewDecision {
+            question: question.to_string(),
+            rationale: rationale.map(str::to_string),
+            kind: None,
+            authority: "escalation".to_string(),
+            status: "pending_user".to_string(),
+            evidence: None,
+        }
+    }
+
+    #[test]
+    fn autonomous_acts_never_appear_open_and_answers_close_escalations() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        let act = NewDecision {
+            question: "Merged PR #2213".to_string(),
+            rationale: Some("CI green, criteria met".to_string()),
+            kind: Some("merge".to_string()),
+            authority: "granted".to_string(),
+            status: "decided".to_string(),
+            evidence: Some(serde_json::json!({"pr_url": "https://github.com/x/y/pull/2213"})),
+        };
+        store.record_decision("verity", &act).expect("act");
+        let at = store
+            .record_decision("verity", &escalation("Ship v2?", None))
+            .expect("escalation");
+
+        // The act is activity, not a question: open shows only the escalation.
+        let open = store.open_decisions("verity").expect("open");
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].question, "Ship v2?");
+
+        // Answering closes it and stamps the answer.
+        assert!(store
+            .answer_decision("verity", &at, "yes, ship")
+            .expect("answer"));
+        assert!(store.open_decisions("verity").expect("open").is_empty());
+        // Answering twice (or a bogus key) is a no-op, not an error.
+        assert!(!store
+            .answer_decision("verity", &at, "again")
+            .expect("re-answer"));
+
+        // Recent activity = the act plus the answered escalation, newest first.
+        let recent = store.recent_decisions("verity", 10).expect("recent");
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].answer.as_deref(), Some("yes, ship"));
+        assert_eq!(recent[1].kind.as_deref(), Some("merge"));
+        assert_eq!(
+            recent[1].evidence.as_ref().unwrap()["pr_url"],
+            "https://github.com/x/y/pull/2213"
+        );
+
+        assert_eq!(store.pending_decision_counts().expect("counts").len(), 0);
+        store
+            .record_decision("verity", &escalation("Another?", None))
+            .expect("second escalation");
+        assert_eq!(
+            store.pending_decision_counts().expect("counts")["verity"],
+            1
+        );
+    }
+
+    /// A database from before the ledger columns must migrate: legacy rows are
+    /// owner escalations (open → pending_user, resolved → answered), and the
+    /// legacy `answered` flag keeps meaning "not open" for old binaries.
+    #[test]
+    fn a_legacy_decisions_table_backfills_status_on_open() {
+        let connection = Connection::open_in_memory().expect("conn");
+        connection
+            .execute_batch(
+                "CREATE TABLE project_decisions (
+                    slug TEXT NOT NULL, at TEXT NOT NULL, question TEXT NOT NULL,
+                    rationale TEXT, answered INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (slug, at));
+                 CREATE TABLE project_grant (
+                    slug TEXT PRIMARY KEY NOT NULL, merge_authority TEXT,
+                    budget_per_tick TEXT, parallel_missions INTEGER,
+                    pause_reason TEXT, resume_condition TEXT, material_bar TEXT,
+                    answered_at TEXT);
+                 INSERT INTO project_decisions VALUES
+                    ('lido', '2026-08-01T10:00:00Z', 'open one', NULL, 0),
+                    ('lido', '2026-08-01T11:00:00Z', 'closed one', NULL, 1);",
+            )
+            .expect("old schema");
+        ProjectsStore::initialize(&connection).expect("migrate");
+        let store = ProjectsStore {
+            connection: Mutex::new(connection),
+        };
+        let open = store.open_decisions("lido").expect("open");
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].question, "open one");
+        assert_eq!(open[0].authority, "escalation");
+        assert_eq!(open[0].status.as_deref(), Some("pending_user"));
+        // Migrating twice is harmless.
+        ProjectsStore::initialize(&store.connection.lock().unwrap()).expect("re-migrate");
     }
 
     // ---- unrouted deliveries ----

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -201,8 +201,7 @@ impl ProjectsStore {
             "authority",
             "authority TEXT NOT NULL DEFAULT 'escalation'",
         )?;
-        let added_status =
-            Self::ensure_column(connection, "project_decisions", "status", "status TEXT")?;
+        Self::ensure_column(connection, "project_decisions", "status", "status TEXT")?;
         Self::ensure_column(connection, "project_decisions", "answer", "answer TEXT")?;
         Self::ensure_column(
             connection,
@@ -221,16 +220,18 @@ impl ProjectsStore {
             "CREATE INDEX IF NOT EXISTS idx_project_decisions_status \
              ON project_decisions(slug, status);",
         )?;
-        if added_status {
-            // Legacy rows were all owner escalations: open ones become
-            // pending_user, resolved ones answered.
-            connection.execute(
-                "UPDATE project_decisions SET status = \
-                 CASE WHEN answered = 1 THEN 'answered' ELSE 'pending_user' END \
-                 WHERE status IS NULL",
-                [],
-            )?;
-        }
+        // Normalize every row missing a status — unconditionally, not only
+        // when the column was just added: after a rollback, the OLD binary's
+        // legacy INSERT writes rows with `status` NULL into the already-
+        // migrated table, and those must land as escalations on the next
+        // upgrade too. Idempotent (WHERE status IS NULL), so it costs nothing
+        // on a healthy database.
+        connection.execute(
+            "UPDATE project_decisions SET status = \
+             CASE WHEN answered = 1 THEN 'answered' ELSE 'pending_user' END \
+             WHERE status IS NULL",
+            [],
+        )?;
         Ok(())
     }
 
@@ -1856,6 +1857,29 @@ mod tests {
         assert_eq!(open[0].status.as_deref(), Some("pending_user"));
         // Migrating twice is harmless.
         ProjectsStore::initialize(&store.connection.lock().unwrap()).expect("re-migrate");
+
+        // Rollback shape: an OLD binary writing into the already-migrated
+        // table leaves status NULL (its INSERT names only the legacy
+        // columns). The next initialize() must normalize that row even
+        // though the column already exists.
+        store
+            .connection
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO project_decisions (slug, at, question, rationale, answered) \
+                 VALUES ('lido', '2026-08-02T10:00:00Z', 'written during rollback', NULL, 0)",
+                [],
+            )
+            .expect("legacy insert");
+        ProjectsStore::initialize(&store.connection.lock().unwrap())
+            .expect("post-rollback migrate");
+        let open = store.open_decisions("lido").expect("open after rollback");
+        assert!(
+            open.iter().any(|d| d.question == "written during rollback"
+                && d.status.as_deref() == Some("pending_user")),
+            "a rollback-era row must surface as a pending escalation: {open:?}"
+        );
     }
 
     // ---- unrouted deliveries ----

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -1345,7 +1345,7 @@ mod tests {
             .upsert_project("old-name", Some("Title"), None, None, Some("job123"))
             .expect("create");
         store
-            .set_grant("old-name", Some("full"), None, None, None, None, None)
+            .set_grant("old-name", Some("full"), None, None, None, None, None, None)
             .expect("grant");
         store.set_binding("old-name", "sess-1", None).expect("bind");
         store


### PR DESCRIPTION
Part 1/4 of the Projects board upgrade (decisions ledger backbone).

- `project_decisions` becomes a two-sided ledger: owner escalations (`authority=escalation`, `status=pending_user`) and declared autonomous acts (`authority=granted`, `status=decided`), with `kind` and `evidence` JSON (`pr_url`, `mission_id`, …). Additive sqlite migration; legacy rows backfill to escalations; the legacy `answered` flag is dual-written so an older binary's open-decisions query never surfaces autonomous acts (safe rollback).
- `project_grant.autonomy_level` ∈ observe|propose|act_reversible|act_full, validated on write.
- Enforcement at record time (`resolve_decision_disposition`, shared with the upcoming trailer ingestor): a controller at observe/propose recording a granted+decided act is coerced to an escalation and told so (`coerced: true`) instead of failing.
- New `POST /api/projects/:slug/decision/answer` marks a pending escalation answered (delivery of the answer into the control conversation is the board relay's job).
- `GET /api/projects/:slug` gains `recent_decisions`; overview rows gain `autonomy_level` + `pending_decisions` and a standing "N decisions awaiting you" attention reason.

Follow-ups: board_tasks→project roadmap endpoint, assistant-mcp tool args, `[DECISION:]` delivery trailer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistent project/grant/decision schema and write-path semantics (autonomy coercion); migrations and dual-written `answered` are designed for rollback, but decision recording is on the controller/board critical path.
> 
> **Overview**
> Extends the projects API and SQLite store so **decisions** and **autonomy** are first-class, with enforcement at write time and richer board/overview payloads.
> 
> **Decision ledger** — `project_decisions` now holds owner **escalations** (`authority=escalation`, `status=pending_user`) and controller **autonomous acts** (`authority=granted`, `status=decided`), plus optional `kind` and JSON `evidence`. Additive migrations backfill legacy rows; `answered` is dual-written so older binaries’ “open” queries still hide autonomous acts. `POST …/decision` accepts the new fields, runs shared **`resolve_decision_disposition`** against the grant’s `autonomy_level`, and returns `coerced` when a claimed act is downgraded to an escalation. **`POST …/decision/answer`** closes pending escalations. **`GET …/:slug`** includes **`recent_decisions`**.
> 
> **Autonomy grant** — `project_grant.autonomy_level` is one of `observe` | `propose` | `act_reversible` | `act_full`, validated on **`POST …/grant`**.
> 
> **Overview** — Rows expose **`autonomy_level`**, **`pending_decisions`**, and a standing attention reason (“N decisions awaiting you”), with alias folding like other grant fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78c1cb7887daa629eec85a8e725bcfcf518b815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->