### PR TITLE
fix: auto-close merged-PR decisions and derive honest board mode

### DIFF
--- a/dashboard/src/components/projects/project-health.test.ts
+++ b/dashboard/src/components/projects/project-health.test.ts
@@ -43,6 +43,11 @@ describe("parseMode", () => {
     expect(mode).toEqual({ base: "blocked", cause: "scanner-dead" });
   });
 
+  test("renders a parked-decision mode as blocked:decision", () => {
+    const mode = parseMode(row({ mode: "blocked:decision" }));
+    expect(mode).toEqual({ base: "blocked", cause: "decision" });
+  });
+
   test("falls back to the delivery trailer when the roster has no mode", () => {
     const mode = parseMode(
       row({

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -208,6 +208,7 @@ fn ingest_deliveries(
         // covers acting. Keyed by the delivery's timestamp (INSERT OR IGNORE),
         // so overlapping ingest windows record it once and never reopen an
         // answered row.
+        let mut recorded_decided = false;
         if let Some(trailer) = delivery.decision.as_ref() {
             let grant = projects.get_grant(slug).ok().flatten();
             let autonomy = grant.as_ref().and_then(|g| g.autonomy_level.clone());
@@ -220,6 +221,7 @@ fn ingest_deliveries(
                 trailer.kind.as_deref(),
             ) {
                 Ok(disposition) => {
+                    recorded_decided = disposition.status == "decided";
                     let decision = super::projects_store::NewDecision {
                         question: trailer.question.clone(),
                         rationale: trailer.rationale.clone(),
@@ -237,6 +239,21 @@ fn ingest_deliveries(
                 Err(error) => {
                     tracing::warn!("state ingest decision trailer rejected: {slug}: {error}");
                 }
+            }
+        }
+        // A merge announcement (headline or a grant-allowed decided act)
+        // retires older "merge #N?" questions so the card stops asking
+        // about a PR that already landed. The current delivery's own
+        // coerced trailer is skipped — it stays the escalation.
+        let needles = merge_announcement_needles(&delivery, recorded_decided);
+        if !needles.is_empty() {
+            if let Err(error) = projects.close_pending_decisions_referencing(
+                slug,
+                &needles,
+                "closed: referenced PR merged",
+                Some(delivery.at.as_str()),
+            ) {
+                tracing::warn!("state ingest close merged decisions: {slug}: {error}");
             }
         }
     }
@@ -848,6 +865,78 @@ pub(crate) fn extract_pr_url(text: &str) -> Option<String> {
                 _ => None,
             }
         })
+}
+
+/// `#N` hashes and GitHub PR URLs a later merge announcement can match
+/// against pending ledger rows. `#1` is kept distinct from `#10`.
+pub(crate) fn extract_pr_needles(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(url) = extract_pr_url(text) {
+        out.push(url.clone());
+        if let Some(number) = url.rsplit('/').next() {
+            let hash = format!("#{number}");
+            if !out.contains(&hash) {
+                out.push(hash);
+            }
+        }
+    }
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'#' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() {
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && bytes[end].is_ascii_digit() {
+                end += 1;
+            }
+            let hash = format!("#{}", &text[start..end]);
+            if !out.contains(&hash) {
+                out.push(hash);
+            }
+            i = end;
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+fn delivery_looks_merged(headline: &str) -> bool {
+    let lower = headline.to_ascii_lowercase();
+    lower.contains("merged") || lower.contains("mergé")
+}
+
+fn merge_announcement_needles(delivery: &DeliveryUpdate, recorded_decided: bool) -> Vec<String> {
+    if !recorded_decided && !delivery_looks_merged(&delivery.headline) {
+        return Vec::new();
+    }
+    let mut blobs: Vec<&str> = vec![delivery.headline.as_str()];
+    if let Some(body) = delivery.body.as_deref() {
+        blobs.push(body);
+    }
+    if let Some(decision) = delivery.decision.as_ref() {
+        blobs.push(decision.question.as_str());
+        if let Some(rationale) = decision.rationale.as_deref() {
+            blobs.push(rationale);
+        }
+        if let Some(url) = decision
+            .evidence
+            .as_ref()
+            .and_then(|value| value.get("pr_url"))
+            .and_then(|value| value.as_str())
+        {
+            blobs.push(url);
+        }
+    }
+    let mut needles = Vec::new();
+    for blob in blobs {
+        for needle in extract_pr_needles(blob) {
+            if !needles.contains(&needle) {
+                needles.push(needle);
+            }
+        }
+    }
+    needles
 }
 
 /// `GET /api/projects/:slug/tasks` — the project's roadmap: every board task
@@ -1819,6 +1908,29 @@ pub(crate) fn humanize_slug(slug: &str) -> String {
         .join(" ")
 }
 
+/// Roster/CTRL mode is the default; live work and parked decisions win.
+/// `paused` is never overridden — the operator (or controller) parked it.
+pub(crate) fn honest_controller_mode(
+    store_mode: Option<&str>,
+    has_live_mission: bool,
+    awaiting_user: bool,
+    pending_decisions: u32,
+) -> Option<String> {
+    let base = store_mode
+        .map(|mode| mode.split_once(':').map_or(mode, |(head, _)| head))
+        .unwrap_or("");
+    if base.eq_ignore_ascii_case("paused") {
+        return store_mode.map(str::to_string);
+    }
+    if has_live_mission && !awaiting_user {
+        return Some("active".to_string());
+    }
+    if pending_decisions > 0 {
+        return Some("blocked:decision".to_string());
+    }
+    store_mode.map(str::to_string)
+}
+
 struct ProjectRowBuilder {
     slug: String,
     /// Roster title/next-action, attached when the slug has a roster record.
@@ -1911,6 +2023,24 @@ impl ProjectRowBuilder {
             .iter()
             .filter(|chip| chip.status == MissionStatus::AwaitingUser)
             .count();
+        let has_live_mission = self
+            .missions
+            .iter()
+            .any(|chip| !chip.status.is_terminal() && chip.status != MissionStatus::Acknowledged);
+        // Live work and parked decisions beat the last CTRL trailer. A
+        // writer already running is `active` even if the last cron said
+        // `blocked:cannot-merge`; a pending question with no writer is
+        // `blocked:decision`. Operator `paused` is never overridden.
+        self.mode = honest_controller_mode(
+            self.mode.as_deref().or_else(|| {
+                self.latest_update
+                    .as_ref()
+                    .and_then(|update| update.mode.as_deref())
+            }),
+            has_live_mission,
+            awaiting_user > 0,
+            self.pending_decisions,
+        );
         if awaiting_user > 0 {
             attention.push(match awaiting_user {
                 1 => "1 mission awaiting user input".to_string(),
@@ -2002,10 +2132,6 @@ impl ProjectRowBuilder {
             .and_then(|t| t.status_line.as_deref())
             .map(|line| line.to_lowercase().contains("paused"))
             .unwrap_or(false);
-        let has_live_mission = self
-            .missions
-            .iter()
-            .any(|chip| !chip.status.is_terminal() && chip.status != MissionStatus::Acknowledged);
         if tracker_active && !has_live_mission {
             let last_signal = self
                 .latest_update
@@ -3168,6 +3294,101 @@ mod tests {
         assert_eq!(extract_pr_url("https://github.com/x/y"), None);
         assert_eq!(extract_pr_url("https://github.com/x/y/issues/12"), None);
         assert_eq!(extract_pr_url("no links here"), None);
+    }
+
+    #[test]
+    fn pr_needles_include_hashes_and_urls_without_prefix_collisions() {
+        let needles = extract_pr_needles(
+            "Certify #2240 merged via https://github.com/lfglabs-dev/verity/pull/2240",
+        );
+        assert!(needles.contains(&"https://github.com/lfglabs-dev/verity/pull/2240".to_string()));
+        assert!(needles.contains(&"#2240".to_string()));
+        assert!(!needles.iter().any(|n| n == "#224" || n == "#2"));
+    }
+
+    #[test]
+    fn a_merge_headline_closes_older_pending_questions_for_that_pr() {
+        let store = super::super::projects_store::ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("lido", None, None, None, None)
+            .expect("seed");
+        store
+            .record_decision(
+                "lido",
+                &super::super::projects_store::NewDecision {
+                    question: "merge #66?".to_string(),
+                    rationale: Some("blocks A.2".to_string()),
+                    kind: Some("merge".to_string()),
+                    authority: "escalation".to_string(),
+                    status: "pending_user".to_string(),
+                    evidence: None,
+                },
+            )
+            .expect("pending");
+        let aliases = HashMap::new();
+        let overrides = HashMap::new();
+        let delivery = parse_delivery(
+            "s",
+            1_754_000_500.0,
+            "[Cron delivery: lido]\n#66 MERGED\n[STATE_SIGNATURE: lido|done|02a0da1]\n",
+        );
+        ingest_deliveries(&store, &aliases, &overrides, vec![delivery]);
+        assert!(
+            store.open_decisions("lido").expect("open").is_empty(),
+            "the merge headline must retire the older merge #66? question"
+        );
+    }
+
+    #[test]
+    fn a_coerced_merge_trailer_does_not_close_itself() {
+        let store = super::super::projects_store::ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity", None, None, None, None)
+            .expect("seed");
+        let content = "[Cron delivery: verity]\nHeadline\n\
+            [DECISION: {\"kind\":\"merge\",\"authority\":\"granted\",\"status\":\"decided\",\"question\":\"Merged #2333\"}]\n\
+            [STATE_SIGNATURE: verity|phase|head]\n";
+        let delivery = parse_delivery("s1", 1_754_000_000.0, content);
+        ingest_deliveries(&store, &HashMap::new(), &HashMap::new(), vec![delivery]);
+        let open = store.open_decisions("verity").expect("open");
+        assert_eq!(open.len(), 1, "coerced merge stays pending");
+        assert_eq!(open[0].question, "Merged #2333");
+    }
+
+    #[test]
+    fn honest_mode_prefers_live_work_and_parked_decisions_over_cron_prose() {
+        assert_eq!(
+            honest_controller_mode(Some("blocked:cannot-merge"), true, false, 1).as_deref(),
+            Some("active")
+        );
+        assert_eq!(
+            honest_controller_mode(Some("active"), false, false, 2).as_deref(),
+            Some("blocked:decision")
+        );
+        assert_eq!(
+            honest_controller_mode(Some("paused:owner"), true, false, 1).as_deref(),
+            Some("paused:owner")
+        );
+        assert_eq!(
+            honest_controller_mode(Some("blocked:transport-cap"), false, false, 0).as_deref(),
+            Some("blocked:transport-cap")
+        );
+    }
+
+    #[test]
+    fn a_live_writer_makes_the_card_mode_active_despite_a_blocked_ctrl() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.mode = Some("blocked:cannot-merge".into());
+        builder.pending_decisions = 1;
+        builder.missions.push(MissionChip {
+            id: "abcd1234".into(),
+            status: MissionStatus::Active,
+            title: Some("rebase #2332".into()),
+            updated_at: "2026-08-14T06:00:00Z".into(),
+            github_pr: None,
+        });
+        let row = builder.finish(&[], None, None, "2026-08-14T06:05:00Z");
+        assert_eq!(row.mode.as_deref(), Some("active"));
     }
 
     // ---- decision disposition (the autonomy enforcement point) ----

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -1301,6 +1301,37 @@ impl ProjectsStore {
         Ok(changed > 0)
     }
 
+    /// Close pending escalations that mention any of `needles` (a `#N` hash
+    /// or a full GitHub PR URL). Used when a later delivery reports that PR
+    /// as merged, so the board stops asking about a decision that is already
+    /// done. `except_at` skips the delivery that just recorded itself — a
+    /// coerced "Merged #N" trailer must stay pending, not close itself.
+    pub fn close_pending_decisions_referencing(
+        &self,
+        slug: &str,
+        needles: &[String],
+        answer: &str,
+        except_at: Option<&str>,
+    ) -> Result<u32, String> {
+        if needles.is_empty() {
+            return Ok(0);
+        }
+        let open = self.open_decisions(slug)?;
+        let mut closed = 0u32;
+        for decision in open {
+            if except_at.is_some_and(|at| at == decision.at) {
+                continue;
+            }
+            if !decision_mentions_any(&decision, needles) {
+                continue;
+            }
+            if self.answer_decision(slug, &decision.at, answer)? {
+                closed += 1;
+            }
+        }
+        Ok(closed)
+    }
+
     pub fn open_decisions(&self, slug: &str) -> Result<Vec<ProjectDecision>, String> {
         self.decisions_where(slug, "status = 'pending_user'", "ORDER BY at", None)
     }
@@ -1514,6 +1545,45 @@ pub struct ProjectTrack {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
     pub updated_at: String,
+}
+
+/// True when `needle` appears in `hay` without being a prefix of a longer
+/// number (`#1` must not match `#10`).
+fn text_mentions_needle(hay: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    if needle.starts_with('#') {
+        let mut start = 0;
+        while let Some(rel) = hay[start..].find(needle) {
+            let abs = start + rel;
+            let after = &hay[abs + needle.len()..];
+            if after
+                .chars()
+                .next()
+                .map(|c| !c.is_ascii_digit())
+                .unwrap_or(true)
+            {
+                return true;
+            }
+            start = abs + 1;
+        }
+        return false;
+    }
+    hay.contains(needle)
+}
+
+fn decision_mentions_any(decision: &ProjectDecision, needles: &[String]) -> bool {
+    let evidence = decision
+        .evidence
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let rationale = decision.rationale.as_deref().unwrap_or("");
+    let hay = format!("{} {} {}", decision.question, rationale, evidence);
+    needles
+        .iter()
+        .any(|needle| text_mentions_needle(&hay, needle))
 }
 
 /// One ledger entry: an owner escalation or a declared autonomous act.
@@ -2254,6 +2324,80 @@ mod tests {
         assert_eq!(
             store.pending_decision_counts().expect("counts")["verity"],
             1
+        );
+    }
+
+    #[test]
+    fn a_merged_pr_closes_only_the_pending_decisions_that_name_it() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .record_decision("lido", &escalation("merge #66?", Some("blocks A.2")))
+            .expect("66");
+        store
+            .record_decision("lido", &escalation("merge #70?", None))
+            .expect("70");
+        let same_delivery = store
+            .record_decision(
+                "lido",
+                &escalation("Merged #66", Some("just recorded this tick")),
+            )
+            .expect("same-tick");
+
+        let closed = store
+            .close_pending_decisions_referencing(
+                "lido",
+                &["#66".to_string()],
+                "closed: referenced PR merged",
+                Some(same_delivery.as_str()),
+            )
+            .expect("close");
+        assert_eq!(closed, 1, "only the older #66 question closes");
+
+        let open = store.open_decisions("lido").expect("open");
+        let questions: Vec<&str> = open.iter().map(|d| d.question.as_str()).collect();
+        assert!(questions.contains(&"merge #70?"));
+        assert!(questions.contains(&"Merged #66"));
+        assert!(!questions.iter().any(|q| q.contains("#66?")));
+
+        // `#6` is not `#66`.
+        assert_eq!(
+            store
+                .close_pending_decisions_referencing(
+                    "lido",
+                    &["#6".to_string()],
+                    "should not match",
+                    None,
+                )
+                .expect("narrow"),
+            0
+        );
+
+        // A URL needle matches evidence.pr_url.
+        let mut with_url = escalation("ship the cert?", None);
+        with_url.evidence = Some(serde_json::json!({
+            "pr_url": "https://github.com/lfglabs-dev/verity/pull/70"
+        }));
+        store.record_decision("lido", &with_url).expect("url");
+        assert_eq!(
+            store
+                .close_pending_decisions_referencing(
+                    "lido",
+                    &["https://github.com/lfglabs-dev/verity/pull/70".to_string()],
+                    "closed: referenced PR merged",
+                    None,
+                )
+                .expect("url close"),
+            1
+        );
+        let left: Vec<String> = store
+            .open_decisions("lido")
+            .expect("left")
+            .into_iter()
+            .map(|d| d.question)
+            .collect();
+        assert_eq!(
+            left,
+            vec!["merge #70?".to_string(), "Merged #66".to_string()]
         );
     }
 


### PR DESCRIPTION
## Why

The Projects tab kept asking about PRs that had already landed (`merge #66?` still pending after #66 merged) and kept showing the last CTRL trailer as the mode (`blocked:cannot-merge`) while a writer was already running. Both made the board look stuck when the work was not.

## What

- Store: `close_pending_decisions_referencing` answers pending_user rows whose question, rationale, or evidence names a `#N` / PR URL needle.
- Ingest: a merge headline (`#66 MERGED`) or a grant-allowed decided merge act closes older questions for that PR. The current delivery's own coerced trailer is skipped so a `Merged #N` escalation does not close itself.
- Read-model: `honest_controller_mode` prefers a live writer (`active`) or a parked decision (`blocked:decision`) over the last CTRL trailer. Operator `paused` is never overridden.
- Dashboard: `parseMode` already understands `blocked:decision`; added a unit test.

## Tests

- `a_merged_pr_closes_only_the_pending_decisions_that_name_it`
- `a_merge_headline_closes_older_pending_questions_for_that_pr`
- `a_coerced_merge_trailer_does_not_close_itself`
- `honest_mode_prefers_live_work_and_parked_decisions_over_cron_prose`
- `a_live_writer_makes_the_card_mode_active_despite_a_blocked_ctrl`
- `pr_needles_include_hashes_and_urls_without_prefix_collisions`
- dashboard `parseMode` `blocked:decision`

Does not deploy. Does not touch in-flight writers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches decision ledger writes on ingest and overview mode derivation; behavior is heavily tested but wrong needle matching could close unrelated escalations.
> 
> **Overview**
> Fixes the Projects board showing **stale merge questions** after a PR already merged and **misleading modes** (e.g. `blocked:cannot-merge` while a writer is running).
> 
> **Decision ledger:** On state ingest, merge headlines (`#N MERGED`) or grant-allowed decided merge acts extract `#N` / PR URL **needles** and call `close_pending_decisions_referencing` to answer older `pending_user` rows with `closed: referenced PR merged`. The current delivery timestamp is excluded so a coerced `Merged #N` escalation does not close itself. Matching uses prefix-safe `#` parsing (`#1` ≠ `#10`).
> 
> **Board read-model:** `honest_controller_mode` overrides stored/CTRL mode: live non-terminal missions → `active` (unless awaiting user); any pending decisions → `blocked:decision`; operator `paused` is never overridden. `ProjectRowBuilder::finish` applies this before bucket/attention logic.
> 
> **Dashboard:** Unit test that `parseMode` maps `blocked:decision` to blocked + cause `decision`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1296f68c1f413dc3ce542b9cc90fdcc0a69862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->