### PR TITLE
projects: roadmap hardening (controller scope, board ownership, drop board_projects)

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4605,6 +4605,30 @@ pub struct BoardVerdictRequest {
     /// Required for reject: feedback delivered to the worker.
     #[serde(default)]
     pub feedback: Option<String>,
+    /// The calling boss mission, when the caller IS a mission (orchestrator
+    /// MCP always sends its own id). Must match the task's board — a mission
+    /// may not judge another board's tasks. Absent = owner/dashboard call,
+    /// which passes on auth alone.
+    #[serde(default)]
+    pub boss_mission_id: Option<Uuid>,
+}
+
+/// A mission may only act on its own board; the owner (no mission id) may act
+/// on any.
+fn assert_board_ownership(
+    task: &BoardTask,
+    caller: Option<Uuid>,
+) -> Result<(), (StatusCode, String)> {
+    match caller {
+        Some(caller) if caller != task.boss_mission_id => Err((
+            StatusCode::FORBIDDEN,
+            format!(
+                "task `{}` belongs to boss {}, not {} — a mission may only judge its own board",
+                task.task_key, task.boss_mission_id, caller
+            ),
+        )),
+        _ => Ok(()),
+    }
 }
 
 /// POST /api/control/board/tasks/:task_id/verdict — boss judgment on a
