### PR TITLE
control: include the mission's final output in the terminal status webhook

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -13282,10 +13282,25 @@ async fn paloma_webhook_forwarder_loop(
                 },
                 None => None,
             };
+            // The mission's ACTUAL final output — not just status metadata — so
+            // a mission-backed delegation returns a real work product to the
+            // delegating Hermes agent (the fold prefers `result_summary`).
+            // Fetched only for terminal (forwardable) transitions; best-effort.
+            let result_summary: Option<String> = if webhook_forwardable_status(status) {
+                mission_store
+                    .latest_assistant_text(mission_id)
+                    .await
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
             let body = serde_json::json!({
                 // Idempotency / ordering (P#6): consumers dedupe on
                 // `event_id` and may order by `sequence`.
                 "event_id": event_id,
+                // The mission's final assistant output on terminal transitions.
+                "result_summary": result_summary,
                 "sequence": seq,
                 "mission_id": mission_id,
                 "old_status": old_status,

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -2335,6 +2335,16 @@ pub trait MissionStore: Send + Sync {
         success: bool,
     ) -> Result<(), String>;
 
+    /// The text of the mission's most recent assistant message (its final
+    /// output/result), or None when there is none. Used to include the actual
+    /// work product — not just status metadata — in the terminal mission-status
+    /// webhook, so a mission-backed delegation returns a real result to the
+    /// delegating agent. Default None; overridden by the SQLite store.
+    async fn latest_assistant_text(&self, mission_id: Uuid) -> Result<Option<String>, String> {
+        let _ = mission_id;
+        Ok(None)
+    }
+
     // === Event logging methods (default no-op for backward compatibility) ===
 
     /// Log a streaming event. Called for every AgentEvent during execution.

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -5007,6 +5007,43 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn latest_assistant_text(&self, mission_id: Uuid) -> Result<Option<String>, String> {
+        let conn = self.conn.clone();
+        let id_str = mission_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let row = conn
+                .query_row(
+                    "SELECT content, content_file FROM mission_events
+                     WHERE mission_id = ?1
+                       AND event_type IN ('assistant_message', 'assistant_message_canonical')
+                     ORDER BY sequence DESC LIMIT 1",
+                    params![id_str],
+                    |row| {
+                        let content: Option<String> = row.get(0)?;
+                        let content_file: Option<String> = row.get(1)?;
+                        Ok((content, content_file))
+                    },
+                )
+                .optional()
+                .map_err(|e| e.to_string())?;
+            Ok(match row {
+                Some((content, content_file)) => {
+                    let text = Self::load_content(content.as_deref(), content_file.as_deref());
+                    let trimmed = text.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    }
+                }
+                None => None,
+            })
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     // === Event logging methods ===
 
     async fn log_event(&self, mission_id: Uuid, event: &AgentEvent) -> Result<(), String> {


### PR DESCRIPTION
Completes the mission-backed delegation feature (Hermes PR #98): a mission-backed `delegate_task(backend='mission')` now returns the mission's ACTUAL work product, not just status metadata.

- `MissionStore::latest_assistant_text()` — default `None` in the trait (no memory/file impl churn); SQLite override queries the last `assistant_message` content.
- `paloma_webhook_forwarder_loop`: fetches it for **terminal (forwardable) transitions only**, best-effort, and adds `result_summary` to the payload. The Hermes fold already prefers `payload.result_summary`, so no Hermes change is needed.

`cargo fmt` clean, `cargo check` passes. Touches the controller-critical mission-status webhook (additive field only) → deploy in a focused window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the controller mission-status webhook path and adds a DB read on forwardable transitions, but the payload change is additive and lookup failures are non-fatal.
> 
> **Overview**
> Terminal mission-status webhooks now carry the mission’s **actual final assistant output**, not only status fields, so mission-backed `delegate_task` can return a real work product to Hermes (consumers already prefer `payload.result_summary`).
> 
> **`MissionStore::latest_assistant_text`** is added with a trait default of `None` (memory/file unchanged). The SQLite store loads the newest `assistant_message` / `assistant_message_canonical` from `mission_events`, including spilled `content_file` bodies, and returns trimmed text or `None` if empty.
> 
> In **`paloma_webhook_forwarder_loop`**, `result_summary` is populated **only for forwardable (actionable/terminal) status transitions**, via a best-effort store read; failures are ignored and the field may be omitted/null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4385df258ce8c06ce9ad3f90cc9e6489369e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->