### PR TITLE
feat(projects): flag next_action when nothing is running

### DIFF
--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -117,6 +117,57 @@ describe("cardSummary", () => {
       "landed-old",
     );
     expect(summary.lastSignalAt).toBe("2026-08-14T05:50:00Z");
+    expect(summary.idleNextAction).toBe(false);
+  });
+
+  test("flags next_action with zero live attempts when the owner is not asked", () => {
+    const summary = cardSummary(
+      row({
+        next_action: "repin Verity after #66 merge",
+        pending_decisions: 0,
+        health: {
+          missions: 9,
+          active: 0,
+          failed: 9,
+          overdue: 0,
+          tracks_needing_attention: 5,
+          tracks: [
+            {
+              track: "lido-verity-closure-v2",
+              verdict: "failing",
+              missions: 1,
+              active: 0,
+              failed: 1,
+              completed: 0,
+              overdue: 0,
+              desired_states: {},
+              last_activity_at: "2026-08-14T15:31:26Z",
+            },
+          ],
+        },
+      }),
+    );
+    expect(summary.nextAction).toBe("repin Verity after #66 merge");
+    expect(summary.liveAttempts).toBe(0);
+    expect(summary.idleNextAction).toBe(true);
+  });
+
+  test("does not flag idle next_action while owner decisions are pending", () => {
+    const summary = cardSummary(
+      row({
+        next_action: "wait for checkpoint answer",
+        pending_decisions: 2,
+        health: {
+          missions: 0,
+          active: 0,
+          failed: 0,
+          overdue: 0,
+          tracks_needing_attention: 0,
+          tracks: [],
+        },
+      }),
+    );
+    expect(summary.idleNextAction).toBe(false);
   });
 
   test("falls back to the attention reason when the controller left no next_action", () => {

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -43,6 +43,8 @@ export type CardSummary = {
   liveAttempts: number;
   lastSignalAt: string | null;
   stale: boolean;
+  /** next_action is set, nothing is running, and the owner is not being asked. */
+  idleNextAction: boolean;
 };
 
 /** Overview-row facts the card should lead with. */
@@ -64,16 +66,24 @@ export function cardSummary(project: ProjectRow): CardSummary {
     nonblank(project.tracker?.status_line);
   const lastSignalAt =
     project.latest_update?.at ?? project.controller_heartbeat_at ?? null;
+  const liveAttempts = project.health?.active ?? 0;
+  const pendingDecisions = project.pending_decisions ?? 0;
+  const mode = parseMode(project);
   return {
     headline,
     nextAction,
     blocker: blocker ?? null,
-    pendingDecisions: project.pending_decisions ?? 0,
+    pendingDecisions,
     openTracks: tracks.slice(0, 3).map(toOpenTrack),
     openTrackCount: tracks.length,
-    liveAttempts: project.health?.active ?? 0,
+    liveAttempts,
     lastSignalAt,
     stale: isStale(project),
+    idleNextAction:
+      nextAction !== null &&
+      liveAttempts === 0 &&
+      pendingDecisions === 0 &&
+      mode?.base !== "paused",
   };
 }
 

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -243,6 +243,31 @@ describe("ProjectsBoard", () => {
     expect(screen.getByText("merge #2332?")).toBeInTheDocument();
   });
 
+  test("shows no live attempt when next_action is set and nothing is running", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity-lido",
+          title: "Lido SRv3 audit",
+          next_action: "repin Verity after #66 merge",
+          pending_decisions: 0,
+          mode: "active",
+          health: health({
+            active: 0,
+            failed: 9,
+            tracks_needing_attention: 5,
+            tracks: [track({ track: "lido-verity-closure-v2", verdict: "failing", active: 0, failed: 1 })],
+          }),
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    expect(await screen.findAllByText("no live attempt")).not.toHaveLength(0);
+    expect(screen.getAllByText("repin Verity after #66 merge").length).toBeGreaterThan(0);
+  });
+
   test("selecting a project loads its updates timeline in the detail pane", async () => {
     mockedOverview.mockResolvedValue(
       overview([

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -603,6 +603,14 @@ function ProjectListRow({
                 silent
               </span>
             )}
+            {summary.idleNextAction && (
+              <span
+                title="next_action is set but nothing is running"
+                className="shrink-0 text-[10px] uppercase tracking-wide text-amber-400/70"
+              >
+                no live attempt
+              </span>
+            )}
             <span className="min-w-0 truncate">
               {summary.headline
                 ? stripMarkdown(summary.headline)
@@ -1049,6 +1057,7 @@ function ProjectDetail({
           pendingDecisions={signal?.pendingDecisions ?? summary.pendingDecisions}
           lastSignalAt={summary.lastSignalAt}
           decisions={decisions}
+          idleNextAction={summary.idleNextAction}
         />
         {project.tracker?.status_line && (
           <p className="mt-1.5 text-xs leading-relaxed text-white/55">
@@ -1129,6 +1138,7 @@ function ControllerSignal({
   pendingDecisions,
   lastSignalAt,
   decisions,
+  idleNextAction,
 }: {
   nextAction: string | null;
   blocker: string | null;
@@ -1136,14 +1146,24 @@ function ControllerSignal({
   pendingDecisions: number;
   lastSignalAt: string | null;
   decisions: ViewDecision[];
+  idleNextAction: boolean;
 }) {
-  if (!nextAction && !blocker && pendingDecisions === 0 && !mode && decisions.length === 0) {
+  if (
+    !nextAction &&
+    !blocker &&
+    pendingDecisions === 0 &&
+    !mode &&
+    decisions.length === 0
+  ) {
     return null;
   }
   return (
     <div className="mt-2 space-y-1 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2">
       <div className="flex flex-wrap items-center gap-2 text-[11px] text-white/45">
         <ModeChip mode={mode} />
+        {idleNextAction && (
+          <span className="text-amber-200/80">no live attempt</span>
+        )}
         {pendingDecisions > 0 && (
           <span className="text-amber-200/80">
             {decisions.length > 0


### PR DESCRIPTION
16:31 Lisbon watch: Lido's only live attempt `04b0a5d8` died (`force_killed_after_cancel_timeout`). The card still showed `next_action: repin Verity after #66 merge` with no live pulse.

- `cardSummary.idleNextAction` is true when next_action is set, `health.active === 0`, and there are no pending owner decisions
- Card + detail show **no live attempt**
- Coldcard (waiting on you) is not flagged

Dashboard only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only display logic with unit and integration tests; no API or auth changes.
> 
> **Overview**
> Surfaces when a project still advertises a **next_action** but has **no live attempts** and is not waiting on the owner—so operators can spot stalled controllers (e.g. after a mission was killed) without inferring it from the headline alone.
> 
> `cardSummary` now exposes **`idleNextAction`**, true when `next_action` is set, `health.active === 0`, `pending_decisions === 0`, and the project is not in **paused** mode. The triage list and detail **`ControllerSignal`** block show an amber **no live attempt** label when that flag is set; projects with pending owner decisions are not flagged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfeb2cf87ebc172508cb2661e45275af21802ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->