### PR TITLE
feat(projects): show item-first project rail on bound Hermes sessions

### DIFF
--- a/dashboard/src/app/control/components/HermesConversation.tsx
+++ b/dashboard/src/app/control/components/HermesConversation.tsx
@@ -30,6 +30,7 @@ import { EnhancedInput } from "@/components/enhanced-input";
 import { stateSignatureKeyFromMessages } from "@/lib/hermes-state-signature";
 import { cn } from "@/lib/utils";
 
+import { SessionProjectRail } from "./session-project-rail";
 import {
   ChatItemRow,
   deriveItemViews,
@@ -558,7 +559,8 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
   const noop = useCallback(() => {}, []);
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="flex h-full min-h-0">
+    <div className="flex min-w-0 flex-1 flex-col">
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-white/5 px-4 py-2.5">
         <Sparkles className="h-4 w-4 shrink-0 text-indigo-400" />
@@ -669,6 +671,8 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
           />
         </div>
       </div>
+    </div>
+    <SessionProjectRail sessionId={sessionId} />
     </div>
   );
 }

--- a/dashboard/src/app/control/components/session-project-rail.tsx
+++ b/dashboard/src/app/control/components/session-project-rail.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import Link from "next/link";
+import useSWR from "swr";
+
+import {
+  getProject,
+  getProjectBySession,
+  getProjectsOverview,
+} from "@/lib/api/projects";
+import {
+  cardSummary,
+  viewMovingItems,
+  viewOpenItems,
+  viewPendingDecisions,
+} from "@/components/projects/project-card-view";
+import { parseMode } from "@/components/projects/project-health";
+import { cn } from "@/lib/utils";
+
+/** Item-first project snapshot docked to the right of a bound Hermes session. */
+export function SessionProjectRail({ sessionId }: { sessionId: string }) {
+  const { data: resolved } = useSWR(
+    ["project-by-session", sessionId],
+    async () => {
+      try {
+        return await getProjectBySession(sessionId);
+      } catch {
+        const overview = await getProjectsOverview();
+        const match = overview.projects.find(
+          (project) => project.conversation?.session_id === sessionId,
+        );
+        return match ? { slug: match.slug, session_id: sessionId } : null;
+      }
+    },
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  );
+  const slug = resolved?.slug;
+  const { data: overview } = useSWR(
+    slug ? "projects-overview" : null,
+    getProjectsOverview,
+    { revalidateOnFocus: false },
+  );
+  const { data: detail } = useSWR(
+    slug ? ["project-detail", slug] : null,
+    () => getProject(slug!),
+    { revalidateOnFocus: false },
+  );
+
+  if (!slug) {
+    return null;
+  }
+
+  const row = overview?.projects.find((project) => project.slug === slug);
+  const summary = row ? cardSummary(row) : null;
+  const items = detail ? viewOpenItems(detail) : [];
+  const moving = viewMovingItems(items);
+  const decisions = detail ? viewPendingDecisions(detail) : [];
+  const mode = row ? parseMode(row) : null;
+  const title = row?.title || slug;
+
+  return (
+    <aside className="hidden h-full w-72 shrink-0 flex-col border-l border-white/5 bg-white/[0.015] lg:flex">
+      <div className="flex items-center gap-2 border-b border-white/5 px-3 py-2.5">
+        <Link
+          href="/"
+          className="min-w-0 flex-1 truncate text-sm font-medium text-white/85 no-underline hover:text-white"
+        >
+          {title}
+        </Link>
+        {mode && (
+          <span className="shrink-0 text-[10px] uppercase tracking-wider text-white/40">
+            {mode.base}
+          </span>
+        )}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        {(summary?.nextAction || summary?.controllerBehind) && (
+          <div className="mb-3 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-white/40">
+              {summary.controllerBehind && (
+                <span className="text-amber-200/80">controller behind</span>
+              )}
+              {summary.lastSignalAt && <span className="ml-auto">last signal</span>}
+            </div>
+            {summary.nextAction && (
+              <p className="mt-1 text-xs text-white/75">
+                <span className="text-white/40">Next: </span>
+                {summary.nextAction}
+              </p>
+            )}
+          </div>
+        )}
+        {decisions.map((decision) => (
+          <p
+            key={decision.question}
+            className="mb-2 text-xs text-amber-100/90"
+          >
+            {decision.question}
+          </p>
+        ))}
+        {moving.length > 0 && (
+          <div className="mb-3">
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-white/35">
+              Moving ({moving.length})
+            </p>
+            {moving.map((item) => (
+              <div key={item.key} className="mb-1.5">
+                <div className="truncate text-xs text-white/80">{item.key}</div>
+                {item.attempts.slice(0, 1).map((attempt) => (
+                  <Link
+                    key={attempt.id}
+                    href={`/control?mission=${attempt.id}`}
+                    className={cn(
+                      "mt-0.5 block truncate text-[11px] text-white/45 no-underline hover:text-white/70",
+                    )}
+                  >
+                    {attempt.title || attempt.id.slice(0, 8)}
+                  </Link>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+        {items.length > moving.length && (
+          <p className="text-[11px] text-white/35">
+            {items.length - moving.length} stalled items
+          </p>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -163,6 +163,15 @@ export function getProject(slug: string): Promise<ProjectDetailPayload> {
   );
 }
 
+export function getProjectBySession(
+  sessionId: string,
+): Promise<{ slug: string; session_id: string }> {
+  return apiGet(
+    `/api/projects/by-session/${encodeURIComponent(sessionId)}`,
+    "Failed to resolve project for session",
+  );
+}
+
 export function getProjectUpdates(
   slug: string,
   limit = 50,

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -373,6 +373,50 @@ fn store_err(error: String) -> (StatusCode, String) {
     (StatusCode::INTERNAL_SERVER_ERROR, error)
 }
 
+/// `GET /api/projects/by-session/:session_id` — resolve a Hermes conversation
+/// (or any continuation in its chain) to the bound project slug.
+pub async fn project_by_session(
+    State(state): State<Arc<AppState>>,
+    AxumPath(session_id): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let session_id = session_id.trim();
+    if session_id.is_empty()
+        || session_id.len() > 128
+        || !session_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "session_id must be 1-128 chars of [A-Za-z0-9._:-]".to_string(),
+        ));
+    }
+    let bindings = state.projects.bindings().map_err(store_err)?;
+    let pairs: Vec<(String, String)> = bindings
+        .iter()
+        .map(|(slug, conversation)| (slug.clone(), conversation.session_id.clone()))
+        .collect();
+    let chain = match hermes_state_db() {
+        Some(path) => super::session_chain::ancestry(&path, session_id),
+        None => vec![session_id.to_string()],
+    };
+    let slug = super::session_chain::slug_for_bound_session(session_id, &pairs, &chain, |bound| {
+        match hermes_state_db() {
+            Some(path) => super::session_chain::live_tip(&path, bound),
+            None => bound.to_string(),
+        }
+    });
+    let Some(slug) = slug else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("no project bound to session '{session_id}'"),
+        ));
+    };
+    Ok(Json(
+        serde_json::json!({ "slug": slug, "session_id": session_id }),
+    ))
+}
+
 /// `GET /api/projects/:slug` — the structured project object: record, grant,
 /// tracks, and open decisions. This is what `get_project` (MCP) returns to a
 /// controller instead of it scanning markdown.
@@ -1314,6 +1358,7 @@ pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/overview", get(projects_overview))
         .route("/", axum::routing::put(upsert_project))
+        .route("/by-session/:session_id", get(project_by_session))
         .route("/:slug", get(get_project))
         .route("/:slug/state", get(project_state))
         .route("/:slug/tasks", get(project_tasks).post(plan_project_tasks))

--- a/src/api/session_chain.rs
+++ b/src/api/session_chain.rs
@@ -94,6 +94,28 @@ pub fn ancestry(db_path: &Path, session_id: &str) -> Vec<String> {
     chain
 }
 
+/// Which project owns `session_id`, walking the continuation chain both ways.
+///
+/// A binding names the session the operator declared. Hermes then forks
+/// children (`parent_session_id`). Looking up the tip must still find the
+/// project; looking up an ancestor must too.
+pub fn slug_for_bound_session(
+    session_id: &str,
+    bindings: &[(String, String)],
+    ancestry: &[String],
+    tip_of: impl Fn(&str) -> String,
+) -> Option<String> {
+    if session_id.trim().is_empty() {
+        return None;
+    }
+    for (slug, bound) in bindings {
+        if ancestry.iter().any(|id| id == bound) || tip_of(bound) == session_id {
+            return Some(slug.clone());
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +199,33 @@ mod tests {
     fn a_blank_parent_is_no_parent() {
         let (_dir, path) = db(&[("root", Some("")), ("child", Some("root"))]);
         assert_eq!(ancestry(&path, "child"), vec!["child", "root"]);
+    }
+
+    #[test]
+    fn a_continuation_tip_resolves_to_the_bound_project() {
+        let (_dir, path) = db(&[
+            ("74bd9b", None),
+            ("202eac", Some("74bd9b")),
+            ("7fdc25", Some("202eac")),
+            ("2a62eb", Some("7fdc25")),
+        ]);
+        let bindings = vec![("verity-core".to_string(), "74bd9b".to_string())];
+        let chain = ancestry(&path, "2a62eb");
+        assert_eq!(
+            slug_for_bound_session("2a62eb", &bindings, &chain, |id| live_tip(&path, id)),
+            Some("verity-core".to_string())
+        );
+        assert_eq!(
+            slug_for_bound_session("74bd9b", &bindings, &ancestry(&path, "74bd9b"), |id| {
+                live_tip(&path, id)
+            }),
+            Some("verity-core".to_string())
+        );
+        assert_eq!(
+            slug_for_bound_session("ghost", &bindings, &ancestry(&path, "ghost"), |id| {
+                live_tip(&path, id)
+            }),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Why

The Verity/Lido control session (`/control?session=`) was a full-width transcript. The project card already shows open items and the controller signal; the session-adjacent view did not.

## What

- `GET /api/projects/by-session/:id` resolves a conversation (or any continuation tip) to the bound project slug.
- `/control?session=` docks an item-first rail: next_action, controller-behind, moving items. Falls back to the overview live tip when the new endpoint is not deployed yet.

## Test

`cargo test --lib session_chain`
`bunx vitest run src/components/projects/project-card-view.test.ts`

Do **not** deploy the backend tonight unless needed: writers are healthy. The rail works against current prod via the overview fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and a new lookup endpoint with validated session ids; no changes to auth, writes, or mission execution. Continuation-chain matching is the main behavioral surface area and is covered by `session_chain` tests.
> 
> **Overview**
> **Bound Hermes sessions** (`/control?session=`) now use a **two-column layout**: the transcript stays on the left and a **project rail** docks on the right (large screens only).
> 
> The rail resolves which project owns the session, then surfaces the same **item-first** snapshot as project cards: **next action**, **controller behind**, **pending decisions**, **moving** work (with links to missions), and a count of **stalled** items. If nothing is bound, the rail is hidden.
> 
> **Backend:** `GET /api/projects/by-session/:session_id` maps a session id—or any **continuation tip** in the Hermes parent chain—to the project slug from stored bindings, using new `slug_for_bound_session` in `session_chain` (with unit tests).
> 
> **Dashboard client:** `getProjectBySession` calls that route; `SessionProjectRail` falls back to matching `conversation.session_id` on **projects overview** when the new API is not deployed yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9f23f1bd23b80a1b07468fcec90fee5d7bd1b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->