### PR TITLE
fix: resume writers killed by deploy cancel-timeout

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -237,6 +237,17 @@ pub(crate) const ACK_PROMOTION_TICK_INTERVAL: std::time::Duration =
 /// (see `MissionStore::update_mission_status`) — otherwise the stale timestamp
 /// survives the later demotion back to `AwaitingUser` and the ack-promotion
 /// sweep can archive a mission whose next turn just started.
+/// Reason written when a cancel's JoinHandle never resolves. During a
+/// deploy/SIGTERM drain this must stay `server_shutdown` so boot recovery
+/// and reconcile resume the writer instead of leaving it stranded.
+fn cancel_timeout_interrupt_reason() -> &'static str {
+    if super::routes::is_shutdown_initiated() {
+        super::reconcile::SERVER_SHUTDOWN_REASON
+    } else {
+        super::reconcile::FORCE_KILLED_CANCEL_TIMEOUT_REASON
+    }
+}
+
 pub(crate) fn message_activates_mission(status: MissionStatus) -> bool {
     matches!(
         status,
@@ -20058,17 +20069,18 @@ async fn control_actor_loop(
                             mission_id = %mission_id,
                             "Force-aborting stuck parallel runner after cancellation grace period"
                         );
+                        let kill_reason = cancel_timeout_interrupt_reason();
                         runner
                             .finish_durable_run(
                                 &mission_store,
-                                Some("force_killed_after_cancel_timeout"),
+                                Some(kill_reason),
                             )
                             .await;
                         if let Err(error) = mission_store
                             .update_mission_status_with_reason(
                                 *mission_id,
                                 MissionStatus::Interrupted,
-                                Some("force_killed_after_cancel_timeout"),
+                                Some(kill_reason),
                             )
                             .await
                         {
@@ -20670,14 +20682,22 @@ async fn control_actor_loop(
                         .finish_mission_run(
                             run.run_id,
                             run.generation,
-                            Some("force_killed_after_cancel_timeout"),
+                            Some(cancel_timeout_interrupt_reason()),
                         )
                         .await;
                 }
                 if let Some(mid) = stuck_mid {
                     // Mark mission as Interrupted so it stays resumable.
+                    // During a deploy drain this must stay `server_shutdown`
+                    // — overwriting it with force_killed strands the writer
+                    // (startup recovery and reconcile only resume restart
+                    // reasons).
                     if let Err(e) = mission_store
-                        .update_mission_status(mid, MissionStatus::Interrupted)
+                        .update_mission_status_with_reason(
+                            mid,
+                            MissionStatus::Interrupted,
+                            Some(cancel_timeout_interrupt_reason()),
+                        )
                         .await
                     {
                         tracing::warn!(

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -4945,7 +4945,7 @@ impl MissionStore for SqliteMissionStore {
                      FROM missions
                      WHERE status = 'interrupted'
                        AND resumable = 1
-                       AND terminal_reason = 'server_shutdown'
+                       AND terminal_reason IN ('server_shutdown', 'service_restart')
                        AND COALESCE(mission_mode, 'task') != 'assistant'
                        AND interrupted_at IS NOT NULL
                        AND interrupted_at >= ?1
@@ -15627,6 +15627,40 @@ mod tests {
 
         assert!(mission_ids.contains(&task_mission.id));
         assert!(!mission_ids.contains(&assistant_mission.id));
+
+        let restart_mission = store
+            .create_mission(Some("restart"), None, None, None, None, None, None)
+            .await
+            .expect("restart mission");
+        store
+            .update_mission_status_with_reason(
+                restart_mission.id,
+                MissionStatus::Interrupted,
+                Some("service_restart"),
+            )
+            .await
+            .expect("mark service_restart");
+        let cancelled = store
+            .create_mission(Some("cancelled"), None, None, None, None, None, None)
+            .await
+            .expect("cancelled mission");
+        store
+            .update_mission_status_with_reason(
+                cancelled.id,
+                MissionStatus::Interrupted,
+                Some("cancelled"),
+            )
+            .await
+            .expect("mark cancelled");
+        let mission_ids = store
+            .get_recent_server_shutdown_mission_ids(48)
+            .await
+            .expect("recent restart missions");
+        assert!(
+            mission_ids.contains(&restart_mission.id),
+            "service_restart must be recovered with server_shutdown"
+        );
+        assert!(!mission_ids.contains(&cancelled.id));
     }
 
     #[tokio::test]

--- a/src/api/reconcile.rs
+++ b/src/api/reconcile.rs
@@ -47,6 +47,32 @@ use crate::workspace_exec::{
 
 /// `end_reason` recorded on missions interrupted by this reconciler.
 pub const SERVICE_RESTART_REASON: &str = "service_restart";
+/// Graceful SIGTERM / SIGINT drain (see `routes::shutdown_signal`).
+pub const SERVER_SHUTDOWN_REASON: &str = "server_shutdown";
+/// Cancel token fired but the JoinHandle never resolved. During a deploy
+/// this overwrites the `server_shutdown` the drain just wrote — treat it
+/// as the same class when a deploy marker is fresh.
+pub const FORCE_KILLED_CANCEL_TIMEOUT_REASON: &str = "force_killed_after_cancel_timeout";
+/// How recent a `/api/system/deploy` marker must be for a
+/// `force_killed_after_cancel_timeout` row to count as a deploy interrupt.
+const DEPLOY_FORCE_KILL_WINDOW_SECS: u64 = 30 * 60;
+
+/// Reasons a restart/deploy may leave on a still-resumable mission.
+pub fn is_recoverable_restart_reason(reason: Option<&str>) -> bool {
+    matches!(
+        reason,
+        Some(SERVICE_RESTART_REASON) | Some(SERVER_SHUTDOWN_REASON)
+    )
+}
+
+/// A cancel-timeout kill that landed inside a just-finished deploy is the
+/// drain race (SIGTERM → cancel → JoinHandle hung → force-kill overwrites
+/// `server_shutdown`). User-cancelled stuck runners outside that window
+/// stay interrupted.
+pub fn is_recent_deploy_force_kill(reason: Option<&str>, deploy_age_secs: Option<u64>) -> bool {
+    reason == Some(FORCE_KILLED_CANCEL_TIMEOUT_REASON)
+        && deploy_age_secs.is_some_and(|age| age < DEPLOY_FORCE_KILL_WINDOW_SECS)
+}
 /// Tag appended to a mission's project tags when its harness session state is
 /// gone (see module docs, class 3).
 pub const ORPHANED_TAG: &str = "orphaned";
@@ -291,9 +317,10 @@ pub fn classify_mission(facts: &MissionFacts) -> MissionVerdict {
 #[derive(Debug, Clone, Copy)]
 pub struct InterruptedFacts {
     pub status: MissionStatus,
-    /// The mission's `terminal_reason` is exactly `service_restart`. We NEVER
-    /// touch user-cancelled or genuinely-failed missions — only the ones this
-    /// reconciler itself parked.
+    /// The mission's `terminal_reason` is a restart/deploy interrupt
+    /// (`service_restart`, `server_shutdown`, or a cancel-timeout kill
+    /// inside the deploy window). User-cancelled and genuinely-failed
+    /// missions stay false.
     pub is_service_restart: bool,
     /// The control actor currently lists this mission as running.
     pub running_in_actor: bool,
@@ -699,10 +726,16 @@ send a new message or re-create the mission.",
                 break;
             }
             report.missions_scanned += 1;
-            // (a) ONLY service_restart — never user-cancelled or genuinely
-            // failed missions.
+            // (a) ONLY restart/deploy interrupts — never user-cancelled
+            // or genuinely-failed missions. `force_killed_after_cancel_timeout`
+            // qualifies only while the deploy marker is still fresh: that
+            // is the SIGTERM drain race that used to strand writers.
             let is_service_restart =
-                mission.terminal_reason.as_deref() == Some(SERVICE_RESTART_REASON);
+                is_recoverable_restart_reason(mission.terminal_reason.as_deref())
+                    || is_recent_deploy_force_kill(
+                        mission.terminal_reason.as_deref(),
+                        super::system::last_deploy_age_secs(),
+                    );
             if !is_service_restart {
                 continue;
             }
@@ -1046,9 +1079,37 @@ mod tests {
     }
 
     #[test]
+    fn server_shutdown_and_service_restart_are_recoverable() {
+        assert!(is_recoverable_restart_reason(Some(SERVICE_RESTART_REASON)));
+        assert!(is_recoverable_restart_reason(Some(SERVER_SHUTDOWN_REASON)));
+        assert!(!is_recoverable_restart_reason(Some(
+            FORCE_KILLED_CANCEL_TIMEOUT_REASON
+        )));
+        assert!(!is_recoverable_restart_reason(Some("cancelled")));
+        assert!(!is_recoverable_restart_reason(None));
+    }
+
+    #[test]
+    fn force_kill_is_recoverable_only_inside_the_deploy_window() {
+        assert!(is_recent_deploy_force_kill(
+            Some(FORCE_KILLED_CANCEL_TIMEOUT_REASON),
+            Some(60)
+        ));
+        assert!(!is_recent_deploy_force_kill(
+            Some(FORCE_KILLED_CANCEL_TIMEOUT_REASON),
+            Some(31 * 60)
+        ));
+        assert!(!is_recent_deploy_force_kill(
+            Some(FORCE_KILLED_CANCEL_TIMEOUT_REASON),
+            None
+        ));
+        assert!(!is_recent_deploy_force_kill(Some("cancelled"), Some(10)));
+    }
+
+    #[test]
     fn interrupted_user_cancel_is_not_reresumed() {
-        // Only `service_restart` qualifies — a user-cancelled or genuinely
-        // failed mission has `is_service_restart == false`.
+        // Only restart/deploy interrupts qualify — a user-cancelled or
+        // genuinely failed mission has `is_service_restart == false`.
         let mut facts = base_interrupted_facts();
         facts.is_service_restart = false;
         assert!(!should_reresume_interrupted(&facts));

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3640,6 +3640,13 @@ fn evaluate_debounce(
     }
 }
 
+/// Seconds since the last `/api/system/deploy` marker was touched.
+/// Used by boot reconcile to treat a just-killed runner as a deploy
+/// interrupt rather than a user cancel.
+pub(crate) fn last_deploy_age_secs() -> Option<u64> {
+    deploy_marker_age_secs(&deploy_marker_path())
+}
+
 /// Read `mtime` of the deploy marker, return seconds since it was written.
 /// `None` if the file doesn't exist or its mtime is in the future (clock skew).
 fn deploy_marker_age_secs(path: &std::path::Path) -> Option<u64> {


### PR DESCRIPTION
## Why

A prod deploy SIGTERMs runners. The drain marks them `server_shutdown`, then the cancel-timeout force-kill overwrites that with `force_killed_after_cancel_timeout`. Boot recovery only looks for `server_shutdown`; reconcile only looks for `service_restart`. Last night every writer stayed dead until a human resumed them.

## What

- Force-kill during shutdown keeps `server_shutdown`.
- Startup query also returns `service_restart`.
- Reconcile re-resumes `server_shutdown` / `service_restart`, and a `force_killed_after_cancel_timeout` only if `/api/system/deploy` ran in the last 30 minutes (the drain race). User-cancelled stuck runners outside that window stay interrupted.

## Tests

- `server_shutdown_and_service_restart_are_recoverable`
- `force_kill_is_recoverable_only_inside_the_deploy_window`
- `recent_server_shutdown_query_skips_assistant_missions` now also asserts `service_restart` is recovered and `cancelled` is not

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission interrupt reasons, boot recovery SQL, and reconcile auto-resume policy—operational correctness for deploys, with a bounded window so user-cancelled force-kills are not resurrected.
> 
> **Overview**
> Fixes writer missions staying **interrupted** after deploys when a cancel-timeout force-kill overwrote the drain’s `server_shutdown` reason, so boot recovery and reconcile no longer skipped them.
> 
> **Control:** Cancel-timeout kills now use `cancel_timeout_interrupt_reason()` — **`server_shutdown`** during SIGTERM drain, **`force_killed_after_cancel_timeout`** otherwise — for parallel runners, main runner run finish, and mission status (main path now persists a reason via `update_mission_status_with_reason`).
> 
> **SQLite boot query:** `get_recent_server_shutdown_mission_ids` also returns rows with `terminal_reason = service_restart`, not only `server_shutdown`.
> 
> **Reconcile:** Shared helpers treat `server_shutdown` and `service_restart` as recoverable; `force_killed_after_cancel_timeout` counts as a deploy interrupt only if `/api/system/deploy` ran within **30 minutes** (`last_deploy_age_secs`). User-cancelled stuck runners outside that window stay interrupted.
> 
> Tests cover recoverable reasons, the deploy window for force-kill, and the expanded shutdown query (including `cancelled` excluded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082e43e3473fd3fa966952261c19061efae0ddec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->