### PR TITLE
feat(projects): show owner questions and rank live items first

### DIFF
--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -5,7 +5,14 @@ import type {
   ProjectItem,
   ProjectRow,
 } from "@/lib/api/projects";
-import { cardSummary, viewControllerSignal, viewOpenItems } from "./project-card-view";
+import {
+  cardSummary,
+  viewControllerSignal,
+  viewMovingItems,
+  viewOpenItems,
+  viewPendingDecisions,
+  viewStalledItems,
+} from "./project-card-view";
 
 function row(overrides: Partial<ProjectRow> = {}): ProjectRow {
   return {
@@ -186,6 +193,16 @@ function payload(overrides: Partial<ProjectDetailPayload> = {}): ProjectDetailPa
       }),
     ],
     open_decisions: [
+      {
+        question: "relancer coldcard_skip depuis le checkpoint ?",
+        status: "pending_user",
+        at: "2026-08-13T20:22:14.411515235+00:00",
+      },
+      {
+        question: "relancer coldcard_skip depuis le checkpoint ?",
+        status: "pending_user",
+        at: "2026-08-13T20:22:12.331480026+00:00",
+      },
       { question: "merge #2332?", status: "pending_user" },
     ],
     ...overrides,
@@ -213,6 +230,28 @@ describe("viewOpenItems / viewControllerSignal", () => {
     );
     expect(signal.blocker).toBe("source #2332 dirty");
     expect(signal.mode).toBe("active");
-    expect(signal.pendingDecisions).toBe(1);
+    expect(signal.pendingDecisions).toBe(3);
+
+    expect(viewMovingItems(items).map((entry) => entry.key)).toEqual([
+      "c5-preflight-pr2332",
+    ]);
+    expect(viewStalledItems(items).map((entry) => entry.key)).toEqual(["core"]);
+    expect(items[0].moving).toBe(true);
+
+    const decisions = viewPendingDecisions(payload());
+    expect(decisions).toEqual([
+      {
+        question: "relancer coldcard_skip depuis le checkpoint ?",
+        at: "2026-08-13T20:22:12.331480026+00:00",
+        count: 2,
+        status: "pending_user",
+      },
+      {
+        question: "merge #2332?",
+        at: null,
+        count: 1,
+        status: "pending_user",
+      },
+    ]);
   });
 });

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  ProjectDecision,
   ProjectDetailPayload,
   ProjectItem,
   ProjectItemAttempt,
