### PR TITLE
feat(projects): keep paused and awaiting_user out of Moving

### DIFF
--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -288,6 +288,63 @@ describe("viewOpenItems / viewControllerSignal", () => {
     ]);
     expect(viewStalledItems(items).map((entry) => entry.key)).toEqual(["core"]);
     expect(items[0].moving).toBe(true);
+  });
+
+  test("paused and awaiting_user items are parked, not moving", () => {
+    const items = viewOpenItems(
+      payload({
+        items: [
+          item({
+            key: "tier2-helpers",
+            attempts: [
+              {
+                id: "old-await",
+                status: "awaiting_user",
+                title: "assign helper bridge catalog",
+                updated_at: "2026-07-30T18:27:55Z",
+              },
+            ],
+          }),
+          item({
+            key: "core-proven-fragment-review",
+            attempts: [
+              {
+                id: "paused-review",
+                status: "paused",
+                title: "adversarial review of #2205",
+                updated_at: "2026-08-10T00:00:00Z",
+              },
+            ],
+          }),
+          item({
+            key: "c5-preflight-pr2332",
+            attempts: [
+              {
+                id: "live-writer",
+                status: "active",
+                title: "repair #2332",
+                updated_at: "2026-08-14T15:35:00Z",
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(items.map((entry) => entry.key)).toEqual([
+      "c5-preflight-pr2332",
+      "tier2-helpers",
+      "core-proven-fragment-review",
+    ]);
+    expect(viewMovingItems(items).map((entry) => entry.key)).toEqual([
+      "c5-preflight-pr2332",
+    ]);
+    expect(viewStalledItems(items).map((entry) => entry.key)).toEqual([
+      "tier2-helpers",
+      "core-proven-fragment-review",
+    ]);
+    expect(items.find((entry) => entry.key === "tier2-helpers")?.attempts[0].live).toBe(
+      false,
+    );
 
     const decisions = viewPendingDecisions(payload());
     expect(decisions).toEqual([

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -16,14 +16,15 @@ import type {
 } from "@/lib/api/projects";
 import { healthDigest, isStale, parseMode } from "./project-health";
 
+/** Actually executing. Parked `paused` / `awaiting_user` rows are open
+ *  items, not movement — Verity was ranking five paused bosses above
+ *  the two writers that were running. */
 const LIVE_ATTEMPT = new Set([
   "created",
   "queued",
   "active",
   "pending",
   "waiting_background",
-  "awaiting_user",
-  "paused",
 ]);
 
 export type CardOpenTrack = {

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -90,8 +90,6 @@ const LIVE_STATUSES = new Set([
   "active",
   "pending",
   "waiting_background",
-  "awaiting_user",
-  "paused",
 ]);
 
 const PROBLEM_STATUSES = new Set([


### PR DESCRIPTION
## Why

Verity's project view listed **Moving (7)** while only two writers were actually running. Five paused bosses and a 15-day-old `awaiting_user` helper slice were treated as live because the item projection used the same set as "not terminal."

## What

- `LIVE_ATTEMPT` / board `LIVE_STATUSES` are now the executing set: `created`, `queued`, `active`, `pending`, `waiting_background`.
- `paused` and `awaiting_user` stay visible as open items, but they sort into **Stalled items**.
- Tests: `viewOpenItems` on that mix ranks the active writer first and parks the rest.

Dashboard-only. Vercel will pick it up after merge. No backend deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only display logic and tests; no backend or auth changes.
> 
> **Overview**
> Fixes inflated **Moving** counts and **live** badges when open work is parked on `paused` or `awaiting_user` instead of actually executing.
> 
> `LIVE_ATTEMPT` in `project-card-view.ts` and `LIVE_STATUSES` in `projects-board.tsx` now only treat `created`, `queued`, `active`, `pending`, and `waiting_background` as live. Those parked statuses still show as open items but land under **Stalled items**, sort below truly moving work, and no longer pulse as live attempts. A Vitest case locks in the mix of active vs paused vs awaiting_user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9715807eddaf59ce047cd9fd78438a586b426ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->