### PR TITLE
feat(projects): flag when the controller lags live work

### DIFF
--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -66,7 +66,7 @@ function row(overrides: Partial<ProjectRow> = {}): ProjectRow {
           completed: 8,
           overdue: 0,
           desired_states: {},
-          last_activity_at: "2026-08-14T12:00:00Z",
+          last_activity_at: "2026-08-14T05:52:00Z",
         },
         {
           track: "core",
@@ -117,6 +117,59 @@ describe("cardSummary", () => {
       "landed-old",
     );
     expect(summary.lastSignalAt).toBe("2026-08-14T05:50:00Z");
+    expect(summary.lastWorkAt).toBe("2026-08-14T05:52:00Z");
+    expect(summary.idleNextAction).toBe(false);
+    expect(summary.controllerBehind).toBe(false);
+  });
+
+  test("flags a controller whose last signal is older than live work", () => {
+    const summary = cardSummary(
+      row({
+        pending_decisions: 0,
+        latest_update: {
+          headline: "Verity #2332 — BLOQUÉE PAR LEASE WRITER",
+          body: null,
+          session_id: "s",
+          at: "2026-08-14T14:30:54Z",
+          signature: "verity",
+          mode: "active",
+          blocker: "source #2332 dirty",
+        },
+        missions: [
+          {
+            id: "08306fdb",
+            status: "active",
+            title: "Grok 4.6 — repair Verity PR #2332",
+            updated_at: "2026-08-14T15:35:08Z",
+            github_pr: null,
+          },
+        ],
+        health: {
+          missions: 8,
+          active: 2,
+          failed: 5,
+          overdue: 0,
+          tracks_needing_attention: 3,
+          tracks: [
+            {
+              track: "c5-preflight-pr2332",
+              verdict: "active",
+              missions: 2,
+              active: 1,
+              failed: 1,
+              completed: 0,
+              overdue: 0,
+              desired_states: {},
+              last_activity_at: "2026-08-14T15:35:08Z",
+            },
+          ],
+        },
+      }),
+    );
+    expect(summary.liveAttempts).toBe(2);
+    expect(summary.lastSignalAt).toBe("2026-08-14T14:30:54Z");
+    expect(summary.lastWorkAt).toBe("2026-08-14T15:35:08Z");
+    expect(summary.controllerBehind).toBe(true);
     expect(summary.idleNextAction).toBe(false);
   });
 

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -43,9 +43,14 @@ export type CardSummary = {
   openTrackCount: number;
   liveAttempts: number;
   lastSignalAt: string | null;
+  /** Newest live mission / active-track activity. Distinct from lastSignalAt
+   *  so a silent controller cannot hide writers that are still ticking. */
+  lastWorkAt: string | null;
   stale: boolean;
   /** next_action is set, nothing is running, and the owner is not being asked. */
   idleNextAction: boolean;
+  /** Live work is more than 15 minutes newer than the last controller signal. */
+  controllerBehind: boolean;
 };
 
 /** Overview-row facts the card should lead with. */
