### PR TITLE
projects: rename a slug with alias forwarding (POST /:slug/rename)

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -330,6 +330,128 @@ pub async fn upsert_project(
 }
 
 #[derive(Debug, Deserialize)]
+pub struct RenameProjectRequest {
+    pub new_slug: String,
+}
+
+/// `POST /api/projects/:slug/rename` — move a project to a new slug.
+///
+/// A rename is "move the canonical + leave a forwarding pointer": the store
+/// rows move in one transaction, then the alias map gains `old → new` (and any
+/// alias that pointed at `old` is flattened onto `new` — `resolve_alias` is
+/// single-hop, so a chain would silently stop resolving). External references
+/// — mission project tags, cron `deliver: project:<old>`, `[CTRL: old | …]`
+/// signatures, tracker files — are deliberately not rewritten: the alias
+/// covers them indefinitely.
+///
+/// Renaming onto an existing project or an established alias key is refused:
+/// the first is a merge (explicit, via routes.json), the second would shadow
+/// whatever that key already routes to.
+pub async fn rename_project(
+    State(state): State<Arc<AppState>>,
+    AxumPath(slug): AxumPath<String>,
+    Json(req): Json<RenameProjectRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let new_slug = req.new_slug.trim();
+    if !is_plain_key(&slug) || !is_plain_key(new_slug) {
+        return Err(bad_slug());
+    }
+    if new_slug == slug {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "new slug is identical to the current one".to_string(),
+        ));
+    }
+    let dir = hermes_projects_dir();
+    if let Some(dir) = &dir {
+        let aliases = read_alias_map(dir);
+        if aliases.contains_key(new_slug) {
+            return Err((
+                StatusCode::CONFLICT,
+                format!(
+                    "'{new_slug}' is already an alias for '{}' — pick another name or remove the alias first",
+                    aliases[new_slug]
+                ),
+            ));
+        }
+    }
+    let record = state
+        .projects
+        .rename_project(&slug, new_slug)
+        .map_err(|error| {
+            if error.contains("not found") {
+                (StatusCode::NOT_FOUND, error)
+            } else if error.contains("already exists") {
+                (StatusCode::CONFLICT, error)
+            } else {
+                (StatusCode::INTERNAL_SERVER_ERROR, error)
+            }
+        })?;
+    let mut aliases_flattened = 0usize;
+    if let Some(dir) = &dir {
+        aliases_flattened = rewrite_aliases_for_rename(dir, &slug, new_slug).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "project rows moved to '{new_slug}' but routes.json update failed ({error}); \
+                     add \"{slug}\": \"{new_slug}\" to it manually or deliveries keyed '{slug}' will unroute"
+                ),
+            )
+        })?;
+        // A board override (paused/archived) follows the project it describes.
+        let mut overrides = read_overrides(dir);
+        if let Some(value) = overrides.remove(&slug) {
+            overrides.insert(new_slug.to_string(), value);
+            write_overrides(dir, &overrides).map_err(|error| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("write board-overrides.json: {error}"),
+                )
+            })?;
+        }
+    }
+    Ok(Json(serde_json::json!({
+        "project": record,
+        "old_slug": slug,
+        "alias_written": dir.is_some(),
+        "aliases_flattened": aliases_flattened,
+    })))
+}
+
+/// Rewrite routes.json for a rename: every alias pointing at `old` is
+/// flattened onto `new` (single-hop resolution — a chain through `old` would
+/// dead-end), then `old → new` itself is added. Returns how many existing
+/// entries were flattened. Written atomically (tmp + rename), like the
+/// overrides file.
+fn rewrite_aliases_for_rename(dir: &Path, old: &str, new: &str) -> std::io::Result<usize> {
+    let mut aliases = read_alias_map(dir);
+    let mut flattened = 0usize;
+    for target in aliases.values_mut() {
+        if target == old {
+            *target = new.to_string();
+            flattened += 1;
+        }
+    }
+    aliases.insert(old.to_string(), new.to_string());
+    let serialized = serde_json::to_string_pretty(&aliases)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let path = dir.join("routes.json");
+    let tmp = dir.join(".routes.json.tmp");
+    std::fs::write(&tmp, serialized)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(flattened)
+}
+
+fn write_overrides(dir: &Path, overrides: &HashMap<String, String>) -> std::io::Result<()> {
+    let serialized = serde_json::to_string_pretty(overrides)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let tmp = dir.join(".board-overrides.json.tmp");
+    std::fs::write(&tmp, serialized)?;
+    std::fs::rename(&tmp, overrides_path(dir))?;
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
 pub struct SetStatusRequest {
     pub mode: String,
     pub next_action: Option<String>,
@@ -489,6 +611,7 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/:slug/state", get(project_state))
         .route("/:slug/updates", get(project_updates))
         .route("/:slug/action", axum::routing::post(project_action))
+        .route("/:slug/rename", axum::routing::post(rename_project))
         .route("/:slug/status", axum::routing::post(set_project_status))
         .route("/:slug/track", axum::routing::post(set_project_track))
         .route(
@@ -1852,6 +1975,56 @@ mod tests {
         assert_eq!(humanize_slug("minimax_m3_full263"), "Minimax M3 Full263");
         assert_eq!(humanize_slug("verity-core"), "Verity Core");
         assert_eq!(humanize_slug(""), "");
+    }
+
+    /// A rename flattens every alias that pointed at the old slug and adds the
+    /// forwarding entry — `resolve_alias` is single-hop, so `x → old → new`
+    /// would dead-end at a slug that no longer exists.
+    #[test]
+    fn rename_alias_rewrite_flattens_chains_and_adds_forwarding() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("routes.json"),
+            r#"{"coldcard": "old-name", "coldcard-rng": "old-name", "lido": "verity-lido"}"#,
+        )
+        .expect("seed");
+
+        let flattened =
+            rewrite_aliases_for_rename(dir.path(), "old-name", "new-name").expect("rewrite");
+        assert_eq!(flattened, 2);
+
+        let aliases = read_alias_map(dir.path());
+        assert_eq!(
+            aliases.get("coldcard").map(String::as_str),
+            Some("new-name")
+        );
+        assert_eq!(
+            aliases.get("coldcard-rng").map(String::as_str),
+            Some("new-name")
+        );
+        assert_eq!(
+            aliases.get("old-name").map(String::as_str),
+            Some("new-name")
+        );
+        assert_eq!(aliases.get("lido").map(String::as_str), Some("verity-lido"));
+        // Single-hop resolution now lands every historical key on the new slug.
+        assert_eq!(resolve_alias(&aliases, "coldcard"), "new-name");
+        assert_eq!(resolve_alias(&aliases, "old-name"), "new-name");
+    }
+
+    /// With no routes.json yet, a rename creates one containing only the
+    /// forwarding entry.
+    #[test]
+    fn rename_alias_rewrite_creates_the_map_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let flattened =
+            rewrite_aliases_for_rename(dir.path(), "old-name", "new-name").expect("rewrite");
+        assert_eq!(flattened, 0);
+        let aliases = read_alias_map(dir.path());
+        assert_eq!(
+            aliases.get("old-name").map(String::as_str),
+            Some("new-name")
+        );
     }
 
     #[test]

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -688,6 +688,86 @@ impl ProjectsStore {
         Ok(removed)
     }
 