@@ -4623,6 +4647,7 @@ pub async fn board_task_verdict(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
         .ok_or((StatusCode::NOT_FOUND, format!("task {} not found", task_id)))?;
+    assert_board_ownership(&task, req.boss_mission_id)?;
 
     match req.action.as_str() {
         "accept" => {
@@ -4714,12 +4739,20 @@ pub async fn board_task_verdict(
     Ok(Json(task))
 }
 
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct CancelBoardTaskRequest {
+    /// See `BoardVerdictRequest::boss_mission_id`.
+    #[serde(default)]
+    pub boss_mission_id: Option<Uuid>,
+}
+
 /// POST /api/control/board/tasks/:task_id/cancel — mark a task cancelled.
 /// A running worker is left to finish its current turn; its settle is ignored.
 pub async fn cancel_board_task(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
     Path(task_id): Path<Uuid>,
+    body: Option<Json<CancelBoardTaskRequest>>,
 ) -> Result<Json<BoardTask>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
     let mut task = control
@@ -4728,6 +4761,7 @@ pub async fn cancel_board_task(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
         .ok_or((StatusCode::NOT_FOUND, format!("task {} not found", task_id)))?;
+    assert_board_ownership(&task, body.and_then(|Json(req)| req.boss_mission_id))?;
     if task.status.is_terminal() {
         return Err((
             StatusCode::CONFLICT,

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -1,9 +1,9 @@
 //! In-memory mission store (non-persistent).
 
 use super::{
-    now_string, BoardOutboxItem, BoardProject, BoardTask, BoardTaskStatus, Mission,
-    MissionExecutionState, MissionHistoryEntry, MissionRun, MissionStatus, MissionStatusCounts,
-    MissionStore, MissionToolExecution, MissionToolExecutionState, NewBoardTask, TaskAttempt,
+    now_string, BoardOutboxItem, BoardTask, BoardTaskStatus, Mission, MissionExecutionState,
+    MissionHistoryEntry, MissionRun, MissionStatus, MissionStatusCounts, MissionStore,
+    MissionToolExecution, MissionToolExecutionState, NewBoardTask, TaskAttempt,
 };
 use crate::api::control::{AgentTreeNode, DesktopSessionInfo};
 use async_trait::async_trait;
@@ -25,7 +25,6 @@ pub struct InMemoryMissionStore {
     deferred_goals: Arc<RwLock<HashMap<Uuid, String>>>,
     runs: Arc<RwLock<HashMap<Uuid, MissionRun>>>,
     tool_executions: Arc<RwLock<HashMap<(Uuid, String), MissionToolExecution>>>,
-    board_projects: Arc<RwLock<HashMap<String, BoardProject>>>,
     task_attempts: Arc<RwLock<HashMap<(Uuid, u32), TaskAttempt>>>,
     board_outbox: Arc<RwLock<HashMap<String, BoardOutboxItem>>>,
 }
@@ -39,7 +38,6 @@ impl InMemoryMissionStore {
             deferred_goals: Arc::new(RwLock::new(HashMap::new())),
             runs: Arc::new(RwLock::new(HashMap::new())),
             tool_executions: Arc::new(RwLock::new(HashMap::new())),
-            board_projects: Arc::new(RwLock::new(HashMap::new())),
             task_attempts: Arc::new(RwLock::new(HashMap::new())),
             board_outbox: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -998,23 +996,6 @@ impl MissionStore for InMemoryMissionStore {
         saved.updated_at = now_string();
         map.insert(task.id, saved);
         Ok(())
-    }
-
-    async fn upsert_board_project(
-        &self,
-        mut project: BoardProject,
-    ) -> Result<BoardProject, String> {
-        let mut projects = self.board_projects.write().await;
-        if let Some(existing) = projects.get(&project.slug) {
-            project.created_at = existing.created_at.clone();
-        }
-        project.updated_at = now_string();
-        projects.insert(project.slug.clone(), project.clone());
-        Ok(project)
-    }
-
-    async fn get_board_project(&self, slug: &str) -> Result<Option<BoardProject>, String> {
-        Ok(self.board_projects.read().await.get(slug).cloned())
     }
 
     async fn create_task_attempt(&self, attempt: TaskAttempt) -> Result<TaskAttempt, String> {

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1586,24 +1586,6 @@ impl BoardTaskRole {
     }
 }
 
-/// Canonical project record. Repository markdown remains the source of human
-/// intent; only its path and immutable revision are stored here.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BoardProject {
-    pub slug: String,
-    pub repository: String,
-    pub workspace_id: Uuid,
-    pub specification_path: String,
-    pub specification_revision: String,
-    pub compute_policy: String,
-    #[serde(default)]
-    pub budget_policy: serde_json::Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_controller_lease: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
-}
-
 /// Immutable history for one task execution attempt.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskAttempt {
@@ -3633,16 +3615,6 @@ pub trait MissionStore: Send + Sync {
     async fn save_board_task(&self, task: &BoardTask) -> Result<(), String> {
         let _ = task;
         Err("Task board not supported by this mission store".to_string())
-    }
-
-    async fn upsert_board_project(&self, project: BoardProject) -> Result<BoardProject, String> {
-        let _ = project;
-        Err("Project ledger not supported by this mission store".to_string())
-    }
-
-    async fn get_board_project(&self, slug: &str) -> Result<Option<BoardProject>, String> {
-        let _ = slug;
-        Ok(None)
     }
 
     async fn create_task_attempt(&self, attempt: TaskAttempt) -> Result<TaskAttempt, String> {

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2,8 +2,8 @@
 
 use super::{
     now_string, sanitize_filename, Automation, AutomationExecution, AwaitingKind, BoardOutboxItem,
-    BoardProject, BoardTask, BoardTaskOutcome, BoardTaskRole, BoardTaskStatus, CommandSource,
-    DailyUsageStats, ExecutionStatus, FreshSession, HourlyUsageStats, Mission, MissionActivity,
+    BoardTask, BoardTaskOutcome, BoardTaskRole, BoardTaskStatus, CommandSource, DailyUsageStats,
+    ExecutionStatus, FreshSession, HourlyUsageStats, Mission, MissionActivity,
     MissionExecutionState, MissionFilter, MissionHistoryEntry, MissionMode, MissionProject,
     MissionProjectPatch, MissionRun, MissionScheduling, MissionStatus, MissionStatusCounts,
     MissionStore, MissionSummary, MissionToolExecution, MissionToolExecutionState, ModelUsageStats,
@@ -733,19 +733,6 @@ CREATE INDEX IF NOT EXISTS idx_board_tasks_boss ON board_tasks(boss_mission_id);
 CREATE INDEX IF NOT EXISTS idx_board_tasks_worker ON board_tasks(worker_mission_id);
 CREATE INDEX IF NOT EXISTS idx_board_tasks_status ON board_tasks(status);
 
-CREATE TABLE IF NOT EXISTS board_projects (
-    slug TEXT PRIMARY KEY,
-    repository TEXT NOT NULL,
-    workspace_id TEXT NOT NULL,
-    specification_path TEXT NOT NULL,
-    specification_revision TEXT NOT NULL,
-    compute_policy TEXT NOT NULL,
-    budget_policy TEXT NOT NULL DEFAULT '{}',
-    active_controller_lease TEXT,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS task_attempts (
     id TEXT PRIMARY KEY,
     task_id TEXT NOT NULL,
@@ -1380,6 +1367,12 @@ impl SqliteMissionStore {
                 }
             }
         }
+
+        // board_projects never got wired up (the `projects` table in
+        // projects.db is the authoritative project object); every deployment
+        // audited at zero rows, so drop it outright.
+        conn.execute("DROP TABLE IF EXISTS board_projects", [])
+            .map_err(|e| format!("Failed to drop board_projects: {e}"))?;
 
         // Check if 'backend' column exists in missions table
         let has_backend_column: bool = conn
@@ -11184,56 +11177,6 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| format!("Task join error: {e}"))?
     }
 
-    async fn upsert_board_project(&self, project: BoardProject) -> Result<BoardProject, String> {
-        let conn = self.conn.clone();
-        tokio::task::spawn_blocking(move || {
-            let conn = conn.blocking_lock();
-            let now = now_string();
-            let budget = serde_json::to_string(&project.budget_policy)
-                .map_err(|error| format!("Failed to serialize project budget: {error}"))?;
-            conn.execute(
-                "INSERT INTO board_projects (slug, repository, workspace_id, specification_path, \
-                 specification_revision, compute_policy, budget_policy, active_controller_lease, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9) \
-                 ON CONFLICT(slug) DO UPDATE SET repository = excluded.repository, workspace_id = excluded.workspace_id, \
-                 specification_path = excluded.specification_path, specification_revision = excluded.specification_revision, \
-                 compute_policy = excluded.compute_policy, budget_policy = excluded.budget_policy, \
-                 active_controller_lease = excluded.active_controller_lease, updated_at = excluded.updated_at",
-                params![
-                    project.slug,
-                    project.repository,
-                    project.workspace_id.to_string(),
-                    project.specification_path,
-                    project.specification_revision,
-                    project.compute_policy,
-                    budget,
-                    project.active_controller_lease,
-                    now,
-                ],
-            )
-            .map_err(|error| format!("Failed to upsert project: {error}"))?;
-            parse_board_project(
-                &conn,
-                &project.slug,
-            )
-            .map_err(|error| format!("Failed to read project: {error}"))?
-            .ok_or_else(|| "Project disappeared after upsert".to_string())
-        })
-        .await
-        .map_err(|error| format!("Task join error: {error}"))?
-    }
-
-    async fn get_board_project(&self, slug: &str) -> Result<Option<BoardProject>, String> {
-        let conn = self.conn.clone();
-        let slug = slug.to_string();
-        tokio::task::spawn_blocking(move || {
-            let conn = conn.blocking_lock();
-            parse_board_project(&conn, &slug).map_err(|error| error.to_string())
-        })
-        .await
-        .map_err(|error| format!("Task join error: {error}"))?
-    }
-
     async fn create_task_attempt(&self, attempt: TaskAttempt) -> Result<TaskAttempt, String> {
         let conn = self.conn.clone();
         tokio::task::spawn_blocking(move || {
@@ -11462,35 +11405,6 @@ fn parse_board_task_row(row: &rusqlite::Row<'_>) -> Result<BoardTask, rusqlite::
         created_at: row.get(29)?,
         updated_at: row.get(30)?,
     })
-}
-
-fn parse_board_project(
-    conn: &Connection,
-    slug: &str,
-) -> Result<Option<BoardProject>, rusqlite::Error> {
-    conn.query_row(
-        "SELECT slug, repository, workspace_id, specification_path, specification_revision, \
-         compute_policy, budget_policy, active_controller_lease, created_at, updated_at \
-         FROM board_projects WHERE slug = ?1",
-        params![slug],
-        |row| {
-            let workspace_id: String = row.get(2)?;
-            let budget_policy: String = row.get(6)?;
-            Ok(BoardProject {
-                slug: row.get(0)?,
-                repository: row.get(1)?,
-                workspace_id: Uuid::parse_str(&workspace_id).unwrap_or_default(),
-                specification_path: row.get(3)?,
-                specification_revision: row.get(4)?,
-                compute_policy: row.get(5)?,
-                budget_policy: serde_json::from_str(&budget_policy).unwrap_or_default(),
-                active_controller_lease: row.get(7)?,
-                created_at: row.get(8)?,
-                updated_at: row.get(9)?,
-            })
-        },
-    )
-    .optional()
 }
 
 fn parse_task_attempt_row(row: &rusqlite::Row<'_>) -> Result<TaskAttempt, rusqlite::Error> {
@@ -16346,7 +16260,7 @@ mod tests {
     #[tokio::test]
     async fn project_attempt_and_outbox_ledgers_are_idempotent() {
         use crate::api::mission_store::{
-            BoardOutboxItem, BoardProject, BoardTaskRole, NewBoardTask, TaskAttempt,
+            BoardOutboxItem, BoardTaskRole, NewBoardTask, TaskAttempt,
         };
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
@@ -16369,29 +16283,6 @@ mod tests {
             .await
             .expect("task")
             .remove(0);
-
-        let project = BoardProject {
-            slug: "beal".into(),
-            repository: "owner/beal".into(),
-            workspace_id: boss.workspace_id,
-            specification_path: "SPEC.md".into(),
-            specification_revision: "abc123".into(),
-            compute_policy: "remote_required".into(),
-            budget_policy: serde_json::json!({"cost_cents": 500}),
-            active_controller_lease: Some("controller-1".into()),
-            created_at: now_string(),
-            updated_at: now_string(),
-        };
-        store.upsert_board_project(project).await.expect("project");
-        assert_eq!(
-            store
-                .get_board_project("beal")
-                .await
-                .unwrap()
-                .unwrap()
-                .compute_policy,
-            "remote_required"
-        );
 
         let attempt = TaskAttempt {
             id: Uuid::new_v4(),

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1107,6 +1107,10 @@ struct AssistantMcp {
     api_url: String,
     api_token: Option<String>,
     jwt_secret: Option<String>,
+    /// Slugs this instance may MUTATE (`SANDBOXED_PROJECT_SCOPE`, comma-list).
+    /// None = unrestricted (the owner's interactive Hermes). Reads are never
+    /// scoped — cross-project awareness is a feature, not a leak.
+    project_scope: Option<std::collections::HashSet<String>>,
     client: reqwest::Client,
 }
 
@@ -1126,14 +1130,42 @@ impl AssistantMcp {
         let jwt_secret = std::env::var("JWT_SECRET")
             .ok()
             .filter(|secret| !secret.trim().is_empty());
+        let project_scope = std::env::var("SANDBOXED_PROJECT_SCOPE")
+            .ok()
+            .map(|raw| {
+                raw.split(',')
+                    .map(|slug| slug.trim().to_string())
+                    .filter(|slug| !slug.is_empty())
+                    .collect::<std::collections::HashSet<_>>()
+            })
+            .filter(|scope| !scope.is_empty());
         Self {
             api_url,
             api_token,
             jwt_secret,
+            project_scope,
             client: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(120))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
+        }
+    }
+
+    /// Gate for MUTATING project tools. Scoped controllers stay inside their
+    /// own project; unscoped instances (owner chat) pass untouched.
+    fn assert_project_scope(&self, slug: &str) -> Result<(), String> {
+        let slug = slug.trim();
+        match &self.project_scope {
+            Some(scope) if !scope.contains(slug) => {
+                let mut allowed: Vec<&str> = scope.iter().map(String::as_str).collect();
+                allowed.sort_unstable();
+                Err(format!(
+                    "project '{slug}' is outside this controller's scope ({}). \
+                     Mutating tools are limited to your own project; reads are unrestricted.",
+                    allowed.join(", ")
+                ))
+            }
+            _ => Ok(()),
         }
     }
 
@@ -2632,6 +2664,7 @@ impl AssistantMcp {
         params: UpdateProjectStatusParams,
     ) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let body = json!({
             "mode": params.mode,
             "next_action": params.next_action,
@@ -2645,6 +2678,7 @@ impl AssistantMcp {
 
     async fn set_project_track(&self, params: SetProjectTrackParams) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let body = json!({
             "track": params.track,
             "desired_state": params.desired_state,
@@ -2664,6 +2698,7 @@ impl AssistantMcp {
 
     async fn set_project_grant(&self, params: SetProjectGrantParams) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let body = json!({
             "merge_authority": params.merge_authority,
             "budget_per_tick": params.budget_per_tick,
@@ -2684,6 +2719,7 @@ impl AssistantMcp {
         params: RecordProjectDecisionParams,
     ) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let body = json!({
             "question": params.question,
             "rationale": params.rationale,
@@ -2703,6 +2739,7 @@ impl AssistantMcp {
         params: AnswerProjectDecisionParams,
     ) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let body = json!({ "at": params.at, "answer": params.answer });
         let response = self
             .api_post(&format!("/api/projects/{slug}/decision/answer"), body)
@@ -2718,6 +2755,7 @@ impl AssistantMcp {
 
     async fn plan_project_tasks(&self, params: PlanProjectTasksParams) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let tasks: Vec<Value> = params
             .tasks
             .iter()
@@ -2742,6 +2780,7 @@ impl AssistantMcp {
 
     async fn update_project_task(&self, params: UpdateProjectTaskParams) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let task_key = params.task_key.trim();
         let response = self
             .api_patch(
@@ -2759,6 +2798,7 @@ impl AssistantMcp {
 
     async fn cancel_project_task(&self, params: CancelProjectTaskParams) -> Result<Value, String> {
         let slug = params.slug.trim();
+        self.assert_project_scope(slug)?;
         let task_key = params.task_key.trim();
         let response = self
             .api_delete(&format!("/api/projects/{slug}/tasks/{task_key}"))
@@ -2770,6 +2810,7 @@ impl AssistantMcp {
         &self,
         params: LinkMissionToProjectParams,
     ) -> Result<Value, String> {
+        self.assert_project_scope(&params.slug)?;
         let id = self.resolve_mission_id(&params.mission_id).await?;
         let mut body = serde_json::Map::new();
         body.insert("project".to_string(), json!(params.slug.trim()));
@@ -4898,6 +4939,33 @@ mod tests {
         let backwards = mission_events_path(id, 40, "all", Some(99), Some(17));
         assert!(backwards.ends_with("&before_seq=99"));
         assert!(!backwards.contains("since_seq"));
+    }
+
+    #[test]
+    fn project_scope_gates_mutations_only() {
+        let scoped = AssistantMcp {
+            api_url: "http://127.0.0.1:3000".to_string(),
+            api_token: None,
+            jwt_secret: None,
+            project_scope: Some(["verity".to_string()].into_iter().collect()),
+            client: reqwest::Client::new(),
+        };
+        assert!(scoped.assert_project_scope("verity").is_ok());
+        assert!(
+            scoped.assert_project_scope(" verity ").is_ok(),
+            "slugs are trimmed"
+        );
+        let err = scoped.assert_project_scope("lido").unwrap_err();
+        assert!(err.contains("outside this controller's scope"), "{err}");
+
+        let open = AssistantMcp {
+            api_url: "http://127.0.0.1:3000".to_string(),
+            api_token: None,
+            jwt_secret: None,
+            project_scope: None,
+            client: reqwest::Client::new(),
+        };
+        assert!(open.assert_project_scope("anything").is_ok());
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1151,6 +1151,32 @@ impl AssistantMcp {
         }
     }
 
+    /// Scope gate for mission-level mutators. A scoped controller may only
+    /// touch missions tagged with one of its projects — anything else
+    /// (another project's mission, or an untagged one it cannot prove it
+    /// owns) is refused. Unscoped instances skip the lookup entirely.
+    async fn assert_mission_scope(&self, mission_id: Uuid) -> Result<(), String> {
+        if self.project_scope.is_none() {
+            return Ok(());
+        }
+        let response = self
+            .api_get(&format!("/api/control/missions/{mission_id}"))
+            .await?;
+        let mission = Self::response_value(response, "load mission for scope check").await?;
+        let project = mission
+            .get("project")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|slug| !slug.is_empty());
+        match project {
+            Some(slug) => self.assert_project_scope(slug),
+            None => Err(format!(
+                "mission {mission_id} carries no project tag — a scoped controller may only \
+                 act on missions tagged with its own project"
+            )),
+        }
+    }
+
     /// Gate for MUTATING project tools. Scoped controllers stay inside their
     /// own project; unscoped instances (owner chat) pass untouched.
     fn assert_project_scope(&self, slug: &str) -> Result<(), String> {
@@ -2180,6 +2206,19 @@ impl AssistantMcp {
     }
 
     async fn start_mission(&self, params: StartMissionParams) -> Result<Value, String> {
+        // A scoped controller must launch work under its own project — an
+        // untagged mission would escape both the roster and this scope.
+        if self.project_scope.is_some() {
+            match params.project.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
+                Some(project) => self.assert_project_scope(project)?,
+                None => {
+                    return Err(
+                        "scoped controllers must pass `project` on start_mission so the                          mission stays inside their scope"
+                            .to_string(),
+                    )
+                }
+            }
+        }
         let workspace_id = resolve_default_workspace_id(params.workspace_id);
         let backend = params
             .backend
@@ -2349,6 +2388,7 @@ impl AssistantMcp {
 
     async fn send_message(&self, params: SendMessageParams) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         let response = self
             .api_post(
                 "/api/control/message",
@@ -2370,6 +2410,7 @@ impl AssistantMcp {
 
     async fn ask_mission(&self, params: AskMissionParams) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         let mut body = json!({
             "content": params.content,
             "sandbox": params.sandbox,
@@ -2418,6 +2459,7 @@ impl AssistantMcp {
         params: AnswerMissionQuestionParams,
     ) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         if params.answers.is_empty() || params.answers.iter().any(Vec::is_empty) {
             return Err(
                 "answers must contain one non-empty inner array per question, e.g. [[\"Option A\"]]"
@@ -2510,6 +2552,7 @@ impl AssistantMcp {
 
     async fn cancel_mission(&self, params: MissionIdParams) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         let response = self
             .api_post(&format!("/api/control/missions/{id}/cancel"), json!({}))
             .await?;
@@ -2522,6 +2565,7 @@ impl AssistantMcp {
 
     async fn adopt_mission(&self, params: AdoptMissionParams) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         // The session id is stamped by the sandboxed-origin-session plugin,
         // exactly as for start_mission. Refuse to adopt into nothing: an
         // adoption without a session would silently CLEAR the mission's
@@ -2561,6 +2605,7 @@ impl AssistantMcp {
 
     async fn acknowledge_mission(&self, params: MissionIdParams) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         let response = self
             .api_get(&format!("/api/control/missions/{id}/digest"))
             .await?;
@@ -2999,6 +3044,7 @@ impl AssistantMcp {
 
     async fn update_mission_settings(&self, params: UpdateSettingsParams) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         let mut body = serde_json::Map::new();
         if let Some(backend) = params
             .backend
@@ -3061,6 +3107,7 @@ impl AssistantMcp {
 
     async fn resume_mission(&self, params: ResumeMissionParams) -> Result<Value, String> {
         let id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(id).await?;
         let hint = params
             .content
             .as_deref()

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -2201,7 +2201,9 @@ impl OrchestratorMcp {
         let response = self
             .api_post(
                 &format!("/api/control/board/tasks/{}/verdict", id),
-                json!({ "action": action, "feedback": feedback }),
+                // Sending our own mission id lets the server enforce that a
+                // boss only judges its own board.
+                json!({ "action": action, "feedback": feedback, "boss_mission_id": self.mission_id }),
             )
             .await?;
         if !response.status().is_success() {


### PR DESCRIPTION
Replaces #818 (its pull_request events died after the base retarget from the merged #817; CI could never schedule).

Implements the three confirmed hardening items plus the review fix from #818:

1. **Controller scoping** — `SANDBOXED_PROJECT_SCOPE=slug[,slug]` restricts the nine mutating project tools; per the review finding it also gates the mission layer: `start_mission` requires an in-scope `project`, and the eight mission mutators (send_message/ask/answer/cancel/adopt/acknowledge/resume/update_settings) check the target mission's project tag, refusing untagged missions. Reads and unscoped instances are untouched.
2. **Board ownership** — `verdict`/`cancel` accept an optional `boss_mission_id`; a mismatch with the task's boss is 403. orchestrator-mcp always sends its own id. Owner/dashboard calls without the field are unchanged.
3. **Drop `board_projects`** — never-wired table removed end to end + `DROP TABLE IF EXISTS` migration; audited zero rows across all prod mission DBs.

Verification: lib 1837 green, assistant-mcp 47 (incl. scope unit test), orchestrator-mcp 32, fmt clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization boundaries for board verdicts/cancels and sandboxed MCP mutators; behavior changes for scoped controllers and mission callers that omit or mismatch `boss_mission_id`, while dropping an unused table is low risk if truly empty.
> 
> **Overview**
> Hardens project roadmap control paths with **scoped sandboxed controllers**, **board task ownership checks**, and removal of dead **`board_projects`** storage.
> 
> **Controller scoping (`assistant_mcp`)** — `SANDBOXED_PROJECT_SCOPE` (comma-separated slugs) limits **mutations** to allowed projects; reads stay global. Project mutators call `assert_project_scope`; mission mutators call `assert_mission_scope` (mission must carry an in-scope project tag). Scoped `start_mission` requires an in-scope `project` argument.
> 
> **Board ownership (`control` + `orchestrator_mcp`)** — Board **verdict** and **cancel** accept optional `boss_mission_id`; when present it must match the task’s boss or the API returns **403**. Orchestrator MCP always sends its own mission id; owner/dashboard calls without the field behave as before.
> 
> **Drop `board_projects`** — Unused `BoardProject` type, store APIs, in-memory/sqlite implementations, and the SQLite table (migration `DROP TABLE IF EXISTS`) are removed; authoritative projects live in `projects.db`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f7a7dab7b066de011ace0c90ecc32fe790f507a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->