### PR TITLE
fix(supervision): do not watchdog-kill Hermes-tagged writers

### DIFF
--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -341,6 +341,22 @@ fn inactivity_is_cancellable(seconds_since_activity: u64, tool_call_in_flight: b
         && (!tool_call_in_flight || seconds_since_activity >= TOOL_CALL_STALL_GRACE_SECS)
 }
 
+/// Control-owned writers must not be auto-killed for a quiet Lean/Grok turn.
+/// The stored `origin` field is sometimes missing even when the MCP tagged
+/// the mission `origin:hermes-assistant` — Verity's overnight flap
+/// (cancel every ~15m) was that hole.
+pub(crate) fn watchdog_skips_control_owned_mission(
+    origin: Option<&str>,
+    origin_session_id: Option<&str>,
+    tags: &[String],
+) -> bool {
+    if origin == Some("hermes") && origin_session_id.is_some() {
+        return true;
+    }
+    tags.iter()
+        .any(|tag| tag == "origin:hermes-assistant" || tag == "pr-writer" || tag == "origin:hermes")
+}
+
 fn execution_state_proves_durable_liveness(state: &str) -> bool {
     state == "waiting_remote_job"
 }
@@ -527,9 +543,11 @@ pub(crate) async fn stuck_mission_watchdog_loop(
             // will re-narrow this to operator-vs-cron. Dashboard/API-direct
             // missions (`origin == None`) keep the watchdog protection.
             if let Ok(Some(mission)) = mission_store.get_mission(info.mission_id).await {
-                if mission.origin.as_deref() == Some("hermes")
-                    && mission.origin_session_id.is_some()
-                {
+                if watchdog_skips_control_owned_mission(
+                    mission.origin.as_deref(),
+                    mission.origin_session_id.as_deref(),
+                    &mission.project.tags,
+                ) {
                     tracing::warn!(
                         mission_id = %info.mission_id,
                         seconds_since_activity = info.seconds_since_activity,
@@ -1029,6 +1047,31 @@ mod tests {
     #[test]
     fn inactivity_watchdog_cancels_idle_runner_at_threshold() {
         assert!(inactivity_is_cancellable(STUCK_SECONDS, false));
+    }
+
+    #[test]
+    fn watchdog_skips_hermes_tag_even_when_origin_field_is_empty() {
+        assert!(watchdog_skips_control_owned_mission(
+            None,
+            None,
+            &["origin:hermes-assistant".to_string()]
+        ));
+        assert!(watchdog_skips_control_owned_mission(
+            None,
+            None,
+            &["pr-writer".to_string()]
+        ));
+        assert!(watchdog_skips_control_owned_mission(
+            Some("hermes"),
+            Some("20260814_224352_2a62eb"),
+            &[]
+        ));
+        assert!(!watchdog_skips_control_owned_mission(None, None, &[]));
+        assert!(!watchdog_skips_control_owned_mission(
+            Some("hermes"),
+            None,
+            &[]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Verity Grok `08306fdb` and Kimi `c91618dc` were cancelled every ~15 minutes tonight. The stuck-mission watchdog is supposed to spare control-session writers, but it only checked `origin == hermes` + `origin_session_id`. Those missions only carry the `origin:hermes-assistant` tag.

## What

`watchdog_skips_control_owned_mission` also honors `origin:hermes-assistant` and `pr-writer`.

## Test

`cargo test --lib watchdog_skips_hermes_tag`

Needs a prod deploy to stop the flap. Writers were just resumed; deploy will SIGTERM them once (auto-resume).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stuck-mission auto-cancel behavior for tagged Hermes/pr-writer missions; mis-tagged idle missions would no longer be watchdog-killed until manually handled.
> 
> **Overview**
> Stops the **stuck-mission watchdog** from auto-cancelling control-owned writer missions that look idle during long Lean/Grok turns but are still legitimate operator work.
> 
> The skip path used to require **`origin == "hermes"`** plus a populated **`origin_session_id`**. Many Hermes-launched missions only carry MCP tags (e.g. **`origin:hermes-assistant`**, **`pr-writer`**) or omit **`origin`**, so they were cancelled on the ~15 minute inactivity threshold in a loop.
> 
> This PR centralizes the rule in **`watchdog_skips_control_owned_mission`**, keeps the existing Hermes session check, and also skips when **`mission.project.tags`** include **`origin:hermes-assistant`**, **`pr-writer`**, or **`origin:hermes`**. The watchdog loop now loads mission tags and uses that helper instead of inline origin checks. Unit tests cover tag-only and session-based cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06f1cd422f1f071a9a63ade1045c1a8cb46cd15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->