### PR TITLE
fix(controllers): treat cancel-timeout flaps as infra, not campaign news

### DIFF
--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -227,6 +227,8 @@ repeated failure `repeat-loop-guard` · tool-call limits `context-budget`.
 - **Do not delete the project's controller because it is noisy.** A repeating `blocked` trailer is a stall to escalate, not spam to silence. Removing the cron removes the only path that can write into the dedicated session.
 - **Acknowledge what you have absorbed.** When a failed/interrupted mission has been superseded (retry dispatched, work re-planned, or intentionally dropped), immediately mark it `acknowledged` — an unacknowledged terminal mission is an open operator alert. The attention surface only counts UNacknowledged failures; leaving absorbed failures unacknowledged cries wolf on every board.
 - **A mission asking a question gets an answer or an escalation, never silence.** Use `answer_mission_question` to respond to a mission blocked on AskUserQuestion — plain messages queue behind the blocked turn and will not unblock it.
+- **The store refuses two classes of lie.** A headline that only restates an auto-resume (`RELANCÉE`, `relaunch`) is ingested as `[SILENT]`. A writer-lease claim while a writer is live is coerced to `mode=active` and also silenced. Do not fight this: if the campaign actually changed heads or gates, change the `STATE_SIGNATURE` fields.
+- **Owner questions are unique and expire.** The same `pending_user` question is recorded once. After 24h unanswered it becomes `expired`; act on the conservative in-grant default, do not re-ask.
 
 ## Optimisations d exécution (2026-08-10, leçons terrain)
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -20907,6 +20907,20 @@ async fn control_actor_loop(
                 }
             }, if runner_force_clear_deadline.is_some() && running.is_some() => {
                 let stuck_mid = running_mission_id;
+                let still_progressing = main_runner_active_tool_calls
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    > 0
+                    || main_runner_last_activity.elapsed()
+                        < super::controller_honesty::CANCEL_TIMEOUT_FRESH_PROGRESS;
+                if still_progressing {
+                    tracing::info!(
+                        mission_id = ?stuck_mid,
+                        "Deferring cancel-timeout force-clear: runner still has fresh progress"
+                    );
+                    runner_force_clear_deadline = Some(
+                        tokio::time::Instant::now() + RUNNER_FORCE_CLEAR_GRACE,
+                    );
+                } else {
                 tracing::warn!(
                     mission_id = ?stuck_mid,
                     "Force-aborting stuck runner: cancel fired but JoinHandle never resolved within {}s",
@@ -20985,6 +20999,7 @@ async fn control_actor_loop(
                         &config.working_dir,
                     )
                     .await;
+                }
                 }
             }
             // Update last_activity for runners when we receive events for them

