### PR TITLE
feat(projects): card and view lead with items and controller signal

### DIFF
--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  ProjectDetailPayload,
+  ProjectItem,
+  ProjectRow,
+} from "@/lib/api/projects";
+import { cardSummary, viewControllerSignal, viewOpenItems } from "./project-card-view";
+
+function row(overrides: Partial<ProjectRow> = {}): ProjectRow {
+  return {
+    slug: "verity",
+    title: "Verity",
+    bucket: "attention",
+    tracker: null,
+    missions: [
+      {
+        id: "old-completed",
+        status: "completed",
+        title: "merged last week",
+        updated_at: "2026-08-01T00:00:00Z",
+        github_pr: "lfglabs-dev/verity#2200",
+      },
+      {
+        id: "acked",
+        status: "acknowledged",
+        title: "already absorbed",
+        updated_at: "2026-08-10T00:00:00Z",
+        github_pr: null,
+      },
+    ],
+    latest_update: {
+      headline: "[SILENT]",
+      body: null,
+      session_id: "s",
+      at: "2026-08-14T05:50:00Z",
+      signature: "verity",
+      mode: "active",
+      blocker: "source #2332 dirty",
+    },
+    updates_count: 4,
+    attention_reasons: ["same state on 3 consecutive updates"],
+    next_action: "rebase/repair #2332 onto main after #2333",
+    mode: "active",
+    pending_decisions: 1,
+    health: {
+      missions: 40,
+      active: 2,
+      failed: 12,
+      overdue: 1,
+      tracks_needing_attention: 2,
+      tracks: [
+        {
+          track: "c5-preflight-pr2332",
+          verdict: "failing",
+          missions: 3,
+          active: 1,
+          failed: 2,
+          completed: 8,
+          overdue: 0,
+          desired_states: {},
+          last_activity_at: "2026-08-14T12:00:00Z",
+        },
+        {
+          track: "core",
+          verdict: "overdue",
+          missions: 5,
+          active: 0,
+          failed: 5,
+          completed: 20,
+          overdue: 1,
+          desired_states: {},
+          last_activity_at: "2026-08-10T00:00:00Z",
+        },
+        {
+          track: "landed-old",
+          verdict: "done",
+          missions: 2,
+          active: 0,
+          failed: 0,
+          completed: 2,
+          overdue: 0,
+          desired_states: {},
+          last_activity_at: "2026-08-01T00:00:00Z",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("cardSummary", () => {
+  test("leads with next_action, open tracks, pending decisions — not historical missions", () => {
+    const summary = cardSummary(row());
+    expect(summary.nextAction).toBe(
+      "rebase/repair #2332 onto main after #2333",
+    );
+    expect(summary.headline).toBe(
+      "rebase/repair #2332 onto main after #2333",
+    );
+    expect(summary.blocker).toBe("source #2332 dirty");
+    expect(summary.pendingDecisions).toBe(1);
+    expect(summary.liveAttempts).toBe(2);
+    expect(summary.openTrackCount).toBe(2);
+    expect(summary.openTracks.map((track) => track.key)).toEqual([
+      "c5-preflight-pr2332",
+      "core",
+    ]);
+    expect(summary.openTracks.map((track) => track.key)).not.toContain(
+      "landed-old",
+    );
+    expect(summary.lastSignalAt).toBe("2026-08-14T05:50:00Z");
+  });
+
+  test("falls back to the attention reason when the controller left no next_action", () => {
+    const summary = cardSummary(
+      row({
+        next_action: null,
+        attention_reasons: ["controller missing"],
+        health: {
+          missions: 0,
+          active: 0,
+          failed: 0,
+          overdue: 0,
+          tracks_needing_attention: 0,
+          tracks: [],
+        },
+      }),
+    );
+    expect(summary.nextAction).toBeNull();
+    expect(summary.headline).toBe("controller missing");
+  });
+});
+
+function item(overrides: Partial<ProjectItem> = {}): ProjectItem {
+  return {
+    key: "c5-preflight-pr2332",
+    kind: "track",
+    open: true,
+    attempts: [
+      {
+        id: "live-1",
+        status: "active",
+        title: "repair #2332",
+        updated_at: "2026-08-14T12:00:00Z",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function payload(overrides: Partial<ProjectDetailPayload> = {}): ProjectDetailPayload {
+  return {
+    project: {
+      slug: "verity",
+      mode: "active",
+      next_action: "rebase/repair #2332 onto main after #2333",
+      blocker: "source #2332 dirty",
+      updated_at: "2026-08-14T05:50:00Z",
+    },
+    items: [
+      item(),
+      item({
+        key: "landed-old",
+        open: false,
+        attempts: [
+          {
+            id: "done-1",
+            status: "completed",
+            title: "merged last week",
+            updated_at: "2026-08-01T00:00:00Z",
+          },
+        ],
+      }),
+      item({
+        key: "core",
+        open: true,
+        attempts: [
+          {
+            id: "fail-1",
+            status: "failed",
+            title: "review #2097",
+            updated_at: "2026-08-12T00:00:00Z",
+          },
+        ],
+      }),
+    ],
+    open_decisions: [
+      { question: "merge #2332?", status: "pending_user" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("viewOpenItems / viewControllerSignal", () => {
+  test("the project view inventory is open items, not historical missions", () => {
+    const items = viewOpenItems(payload());
+    expect(items.map((entry) => entry.key)).toEqual([
+      "c5-preflight-pr2332",
+      "core",
+    ]);
+    expect(items.every((entry) => entry.open)).toBe(true);
+    expect(items.flatMap((entry) => entry.attempts).map((a) => a.status)).not.toContain(
+      "completed",
+    );
+    expect(items.flatMap((entry) => entry.attempts).map((a) => a.status)).not.toContain(
+      "acknowledged",
+    );
+
+    const signal = viewControllerSignal(payload());
+    expect(signal.nextAction).toBe(
+      "rebase/repair #2332 onto main after #2333",
+    );
+    expect(signal.blocker).toBe("source #2332 dirty");
+    expect(signal.mode).toBe("active");
+    expect(signal.pendingDecisions).toBe(1);
+  });
+});

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -1,0 +1,152 @@
+/**
+ * Item-first projection for the projects board card and detail pane.
+ *
+ * The overview row still carries a recency dump of mission chips. Operators
+ * should see durable work items, the controller's last honest signal, and
+ * pending owner decisions — not that dump.
+ */
+
+import type {
+  ProjectDetailPayload,
+  ProjectItem,
+  ProjectItemAttempt,
+  ProjectRow,
+  TrackHealth,
+} from "@/lib/api/projects";
+import { healthDigest, isStale, parseMode } from "./project-health";
+
+const LIVE_ATTEMPT = new Set([
+  "created",
+  "queued",
+  "active",
+  "pending",
+  "waiting_background",
+  "awaiting_user",
+  "paused",
+]);
+
+export type CardOpenTrack = {
+  key: string;
+  verdict: string;
+  live: number;
+  failed: number;
+};
+
+export type CardSummary = {
+  headline: string | null;
+  nextAction: string | null;
+  blocker: string | null;
+  pendingDecisions: number;
+  openTracks: CardOpenTrack[];
+  openTrackCount: number;
+  liveAttempts: number;
+  lastSignalAt: string | null;
+  stale: boolean;
+};
+
+/** Overview-row facts the card should lead with. */
+export function cardSummary(project: ProjectRow): CardSummary {
+  const tracks = (project.health?.tracks ?? []).filter(
+    (track) => track.verdict !== "done",
+  );
+  const nextAction = nonblank(project.next_action);
+  const blocker =
+    nonblank(project.latest_update?.blocker) ??
+    (parseMode(project)?.base === "blocked"
+      ? parseMode(project)?.cause
+      : null);
+  const headline =
+    nextAction ??
+    healthDigest(project.health) ??
+    project.attention_reasons[0] ??
+    nonblank(project.latest_update?.headline) ??
+    nonblank(project.tracker?.status_line);
+  const lastSignalAt =
+    project.latest_update?.at ?? project.controller_heartbeat_at ?? null;
+  return {
+    headline,
+    nextAction,
+    blocker: blocker ?? null,
+    pendingDecisions: project.pending_decisions ?? 0,
+    openTracks: tracks.slice(0, 3).map(toOpenTrack),
+    openTrackCount: tracks.length,
+    liveAttempts: project.health?.active ?? 0,
+    lastSignalAt,
+    stale: isStale(project),
+  };
+}
+
+function toOpenTrack(track: TrackHealth): CardOpenTrack {
+  return {
+    key: track.track ?? "untracked",
+    verdict: track.verdict,
+    live: track.active,
+    failed: track.failed,
+  };
+}
+
+export type ViewAttempt = {
+  id: string;
+  status: string;
+  title: string | null;
+  updated_at: string;
+  live: boolean;
+};
+
+export type ViewItem = {
+  key: string;
+  open: boolean;
+  desiredState: string | null;
+  attempts: ViewAttempt[];
+};
+
+export type ViewSignal = {
+  mode: string | null;
+  nextAction: string | null;
+  blocker: string | null;
+  updatedAt: string | null;
+  pendingDecisions: number;
+};
+
+/** Items still open on the shipped get_project payload. Historical
+ *  (acknowledged / completed / superseded) attempts never appear here. */
+export function viewOpenItems(payload: ProjectDetailPayload): ViewItem[] {
+  return (payload.items ?? [])
+    .filter((item) => item.open)
+    .map(toViewItem);
+}
+
+export function viewControllerSignal(payload: ProjectDetailPayload): ViewSignal {
+  const record = payload.project ?? {};
+  return {
+    mode: record.mode ?? null,
+    nextAction: nonblank(record.next_action),
+    blocker: nonblank(record.blocker),
+    updatedAt: record.updated_at ?? null,
+    pendingDecisions: (payload.open_decisions ?? []).length,
+  };
+}
+
+function toViewItem(item: ProjectItem): ViewItem {
+  return {
+    key: item.key,
+    open: item.open,
+    desiredState: item.desired_state ?? item.status ?? null,
+    attempts: (item.attempts ?? []).map(toViewAttempt),
+  };
+}
+
+function toViewAttempt(attempt: ProjectItemAttempt): ViewAttempt {
+  return {
+    id: attempt.id,
+    status: attempt.status,
+    title: attempt.title ?? null,
+    updated_at: attempt.updated_at,
+    live: LIVE_ATTEMPT.has(attempt.status),
+  };
+}
+
+function nonblank(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -3,6 +3,7 @@ import { SWRConfig } from "swr";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
+  getProject,
   getProjectsOverview,
   getProjectUpdates,
   postProjectAction,
@@ -21,6 +22,7 @@ import ProjectsBoard, {
 
 vi.mock("@/lib/api/projects", () => ({
   getProjectsOverview: vi.fn(),
+  getProject: vi.fn(),
   getProjectUpdates: vi.fn(),
   postProjectAction: vi.fn(),
   bindProjectConversation: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock("@/components/markdown-content", () => ({
 }));
 
 const mockedOverview = vi.mocked(getProjectsOverview);
+const mockedProject = vi.mocked(getProject);
 const mockedListHermesSessions = vi.mocked(listHermesSessions);
 const mockedUpdates = vi.mocked(getProjectUpdates);
 const mockedAction = vi.mocked(postProjectAction);
@@ -103,10 +106,12 @@ function renderBoard() {
 describe("ProjectsBoard", () => {
   beforeEach(() => {
     mockedOverview.mockReset();
+    mockedProject.mockReset();
     mockedUpdates.mockReset();
     mockedAction.mockReset();
     mockedChat.mockReset();
     mockedUpdates.mockResolvedValue({ slug: "verity", updates: [] });
+    mockedProject.mockResolvedValue({ items: [], open_decisions: [] });
   });
 
   afterEach(() => {
@@ -161,12 +166,80 @@ describe("ProjectsBoard", () => {
     renderBoard();
 
     // Missions are behind a collapsible summary now — expand it first.
-    fireEvent.click(await screen.findByRole("button", { name: /Missions \(1\)/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /Attempts \(1\)/ }));
     const row = await screen.findByRole("link", { name: /Phase 1C slice/ });
     expect(row).toHaveAttribute(
       "href",
       "/control?mission=f98e1ee2-0000-0000-0000-000000000000",
     );
+  });
+
+  test("card and detail lead with next_action, pending decisions, and open items", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity",
+          title: "Verity",
+          next_action: "rebase/repair #2332 onto main after #2333",
+          pending_decisions: 1,
+          mode: "active",
+          health: health({
+            active: 1,
+            tracks_needing_attention: 1,
+            tracks: [track({ track: "c5-preflight-pr2332", verdict: "failing" })],
+          }),
+        }),
+      ]),
+    );
+    mockedProject.mockResolvedValue({
+      project: {
+        slug: "verity",
+        mode: "active",
+        next_action: "rebase/repair #2332 onto main after #2333",
+        blocker: "source #2332 dirty",
+      },
+      items: [
+        {
+          key: "c5-preflight-pr2332",
+          kind: "track",
+          open: true,
+          attempts: [
+            {
+              id: "live-1",
+              status: "active",
+              title: "repair #2332",
+              updated_at: "2026-08-14T12:00:00Z",
+            },
+          ],
+        },
+        {
+          key: "old-merged",
+          kind: "track",
+          open: false,
+          attempts: [
+            {
+              id: "done-1",
+              status: "completed",
+              title: "merged last week",
+              updated_at: "2026-08-01T00:00:00Z",
+            },
+          ],
+        },
+      ],
+      open_decisions: [{ question: "merge #2332?", status: "pending_user" }],
+    });
+
+    renderBoard();
+
+    expect(
+      await screen.findAllByText("rebase/repair #2332 onto main after #2333"),
+    ).not.toHaveLength(0);
+    expect(screen.getAllByText(/need you/).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/Open items \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText("c5-preflight-pr2332")).toBeInTheDocument();
+    expect(screen.queryByText("old-merged")).not.toBeInTheDocument();
+    expect(screen.queryByText("merged last week")).not.toBeInTheDocument();
+    expect(screen.getByText("source #2332 dirty")).toBeInTheDocument();
   });
 
   test("selecting a project loads its updates timeline in the detail pane", async () => {
@@ -493,7 +566,9 @@ describe("ProjectsBoard", () => {
 
     renderBoard();
 
-    expect(await screen.findByText("blocked: transport-cap")).toBeInTheDocument();
+    expect(
+      await screen.findAllByText("blocked: transport-cap"),
+    ).not.toHaveLength(0);
     expect(screen.queryByText(/unknown/i)).not.toBeInTheDocument();
     // The legacy row gets no chip at all — absence must look like the old board.
     expect(screen.queryByTitle("active")).not.toBeInTheDocument();

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -35,6 +35,7 @@ import {
   bindProjectConversation,
   unbindProjectConversation,
   type ProjectConversation,
+  getProject,
   getProjectsOverview,
   getProjectUpdates,
   postProjectAction,
@@ -44,6 +45,12 @@ import {
   type ProjectMissionChip,
   type ProjectRow,
 } from "@/lib/api/projects";
+import {
+  cardSummary,
+  viewControllerSignal,
+  viewOpenItems,
+  type ViewItem,
+} from "./project-card-view";
 import {
   listHermesSessions,
   type HermesSession,
@@ -184,9 +191,14 @@ export function unreadCountFor(
   return latestMs > seenMs ? 1 : 0;
 }
 
-/** A project with no missions and no updates is a quiet tracker file. */
+/** A project with no missions, no updates, and no declared next step. */
 function isQuiet(project: ProjectRow): boolean {
-  return project.missions.length === 0 && project.updates_count === 0;
+  return (
+    project.missions.length === 0 &&
+    project.updates_count === 0 &&
+    !project.next_action &&
+    (project.pending_decisions ?? 0) === 0
+  );
 }
 
 export default function ProjectsBoard() {
@@ -515,6 +527,7 @@ function ProjectListRow({
   const mode = parseMode(project);
   const digest = healthDigest(project.health);
   const stale = isStale(project);
+  const summary = cardSummary(project);
   return (
     <button
       type="button"
@@ -536,6 +549,14 @@ function ProjectListRow({
             {project.title || project.slug}
           </span>
           <span className="flex shrink-0 items-center gap-1.5">
+            {summary.pendingDecisions > 0 && (
+              <span
+                title={`${summary.pendingDecisions} pending owner decision${summary.pendingDecisions === 1 ? "" : "s"}`}
+                className="rounded-full bg-amber-500/20 px-1.5 py-px text-[10px] font-semibold tabular-nums text-amber-200"
+              >
+                {summary.pendingDecisions} need you
+              </span>
+            )}
             {unread > 0 && (
               <span
                 title={`${unread > 9 ? "9+" : unread} new update${unread === 1 ? "" : "s"}`}
@@ -544,16 +565,19 @@ function ProjectListRow({
                 {unread > 9 ? "9+" : unread}
               </span>
             )}
-            {project.latest_update && (
-              <UpdateAge at={project.latest_update.at} />
-            )}
+            {summary.lastSignalAt && <UpdateAge at={summary.lastSignalAt} />}
           </span>
         </span>
         {/* A blocked or stale controller is worth a second line even when the
             project is otherwise quiet — silence was exactly how a stuck
             controller used to hide. */}
-        {(!quiet || mode?.base === "blocked" || stale) && (
+        {(!quiet || mode?.base === "blocked" || stale || summary.nextAction) && (
           <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-white/40">
+            {summary.openTrackCount > 0 && (
+              <span className="shrink-0 text-white/55">
+                {summary.openTrackCount} item{summary.openTrackCount === 1 ? "" : "s"}
+              </span>
+            )}
             {live > 0 && (
               <span className="flex shrink-0 items-center gap-1 text-white/55">
                 <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[rgb(var(--text)/0.6)]" />
@@ -576,13 +600,15 @@ function ProjectListRow({
               </span>
             )}
             <span className="min-w-0 truncate">
-              {digest ??
-                stripMarkdown(
-                  project.attention_reasons[0] ??
-                    project.latest_update?.headline ??
-                    project.tracker?.status_line ??
-                    "",
-                )}
+              {summary.headline
+                ? stripMarkdown(summary.headline)
+                : (digest ??
+                  stripMarkdown(
+                    project.attention_reasons[0] ??
+                      project.latest_update?.headline ??
+                      project.tracker?.status_line ??
+                      "",
+                  ))}
             </span>
           </span>
         )}
@@ -965,8 +991,16 @@ function ProjectDetail({
     () => getProjectUpdates(project.slug, 50),
     { revalidateOnFocus: false },
   );
+  const { data: detail } = useSWR(
+    ["project-detail", project.slug],
+    () => getProject(project.slug),
+    { revalidateOnFocus: false },
+  );
   const updates = data?.updates ?? [];
   const section = SECTIONS.find((s) => s.bucket === project.bucket);
+  const summary = cardSummary(project);
+  const signal = detail ? viewControllerSignal(detail) : null;
+  const items = detail ? viewOpenItems(detail) : [];
 
   return (
     <div className="flex min-h-full flex-col">
@@ -1001,6 +1035,13 @@ function ProjectDetail({
             <ProjectActions project={project} />
           </span>
         </div>
+        <ControllerSignal
+          nextAction={signal?.nextAction ?? summary.nextAction}
+          blocker={signal?.blocker ?? summary.blocker}
+          mode={parseMode(project)}
+          pendingDecisions={signal?.pendingDecisions ?? summary.pendingDecisions}
+          lastSignalAt={summary.lastSignalAt}
+        />
         {project.tracker?.status_line && (
           <p className="mt-1.5 text-xs leading-relaxed text-white/55">
             {project.tracker.status_line}
@@ -1019,14 +1060,16 @@ function ProjectDetail({
             ))}
           </div>
         )}
-        {project.health && project.health.tracks.length > 0 && (
+        {items.length > 0 ? (
+          <ItemList items={items} />
+        ) : project.health && project.health.tracks.length > 0 ? (
           <div className="mt-2 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2">
             <p className="mb-1 text-[10px] uppercase tracking-wider text-white/40">
-              Tracks
+              Open items
             </p>
             <TrackHealthList health={project.health} />
           </div>
-        )}
+        ) : null}
         {project.missions.length > 0 && <MissionList missions={project.missions} />}
       </div>
 
@@ -1069,7 +1112,119 @@ function ProjectDetail({
   );
 }
 
-/** Collapsible mission list for the detail header: summary row, expand for detail. */
+function ControllerSignal({
+  nextAction,
+  blocker,
+  mode,
+  pendingDecisions,
+  lastSignalAt,
+}: {
+  nextAction: string | null;
+  blocker: string | null;
+  mode: ReturnType<typeof parseMode>;
+  pendingDecisions: number;
+  lastSignalAt: string | null;
+}) {
+  if (!nextAction && !blocker && pendingDecisions === 0 && !mode) {
+    return null;
+  }
+  return (
+    <div className="mt-2 space-y-1 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2">
+      <div className="flex flex-wrap items-center gap-2 text-[11px] text-white/45">
+        <ModeChip mode={mode} />
+        {pendingDecisions > 0 && (
+          <span className="text-amber-200/80">
+            {pendingDecisions} pending decision{pendingDecisions === 1 ? "" : "s"}
+          </span>
+        )}
+        {lastSignalAt && (
+          <span className="ml-auto flex items-center gap-1 text-white/35">
+            last signal <UpdateAge at={lastSignalAt} />
+          </span>
+        )}
+      </div>
+      {nextAction && (
+        <p className="text-xs text-white/75">
+          <span className="text-white/40">Next: </span>
+          {nextAction}
+        </p>
+      )}
+      {blocker && (
+        <p className="flex items-start gap-1.5 text-xs text-amber-200/80">
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          {blocker}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ItemList({ items }: { items: ViewItem[] }) {
+  const [expanded, setExpanded] = useState(true);
+  const live = items.reduce(
+    (count, item) => count + item.attempts.filter((attempt) => attempt.live).length,
+    0,
+  );
+  return (
+    <div className="mt-2.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-1.5 rounded-md py-1 text-left text-[11px] font-semibold uppercase tracking-wider text-white/35 transition-colors hover:text-white/60"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        Open items ({items.length})
+        <span className="font-normal normal-case tracking-normal text-white/30">
+          {live > 0 && ` · ${live} live`}
+        </span>
+      </button>
+      {expanded && (
+        <div className="mt-1 divide-y divide-white/[0.04] rounded-lg border border-white/[0.06] bg-white/[0.02]">
+          {items.map((item) => (
+            <div key={item.key} className="px-3 py-1.5">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="truncate text-xs text-white/80">{item.key}</span>
+                {item.desiredState && (
+                  <span className="shrink-0 text-[10px] text-white/35">
+                    {item.desiredState}
+                  </span>
+                )}
+              </div>
+              {item.attempts.slice(0, 2).map((attempt) => (
+                <Link
+                  key={attempt.id}
+                  href={`/control?mission=${attempt.id}`}
+                  className="mt-0.5 flex items-center gap-2 !no-underline"
+                >
+                  <span
+                    className={cn(
+                      "h-1.5 w-1.5 shrink-0 rounded-full",
+                      attempt.live
+                        ? "animate-pulse bg-[rgb(var(--text)/0.65)]"
+                        : "bg-[rgb(var(--text)/0.25)]",
+                    )}
+                  />
+                  <span className="min-w-0 flex-1 truncate text-[11px] text-white/50">
+                    {attempt.title || attempt.id.slice(0, 8)}
+                  </span>
+                  <span className="shrink-0 text-[10px] text-white/35">
+                    {attempt.status}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsible attempt list — lineage, not the work inventory. */
 function MissionList({ missions }: { missions: ProjectMissionChip[] }) {
   const [expanded, setExpanded] = useState(false);
   const live = missions.filter((m) => LIVE_STATUSES.has(m.status)).length;
@@ -1086,7 +1241,7 @@ function MissionList({ missions }: { missions: ProjectMissionChip[] }) {
         ) : (
           <ChevronRight className="h-3 w-3" />
         )}
-        Missions ({missions.length})
+        Attempts ({missions.length})
         <span className="font-normal normal-case tracking-normal text-white/30">
           {live > 0 && ` · ${live} live`}
           {problems > 0 && ` · ${problems} failed`}

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -87,6 +87,8 @@ export interface ProjectRow {
   /** Roster mode (`active` / `blocked[:cause]` / `paused`). Prefer this over
    *  guessing from `latest_update` when the last delivery was `[SILENT]`. */
   mode?: string | null;
+  /** Last successful controller cron run, even if the tick was `[SILENT]`. */
+  controller_heartbeat_at?: string | null;
   controller_health?: "healthy" | "stale" | "missing" | null;
   delivery_health?: "reaching_user" | "misrouted" | "dropped" | null;
   progress_state?: "working" | "waiting_external" | "blocked" | null;
@@ -106,8 +108,58 @@ export interface ProjectUpdatesResponse {
   updates: ProjectDeliveryUpdate[];
 }
 
+export interface ProjectItemAttempt {
+  id: string;
+  status: string;
+  title?: string | null;
+  updated_at: string;
+  role?: string | null;
+}
+
+export interface ProjectItem {
+  key: string;
+  kind: string;
+  desired_state?: string | null;
+  status?: string | null;
+  open: boolean;
+  attempts: ProjectItemAttempt[];
+}
+
+export interface ProjectDecision {
+  question?: string;
+  kind?: string;
+  status?: string;
+  created_at?: string;
+  at?: string;
+}
+
+export interface ProjectRecord {
+  slug?: string;
+  title?: string | null;
+  status?: string | null;
+  mode?: string | null;
+  next_action?: string | null;
+  blocker?: string | null;
+  updated_at?: string | null;
+}
+
+export interface ProjectDetailPayload {
+  project?: ProjectRecord;
+  items?: ProjectItem[];
+  open_decisions?: ProjectDecision[];
+  conversation?: ProjectConversation | null;
+  tracks?: unknown[];
+}
+
 export function getProjectsOverview(): Promise<ProjectsOverview> {
   return apiGet("/api/projects/overview", "Failed to load projects overview");
+}
+
+export function getProject(slug: string): Promise<ProjectDetailPayload> {
+  return apiGet(
+    `/api/projects/${encodeURIComponent(slug)}`,
+    "Failed to load project",
+  );
 }
 
 export function getProjectUpdates(


### PR DESCRIPTION
The projects board still presented a recency dump of mission chips as the work. Controllers already get item-first `get_project.items` (#828/#829); the operator surfaces did not.

## Card
- Open-item count from the health rollup (done tracks excluded)
- `next_action` as the headline when the controller declared one
- Pending owner-decision badge
- Last-signal age (delivery or heartbeat)

## Detail
- Controller signal block: mode, next action, blocker, pending decisions
- Fetches `GET /api/projects/:slug` and lists **open items** with live/unabsorbed attempts
- The old mission list is relabeled **Attempts** (lineage, not inventory)

Tests drive `cardSummary` / `viewOpenItems` and the board render path.

No backend deploy required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UI and read-side API client; no auth or backend changes in this diff. Main risk is UX mismatch if overview and detail endpoints disagree before backend is deployed everywhere.
> 
> **Overview**
> The projects board no longer treats the mission chip recency dump as the primary work picture. A new **`project-card-view`** layer projects overview rows and detail payloads into **controller signal** (next action, blocker, pending decisions, last signal) and **open items** instead of historical missions.
> 
> **List cards** use `cardSummary`: headline prefers `next_action`, show open-item counts (non-done tracks), a **“need you”** badge for pending decisions, and last-signal age from delivery or `controller_heartbeat_at`. **Quiet** projects now account for `next_action` and pending decisions.
> 
> **Detail pane** loads **`GET /api/projects/:slug`** via `getProject` and renders a **Controller signal** block plus an **Open items** list (open items only, with live attempt links to `/control`). Closed items and completed/acknowledged attempts stay out of the inventory; the old mission list is relabeled **Attempts** (lineage). Track health is a fallback when detail items are empty.
> 
> The client adds **`ProjectDetailPayload`** types and **`getProject`**; tests cover `cardSummary` / `viewOpenItems` / `viewControllerSignal` and the board render path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9fa261f201f96d236baa65b7fe5a172d9a0f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->