### PR TITLE
overview: scheduler heartbeat keeps a quiet controller healthy

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -524,6 +524,63 @@ fn hermes_state_db() -> Option<PathBuf> {
         .filter(|path| path.is_file())
 }
 
+/// The Hermes cron scheduler's jobs file, next to `state.db` in the Hermes
+/// home (`<home>/cron/jobs.json`). Overridable for tests and non-standard
+/// layouts via `HERMES_CRON_JOBS`.
+fn hermes_cron_jobs_path() -> Option<PathBuf> {
+    std::env::var("HERMES_CRON_JOBS")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| {
+            hermes_state_db().and_then(|db| db.parent().map(|home| home.join("cron/jobs.json")))
+        })
+        .filter(|path| path.is_file())
+}
+
+/// Scheduler-side controller heartbeats: job id → last successful run
+/// (RFC3339). Read from the Hermes cron jobs file; only enabled jobs whose
+/// last run succeeded count — a job erroring every tick is not a heartbeat.
+/// Best-effort: a missing or malformed file yields an empty map, never an
+/// error (the board must render without Hermes on disk).
+fn read_controller_heartbeats(path: Option<PathBuf>) -> HashMap<String, String> {
+    let Some(path) = path else {
+        return HashMap::new();
+    };
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return HashMap::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return HashMap::new();
+    };
+    let jobs = match &value {
+        serde_json::Value::Object(map) => match map.get("jobs") {
+            Some(serde_json::Value::Array(jobs)) => jobs.as_slice(),
+            _ => return HashMap::new(),
+        },
+        serde_json::Value::Array(jobs) => jobs.as_slice(),
+        _ => return HashMap::new(),
+    };
+    jobs.iter()
+        .filter_map(|job| {
+            let id = job.get("id")?.as_str()?;
+            if !job
+                .get("enabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                return None;
+            }
+            if job.get("last_status").and_then(|v| v.as_str()) != Some("ok") {
+                return None;
+            }
+            let last_run = job.get("last_run_at")?.as_str()?;
+            // Normalize to RFC3339 UTC so `finish()` parses it uniformly.
+            let at = chrono::DateTime::parse_from_rfc3339(last_run).ok()?;
+            Some((id.to_string(), at.with_timezone(&chrono::Utc).to_rfc3339()))
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct TrackerInfo {
     slug: String,
@@ -611,6 +668,12 @@ struct ProjectRow {
     /// controller ↔ project link.
     #[serde(skip_serializing_if = "Option::is_none")]
     controller_cron_id: Option<String>,
+    /// When the linked controller job last ran successfully (from the Hermes
+    /// cron scheduler), regardless of whether it delivered anything. A
+    /// controller that answers `[SILENT]` for hours is quiet, not dead — this
+    /// is the signal that lets the board tell the two apart.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    controller_heartbeat_at: Option<String>,
     /// The roster record's controller-reported mode (`active` / `blocked` /
     /// `paused`), surfaced directly on the row. Also still rides on
     /// `latest_update.mode` for compatibility.
@@ -873,9 +936,18 @@ pub async fn projects_overview(
         })
         .collect();
 
+    // Scheduler-side heartbeats, resolved once per request: a controller that
+    // ran successfully but delivered nothing ([SILENT] ticks) still proves it
+    // is alive.
+    let heartbeats = read_controller_heartbeats(hermes_cron_jobs_path());
     let mut projects: Vec<ProjectRow> = rows
         .into_values()
-        .map(|builder| {
+        .map(|mut builder| {
+            builder.controller_heartbeat_at = builder
+                .controller_cron_id
+                .as_ref()
+                .and_then(|id| heartbeats.get(id))
+                .cloned();
             let forced = overrides.get(&builder.slug).cloned();
             let binding = bindings.get(&builder.slug).cloned();
             builder.finish(&archived, forced.as_deref(), binding, &now)
@@ -991,6 +1063,9 @@ struct ProjectRowBuilder {
     /// Roster mode + controller link, attached alongside title/next_action.
     mode: Option<String>,
     controller_cron_id: Option<String>,
+    /// Last successful run of the linked controller job (scheduler-side
+    /// heartbeat), resolved by the handler from the Hermes cron jobs file.
+    controller_heartbeat_at: Option<String>,
     tracker: Option<TrackerInfo>,
     missions: Vec<MissionChip>,
     /// Health inputs, accumulated alongside the display chips.
@@ -1010,6 +1085,7 @@ impl ProjectRowBuilder {
             next_action: None,
             mode: None,
             controller_cron_id: None,
+            controller_heartbeat_at: None,
             tracker: None,
             missions: Vec::new(),
             health_inputs: Vec::new(),
@@ -1196,9 +1272,21 @@ impl ProjectRowBuilder {
                 now.signed_duration_since(at) <= chrono::Duration::hours(STALE_ACTIVE_HOURS)
             })
             .unwrap_or(false);
+        // Scheduler-side heartbeat: the linked job ran successfully recently,
+        // even if it delivered nothing ([SILENT] ticks produce no state event).
+        // A quiet controller is not a dead one.
+        let heartbeat_within_stale_window = self
+            .controller_heartbeat_at
+            .as_deref()
+            .and_then(|at| chrono::DateTime::parse_from_rfc3339(at).ok())
+            .zip(now_parsed)
+            .map(|(at, now)| {
+                now.signed_duration_since(at) <= chrono::Duration::hours(STALE_ACTIVE_HOURS)
+            })
+            .unwrap_or(false);
         let controller_health: Option<&'static str> =
             if claims_active || self.controller_cron_id.is_some() {
-                if signal_within_stale_window || has_live_mission {
+                if signal_within_stale_window || has_live_mission || heartbeat_within_stale_window {
                     // Something is clearly driving it (fresh delivery or live
                     // work) — don't cry wolf over a missing link when the engine
                     // is demonstrably running. The link mismatch is a P2 concern.
@@ -1298,6 +1386,7 @@ impl ProjectRowBuilder {
             bucket,
             board_override: forced.map(str::to_string),
             controller_cron_id: self.controller_cron_id,
+            controller_heartbeat_at: self.controller_heartbeat_at,
             mode: self.mode,
             controller_health,
             delivery_health,
@@ -2179,6 +2268,63 @@ mod tests {
         let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
         assert_eq!(row.bucket, "attention");
         assert!(row.attention_reasons.iter().any(|r| r.contains("Failed")));
+    }
+
+    /// A controller that runs on schedule but delivers nothing ([SILENT]
+    /// ticks) is quiet, not dead: a fresh scheduler heartbeat keeps
+    /// `controller_health=healthy` even when the last state event is old.
+    #[test]
+    fn silent_controller_with_fresh_heartbeat_is_healthy() {
+        let mut builder = ProjectRowBuilder::new("lean-silicon".to_string());
+        builder.mode = Some("active".to_string());
+        builder.controller_cron_id = Some("job42".to_string());
+        // Last delivered state is 2 days old …
+        builder.attach_store_update(active_update("2026-08-02T12:00:00Z", None), 1, 5);
+        // … but the job itself ran successfully 10 minutes ago.
+        builder.controller_heartbeat_at = Some("2026-08-04T11:50:00+00:00".to_string());
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert_eq!(row.controller_health, Some("healthy"));
+        assert_eq!(
+            row.controller_heartbeat_at.as_deref(),
+            Some("2026-08-04T11:50:00+00:00")
+        );
+    }
+
+    /// Without a heartbeat the same silent controller is `stale` — the field
+    /// is what separates the two regimes.
+    #[test]
+    fn silent_controller_without_heartbeat_stays_stale() {
+        let mut builder = ProjectRowBuilder::new("lean-silicon".to_string());
+        builder.mode = Some("active".to_string());
+        builder.controller_cron_id = Some("job42".to_string());
+        builder.attach_store_update(active_update("2026-08-02T12:00:00Z", None), 1, 5);
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert_eq!(row.controller_health, Some("stale"));
+    }
+
+    /// jobs.json → heartbeat map: only enabled jobs whose last run succeeded
+    /// count, and timestamps normalize to UTC.
+    #[test]
+    fn heartbeats_read_only_successful_enabled_jobs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("jobs.json");
+        std::fs::write(
+            &path,
+            r#"{"jobs": [
+                {"id": "ok1", "enabled": true, "last_status": "ok", "last_run_at": "2026-08-13T12:33:20.283248+02:00"},
+                {"id": "err1", "enabled": true, "last_status": "error", "last_run_at": "2026-08-13T12:14:43+02:00"},
+                {"id": "off1", "enabled": false, "last_status": "ok", "last_run_at": "2026-08-13T12:14:43+02:00"},
+                {"id": "new1", "enabled": true, "last_status": null, "last_run_at": null}
+            ]}"#,
+        )
+        .expect("seed");
+        let map = read_controller_heartbeats(Some(path));
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.get("ok1").map(String::as_str),
+            Some("2026-08-13T10:33:20.283248+00:00")
+        );
+        assert!(read_controller_heartbeats(None).is_empty());
     }
 
     /// Honesty read-model: an active project whose engine is gone (no fresh


### PR DESCRIPTION
## Problem

A controller that answers `[SILENT]` for hours delivers nothing, so its project's `latest_update` ages and both the server axis and the board plugin's 2h client heuristic read it as dead (seen on lean-silicon 2026-08-13: certification running, controller quiet, card said stale).

## What

- Read the Hermes cron jobs file once per overview request (`HERMES_CRON_JOBS`, defaulting to `<hermes-home>/cron/jobs.json` next to `HERMES_STATE_DB`). Best-effort: missing/malformed file → empty map.
- Expose `controller_heartbeat_at` per row: last successful run of the linked `controller_cron_id` job. Only **enabled** jobs whose `last_status == ok` count — a job erroring every tick is not a heartbeat.
- `controller_health`: a heartbeat within the stale window now counts as a live signal (healthy), alongside fresh deliveries and live missions.

Companion plugin change: Th0rgal/hermes-agent#100 (trust the server verdict + use the heartbeat as alternative proof of life).

## Tests
`silent_controller_with_fresh_heartbeat_is_healthy`, `silent_controller_without_heartbeat_stays_stale`, `heartbeats_read_only_successful_enabled_jobs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only overview enrichment with graceful degradation when Hermes cron files are absent; only changes derived `controller_health` and adds an optional JSON field.
> 
> **Overview**
> Fixes **false “stale/dead” controller health** when a project’s linked cron job keeps running successfully but delivers nothing (`[SILENT]` ticks), so `latest_update` ages even though the scheduler is fine.
> 
> On each **projects overview** request, the API **best-effort reads** the Hermes cron jobs file (`HERMES_CRON_JOBS`, default `<hermes-home>/cron/jobs.json` beside `HERMES_STATE_DB`). It builds a map of **enabled jobs whose `last_status` is `ok`** → normalized UTC `last_run_at`, then sets **`controller_heartbeat_at`** on each row from `controller_cron_id`.
> 
> **`controller_health`** now treats a heartbeat within the existing stale window like a fresh delivery or live mission: **`healthy`** instead of **`stale`** when the last state event is old but the job recently succeeded. Missing or bad `jobs.json` yields an empty map so the board still renders.
> 
> Tests cover fresh vs absent heartbeat for silent controllers and heartbeat parsing/filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad74753ca87fcb170e2709d38863e280d2f5c7cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->