--- a/src/api/controller_honesty.rs
+++ b/src/api/controller_honesty.rs
@@ -1,0 +1,187 @@
+//! Gates that keep controller prose from rewriting live store facts.
+//!
+//! Controllers are LLM cron ticks. They already *may* read `get_project` /
+//! `list_missions`; nothing forced them to, so a lease-writer headline could
+//! land while two writers were active, and a cancel-timeout auto-resume could
+//! land as "CAMPAGNE RELANCÉE". These helpers are the store-side refusal.
+
+use super::control::events::MissionStatus;
+
+/// How long an unanswered owner question stays `pending_user` before the
+/// ledger expires it. After that the controller must act on the conservative
+/// in-grant default instead of re-asking. Coldcard sat on a duplicate
+/// checkpoint prompt from 2026-08-13T20:22Z through the next afternoon.
+pub const PENDING_DECISION_TTL: chrono::Duration = chrono::Duration::hours(24);
+
+/// A cancel-timeout must not abort a runner that still has a live tool or
+/// that emitted an event in this window. Long Lean/Codex turns go quiet
+/// between tool results; 90s is longer than the 30s force-clear grace and
+/// shorter than the ~15 min watchdog.
+pub const CANCEL_TIMEOUT_FRESH_PROGRESS: std::time::Duration = std::time::Duration::from_secs(90);
+
+/// Statuses that mean a writer is actually executing (not parked).
+pub fn is_live_writer_status(status: MissionStatus) -> bool {
+    matches!(
+        status,
+        MissionStatus::Pending | MissionStatus::Active | MissionStatus::WaitingBackground
+    )
+}
+
+/// Headline that only restates an auto-resume of the same campaign.
+pub fn is_relaunch_headline(headline: &str) -> bool {
+    let folded = fold_headline(headline);
+    folded.contains("relanc")
+        || folded.contains("relaunch")
+        || folded.contains("re-pin relanc")
+        || folded.contains("repin relanc")
+}
+
+/// Headline that claims a writer-lease block (Verity's stale 14:30Z signal).
+pub fn is_stale_lease_claim(headline: &str) -> bool {
+    let folded = fold_headline(headline);
+    (folded.contains("lease") && folded.contains("writer"))
+        || folded.contains("bloquee par lease")
+        || folded.contains("blocked by writer lease")
+}
+
+/// CTRL/roster cause that is a writer-lease story.
+pub fn is_lease_blocker(blocker: Option<&str>) -> bool {
+    let Some(raw) = blocker.map(str::trim).filter(|s| !s.is_empty()) else {
+        return false;
+    };
+    let folded = fold_headline(raw);
+    folded.contains("lease") || (folded.contains("writer") && folded.contains("block"))
+}
+
+/// `blocked:lease` / `blocked:lease-writer` on the mode string itself.
+pub fn mode_claims_lease_block(mode: Option<&str>) -> bool {
+    let Some(raw) = mode.map(str::trim).filter(|s| !s.is_empty()) else {
+        return false;
+    };
+    let lower = raw.to_ascii_lowercase();
+    if let Some((_, cause)) = lower.split_once(':') {
+        return cause.contains("lease") || cause.contains("writer");
+    }
+    false
+}
+
+/// Live writer + lease-block claim → report `active` and drop the cause.
+pub fn coerce_mode_against_live<'a>(
+    mode: Option<&'a str>,
+    blocker: Option<&'a str>,
+    has_live_writer: bool,
+) -> (Option<&'a str>, Option<&'a str>) {
+    if !has_live_writer {
+        return (mode, blocker);
+    }
+    if mode_claims_lease_block(mode) || is_lease_blocker(blocker) {
+        return (Some("active"), None);
+    }
+    (mode, blocker)
+}
+
+/// Whether this delivery's human headline should be folded as `[SILENT]`.
+///
+/// A relaunch of the same campaign after cancel-timeout is infra, not a
+/// chapter. A lease-writer claim while a writer is live is a lie.
+pub fn should_silence_headline(headline: &str, has_live_writer: bool) -> bool {
+    if headline.trim() == "[SILENT]" || headline.trim().is_empty() {
+        return true;
+    }
+    if is_relaunch_headline(headline) {
+        return true;
+    }
+    has_live_writer && is_stale_lease_claim(headline)
+}
+
+/// Collapse a question so "relancer X ?" and "Relancer  X?" are one row.
+pub fn normalize_decision_question(question: &str) -> String {
+    question
+        .trim()
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn fold_headline(headline: &str) -> String {
+    headline
+        .chars()
+        .map(|ch| match ch {
+            'é' | 'è' | 'ê' | 'ë' => 'e',
+            'É' | 'È' | 'Ê' | 'Ë' => 'e',
+            'à' | 'á' | 'â' => 'a',
+            _ => ch.to_ascii_lowercase(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relaunch_headlines_are_infra_noise() {
+        assert!(is_relaunch_headline("Lido audit — RE-PIN RELANCÉ"));
+        assert!(is_relaunch_headline(
+            "Campagne lido-verity-closure-v2 relancée sur son propriétaire unique"
+        ));
+        assert!(is_relaunch_headline("campaign relaunched"));
+        assert!(!is_relaunch_headline("Lido — CAMPAGNE DE RE-PIN LANCÉE"));
+        assert!(!is_relaunch_headline(
+            "rebase/repair #2332 onto main after #2333"
+        ));
+    }
+
+    #[test]
+    fn lease_claims_are_detected() {
+        assert!(is_stale_lease_claim(
+            "Verity #2332 — BLOQUÉE PAR LEASE WRITER"
+        ));
+        assert!(is_stale_lease_claim("blocked by writer lease"));
+        assert!(is_lease_blocker(Some("source #2332 dirty lease writer")));
+        assert!(mode_claims_lease_block(Some("blocked:lease-writer")));
+        assert!(!is_stale_lease_claim("blocked by dirty source"));
+    }
+
+    #[test]
+    fn live_writer_silences_lease_and_relaunch() {
+        assert!(should_silence_headline(
+            "Verity #2332 — BLOQUÉE PAR LEASE WRITER",
+            true
+        ));
+        assert!(!should_silence_headline(
+            "Verity #2332 — BLOQUÉE PAR LEASE WRITER",
+            false
+        ));
+        assert!(should_silence_headline(
+            "Lido audit — CAMPAGNE RELANCÉE",
+            false
+        ));
+        assert!(!should_silence_headline("Certify #69 at exact head", false));
+    }
+
+    #[test]
+    fn live_writer_clears_a_lease_mode() {
+        assert_eq!(
+            coerce_mode_against_live(Some("blocked:lease-writer"), Some("lease"), true),
+            (Some("active"), None)
+        );
+        assert_eq!(
+            coerce_mode_against_live(Some("blocked"), Some("lease writer"), true),
+            (Some("active"), None)
+        );
+        assert_eq!(
+            coerce_mode_against_live(Some("blocked:transport-cap"), None, true),
+            (Some("blocked:transport-cap"), None)
+        );
+    }
+
+    #[test]
+    fn decision_questions_collapse_whitespace_and_case() {
+        assert_eq!(
+            normalize_decision_question("Relancer  coldcard_skip depuis le checkpoint ?"),
+            normalize_decision_question("relancer coldcard_skip depuis le checkpoint ?")
+        );
+    }
+}

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2813,6 +2813,16 @@ impl MissionRunner {
         self.last_activity = Instant::now();
     }
 
+    /// Live tool or a recent event — do not treat this runner as stuck
+    /// in a cancel drain. See [`crate::api::controller_honesty::CANCEL_TIMEOUT_FRESH_PROGRESS`].
+    pub fn has_fresh_progress(&self) -> bool {
+        self.active_tool_calls
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0
+            || self.last_activity.elapsed()
+                < crate::api::controller_honesty::CANCEL_TIMEOUT_FRESH_PROGRESS
+    }
+
     /// Clear turn-scoped tool hints before a runner is reused. Some harnesses
     /// can omit a terminal ToolResult, so the counter must not survive into a
     /// later queued turn and incorrectly extend its watchdog grace period.
@@ -2906,6 +2916,10 @@ impl MissionRunner {
     /// Returns `true` when the runner should be removed from the actor's
     /// registry. A handle which has already finished is left for the normal
     /// completion path so its terminal result can still be recorded.
+    ///
+    /// A runner that still has a live tool or a recent event is *not*
+    /// force-killed: that is the cancel-timeout drain race that turned
+    /// Lido's same writer into a "CAMPAGNE RELANCÉE" every ~30 minutes.
     pub fn force_clear_cancelled_if_due(&mut self) -> bool {
         if !self.cancellation_requested
             || self
@@ -2920,6 +2934,12 @@ impl MissionRunner {
             .as_ref()
             .is_some_and(|handle| handle.is_finished())
         {
+            return false;
+        }
+
+        if self.has_fresh_progress() {
+            self.cancellation_force_clear_deadline =
+                Some(Instant::now() + RUNNER_FORCE_CLEAR_GRACE);
             return false;
         }
 
@@ -12801,11 +12821,43 @@ mod tests {
         runner.cancel();
         runner.cancellation_force_clear_deadline =
             Some(std::time::Instant::now() - std::time::Duration::from_secs(1));
+        // Age last_activity so the cancel-timeout fresh-progress gate does
+        // not keep a truly stuck handle alive.
+        runner.last_activity = std::time::Instant::now() - std::time::Duration::from_secs(120);
 
         assert!(runner.force_clear_cancelled_if_due());
         assert!(runner.running_handle.is_none());
         assert!(matches!(runner.state, MissionRunState::Finished));
         assert!(!runner.force_clear_cancelled_if_due());
+    }
+
+    #[tokio::test]
+    async fn cancel_timeout_does_not_kill_a_runner_with_fresh_progress() {
+        let mut runner = MissionRunner::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            Some("codex".to_string()),
+            None,
+            None,
+            None,
+            None,
+            false,
+        );
+        runner.state = MissionRunState::Running;
+        runner.running_handle = Some(tokio::spawn(async {
+            std::future::pending::<(Uuid, String, AgentResult)>().await
+        }));
+        runner
+            .active_tool_calls
+            .store(1, std::sync::atomic::Ordering::Relaxed);
+        runner.cancel();
+        runner.cancellation_force_clear_deadline =
+            Some(std::time::Instant::now() - std::time::Duration::from_secs(1));
+
+        assert!(!runner.force_clear_cancelled_if_due());
+        assert!(runner.running_handle.is_some());
+        assert!(matches!(runner.state, MissionRunState::Running));
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -26,6 +26,7 @@ pub mod codex_usage;
 mod console;
 pub mod control;
 pub mod control_metrics;
+pub(crate) mod controller_honesty;
 pub mod deferred_proxy;
 pub mod desktop;
 mod desktop_stream;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -15,7 +15,7 @@
 //! anything still unmatched surfaces in an explicit `unrouted` bucket rather
 //! than being dropped.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -99,9 +99,41 @@ pub fn spawn_state_ingestor(state: Arc<AppState>) {
             let (aliases, overrides) = hermes_projects_dir()
                 .map(|dir| (read_alias_map(&dir), read_overrides(&dir)))
                 .unwrap_or_default();
-            ingest_deliveries(&state.projects, &aliases, &overrides, deliveries);
+            let live = live_writer_project_slugs(&state).await;
+            ingest_deliveries_with_live(&state.projects, &aliases, &overrides, deliveries, &live);
+            if let Err(error) = state
+                .projects
+                .expire_pending_decisions(super::controller_honesty::PENDING_DECISION_TTL)
+            {
+                tracing::warn!("state ingest expire decisions: {error}");
+            }
         }
     });
+}
+
+/// Roster slugs that currently have an executing writer. Used so ingest can
+/// refuse a lease-writer headline while work is live.
+async fn live_writer_project_slugs(state: &super::routes::AppState) -> HashSet<String> {
+    let Ok(projects) = state.projects.list_projects() else {
+        return HashSet::new();
+    };
+    let mut live = HashSet::new();
+    for project in projects {
+        let Ok(missions) = state
+            .control
+            .collect_attention_missions_for_project(&project.slug)
+            .await
+        else {
+            continue;
+        };
+        if missions
+            .iter()
+            .any(|mission| super::controller_honesty::is_live_writer_status(mission.status))
+        {
+            live.insert(project.slug);
+        }
+    }
+    live
 }
 
 /// Marker prefix for state descriptors the ingestor synthesizes for CTRL-only
@@ -120,6 +152,16 @@ fn ingest_deliveries(
     aliases: &HashMap<String, String>,
     overrides: &HashMap<String, String>,
     deliveries: Vec<DeliveryUpdate>,
+) {
+    ingest_deliveries_with_live(projects, aliases, overrides, deliveries, &HashSet::new());
+}
+
+fn ingest_deliveries_with_live(
+    projects: &super::projects_store::ProjectsStore,
+    aliases: &HashMap<String, String>,
+    overrides: &HashMap<String, String>,
+    deliveries: Vec<DeliveryUpdate>,
+    live_projects: &HashSet<String>,
 ) {
     // read_deliveries returns newest-first; replay oldest-first so a
     // run of the same state lands as one extended row rather than
@@ -158,24 +200,32 @@ fn ingest_deliveries(
         // synthetic `ctrl:…` descriptor is recorded then, so the delivery's
         // headline and session still reach the timeline — that is what the
         // overview builds `latest_update` from. `observations` drives `wait`.
+        let has_live_writer = live_projects.contains(slug);
+        let (gated_mode, _) = super::controller_honesty::coerce_mode_against_live(
+            delivery.mode.as_deref(),
+            delivery.blocker.as_deref(),
+            has_live_writer,
+        );
         let headline = Some(delivery.headline.trim()).filter(|h| !h.is_empty());
         let session = Some(delivery.session_id.as_str()).filter(|s| !s.is_empty());
         let descriptor = delivery.state.clone().unwrap_or_else(|| {
-            format!(
-                "{CTRL_DESCRIPTOR_PREFIX}{}",
-                delivery.mode.as_deref().unwrap_or("report")
-            )
+            format!("{CTRL_DESCRIPTOR_PREFIX}{}", gated_mode.unwrap_or("report"))
         });
         // `[SILENT]` is the controllers-policy convention for "nothing to
         // report". It must advance freshness (a quiet tick is proof of life),
         // but it must never become the headline the card shows — fold it onto
         // the previous state event so `latest_update` keeps surfacing the last
         // meaningful headline with the fresh timestamp.
-        let recorded = match headline {
-            Some("[SILENT]") | None => {
-                projects.record_silent_observation(slug, &descriptor, &delivery.at, session)
-            }
-            Some(_) => projects.record_state(slug, &descriptor, headline, &delivery.at, session),
+        //
+        // A relaunch-after-cancel-timeout or a lease-writer claim while a
+        // writer is live is the same class: infra / a lie, not a chapter.
+        let silence = headline.is_none_or(|text| {
+            super::controller_honesty::should_silence_headline(text, has_live_writer)
+        });
+        let recorded = if silence {
+            projects.record_silent_observation(slug, &descriptor, &delivery.at, session)
+        } else {
+            projects.record_state(slug, &descriptor, headline, &delivery.at, session)
         };
         let observations = match recorded {
             Ok(observations) => observations,
@@ -189,7 +239,7 @@ fn ingest_deliveries(
         // CTRL-only delivery still updates the mode column. Idempotent
         // on replay: `wait` comes from the observation count, not a
         // per-call increment.
-        if let Some(mode) = delivery.mode.as_deref() {
+        if let Some(mode) = gated_mode {
             let base = mode.split_once(':').map_or(mode, |(base, _)| base);
             let blocker = mode.split_once(':').map(|(_, cause)| cause);
             if let Err(error) = projects.project_mode_from_signal(
@@ -545,21 +595,33 @@ pub async fn set_project_status(
     if !is_plain_key(&slug) {
         return Err(bad_slug());
     }
-    let mode = req.mode.trim().to_ascii_lowercase();
+    let mut mode = req.mode.trim().to_ascii_lowercase();
     if !matches!(mode.as_str(), "active" | "blocked" | "paused") {
         return Err((
             StatusCode::BAD_REQUEST,
             "mode must be active, blocked, or paused".to_string(),
         ));
     }
+    let mut blocker = req.blocker.clone();
+    if mode == "blocked" && super::controller_honesty::is_lease_blocker(blocker.as_deref()) {
+        let has_live = state
+            .control
+            .collect_attention_missions_for_project(&slug)
+            .await
+            .ok()
+            .is_some_and(|missions| {
+                missions
+                    .iter()
+                    .any(|mission| super::controller_honesty::is_live_writer_status(mission.status))
+            });
+        if has_live {
+            mode = "active".to_string();
+            blocker = None;
+        }
+    }
     state
         .projects
-        .set_mode(
-            &slug,
-            &mode,
-            req.next_action.as_deref(),
-            req.blocker.as_deref(),
-        )
+        .set_mode(&slug, &mode, req.next_action.as_deref(), blocker.as_deref())
         .map_err(|error| (StatusCode::NOT_FOUND, error))?;
     let project = state.projects.get_project(&slug).map_err(store_err)?;
     Ok(Json(serde_json::json!({ "project": project })))
@@ -3442,6 +3504,70 @@ mod tests {
         let open = store.open_decisions("verity").expect("open");
         assert_eq!(open.len(), 1, "coerced merge stays pending");
         assert_eq!(open[0].question, "Merged #2333");
+    }
+
+    #[test]
+    fn relaunch_and_stale_lease_deliveries_are_folded_silent() {
+        let store = super::super::projects_store::ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity-lido", None, None, None, None)
+            .expect("seed lido");
+        store
+            .upsert_project("verity-core", None, None, None, None)
+            .expect("seed verity");
+        let aliases = HashMap::new();
+        let overrides = HashMap::new();
+        let first = parse_delivery(
+            "s",
+            1_754_000_000.0,
+            "[Cron delivery: verity-lido]\nLido closure-v2 — re-pin started\n\
+             [CTRL: verity-lido | mode=active | wait=0 | next=repin]\n\
+             [STATE_SIGNATURE: verity-lido|closure|04729a9|none|repin]\n",
+        );
+        ingest_deliveries(&store, &aliases, &overrides, vec![first]);
+        let relaunch = parse_delivery(
+            "s",
+            1_754_000_100.0,
+            "[Cron delivery: verity-lido]\nLido audit — CAMPAGNE RELANCÉE\n\
+             [CTRL: verity-lido | mode=active | wait=0 | next=repin]\n\
+             [STATE_SIGNATURE: verity-lido|closure|04729a9|none|repin]\n",
+        );
+        ingest_deliveries(&store, &aliases, &overrides, vec![relaunch]);
+        let lido = &store.latest_states().expect("latest")["verity-lido"];
+        assert_eq!(
+            lido.headline.as_deref(),
+            Some("Lido closure-v2 — re-pin started"),
+            "relaunch prose must not become the card headline"
+        );
+        assert!(lido.observations >= 2);
+
+        let live = HashSet::from(["verity-core".to_string()]);
+        let lease = parse_delivery(
+            "s",
+            1_754_000_200.0,
+            "[Cron delivery: verity-core]\nVerity #2332 — BLOQUÉE PAR LEASE WRITER\n\
+             [CTRL: verity-core | mode=blocked:lease-writer | wait=3 | next=wait]\n\
+             [STATE_SIGNATURE: verity-core|c5|#2332|lease|wait]\n",
+        );
+        ingest_deliveries_with_live(&store, &aliases, &overrides, vec![lease], &live);
+        let verity = store
+            .get_project("verity-core")
+            .expect("row")
+            .expect("exists");
+        assert_eq!(
+            verity.mode.as_deref(),
+            Some("active"),
+            "a live writer cannot stay blocked:lease"
+        );
+        assert!(
+            store
+                .latest_states()
+                .expect("latest")
+                .get("verity-core")
+                .and_then(|s| s.headline.as_deref())
+                .is_none(),
+            "lease-writer lie must not open a headline while a writer is live"
+        );
     }
 
     #[test]

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -273,7 +273,7 @@ impl ProjectsStore {
         Ok(true)
     }
 
-    fn lock(&self) -> Result<MutexGuard<'_, Connection>, String> {
+    pub(crate) fn lock(&self) -> Result<MutexGuard<'_, Connection>, String> {
         self.connection
             .lock()
             .map_err(|_| "projects database lock poisoned".to_string())
@@ -1226,6 +1226,11 @@ impl ProjectsStore {
     /// dual-written: only `pending_user` rows count as open, so an older binary
     /// reading `answered = 0` never surfaces autonomous acts.
     pub fn record_decision(&self, slug: &str, decision: &NewDecision) -> Result<String, String> {
+        if decision.status == "pending_user" {
+            if let Some(existing) = self.pending_question_at(slug, &decision.question)? {
+                return Ok(existing);
+            }
+        }
         let now = Utc::now().to_rfc3339();
         let answered = i64::from(decision.status != "pending_user");
         let evidence = decision.evidence.as_ref().map(|value| value.to_string());
@@ -1261,6 +1266,13 @@ impl ProjectsStore {
         at: &str,
         decision: &NewDecision,
     ) -> Result<bool, String> {
+        if decision.status == "pending_user"
+            && self
+                .pending_question_at(slug, &decision.question)?
+                .is_some()
+        {
+            return Ok(false);
+        }
         let answered = i64::from(decision.status != "pending_user");
         let evidence = decision.evidence.as_ref().map(|value| value.to_string());
         let connection = self.lock()?;
@@ -1334,6 +1346,36 @@ impl ProjectsStore {
 
     pub fn open_decisions(&self, slug: &str) -> Result<Vec<ProjectDecision>, String> {
         self.decisions_where(slug, "status = 'pending_user'", "ORDER BY at", None)
+    }
+
+    /// Existing open row for this question, if any. Used so Coldcard cannot
+    /// record the same checkpoint prompt twice two seconds apart.
+    fn pending_question_at(&self, slug: &str, question: &str) -> Result<Option<String>, String> {
+        let needle = super::controller_honesty::normalize_decision_question(question);
+        if needle.is_empty() {
+            return Ok(None);
+        }
+        Ok(self.open_decisions(slug)?.into_iter().find_map(|decision| {
+            (super::controller_honesty::normalize_decision_question(&decision.question) == needle)
+                .then_some(decision.at)
+        }))
+    }
+
+    /// Expire unanswered owner questions older than `max_age`. Returns how
+    /// many rows flipped. The card then stops showing them; the controller
+    /// must act on the conservative default instead of re-asking.
+    pub fn expire_pending_decisions(&self, max_age: chrono::Duration) -> Result<u32, String> {
+        let cutoff = (Utc::now() - max_age).to_rfc3339();
+        let connection = self.lock()?;
+        let changed = connection
+            .execute(
+                "UPDATE project_decisions \
+                 SET status = 'expired', answered = 1 \
+                 WHERE status = 'pending_user' AND at < ?1",
+                params![cutoff],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(changed as u32)
     }
 
     /// Newest-first autonomous acts (`status = 'decided'`) plus recently
@@ -2325,6 +2367,50 @@ mod tests {
             store.pending_decision_counts().expect("counts")["verity"],
             1
         );
+    }
+
+    #[test]
+    fn pending_user_questions_dedupe_and_expire() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        let first = store
+            .record_decision(
+                "coldcard",
+                &escalation("relancer coldcard_skip depuis le checkpoint ?", None),
+            )
+            .expect("first");
+        let second = store
+            .record_decision(
+                "coldcard",
+                &escalation("Relancer  coldcard_skip depuis le checkpoint ?", None),
+            )
+            .expect("dup");
+        assert_eq!(first, second, "duplicate question must reuse the row");
+        assert_eq!(store.open_decisions("coldcard").expect("open").len(), 1);
+
+        let inserted = store
+            .record_decision_from_delivery(
+                "coldcard",
+                "2026-08-13T20:22:14Z",
+                &escalation("relancer coldcard_skip depuis le checkpoint ?", None),
+            )
+            .expect("from delivery");
+        assert!(!inserted, "ingest must not insert a second pending row");
+
+        {
+            let aged = (Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+            let connection = store.lock().expect("lock");
+            connection
+                .execute(
+                    "UPDATE project_decisions SET at = ?1 WHERE slug = 'coldcard'",
+                    params![aged],
+                )
+                .expect("age");
+        }
+        let expired = store
+            .expire_pending_decisions(chrono::Duration::hours(24))
+            .expect("expire");
+        assert_eq!(expired, 1);
+        assert!(store.open_decisions("coldcard").expect("open").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Why

Lido's same writer (`04b0a5d8`) was force-killed after cancel-timeout, auto-resumed, and announced as **CAMPAGNE RELANCÉE** every ~30 minutes. Verity's controller kept **BLOQUÉE PAR LEASE WRITER** for hours while two writers were live. Coldcard recorded the same checkpoint question twice.

These are store/runtime facts. Prompt policy already said "reconcile live state" and `[SILENT]` — the LLM was not forced to.

## What

**A — cancel-timeout is infra.** `force_clear_cancelled_if_due` (and the main runner equivalent) defers the abort while a tool is live or an event landed in the last 90s.

**B — ingest refuses the lie.** Relaunch headlines fold as `[SILENT]`. A lease-writer claim / `blocked:lease*` while a writer is live is coerced to `mode=active`. Same gate on `POST /api/projects/:slug/status`.

**C — owner questions are unique and expire.** `pending_user` dedupes on `(slug, normalized question)`. Rows older than 24h become `expired`.

Tests drive all three on the shipped paths. Needs a **backend deploy** after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission cancel/force-abort timing and how project mode/headlines are derived from cron deliveries—operator-visible control-plane behavior with regression tests but non-trivial runtime edge cases.
> 
> **Overview**
> Stops cancel-timeout from killing still-active writers and keeps controller cron prose from overwriting live project-board facts.
> 
> **Runtime:** `force_clear_cancelled_if_due` and the main control-loop force-clear path now defer abort when a tool is in flight or any event landed within **90s** (`CANCEL_TIMEOUT_FRESH_PROGRESS`), instead of force-killing quiet long turns.
> 
> **Ingest / API:** New `controller_honesty` helpers drive delivery ingest and `POST /api/projects/:slug/status`: auto-resume **relaunch** headlines fold to `[SILENT]`; **lease-writer** `blocked` claims while a live writer exists are coerced to `mode=active` and silenced. Background ingest loads live-writer slugs from attention missions before applying those gates.
> 
> **Decisions:** `pending_user` rows dedupe on normalized question text; ingest runs **24h** expiry (`expire_pending_decisions`) so stale owner prompts drop off the card.
> 
> Controller policy documents the store-side refusals. Tests cover honesty rules, ingest folding, and cancel-timeout fresh-progress behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97acde7f064291d76bc1d47d2272b7297988a916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->