### PR TITLE
feat: items are the work, missions are hidden attempts

### DIFF
--- a/patches/hermes/mission_status_route.py
+++ b/patches/hermes/mission_status_route.py
@@ -134,10 +134,25 @@ def resolve_project_session_id(project: str, session_db: Any = None) -> Optional
         return None
 
 
+def extract_wake_session(payload: dict) -> str:
+    return str(payload.get("wake_session") or "").strip()
+
+
 def resolve_mission_delivery_session(payload: dict, session_db: Any) -> Optional[str]:
     """Pick the dedicated conversation for this mission-status event."""
     if not is_routable_mission_status(payload):
         return None
+    # Producer-resolved tip (project binding, else origin). Use the id as-is
+    # when the row exists: walking resume children is how a project click
+    # used to land on a live review thread instead of the bound session.
+    hinted = extract_wake_session(payload)
+    if hinted:
+        row = session_db.get_session(hinted)
+        if row:
+            return hinted
+        live = resolve_live_session_id(hinted, session_db)
+        if live:
+            return live
     origin = extract_origin_session(payload)
     if origin:
         live = resolve_live_session_id(origin, session_db)

--- a/patches/hermes/test_mission_status_route.py
+++ b/patches/hermes/test_mission_status_route.py
@@ -62,6 +62,25 @@ def test_acknowledged_is_not_routable():
     assert not is_routable_mission_status({"status": "failed"})
 
 
+def test_wake_session_is_used_as_is_without_child_walk():
+    db = _FakeSessionDB(
+        {
+            "20260814_094937_8c5097": {"source": "desktop"},
+            "3abf1a_review": {"source": "desktop"},
+        },
+        resumes={"20260814_094937_8c5097": "3abf1a_review"},
+    )
+    payload = {
+        "mission_id": "acfb03d2",
+        "status": "awaiting_user",
+        "origin_session": "20260814_review_child",
+        "project": "verity-benchmark",
+        "wake_session": "20260814_094937_8c5097",
+        "wake_source": "project",
+    }
+    assert resolve_mission_delivery_session(payload, db) == "20260814_094937_8c5097"
+
+
 def test_prefers_live_origin_over_project():
     db = _FakeSessionDB(
         {"20260813_111430_1310a9": {"source": "desktop"}},

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4045,6 +4045,62 @@ impl ControlHub {
         Ok(collected)
     }
 
+    /// Attention-horizon missions for one project: live / waiting / blocked
+    /// and unabsorbed failed/interrupted attempts. Used by the item-first
+    /// project read so controllers do not walk historical missions.
+    pub(crate) async fn collect_attention_missions_for_project(
+        &self,
+        project: &str,
+    ) -> Result<Vec<Mission>, String> {
+        const PAGE_SIZE: usize = 200;
+        let inventory = self.mission_store_inventory().await?;
+        let mut stores: Vec<Arc<dyn MissionStore>> = inventory.live;
+        for user in inventory.offline_file_users {
+            stores.push(Arc::new(
+                mission_store::FileMissionStore::new(inventory.base_dir.clone(), &user).await?,
+            ));
+        }
+        for path in inventory.offline_sqlite {
+            let Some(user) = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_prefix("missions-"))
+                .and_then(|name| name.strip_suffix(".db"))
+            else {
+                continue;
+            };
+            stores.push(Arc::new(
+                mission_store::SqliteMissionStore::new(inventory.base_dir.clone(), user).await?,
+            ));
+        }
+        let filter = mission_store::MissionFilter {
+            project: Some(project.to_string()),
+            attention_only: true,
+            ..Default::default()
+        };
+        let mut collected = Vec::new();
+        let mut seen: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+        for store in stores {
+            let mut offset = 0;
+            loop {
+                let page = store
+                    .list_missions_filtered(&filter, PAGE_SIZE, offset)
+                    .await?;
+                let page_len = page.len();
+                for mission in page {
+                    if seen.insert(mission.id) {
+                        collected.push(mission);
+                    }
+                }
+                if page_len < PAGE_SIZE {
+                    break;
+                }
+                offset += page_len;
+            }
+        }
+        Ok(collected)
+    }
+
     /// Delete every mission tagged with this exact project across live and
     /// offline stores. This is intentionally fail-closed: a project-wide data
     /// delete cannot race a running, queued, paused, or otherwise resumable