+    /// Move a project to a new slug across every table that keys on it, in one
+    /// transaction. This is only the store-side move: the caller owns alias
+    /// forwarding (routes.json) so external references — mission tags, cron
+    /// `deliver: project:<old>`, `[CTRL:]` signatures — keep resolving.
+    ///
+    /// Refuses to clobber: the target slug must not already be a roster
+    /// project. Historical rows that would collide under the new slug (state
+    /// events, tracks, decisions ingested under it before the rename) keep the
+    /// target's copy and drop the source's, so the move never fails midway on
+    /// a primary-key conflict.
+    pub fn rename_project(&self, old: &str, new: &str) -> Result<ProjectRecord, String> {
+        if old == new {
+            return Err("new slug is identical to the current one".to_string());
+        }
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction().map_err(|e| e.to_string())?;
+        // `project_grant` references projects(slug) with no ON UPDATE action,
+        // so parent and child must both move before constraints are checked.
+        transaction
+            .pragma_update(None, "defer_foreign_keys", "ON")
+            .map_err(|e| e.to_string())?;
+        let exists: Option<i64> = transaction
+            .query_row(
+                "SELECT 1 FROM projects WHERE slug = ?1",
+                params![old],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(|e| e.to_string())?;
+        if exists.is_none() {
+            return Err(format!("project '{old}' not found"));
+        }
+        let taken: Option<i64> = transaction
+            .query_row(
+                "SELECT 1 FROM projects WHERE slug = ?1",
+                params![new],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(|e| e.to_string())?;
+        if taken.is_some() {
+            return Err(format!(
+                "project '{new}' already exists — renaming onto an existing project is a merge, which stays explicit via the alias map"
+            ));
+        }
+        let now = Utc::now().to_rfc3339();
+        transaction
+            .execute(
+                "UPDATE projects SET slug = ?2, updated_at = ?3 WHERE slug = ?1",
+                params![old, new, now],
+            )
+            .map_err(|e| e.to_string())?;
+        for table in [
+            "project_grant",
+            "project_bindings",
+            "project_tracks",
+            "project_state_events",
+            "project_decisions",
+        ] {
+            transaction
+                .execute(
+                    &format!("UPDATE OR IGNORE {table} SET slug = ?2 WHERE slug = ?1"),
+                    params![old, new],
+                )
+                .map_err(|e| e.to_string())?;
+            // Rows OR IGNORE skipped collided with an existing row under the
+            // new slug; the target's copy wins and the leftover is dropped.
+            transaction
+                .execute(
+                    &format!("DELETE FROM {table} WHERE slug = ?1"),
+                    params![old],
+                )
+                .map_err(|e| e.to_string())?;
+        }
+        transaction.commit().map_err(|e| e.to_string())?;
+        drop(connection);
+        self.get_project(new)?
+            .ok_or_else(|| "project vanished after rename".to_string())
+    }
+
     fn project_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ProjectRecord> {
         Ok(ProjectRecord {
             slug: row.get(0)?,
@@ -1063,6 +1143,85 @@ pub struct ProjectDecision {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A rename moves every table that keys on the slug — record, grant
+    /// (FK child), binding, tracks, state events, decisions — and the old
+    /// slug is gone from all of them.
+    #[test]
+    fn rename_moves_every_slug_keyed_row() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("old-name", Some("Title"), None, None, Some("job123"))
+            .expect("create");
+        store
+            .set_grant("old-name", Some("full"), None, None, None, None, None)
+            .expect("grant");
+        store.set_binding("old-name", "sess-1", None).expect("bind");
+        store
+            .set_track("old-name", "track-a", Some("green"), Some("running"))
+            .expect("track");
+        store
+            .record_state(
+                "old-name",
+                "sig|state",
+                Some("headline"),
+                "2026-08-13T10:00:00Z",
+                None,
+            )
+            .expect("state");
+
+        let renamed = store
+            .rename_project("old-name", "new-name")
+            .expect("rename");
+        assert_eq!(renamed.slug, "new-name");
+        assert_eq!(renamed.controller_cron_id.as_deref(), Some("job123"));
+
+        assert!(store.get_project("old-name").expect("read").is_none());
+        assert_eq!(
+            store
+                .binding("new-name")
+                .expect("read")
+                .expect("bound")
+                .session_id,
+            "sess-1"
+        );
+        assert!(store.binding("old-name").expect("read").is_none());
+        assert_eq!(store.tracks("new-name").expect("tracks").len(), 1);
+        assert_eq!(
+            store
+                .state_timeline("new-name", 10)
+                .expect("timeline")
+                .len(),
+            1
+        );
+        assert!(store
+            .state_timeline("old-name", 10)
+            .expect("timeline")
+            .is_empty());
+    }
+
+    /// Renaming onto an existing project is refused: a merge stays an explicit
+    /// alias-map operation, never an accidental clobber.
+    #[test]
+    fn rename_refuses_to_clobber_an_existing_project() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("a", None, None, None, None)
+            .expect("a");
+        store
+            .upsert_project("b", None, None, None, None)
+            .expect("b");
+        let error = store.rename_project("a", "b").expect_err("must refuse");
+        assert!(error.contains("already exists"), "{error}");
+        assert!(store.get_project("a").expect("read").is_some());
+    }
+
+    #[test]
+    fn rename_of_a_missing_project_is_not_found() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        let error = store.rename_project("ghost", "x").expect_err("must fail");
+        assert!(error.contains("not found"), "{error}");
+    }
 
     #[test]
     fn binding_round_trips_and_rebinds_in_place() {


### PR DESCRIPTION
## What

`POST /api/projects/:slug/rename {"new_slug": "..."}` — true slug rename, built as **move the canonical + leave a forwarding pointer**.

- Store: `rename_project` moves `projects`, `project_grant` (FK child, deferred-FK transaction), `project_bindings`, `project_tracks`, `project_state_events`, `project_decisions` in one transaction. Historical rows colliding under the new slug keep the target's copy (UPDATE OR IGNORE + sweep) so the move never fails midway.
- routes.json: adds `old → new`, and **flattens** any alias that pointed at `old` onto `new` — `resolve_alias` is single-hop, so a chain through the old slug would dead-end.
- board-overrides.json: an override (paused/archived) follows the project.
- Refusals: rename onto an existing project (that's a merge — stays explicit via the alias map) or onto an established alias key (would shadow its target); missing project → 404.
- External references (mission project tags, cron `deliver: project:old`, `[CTRL: old | …]` signatures, tracker files) are deliberately **not** rewritten — the forwarding alias covers them indefinitely.

## Tests

- `rename_moves_every_slug_keyed_row`, `rename_refuses_to_clobber_an_existing_project`, `rename_of_a_missing_project_is_not_found` (store)
- `rename_alias_rewrite_flattens_chains_and_adds_forwarding`, `rename_alias_rewrite_creates_the_map_when_absent` (routes.json rewrite)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames mutate core project identity across SQLite and on-disk routing in separate steps; a partial failure (DB moved, `routes.json` not updated) can leave deliveries unrouted until fixed manually.
> 
> **Overview**
> Adds **`POST /api/projects/:slug/rename`** with body `{"new_slug": "..."}` so operators can change a project’s canonical slug without treating it as a merge.
> 
> **Store:** `rename_project` updates the `projects` row and every slug-keyed table (`project_grant`, bindings, tracks, state events, decisions) in one transaction (deferred FKs for grant). Renaming onto an existing roster slug is rejected; PK collisions under the new slug resolve by keeping the target’s row and dropping the source’s (`UPDATE OR IGNORE` + delete leftovers).
> 
> **Filesystem (when `HERMES_PROJECTS_DIR` is set):** `routes.json` gets `old → new`, aliases that pointed at `old` are flattened to `new` (single-hop `resolve_alias`), and matching **`board-overrides.json`** entries move with the project. Mission tags, cron deliver keys, CTRL signatures, and tracker files are **not** rewritten—forwarding aliases are meant to cover those indefinitely.
> 
> Validation returns 400 for bad/identical slugs, 409 if the new name is already an alias key or an existing project, 404 if missing; a failed `routes.json` write after a successful DB move returns 500 with a manual-recovery hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfc5c4ec8c0372645b28d68ae8029f8879e30b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->