### PR TITLE
fix(supervision): do not 2h-autoclose Hermes-tagged writers

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -26930,6 +26930,59 @@ mod tests {
         assert_eq!(stored.status, MissionStatus::Active);
     }
 
+    #[tokio::test]
+    async fn cleanup_stale_active_missions_once_skips_hermes_tagged_writer() {
+        let inner = Arc::new(mission_store::InMemoryMissionStore::new());
+        let store: Arc<dyn MissionStore> = inner.clone();
+        let mission = store
+            .create_mission(
+                Some("Grok 4.6 — repair Verity PR #2332"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("mission should be created");
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await
+            .expect("mission should become active");
+        store
+            .update_mission_project(
+                mission.id,
+                mission_store::MissionProjectPatch {
+                    project: None,
+                    track: None,
+                    intent: None,
+                    github_pr: None,
+                    tags: Some(vec!["origin:hermes-assistant".to_string()]),
+                    desired_state: None,
+                    next_check_at: None,
+                },
+            )
+            .await
+            .expect("tags should apply");
+        let stale_at = (chrono::Utc::now() - chrono::Duration::hours(3)).to_rfc3339();
+        inner
+            .test_set_updated_at(mission.id, stale_at)
+            .await
+            .expect("updated_at should backdate");
+
+        let (events_tx, _events_rx) = broadcast::channel(8);
+        let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+        cleanup_stale_active_missions_once(&store, 2, &events_tx, &cmd_tx).await;
+
+        let stored = store
+            .get_mission(mission.id)
+            .await
+            .expect("mission lookup should succeed")
+            .expect("mission should exist");
+        assert_eq!(stored.status, MissionStatus::Active);
+    }
+
     #[test]
     fn test_parse_image_tag() {
         let tags = parse_rich_tags(r#"<image path="./chart.png" alt="My Chart" />"#);

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -26983,6 +26983,41 @@ mod tests {
         assert_eq!(stored.status, MissionStatus::Active);
     }
 
+    #[tokio::test]
+    async fn cleanup_stale_active_missions_once_closes_untagged_stale_mission() {
+        let inner = Arc::new(mission_store::InMemoryMissionStore::new());
+        let store: Arc<dyn MissionStore> = inner.clone();
+        let mission = store
+            .create_mission(Some("untagged worker"), None, None, None, None, None, None)
+            .await
+            .expect("mission should be created");
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await
+            .expect("mission should become active");
+        let stale_at = (chrono::Utc::now() - chrono::Duration::hours(3)).to_rfc3339();
+        inner
+            .test_set_updated_at(mission.id, stale_at)
+            .await
+            .expect("updated_at should backdate");
+
+        let (events_tx, _events_rx) = broadcast::channel(8);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ControlCommand::CancelMission { respond, .. }) = cmd_rx.recv().await {
+                let _ = respond.send(Ok(CancelMissionOutcome::Cancelled));
+            }
+        });
+        cleanup_stale_active_missions_once(&store, 2, &events_tx, &cmd_tx).await;
+
+        let stored = store
+            .get_mission(mission.id)
+            .await
+            .expect("mission lookup should succeed")
+            .expect("mission should exist");
+        assert_eq!(stored.status, MissionStatus::Completed);
+    }
+
     #[test]
     fn test_parse_image_tag() {
         let tags = parse_rich_tags(r#"<image path="./chart.png" alt="My Chart" />"#);

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -42,6 +42,22 @@ impl InMemoryMissionStore {
             board_outbox: Arc::new(RwLock::new(HashMap::new())),
         }
     }
+
+    /// Test-only: backdate `updated_at` so `get_stale_active_missions` can
+    /// select a row without waiting real hours.
+    #[cfg(test)]
+    pub(crate) async fn test_set_updated_at(
+        &self,
+        id: Uuid,
+        updated_at: String,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {id} not found"))?;
+        mission.updated_at = updated_at;
+        Ok(())
+    }
 }
 
 impl Default for InMemoryMissionStore {

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -214,6 +214,23 @@ pub(crate) async fn cleanup_stale_active_missions_once(
     match mission_store.get_stale_active_missions(stale_hours).await {
         Ok(stale_missions) => {
             for mission in stale_missions {
+                // Same ownership rule as the 15-minute watchdog (#840) and
+                // registered-liveness interrupt (#841). Grok 08306fdb / Kimi
+                // c91618dc / cert 203a49d5 were still in a long turn (CPU
+                // 11–14%) when this 2-hour net marked them Completed with
+                // "Auto-closed after 2 hours of inactivity" — a false
+                // terminal that resume() then refuses.
+                if watchdog_skips_control_owned_mission(
+                    mission.origin.as_deref(),
+                    mission.origin_session_id.as_deref(),
+                    &mission.project.tags,
+                ) {
+                    tracing::warn!(
+                        mission_id = %mission.id,
+                        "Stale cleanup: control-owned mission idle — NOT auto-closing"
+                    );
+                    continue;
+                }
                 tracing::info!(
                     "Auto-closing stale mission {}: '{}' (inactive since {})",
                     mission.id,


### PR DESCRIPTION
## Why

#840 skipped the 15m watchdog. #841 skipped the 15m registered-liveness interrupt. A **third** idle gate still false-completes Hermes-tagged writers:

- 00:40:39Z Grok `08306fdb` `Auto-closed after 2 hours of inactivity` then `completed (success: false)`
- 00:41:09Z cert `203a49d5` same
- 00:45:39Z Lido `04b0a5d8` same

`resume()` then returns 400 `cannot be resumed (status: completed)`.

## Change

`cleanup_stale_active_missions_once` uses `watchdog_skips_control_owned_mission` before auto-closing. Test `cleanup_stale_active_missions_once_skips_hermes_tagged_writer`.

## Deploy

Do **not** deploy this SHA while the four writers have fresh heartbeats after the 01:55 WEST reopen. Land for the next backend window (otherwise the 2h net will fire again ~03:55 WEST).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission lifecycle termination in supervision; misclassification could leave stale missions open or still auto-close the wrong rows, but logic is reused from existing watchdog paths with new tests.
> 
> **Overview**
> Extends the same **control-owned mission** exemption used by the 15-minute stuck watchdog (#840) and registered-liveness interrupt (#841) to the **2-hour stale active mission cleanup**, which was still marking long-running Hermes-tagged writers as `Completed` with “Auto-closed after 2 hours of inactivity” even when they were actively working.
> 
> `cleanup_stale_active_missions_once` now calls `watchdog_skips_control_owned_mission` (Hermes origin/session or tags like `origin:hermes-assistant`) and **skips** auto-close for those missions. Untagged stale missions still go through cancel + complete as before.
> 
> Tests cover Hermes-tagged stale missions staying `Active` and untagged ones completing; `InMemoryMissionStore::test_set_updated_at` backdates `updated_at` for those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec0f64300e9435df64a4691340a604a900f392e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->