@@ -98,6 +99,14 @@ export type ViewItem = {
   open: boolean;
   desiredState: string | null;
   attempts: ViewAttempt[];
+  moving: boolean;
+};
+
+export type ViewDecision = {
+  question: string;
+  at: string | null;
+  count: number;
+  status: string | null;
 };
 
 export type ViewSignal = {
@@ -109,31 +118,78 @@ export type ViewSignal = {
 };
 
 /** Items still open on the shipped get_project payload. Historical
- *  (acknowledged / completed / superseded) attempts never appear here. */
+ *  (acknowledged / completed / superseded) attempts never appear here.
+ *  Live attempts sort first so a graveyard of failed retries cannot bury
+ *  the one item that is actually moving. */
 export function viewOpenItems(payload: ProjectDetailPayload): ViewItem[] {
   return (payload.items ?? [])
     .filter((item) => item.open)
-    .map(toViewItem);
+    .map(toViewItem)
+    .sort((left, right) => Number(right.moving) - Number(left.moving));
+}
+
+export function viewMovingItems(items: ViewItem[]): ViewItem[] {
+  return items.filter((item) => item.moving);
+}
+
+export function viewStalledItems(items: ViewItem[]): ViewItem[] {
+  return items.filter((item) => !item.moving);
+}
+
+/** Collapse duplicate owner questions (Coldcard recorded the same
+ *  checkpoint prompt twice two seconds apart). */
+export function viewPendingDecisions(
+  payload: ProjectDetailPayload,
+): ViewDecision[] {
+  const grouped = new Map<string, ViewDecision>();
+  for (const raw of payload.open_decisions ?? []) {
+    if (!isPendingDecision(raw)) continue;
+    const question = nonblank(raw.question);
+    if (!question) continue;
+    const key = question.toLowerCase();
+    const existing = grouped.get(key);
+    const at = raw.at ?? raw.created_at ?? null;
+    if (!existing) {
+      grouped.set(key, {
+        question,
+        at,
+        count: 1,
+        status: raw.status ?? null,
+      });
+      continue;
+    }
+    existing.count += 1;
+    if (at && (!existing.at || at < existing.at)) existing.at = at;
+  }
+  return [...grouped.values()];
 }
 
 export function viewControllerSignal(payload: ProjectDetailPayload): ViewSignal {
   const record = payload.project ?? {};
+  const pending = viewPendingDecisions(payload);
   return {
     mode: record.mode ?? null,
     nextAction: nonblank(record.next_action),
     blocker: nonblank(record.blocker),
     updatedAt: record.updated_at ?? null,
-    pendingDecisions: (payload.open_decisions ?? []).length,
+    pendingDecisions: pending.reduce((sum, decision) => sum + decision.count, 0),
   };
 }
 
 function toViewItem(item: ProjectItem): ViewItem {
+  const attempts = (item.attempts ?? []).map(toViewAttempt);
   return {
     key: item.key,
     open: item.open,
     desiredState: item.desired_state ?? item.status ?? null,
-    attempts: (item.attempts ?? []).map(toViewAttempt),
+    attempts,
+    moving: attempts.some((attempt) => attempt.live),
   };
+}
+
+function isPendingDecision(decision: ProjectDecision): boolean {
+  const status = decision.status?.trim();
+  return !status || status === "pending_user";
 }
 
 function toViewAttempt(attempt: ProjectItemAttempt): ViewAttempt {

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -235,11 +235,12 @@ describe("ProjectsBoard", () => {
       await screen.findAllByText("rebase/repair #2332 onto main after #2333"),
     ).not.toHaveLength(0);
     expect(screen.getAllByText(/need you/).length).toBeGreaterThan(0);
-    expect(await screen.findByText(/Open items \(1\)/)).toBeInTheDocument();
+    expect(await screen.findByText(/Moving \(1\)/)).toBeInTheDocument();
     expect(screen.getByText("c5-preflight-pr2332")).toBeInTheDocument();
     expect(screen.queryByText("old-merged")).not.toBeInTheDocument();
     expect(screen.queryByText("merged last week")).not.toBeInTheDocument();
     expect(screen.getByText("source #2332 dirty")).toBeInTheDocument();
+    expect(screen.getByText("merge #2332?")).toBeInTheDocument();
   });
 
   test("selecting a project loads its updates timeline in the detail pane", async () => {

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -48,7 +48,11 @@ import {
 import {
   cardSummary,
   viewControllerSignal,
+  viewMovingItems,
   viewOpenItems,
+  viewPendingDecisions,
+  viewStalledItems,
+  type ViewDecision,
   type ViewItem,
 } from "./project-card-view";
 import {
@@ -1001,6 +1005,9 @@ function ProjectDetail({
   const summary = cardSummary(project);
   const signal = detail ? viewControllerSignal(detail) : null;
   const items = detail ? viewOpenItems(detail) : [];
+  const decisions = detail ? viewPendingDecisions(detail) : [];
+  const moving = viewMovingItems(items);
+  const stalled = viewStalledItems(items);
 
   return (
     <div className="flex min-h-full flex-col">
@@ -1041,6 +1048,7 @@ function ProjectDetail({
           mode={parseMode(project)}
           pendingDecisions={signal?.pendingDecisions ?? summary.pendingDecisions}
           lastSignalAt={summary.lastSignalAt}
+          decisions={decisions}
         />
         {project.tracker?.status_line && (
           <p className="mt-1.5 text-xs leading-relaxed text-white/55">
@@ -1060,9 +1068,11 @@ function ProjectDetail({
             ))}
           </div>
         )}
-        {items.length > 0 ? (
-          <ItemList items={items} />
-        ) : project.health && project.health.tracks.length > 0 ? (
+        {moving.length > 0 && <ItemList items={moving} heading="Moving" />}
+        {stalled.length > 0 && (
+          <ItemList items={stalled} heading="Stalled items" defaultExpanded={moving.length === 0} />
+        )}
+        {items.length === 0 && project.health && project.health.tracks.length > 0 ? (
           <div className="mt-2 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2">
             <p className="mb-1 text-[10px] uppercase tracking-wider text-white/40">
               Open items
@@ -1118,14 +1128,16 @@ function ControllerSignal({
   mode,
   pendingDecisions,
   lastSignalAt,
+  decisions,
 }: {
   nextAction: string | null;
   blocker: string | null;
   mode: ReturnType<typeof parseMode>;
   pendingDecisions: number;
   lastSignalAt: string | null;
+  decisions: ViewDecision[];
 }) {
-  if (!nextAction && !blocker && pendingDecisions === 0 && !mode) {
+  if (!nextAction && !blocker && pendingDecisions === 0 && !mode && decisions.length === 0) {
     return null;
   }
   return (
@@ -1134,7 +1146,9 @@ function ControllerSignal({
         <ModeChip mode={mode} />
         {pendingDecisions > 0 && (
           <span className="text-amber-200/80">
-            {pendingDecisions} pending decision{pendingDecisions === 1 ? "" : "s"}
+            {decisions.length > 0
+              ? `${decisions.length} pending decision${decisions.length === 1 ? "" : "s"}`
+              : `${pendingDecisions} pending decision${pendingDecisions === 1 ? "" : "s"}`}
           </span>
         )}
         {lastSignalAt && (
@@ -1155,12 +1169,32 @@ function ControllerSignal({
           {blocker}
         </p>
       )}
+      {decisions.map((decision) => (
+        <p
+          key={decision.question}
+          className="flex items-start gap-1.5 text-xs text-amber-100/90"
+        >
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          {decision.question}
+          {decision.count > 1 && (
+            <span className="text-white/35">×{decision.count}</span>
+          )}
+        </p>
+      ))}
     </div>
   );
 }
 
-function ItemList({ items }: { items: ViewItem[] }) {
-  const [expanded, setExpanded] = useState(true);
+function ItemList({
+  items,
+  heading,
+  defaultExpanded = true,
+}: {
+  items: ViewItem[];
+  heading?: string;
+  defaultExpanded?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const live = items.reduce(
     (count, item) => count + item.attempts.filter((attempt) => attempt.live).length,
     0,
@@ -1177,7 +1211,7 @@ function ItemList({ items }: { items: ViewItem[] }) {
         ) : (
           <ChevronRight className="h-3 w-3" />
         )}
-        Open items ({items.length})
+        {heading ?? "Open items"} ({items.length})
         <span className="font-normal normal-case tracking-normal text-white/30">
           {live > 0 && ` · ${live} live`}
         </span>

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -131,6 +131,7 @@ export interface ProjectDecision {
   status?: string;
   created_at?: string;
   at?: string;
+  rationale?: string | null;
 }
 
 export interface ProjectRecord {


### PR DESCRIPTION
Follow-up to #832 after the 16:00 Lisbon watch.

Coldcard is not silent — the scan is LIVE — but the operator cannot see *what* they are asked. Two identical `pending_user` rows ask « relancer coldcard_skip depuis le checkpoint ? » while the detail lists 15 failed/interrupted kernel items as if they were the work.

- Dedup owner questions and render them on the project view
- Sort/split items: **Moving** (live attempts) above collapsed **Stalled items**
- Tests on `viewPendingDecisions` / `viewMovingItems` and the board render

Dashboard only. No backend deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard presentation and client-side projection only; no API or auth changes.
> 
> **Overview**
> Improves the project **detail pane** so operators see what they are being asked and which work is actually in flight, instead of a flat pile of open items and hidden duplicate prompts.
> 
> **Pending owner decisions** are deduped by question text (case-insensitive), keeping the earliest timestamp and a repeat count. They render in the controller signal block alongside next action and blocker; the pending count uses the sum of those counts (not raw `open_decisions` length). The chip label uses the number of unique questions when detail data is available.
> 
> **Open items** gain a `moving` flag (any live attempt). The list sorts moving items first and the UI splits into **Moving** and **Stalled items** sections, with stalled collapsed when something is moving. `ProjectDecision` typing adds optional `rationale`.
> 
> Dashboard-only; tests cover the view helpers and board copy (`Moving (1)`, decision text visible).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb07dad7e66a8bb3916065f8920384d64120c253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->