@@ -67,6 +72,7 @@ export function cardSummary(project: ProjectRow): CardSummary {
     nonblank(project.tracker?.status_line);
   const lastSignalAt =
     project.latest_update?.at ?? project.controller_heartbeat_at ?? null;
+  const lastWorkAt = latestLiveWorkAt(project);
   const liveAttempts = project.health?.active ?? 0;
   const pendingDecisions = project.pending_decisions ?? 0;
   const mode = parseMode(project);
@@ -79,13 +85,52 @@ export function cardSummary(project: ProjectRow): CardSummary {
     openTrackCount: tracks.length,
     liveAttempts,
     lastSignalAt,
+    lastWorkAt,
     stale: isStale(project),
     idleNextAction:
       nextAction !== null &&
       liveAttempts === 0 &&
       pendingDecisions === 0 &&
       mode?.base !== "paused",
+    controllerBehind: isControllerBehind(lastSignalAt, lastWorkAt, liveAttempts),
   };
+}
+
+const CONTROLLER_BEHIND_MS = 15 * 60 * 1000;
+
+function latestLiveWorkAt(project: ProjectRow): string | null {
+  const fromMissions = (project.missions ?? [])
+    .filter((mission) => LIVE_ATTEMPT.has(mission.status))
+    .map((mission) => mission.updated_at);
+  const fromTracks = (project.health?.tracks ?? [])
+    .filter((track) => track.active > 0)
+    .map((track) => track.last_activity_at);
+  return latestTimestamp([...fromMissions, ...fromTracks]);
+}
+
+function isControllerBehind(
+  lastSignalAt: string | null,
+  lastWorkAt: string | null,
+  liveAttempts: number,
+): boolean {
+  if (liveAttempts < 1 || !lastSignalAt || !lastWorkAt) return false;
+  const signalMs = Date.parse(lastSignalAt);
+  const workMs = Date.parse(lastWorkAt);
+  if (!Number.isFinite(signalMs) || !Number.isFinite(workMs)) return false;
+  return workMs - signalMs > CONTROLLER_BEHIND_MS;
+}
+
+function latestTimestamp(values: Array<string | null | undefined>): string | null {
+  let best: string | null = null;
+  let bestMs = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (!value) continue;
+    const ms = Date.parse(value);
+    if (!Number.isFinite(ms) || ms <= bestMs) continue;
+    bestMs = ms;
+    best = value;
+  }
+  return best;
 }
 
 function toOpenTrack(track: TrackHealth): CardOpenTrack {

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -268,6 +268,58 @@ describe("ProjectsBoard", () => {
     expect(screen.getAllByText("repin Verity after #66 merge").length).toBeGreaterThan(0);
   });
 
+  test("shows controller behind when live work is newer than the last signal", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity-core",
+          title: "Verity",
+          next_action: "rebase/repair #2332 onto main after #2333",
+          pending_decisions: 0,
+          mode: "active",
+          latest_update: {
+            headline: "Verity #2332 — BLOQUÉE PAR LEASE WRITER",
+            body: null,
+            session_id: "s",
+            at: "2026-08-14T14:30:54Z",
+            signature: "verity",
+            blocker: "source #2332 dirty",
+          },
+          missions: [
+            {
+              id: "08306fdb",
+              status: "active",
+              title: "Grok 4.6 — repair Verity PR #2332",
+              updated_at: "2026-08-14T15:35:08Z",
+              github_pr: null,
+            },
+          ],
+          health: health({
+            active: 2,
+            failed: 5,
+            tracks_needing_attention: 3,
+            tracks: [
+              track({
+                track: "c5-preflight-pr2332",
+                verdict: "active",
+                active: 1,
+                failed: 1,
+                last_activity_at: "2026-08-14T15:35:08Z",
+              }),
+            ],
+          }),
+        }),
+      ]),
+    );
+
+    renderBoard();
+
+    expect(await screen.findAllByText("controller behind")).not.toHaveLength(0);
+    expect(
+      screen.getAllByText("rebase/repair #2332 onto main after #2333").length,
+    ).toBeGreaterThan(0);
+  });
+
   test("selecting a project loads its updates timeline in the detail pane", async () => {
     mockedOverview.mockResolvedValue(
       overview([

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -609,6 +609,14 @@ function ProjectListRow({
                 no live attempt
               </span>
             )}
+            {summary.controllerBehind && (
+              <span
+                title="live work is newer than the last controller signal"
+                className="shrink-0 text-[10px] uppercase tracking-wide text-amber-400/70"
+              >
+                controller behind
+              </span>
+            )}
             <span className="min-w-0 truncate">
               {summary.headline
                 ? stripMarkdown(summary.headline)
@@ -1054,8 +1062,10 @@ function ProjectDetail({
           mode={parseMode(project)}
           pendingDecisions={signal?.pendingDecisions ?? summary.pendingDecisions}
           lastSignalAt={summary.lastSignalAt}
+          lastWorkAt={summary.lastWorkAt}
           decisions={decisions}
           idleNextAction={summary.idleNextAction}
+          controllerBehind={summary.controllerBehind}
         />
         {project.tracker?.status_line && (
           <p className="mt-1.5 text-xs leading-relaxed text-white/55">
@@ -1135,16 +1145,20 @@ function ControllerSignal({
   mode,
   pendingDecisions,
   lastSignalAt,
+  lastWorkAt,
   decisions,
   idleNextAction,
+  controllerBehind,
 }: {
   nextAction: string | null;
   blocker: string | null;
   mode: ReturnType<typeof parseMode>;
   pendingDecisions: number;
   lastSignalAt: string | null;
+  lastWorkAt: string | null;
   decisions: ViewDecision[];
   idleNextAction: boolean;
+  controllerBehind: boolean;
 }) {
   if (
     !nextAction &&
@@ -1162,6 +1176,9 @@ function ControllerSignal({
         {idleNextAction && (
           <span className="text-amber-200/80">no live attempt</span>
         )}
+        {controllerBehind && (
+          <span className="text-amber-200/80">controller behind</span>
+        )}
         {pendingDecisions > 0 && (
           <span className="text-amber-200/80">
             {decisions.length > 0
@@ -1169,9 +1186,19 @@ function ControllerSignal({
               : `${pendingDecisions} pending decision${pendingDecisions === 1 ? "" : "s"}`}
           </span>
         )}
-        {lastSignalAt && (
+        {(lastWorkAt || lastSignalAt) && (
           <span className="ml-auto flex items-center gap-1 text-white/35">
-            last signal <UpdateAge at={lastSignalAt} />
+            {lastWorkAt && controllerBehind ? (
+              <>
+                work <UpdateAge at={lastWorkAt} />
+                <span aria-hidden="true">·</span>
+              </>
+            ) : null}
+            {lastSignalAt && (
+              <>
+                last signal <UpdateAge at={lastSignalAt} />
+              </>
+            )}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Why

Verity's card treated the last controller delivery as the project's age. That made a 14:30Z `BLOQUÉE PAR LEASE WRITER` look like "1h ago" while two writers were still ticking at 15:35Z.

## What

- `cardSummary` keeps `lastSignalAt` (controller) and `lastWorkAt` (newest live mission / active track).
- `controllerBehind` is true when live work is more than 15 minutes newer than the last signal.
- Card and detail show a `controller behind` chip; the detail also shows work age next to last signal.

Dashboard-only. Vercel picks this up after merge. No backend deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only presentation logic on existing overview fields; no API or backend changes.
> 
> **Overview**
> Project cards no longer treat **last controller delivery** as the only freshness signal. **`cardSummary`** now exposes **`lastWorkAt`** (newest live mission or active-track activity) alongside **`lastSignalAt`**, and sets **`controllerBehind`** when there is at least one live attempt and work is **more than 15 minutes** newer than the last signal.
> 
> The triage list and **`ControllerSignal`** detail block show a **`controller behind`** amber chip (same family as **`no live attempt`**). When that flag is on, the detail pane also shows **work** age next to **last signal** so operators can see writers still moving while the controller narrative is stale.
> 
> Unit and board tests cover the happy path, the lag case, and the UI label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334b9fce5e121fcb8b99eac512bf10a3e1dc6305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->