@@ -5313,6 +5369,9 @@ pub async fn list_missions(
         track: query.track.clone(),
         tag: query.tag.clone(),
         origin_session_id: query.origin_session_id.clone(),
+        // Default listings (no explicit status) hide acknowledged / completed /
+        // absorbed attempts. An explicit status is a precise query.
+        attention_only: query.status.is_none(),
     };
     // Workspace is the one predicate the store cannot answer: matching by
     // name needs `populate_workspace_names`, and the persisted
@@ -8716,6 +8775,18 @@ pub async fn create_mission(
         mission.project.next_check_at = next_check_at.or(mission.project.next_check_at);
         if let Some(v) = tags {
             mission.project.tags = v;
+        }
+        if let Err(error) = super::mission_horizon::supersede_prior_attempts(
+            control.mission_store.as_ref(),
+            &mission,
+        )
+        .await
+        {
+            tracing::warn!(
+                mission_id = %mission.id,
+                %error,
+                "could not absorb prior attempts on the same item"
+            );
         }
     }
     drop(pr_writer_guard);
@@ -13458,6 +13529,9 @@ async fn paloma_webhook_forwarder_loop(
             } else {
                 None
             };
+            let wake = mission
+                .as_ref()
+                .map(|m| super::mission_horizon::wake_fields_for_mission(m, &working_dir));
             let body = serde_json::json!({
                 // Idempotency / ordering (P#6): consumers dedupe on
                 // `event_id` and may order by `sequence`.
@@ -13529,6 +13603,11 @@ async fn paloma_webhook_forwarder_loop(
                 "origin_session": mission
                     .as_ref()
                     .and_then(|m| m.origin_session_id.clone()),
+                // Producer-resolved wake tip: the bound project conversation
+                // if one exists, else the creating origin. Hermes prefers
+                // this over opening an isolated webhook session.
+                "wake_session": wake.as_ref().and_then(|w| w.session.clone()),
+                "wake_source": wake.as_ref().map(|w| w.source),
                 // Track state so a watchdog can tell "intentionally
                 // waiting (CI/review/external)" from "no worker = stuck".
                 "desired_state": project.and_then(|p| p.desired_state.clone()),

--- a/src/api/mission_horizon.rs
+++ b/src/api/mission_horizon.rs
@@ -1,0 +1,629 @@
+//! Item-first mission horizon.
+//!
+//! Controllers should see durable work items (`track` / `task_key`) and only
+//! the live or unabsorbed attempts on those items. Historical, acknowledged,
+//! completed, and replaced attempts stay in the store for lineage but drop
+//! out of the default listing and the project snapshot.
+//!
+//! Wake routing prefers the bound project conversation over an isolated
+//! `webhook:mission-complete:*` session.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Serialize;
+use uuid::Uuid;
+
+use super::control::events::MissionStatus;
+use super::mission_store::{
+    default_attention_keeps, Mission, MissionFilter, MissionProjectPatch, MissionStore,
+    SUPERSEDED_TAG,
+};
+use super::projects_store::{ProjectTrack, RoadmapProposal};
+
+/// How this mission participates in a PR, if at all. Writer and reviewer
+/// attempts on the same track are different items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriterRole {
+    Writer,
+    Readonly,
+    None,
+}
+
+pub fn writer_role(mission: &Mission) -> WriterRole {
+    if mission.project.tags.iter().any(|tag| tag == "pr-writer") {
+        WriterRole::Writer
+    } else if mission.project.tags.iter().any(|tag| tag == "pr-readonly") {
+        WriterRole::Readonly
+    } else {
+        WriterRole::None
+    }
+}
+
+fn role_label(role: WriterRole) -> Option<&'static str> {
+    match role {
+        WriterRole::Writer => Some("pr-writer"),
+        WriterRole::Readonly => Some("pr-readonly"),
+        WriterRole::None => None,
+    }
+}
+
+/// Absorb every prior attention-horizon attempt on the same
+/// `(project, track, writer role)` so a new start replaces the old one
+/// without a separate model acknowledge.
+pub async fn supersede_prior_attempts(
+    store: &dyn MissionStore,
+    new_mission: &Mission,
+) -> Result<Vec<Uuid>, String> {
+    let Some(project) = new_mission
+        .project
+        .project
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(Vec::new());
+    };
+    let Some(track) = new_mission
+        .project
+        .track
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(Vec::new());
+    };
+    let role = writer_role(new_mission);
+    let candidates = store
+        .list_missions_filtered(
+            &MissionFilter {
+                project: Some(project.to_string()),
+                track: Some(track.to_string()),
+                attention_only: true,
+                ..Default::default()
+            },
+            50,
+            0,
+        )
+        .await?;
+    let mut absorbed = Vec::new();
+    for prior in candidates {
+        if prior.id == new_mission.id || writer_role(&prior) != role {
+            continue;
+        }
+        let mut tags = prior.project.tags.clone();
+        if !tags.iter().any(|tag| tag == SUPERSEDED_TAG) {
+            tags.push(SUPERSEDED_TAG.to_string());
+        }
+        store
+            .update_mission_project(
+                prior.id,
+                MissionProjectPatch {
+                    tags: Some(tags),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        if store.get_active_mission_run(prior.id).await?.is_none() {
+            if let Err(error) = store
+                .update_mission_status(prior.id, MissionStatus::Acknowledged)
+                .await
+            {
+                tracing::warn!(
+                    mission_id = %prior.id,
+                    %error,
+                    "could not acknowledge a superseded attempt"
+                );
+            }
+        }
+        absorbed.push(prior.id);
+    }
+    Ok(absorbed)
+}
+
+/// One durable work item as presented to a controller.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProjectItem {
+    pub key: String,
+    pub kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub desired_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    pub open: bool,
+    pub attempts: Vec<ProjectItemAttempt>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProjectItemAttempt {
+    pub id: Uuid,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+}
+
+/// Group declared tracks, open proposals, and attention-horizon missions
+/// into items. Historical / absorbed missions never become the inventory.
+pub fn project_items(
+    tracks: &[ProjectTrack],
+    proposals: &[RoadmapProposal],
+    missions: &[Mission],
+) -> Vec<ProjectItem> {
+    let mut items: BTreeMap<String, ProjectItem> = BTreeMap::new();
+    for track in tracks {
+        items.insert(
+            track.track.clone(),
+            ProjectItem {
+                key: track.track.clone(),
+                kind: "track",
+                desired_state: track.desired_state.clone(),
+                status: track.status.clone(),
+                open: track.status.as_deref() != Some("done"),
+                attempts: Vec::new(),
+            },
+        );
+    }
+    for proposal in proposals {
+        items
+            .entry(proposal.task_key.clone())
+            .or_insert_with(|| ProjectItem {
+                key: proposal.task_key.clone(),
+                kind: "task",
+                desired_state: None,
+                status: Some("proposed".to_string()),
+                open: true,
+                attempts: Vec::new(),
+            });
+    }
+    for mission in missions {
+        if !default_attention_keeps(mission) {
+            continue;
+        }
+        let key = mission
+            .project
+            .track
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("untagged")
+            .to_string();
+        let item = items.entry(key.clone()).or_insert_with(|| ProjectItem {
+            key: key.clone(),
+            kind: "track",
+            desired_state: mission.project.desired_state.clone(),
+            status: None,
+            open: true,
+            attempts: Vec::new(),
+        });
+        item.attempts.push(ProjectItemAttempt {
+            id: mission.id,
+            status: mission.status.to_string(),
+            title: mission.title.clone(),
+            updated_at: mission.updated_at.clone(),
+            role: role_label(writer_role(mission)).map(str::to_string),
+        });
+        item.open = true;
+    }
+    for item in items.values_mut() {
+        item.attempts
+            .sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    }
+    items.into_values().collect()
+}
+
+/// Where a terminal / `awaiting_user` callback should land.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WakeTarget {
+    pub session: Option<String>,
+    pub source: &'static str,
+}
+
+impl WakeTarget {
+    pub fn isolated() -> Self {
+        Self {
+            session: None,
+            source: "isolated",
+        }
+    }
+}
+
+/// Prefer the bound project conversation, then the creating origin.
+/// Isolated is last: that is the `webhook:mission-complete:*` fallback.
+pub fn resolve_mission_wake_target(
+    origin_session: Option<&str>,
+    project_session: Option<&str>,
+) -> WakeTarget {
+    if let Some(session) = project_session
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return WakeTarget {
+            session: Some(session.to_string()),
+            source: "project",
+        };
+    }
+    if let Some(session) = origin_session
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return WakeTarget {
+            session: Some(session.to_string()),
+            source: "origin",
+        };
+    }
+    WakeTarget::isolated()
+}
+
+/// Read-only lookup of the bound control session. Does not open the
+/// projects store (which would migrate); a missing file is "no binding".
+pub fn bound_session_from_projects_db(working_dir: &Path, slug: &str) -> Option<String> {
+    let path = working_dir.join(".sandboxed-sh/projects.db");
+    if !path.exists() {
+        return None;
+    }
+    let connection =
+        rusqlite::Connection::open_with_flags(&path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .ok()?;
+    connection
+        .query_row(
+            "SELECT control_session_id FROM project_bindings WHERE slug = ?1",
+            [slug],
+            |row| row.get::<_, String>(0),
+        )
+        .ok()
+        .map(|session| session.trim().to_string())
+        .filter(|session| !session.is_empty())
+}
+
+/// Shipped wake decision for a mission-status webhook: project binding,
+/// then origin, else isolated.
+pub fn wake_fields_for_mission(mission: &Mission, working_dir: &Path) -> WakeTarget {
+    let bound = mission
+        .project
+        .project
+        .as_deref()
+        .and_then(|slug| bound_session_from_projects_db(working_dir, slug));
+    resolve_mission_wake_target(mission.origin_session_id.as_deref(), bound.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::mission_store::{InMemoryMissionStore, MissionStore};
+    use crate::api::projects_store::ProjectsStore;
+    use std::sync::Arc;
+
+    async fn seed(
+        store: &Arc<dyn MissionStore>,
+        title: &str,
+        project: &str,
+        track: &str,
+        status: MissionStatus,
+        tags: &[&str],
+    ) -> Mission {
+        let mission = store
+            .create_mission(Some(title), None, None, None, None, None, None)
+            .await
+            .expect("create");
+        store
+            .update_mission_project(
+                mission.id,
+                MissionProjectPatch {
+                    project: Some(Some(project.to_string())),
+                    track: Some(Some(track.to_string())),
+                    tags: Some(tags.iter().map(|tag| (*tag).to_string()).collect()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+        if status != MissionStatus::Pending {
+            store
+                .update_mission_status(mission.id, status)
+                .await
+                .expect("status");
+        }
+        store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("exists")
+    }
+
+    async fn default_list(store: &Arc<dyn MissionStore>) -> Vec<Uuid> {
+        store
+            .list_missions_filtered(
+                &MissionFilter {
+                    attention_only: true,
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("list")
+            .into_iter()
+            .map(|mission| mission.id)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn default_list_keeps_live_and_unabsorbed_failed() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let live = seed(&store, "live", "verity", "core", MissionStatus::Active, &[]).await;
+        let waiting = seed(
+            &store,
+            "waiting",
+            "verity",
+            "core",
+            MissionStatus::AwaitingUser,
+            &[],
+        )
+        .await;
+        let failed = seed(
+            &store,
+            "failed",
+            "verity",
+            "review",
+            MissionStatus::Failed,
+            &[],
+        )
+        .await;
+        let interrupted = seed(
+            &store,
+            "interrupted",
+            "verity",
+            "review",
+            MissionStatus::Interrupted,
+            &[],
+        )
+        .await;
+        let acked = seed(
+            &store,
+            "acked",
+            "verity",
+            "old",
+            MissionStatus::Acknowledged,
+            &[],
+        )
+        .await;
+        let completed = seed(
+            &store,
+            "done",
+            "verity",
+            "old",
+            MissionStatus::Completed,
+            &[],
+        )
+        .await;
+        let absorbed = seed(
+            &store,
+            "replaced",
+            "verity",
+            "core",
+            MissionStatus::Failed,
+            &[SUPERSEDED_TAG],
+        )
+        .await;
+
+        let ids = default_list(&store).await;
+        assert!(ids.contains(&live.id));
+        assert!(ids.contains(&waiting.id));
+        assert!(ids.contains(&failed.id));
+        assert!(ids.contains(&interrupted.id));
+        assert!(!ids.contains(&acked.id));
+        assert!(!ids.contains(&completed.id));
+        assert!(!ids.contains(&absorbed.id));
+    }
+
+    #[tokio::test]
+    async fn start_attempt_absorbs_the_prior_same_item() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let first = seed(
+            &store,
+            "attempt-1",
+            "coldcard",
+            "skip-kernel",
+            MissionStatus::Failed,
+            &[],
+        )
+        .await;
+        let second = seed(
+            &store,
+            "attempt-2",
+            "coldcard",
+            "skip-kernel",
+            MissionStatus::Pending,
+            &[],
+        )
+        .await;
+
+        let absorbed = supersede_prior_attempts(store.as_ref(), &second)
+            .await
+            .expect("supersede");
+        assert_eq!(absorbed, vec![first.id]);
+
+        let ids = default_list(&store).await;
+        assert!(ids.contains(&second.id));
+        assert!(!ids.contains(&first.id));
+
+        let prior = store
+            .get_mission(first.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(prior.status, MissionStatus::Acknowledged);
+        assert!(prior.project.tags.iter().any(|tag| tag == SUPERSEDED_TAG));
+    }
+
+    #[tokio::test]
+    async fn writer_and_reviewer_do_not_absorb_each_other() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let writer = seed(
+            &store,
+            "write",
+            "lido",
+            "merge-66",
+            MissionStatus::AwaitingUser,
+            &["pr-writer"],
+        )
+        .await;
+        let reviewer = seed(
+            &store,
+            "review",
+            "lido",
+            "merge-66",
+            MissionStatus::Pending,
+            &["pr-readonly"],
+        )
+        .await;
+
+        let absorbed = supersede_prior_attempts(store.as_ref(), &reviewer)
+            .await
+            .expect("supersede");
+        assert!(absorbed.is_empty());
+        let ids = default_list(&store).await;
+        assert!(ids.contains(&writer.id));
+        assert!(ids.contains(&reviewer.id));
+    }
+
+    #[tokio::test]
+    async fn project_items_are_keyed_by_track_not_history() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let live = seed(&store, "now", "verity", "core", MissionStatus::Active, &[]).await;
+        seed(
+            &store,
+            "old",
+            "verity",
+            "core",
+            MissionStatus::Completed,
+            &[],
+        )
+        .await;
+        seed(
+            &store,
+            "replaced",
+            "verity",
+            "core",
+            MissionStatus::Failed,
+            &[SUPERSEDED_TAG],
+        )
+        .await;
+        let failed = seed(
+            &store,
+            "review-fail",
+            "verity",
+            "review",
+            MissionStatus::Failed,
+            &[],
+        )
+        .await;
+
+        let tracks = vec![ProjectTrack {
+            track: "core".to_string(),
+            desired_state: Some("landed".to_string()),
+            status: Some("active".to_string()),
+            updated_at: "2026-08-14T00:00:00Z".to_string(),
+        }];
+        let proposals = vec![RoadmapProposal {
+            task_key: "docs".to_string(),
+            title: "Write the guide".to_string(),
+            prompt: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+            created_at: "2026-08-14T00:00:00Z".to_string(),
+            updated_at: "2026-08-14T00:00:00Z".to_string(),
+        }];
+        let missions = store.list_missions(50, 0).await.expect("all");
+        let items = project_items(&tracks, &proposals, &missions);
+
+        let core = items.iter().find(|item| item.key == "core").expect("core");
+        assert_eq!(core.kind, "track");
+        assert!(core.open);
+        assert_eq!(core.attempts.len(), 1);
+        assert_eq!(core.attempts[0].id, live.id);
+
+        let review = items
+            .iter()
+            .find(|item| item.key == "review")
+            .expect("review");
+        assert_eq!(review.attempts.len(), 1);
+        assert_eq!(review.attempts[0].id, failed.id);
+
+        let docs = items.iter().find(|item| item.key == "docs").expect("docs");
+        assert_eq!(docs.kind, "task");
+        assert!(docs.open);
+        assert!(docs.attempts.is_empty());
+
+        assert!(items.iter().all(|item| item
+            .attempts
+            .iter()
+            .all(|attempt| attempt.id != live.id || item.key == "core")));
+        let historical = missions
+            .iter()
+            .filter(|mission| {
+                matches!(
+                    mission.status,
+                    MissionStatus::Completed | MissionStatus::Acknowledged
+                ) || mission.project.tags.iter().any(|tag| tag == SUPERSEDED_TAG)
+            })
+            .count();
+        assert!(historical >= 2);
+        assert!(items
+            .iter()
+            .flat_map(|item| item.attempts.iter())
+            .all(|attempt| attempt.status != "completed" && attempt.status != "acknowledged"));
+    }
+
+    #[test]
+    fn wake_prefers_project_binding_over_origin_and_isolated() {
+        let isolated = resolve_mission_wake_target(None, None);
+        assert_eq!(isolated.source, "isolated");
+        assert!(isolated.session.is_none());
+
+        let origin = resolve_mission_wake_target(Some("origin-sess"), None);
+        assert_eq!(origin.source, "origin");
+        assert_eq!(origin.session.as_deref(), Some("origin-sess"));
+
+        let project = resolve_mission_wake_target(Some("origin-sess"), Some("project-tip"));
+        assert_eq!(project.source, "project");
+        assert_eq!(project.session.as_deref(), Some("project-tip"));
+        assert_ne!(
+            project.session.as_deref(),
+            Some("webhook:mission-complete:x")
+        );
+    }
+
+    #[tokio::test]
+    async fn shipped_wake_path_uses_project_tip_from_binding() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_dir = dir.path().join(".sandboxed-sh");
+        std::fs::create_dir_all(&db_dir).expect("mkdir");
+        let store = ProjectsStore::open(db_dir.join("projects.db")).expect("projects db");
+        store
+            .upsert_project("benchmark", Some("Benchmark"), None, None, None)
+            .expect("project");
+        store
+            .set_binding("benchmark", "20260814_094937_8c5097", None)
+            .expect("bind");
+
+        let missions: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let mut mission = seed(
+            &missions,
+            "strat-50",
+            "benchmark",
+            "run",
+            MissionStatus::AwaitingUser,
+            &[],
+        )
+        .await;
+        mission.origin_session_id = Some("20260814_review_child".to_string());
+
+        let wake = wake_fields_for_mission(&mission, dir.path());
+        assert_eq!(wake.source, "project");
+        assert_eq!(wake.session.as_deref(), Some("20260814_094937_8c5097"));
+    }
+}

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -43,6 +43,10 @@ pub struct MissionScheduling {
     pub deadline: Option<String>,
 }
 
+/// Tag written on an attempt that a later start on the same item replaced.
+/// Default listings hide these without requiring a separate acknowledge.
+pub const SUPERSEDED_TAG: &str = "superseded";
+
 /// Which missions a listing wants. One value, one predicate — so the SQL
 /// pushdown and the in-memory scan can never disagree about what a filter
 /// means.
@@ -52,6 +56,10 @@ pub struct MissionScheduling {
 /// instead, which matches a project family (`verity` covers `verity-core`,
 /// `verity-phase1d`, …) while a project is being migrated onto the
 /// `project` + `track` convention.
+///
+/// `attention_only` is the default MCP/API horizon: hide `acknowledged`,
+/// `completed`, and absorbed/replaced attempts. Supervision and reconcile
+/// keep the empty filter (this flag off) so they still see the full fleet.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MissionFilter {
     pub status: Option<String>,
@@ -62,6 +70,22 @@ pub struct MissionFilter {
     pub tag: Option<String>,
     /// The conversation a mission was launched from (Hermes session id).
     pub origin_session_id: Option<String>,
+    /// When true, keep only live / waiting / blocked / unabsorbed-failed
+    /// attempts. Default listings set this; internal scanners do not.
+    pub attention_only: bool,
+}
+
+/// Live / waiting / blocked, plus unabsorbed `failed` / `interrupted`.
+/// Acknowledged, completed, and absorbed/replaced attempts drop out.
+pub fn default_attention_keeps(mission: &Mission) -> bool {
+    if mission.project.tags.iter().any(|tag| tag == SUPERSEDED_TAG) {
+        return false;
+    }
+    !matches!(
+        mission.status,
+        crate::api::control::events::MissionStatus::Acknowledged
+            | crate::api::control::events::MissionStatus::Completed
+    )
 }
 
 impl MissionFilter {
@@ -80,6 +104,9 @@ impl MissionFilter {
     }
 
     pub fn matches(&self, mission: &Mission) -> bool {
+        if self.attention_only && !default_attention_keeps(mission) {
+            return false;
+        }
         self.status
             .as_deref()
             .is_none_or(|s| mission.status.to_string() == s)

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -17,6 +17,7 @@ use super::{
     TelegramStructuredMemoryScope, TelegramStructuredMemorySearchHit, TelegramUser,
     TelegramUserCursor, TelegramUserRole, TelegramWorkflow, TelegramWorkflowEvent,
     TelegramWorkflowKind, TelegramWorkflowStatus, ToolCallSummary, TriggerType, WebhookConfig,
+    SUPERSEDED_TAG,
 };
 use crate::api::control::{AgentEvent, AgentTreeNode, DesktopSessionInfo, TextOp};
 use async_trait::async_trait;
@@ -2921,7 +2922,7 @@ impl MissionStore for SqliteMissionStore {
 
             let mut clauses: Vec<String> = Vec::new();
             let mut binds: Vec<String> = Vec::new();
-            let mut bind =
+            let bind =
                 |clause: &str, value: &str, clauses: &mut Vec<String>, binds: &mut Vec<String>| {
                     binds.push(value.to_string());
                     clauses.push(clause.replace("?n", &format!("?{}", binds.len())));
@@ -2975,6 +2976,26 @@ impl MissionStore for SqliteMissionStore {
                     .replace('_', "\\_");
                 bind(
                     r"tags LIKE '%' || ?n || '%' ESCAPE '\'",
+                    &pattern,
+                    &mut clauses,
+                    &mut binds,
+                );
+            }
+            if filter.attention_only {
+                clauses.push(
+                    "status NOT IN ('acknowledged', 'completed')".to_string(),
+                );
+                // Tags are a JSON array. The superseded token is stored as
+                // the JSON string `"superseded"`; this is a prefilter — the
+                // Rust `matches` call below is the authority.
+                let encoded = serde_json::to_string(SUPERSEDED_TAG)
+                    .unwrap_or_else(|_| format!("\"{SUPERSEDED_TAG}\""));
+                let pattern = encoded
+                    .replace('\\', "\\\\")
+                    .replace('%', "\\%")
+                    .replace('_', "\\_");
+                bind(
+                    r"(tags IS NULL OR tags = '' OR tags = '[]' OR tags NOT LIKE '%' || ?n || '%' ESCAPE '\')",
                     &pattern,
                     &mut clauses,
                     &mut binds,
@@ -16804,6 +16825,55 @@ mod filter_tests {
             .expect("filtered list");
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].project.project.as_deref(), Some("verity"));
+    }
+
+    #[tokio::test]
+    async fn attention_only_hides_acknowledged_completed_and_superseded() {
+        use crate::api::control::events::MissionStatus;
+        use crate::api::mission_store::{MissionStore, SUPERSEDED_TAG};
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = store(&dir).await;
+        let live = seed(&store, "live", Some("verity"), Some("core"), None).await;
+        let acked = seed(&store, "acked", Some("verity"), Some("old"), None).await;
+        let done = seed(&store, "done", Some("verity"), Some("old"), None).await;
+        let absorbed = seed(&store, "absorbed", Some("verity"), Some("core"), None).await;
+        store
+            .update_mission_status(acked, MissionStatus::Acknowledged)
+            .await
+            .expect("ack");
+        store
+            .update_mission_status(done, MissionStatus::Completed)
+            .await
+            .expect("complete");
+        store
+            .update_mission_project(
+                absorbed,
+                MissionProjectPatch {
+                    tags: Some(vec![SUPERSEDED_TAG.to_string()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag superseded");
+
+        let found = store
+            .list_missions_filtered(
+                &MissionFilter {
+                    project: Some("verity".into()),
+                    attention_only: true,
+                    ..Default::default()
+                },
+                50,
+                0,
+            )
+            .await
+            .expect("filtered list");
+        let ids: Vec<_> = found.iter().map(|m| m.id).collect();
+        assert!(ids.contains(&live));
+        assert!(!ids.contains(&acked));
+        assert!(!ids.contains(&done));
+        assert!(!ids.contains(&absorbed));
     }
 
     #[tokio::test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod grok_tool_bridge;
 pub mod library;
 pub mod mcp;
 pub mod metadata_llm;
+pub mod mission_horizon;
 pub mod mission_runner;
 pub mod mission_store;
 pub mod mission_workspace_gc;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -346,10 +346,21 @@ pub async fn get_project(
         .recent_decisions(&slug, 20)
         .map_err(store_err)?;
     let conversation = state.projects.binding(&slug).map_err(store_err)?;
+    let proposals = state
+        .projects
+        .list_open_proposals(&slug)
+        .map_err(store_err)?;
+    let missions = state
+        .control
+        .collect_attention_missions_for_project(&slug)
+        .await
+        .unwrap_or_default();
+    let items = super::mission_horizon::project_items(&tracks, &proposals, &missions);
     Ok(Json(serde_json::json!({
         "project": project,
         "grant": grant,
         "tracks": tracks,
+        "items": items,
         "open_decisions": decisions,
         "recent_decisions": recent,
         "conversation": conversation,

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1394,7 +1394,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "list_missions".to_string(),
-                description: "List recent missions, optionally filtered by status, project, or tag.".to_string(),
+                description: "List missions on the attention horizon: live, waiting, blocked, and unabsorbed failed/interrupted attempts. Acknowledged, completed, and replaced attempts are omitted unless you pass an explicit status. Filter by project or track to see attempts on one item. Prefer get_project for the item-first inventory.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -1474,7 +1474,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "start_mission".to_string(),
-                description: "Create a new sandboxed.sh mission and send its initial prompt. Set backend explicitly when possible. For Codex GPT-5.6/5.5/5.4, set fast_mode=true to request the native fast service tier; this consumes ChatGPT credits faster. Use backend=chatgpt_ui with model_override=gpt-5.6-pro only for exceptionally difficult read-only synthesis, research, or design-conflict questions; keep writer=false, then retrieve any generated files with list_mission_shared_files and download_shared_file. For compatibility, a native agent name (codex/claudecode/gemini/grok) selects the matching backend when backend is omitted; ordinary library agent names do not. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title). Reviewers and certifiers must use writer=false: the server tags them pr-readonly and blocks git/gh mutations. Any PR-changing mission must use writer=true; the API rejects concurrent writers for the same PR.".to_string(),
+                description: "Start a new attempt on a work item. Pass project+track (the durable item); a new start on the same project/track/writer role absorbs the previous attempt so you do not have to acknowledge it. Missions are attempts, not the work itself — use get_project to read open items. Set backend explicitly when possible. For Codex GPT-5.6/5.5/5.4, set fast_mode=true to request the native fast service tier; this consumes ChatGPT credits faster. Use backend=chatgpt_ui with model_override=gpt-5.6-pro only for exceptionally difficult read-only synthesis, research, or design-conflict questions; keep writer=false, then retrieve any generated files with list_mission_shared_files and download_shared_file. For compatibility, a native agent name (codex/claudecode/gemini/grok) selects the matching backend when backend is omitted; ordinary library agent names do not. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title). Reviewers and certifiers must use writer=false: the server tags them pr-readonly and blocks git/gh mutations. Any PR-changing mission must use writer=true; the API rejects concurrent writers for the same PR.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["title", "prompt"],
@@ -1580,7 +1580,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "get_project".to_string(),
-                description: "Get one project's structured state: record (objective, status, mode, blocker), autonomy grant, tracks, open decisions for the owner, and the bound control conversation. This is the source of truth for your project — prefer it over reading markdown trackers.".to_string(),
+                description: "Get one project's structured state. `items` are the durable work (track / task_key) with only live or unabsorbed attempts attached — do not treat the mission list as the inventory. Also includes record (objective, status, mode, blocker), autonomy grant, tracks, open decisions, and the bound control conversation. Prefer this over list_missions and over markdown trackers.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["slug"],


### PR DESCRIPTION
Fixes #827.

Controllers were treating every mission row as the work. The default list and `get_project` dumped recency, so absorbed attempts stayed visible and a 15-minute cron had to rebuild the fleet to notice a finish.

## What changed

- **Default listings** (`GET /api/control/missions` and MCP `list_missions` with no `status`) keep live / waiting / blocked / unabsorbed-failed attempts and omit `acknowledged`, `completed`, and `superseded` ones. Supervision and reconcile still use an empty filter and see the full fleet.
- **Start-attempt** on the same `(project, track, writer role)` absorbs the previous attempt (tag + acknowledge) so the model does not have to.
- **`get_project`** now includes `items`: tracks / task keys with only those attempts attached. MCP `get_project` / `start_mission` / `list_missions` descriptions match that model.
- **Wake**: the mission-status webhook carries `wake_session` / `wake_source` (bound project conversation, else origin). The Hermes patch uses that id as-is and does not walk resume children, which is what used to land a project click on a live review thread.

## Tests

`cargo test --lib -- mission_horizon attention_only_hides` (and the existing sqlite filter / campaign guard tests). `cargo fmt --all --check` is clean.

## Deploy / Hermes

Redeploy sandboxed.sh from this PR. Re-apply `patches/hermes/mission_status_route.py` on the Hermes host so the consumer honors `wake_session`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default mission list semantics and project overview shape for controllers/MCP; supersede-on-start and wake routing affect how callbacks land and which attempts stay visible.
> 
> **Overview**
> Introduces an **item-first mission horizon**: durable work is `track` / task keys; mission rows are attempts. Default API/MCP mission listings now use **`attention_only`** (live, waiting, blocked, unabsorbed failed/interrupted) and hide acknowledged, completed, and **`superseded`** attempts unless callers pass an explicit `status`.
> 
> **`get_project`** adds an **`items`** inventory (tracks, open proposals, attention attempts only) via new **`mission_horizon`** logic and **`collect_attention_missions_for_project`**. Starting a mission on the same `(project, track, writer role)` **supersedes** the prior attempt (tag + acknowledge when idle).
> 
> Mission-status webhooks now ship **`wake_session`** / **`wake_source`** (bound project conversation, else origin). The Hermes patch **honors `wake_session` as-is** when the session exists, avoiding resume-child walks that misrouted project clicks.
> 
> Assistant MCP tool descriptions are updated to match the items-vs-attempts model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81480c55b35c6fa6f883634ce05ac5f9673ec67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->