### PR TITLE
feat: add Z.AI GLM-5.3 support

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -70,7 +70,8 @@ curl -X POST https://YOUR-BACKEND/api/ai/providers \
 **Get API Key:** https://bigmodel.cn
 
 **Recommended Models:**
-- `glm-5.1` - Current flagship GLM reasoning and coding model
+- `glm-5.3` - Current flagship GLM reasoning and coding model
+- `glm-5.3[1m]` - Same weights with the Coding Plan 1M-token context window
 - `glm-5-turbo` - Fast reasoning model with deep thinking
 - `glm-4.7` - Strong general-purpose GLM model
 
@@ -110,7 +111,7 @@ curl -X POST https://YOUR-BACKEND/api/ai/providers \
 ```
 
 Use OpenCode model overrides in `provider/model` format, for example
-`zai/glm-5.1` or `minimax/MiniMax-M3`.
+`zai/glm-5.3` or `minimax/MiniMax-M3`.
 
 ### DeepInfra
 

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -160,7 +160,7 @@ export interface CatalogModel {
   provider_id: string;
   provider_name: string;
   id: string;
-  /** The `provider/model` id to pass to the router (e.g. "zai/glm-5.2"). */
+  /** The `provider/model` id to pass to the router (e.g. "zai/glm-5.3"). */
   value: string;
   name: string;
   description?: string;

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1125,9 +1125,25 @@ fn default_providers_config() -> ProvidersConfig {
                     // Check Z.AI / GLM model IDs here:
                     // https://docs.z.ai/guides/llm/glm
                     ProviderModel {
+                        id: "glm-5.3".to_string(),
+                        name: "GLM-5.3".to_string(),
+                        description: Some(
+                            "Current flagship GLM reasoning and coding model".to_string(),
+                        ),
+                    },
+                    ProviderModel {
+                        id: "glm-5.3[1m]".to_string(),
+                        name: "GLM-5.3 (1M context)".to_string(),
+                        description: Some(
+                            "GLM-5.3 with the Coding Plan 1M-token context window".to_string(),
+                        ),
+                    },
+                    ProviderModel {
                         id: "glm-5.2".to_string(),
                         name: "GLM-5.2".to_string(),
-                        description: Some("Most capable GLM reasoning model".to_string()),
+                        description: Some(
+                            "Previous flagship; Coding Plan routes this to GLM-5.3".to_string(),
+                        ),
                     },
                     ProviderModel {
                         id: "glm-5.1".to_string(),

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -299,6 +299,17 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         pricing: pricing(1_250, 2_500, None, Some(200)),
     },
     PricingEntry {
+        // Pay-as-you-go list for glm-5.3 is not on
+        // https://docs.z.ai/guides/overview/pricing yet. Coding Plan
+        // treats it as the successor of glm-5.2/5.1 and auto-routes those
+        // IDs to glm-5.3, so keep the published 5.2 rates ($1.4/$4.4 per
+        // Mtok, $0.26 cached) until Z.AI posts a distinct 5.3 row.
+        // `glm-5.3[1m]` is the 1M-context Coding Plan alias.
+        canonical: "glm-5.3",
+        aliases: &["glm-5.3", "glm-5-3", "glm-5.3[1m]"],
+        pricing: pricing(1_400, 4_400, None, Some(260)),
+    },
+    PricingEntry {
         // glm-5.2 list price not yet published separately; mirrors glm-5.1
         // ($1.4/$4.4 per Mtok, $0.26 cached) until Z.AI publishes it.
         canonical: "glm-5.2",
@@ -632,6 +643,8 @@ mod tests {
         assert_eq!(normalize_model("xai/grok-build-latest"), "grok-4.5");
         assert_eq!(normalize_model("grok-build"), "grok-build");
         assert_eq!(normalize_model("zai/glm-5"), "glm-5");
+        assert_eq!(normalize_model("zai/glm-5.3"), "glm-5.3");
+        assert_eq!(normalize_model("zai/glm-5.3[1m]"), "glm-5.3");
         assert_eq!(normalize_model("zai/glm-5.2"), "glm-5.2");
         assert_eq!(normalize_model("zai/glm-5.1"), "glm-5.1");
         assert_eq!(normalize_model("zai/glm-5-turbo"), "glm-5-turbo");
@@ -674,6 +687,8 @@ mod tests {
         assert!(pricing_for_model("xai/grok-4.5").is_some());
         assert!(pricing_for_model("grok-build").is_some());
         assert!(pricing_for_model("glm-5").is_some());
+        assert!(pricing_for_model("zai/glm-5.3").is_some());
+        assert!(pricing_for_model("zai/glm-5.3[1m]").is_some());
         assert!(pricing_for_model("zai/glm-5.2").is_some());
         assert!(pricing_for_model("glm-5.1").is_some());
         assert!(pricing_for_model("zai/glm-5-turbo").is_some());
@@ -705,9 +720,12 @@ mod tests {
         assert_eq!(grok_45.output_nano_per_token, 6_000);
         assert_eq!(grok_45.cache_read_nano_per_token, Some(500));
 
-        let glm = pricing_for_model("zai/glm-5.1").expect("glm-5.1 pricing");
+        let glm = pricing_for_model("zai/glm-5.3").expect("glm-5.3 pricing");
         assert_eq!(glm.input_nano_per_token, 1_400);
         assert_eq!(glm.output_nano_per_token, 4_400);
+        assert_eq!(glm.cache_read_nano_per_token, Some(260));
+        let glm_1m = pricing_for_model("zai/glm-5.3[1m]").expect("glm-5.3[1m] pricing");
+        assert_eq!(glm_1m.input_nano_per_token, glm.input_nano_per_token);
 
         let minimax = pricing_for_model("minimax/MiniMax-M3").expect("minimax pricing");
         assert_eq!(minimax.input_nano_per_token, 600);

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -915,7 +915,7 @@ impl ModelChainStore {
                     },
                     ChainEntry {
                         provider_id: "zai".to_string(),
-                        model_id: "glm-5.2".to_string(),
+                        model_id: "glm-5.3".to_string(),
                     },
                     ChainEntry {
                         provider_id: "muse".to_string(),
@@ -935,9 +935,9 @@ impl ModelChainStore {
                 let mut migrated = false;
                 for entry in &mut chain.entries {
                     if entry.provider_id == "zai"
-                        && matches!(entry.model_id.as_str(), "glm-5" | "glm-5.1")
+                        && matches!(entry.model_id.as_str(), "glm-5" | "glm-5.1" | "glm-5.2")
                     {
-                        entry.model_id = "glm-5.2".to_string();
+                        entry.model_id = "glm-5.3".to_string();
                         migrated = true;
                     }
                     if entry.provider_id == "minimax"
@@ -1851,8 +1851,8 @@ mod tests {
             models,
             vec![
                 ("minimax".to_string(), "MiniMax-M3".to_string()),
-                // glm-5.1 is migrated to glm-5.2 by ensure_default_chain.
-                ("zai".to_string(), "glm-5.2".to_string()),
+                // glm-5.1 is migrated to glm-5.3 by ensure_default_chain.
+                ("zai".to_string(), "glm-5.3".to_string()),
                 ("cerebras".to_string(), "zai-glm-4.7".to_string()),
                 // The 2026-08-06 migration appends Meta Muse as a tail
                 // fallback to persisted chains, never reordering them.
@@ -1863,6 +1863,42 @@ mod tests {
         let custom = store.get("user/custom").await.unwrap();
         assert_eq!(custom.entries.len(), 1);
         assert_eq!(custom.entries[0].model_id, "gpt-oss-120b");
+    }
+
+    #[tokio::test]
+    async fn ensure_defaults_migrates_stock_glm_52_to_53() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("chains.json");
+        let now = chrono::Utc::now();
+        let chains = vec![ModelChain {
+            id: "builtin/smart".to_string(),
+            name: "Smart (Default)".to_string(),
+            entries: vec![
+                ChainEntry {
+                    provider_id: "minimax".to_string(),
+                    model_id: "MiniMax-M3".to_string(),
+                },
+                ChainEntry {
+                    provider_id: "zai".to_string(),
+                    model_id: "glm-5.2".to_string(),
+                },
+            ],
+            is_default: true,
+            strip_thinking: false,
+            created_at: now,
+            updated_at: now,
+        }];
+        std::fs::write(&path, serde_json::to_string(&chains).unwrap()).unwrap();
+        let store = ModelChainStore::new(path).await;
+        std::mem::forget(tmp);
+
+        let smart = store.get("builtin/smart").await.unwrap();
+        let zai = smart
+            .entries
+            .iter()
+            .find(|e| e.provider_id == "zai")
+            .expect("zai entry");
+        assert_eq!(zai.model_id, "glm-5.3");
     }
 
     fn past_ms(hours: i64) -> i64 {


### PR DESCRIPTION
## Why

Z.AI's Coding Plan now lists **GLM-5.3** as the current flagship (`glm-5.3`, plus `glm-5.3[1m]` for the 1M-token window) and auto-routes `glm-5.2` / `glm-5.1` to it. Sandboxed.sh still advertised 5.2 as "most capable".

Docs: https://docs.z.ai/devpack/latest-model and https://docs.z.ai/devpack/overview

## What

- Catalog: `glm-5.3` and `glm-5.3[1m]` on the Z.AI provider; 5.2 kept as previous.
- Pricing: same published 5.2 rates ($1.4 / $4.4 per Mtok, $0.26 cached) until Z.AI posts a distinct 5.3 pay-as-you-go row. The `[1m]` alias shares that row.
- `builtin/smart` now uses `glm-5.3`; persisted `glm-5` / `glm-5.1` / `glm-5.2` stock entries migrate.
- OpenCode already declares `reasoning_content` for any `zai/glm-5*`.

## Tests

- `test_normalize_model` / `test_pricing_for_known_models` / `test_official_api_price_points`
- `ensure_defaults_migrates_stock_glm_52_to_53`
- `ensure_defaults_migrates_retired_cerebras_models`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog, documentation, cost estimates, and default chain migrations only; no auth or routing protocol changes beyond newer model IDs.
> 
> **Overview**
> Adds **Z.AI GLM-5.3** as the current flagship: `glm-5.3` and the Coding Plan 1M alias `glm-5.3[1m]` appear in the provider catalog, docs, and dashboard examples; **GLM-5.2** is kept but described as superseded.
> 
> **Cost tracking** gains a `glm-5.3` pricing row (same published 5.2 rates until Z.AI lists 5.3 pay-as-you-go) with normalization for `zai/glm-5.3` and `glm-5.3[1m]`.
> 
> The **`builtin/smart`** fallback chain now targets **`glm-5.3`** instead of 5.2, and persisted Z.AI entries on `glm-5`, `glm-5.1`, or `glm-5.2` migrate to 5.3 on load (new test covers 5.2 → 5.3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 711a85a8ec46893d88840ee27aa539e75813c661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->