### PR TITLE
fix(projects): session rail alias/title 404

### DIFF
--- a/dashboard/src/app/control/components/session-project-rail.tsx
+++ b/dashboard/src/app/control/components/session-project-rail.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/api/projects";
 import {
   cardSummary,
+  resolveSessionProjectSlug,
   viewMovingItems,
   viewOpenItems,
   viewPendingDecisions,
@@ -34,12 +35,17 @@ export function SessionProjectRail({ sessionId }: { sessionId: string }) {
     },
     { revalidateOnFocus: false, shouldRetryOnError: false },
   );
-  const slug = resolved?.slug;
+  const rawSlug = resolved?.slug;
   const { data: overview } = useSWR(
-    slug ? "projects-overview" : null,
+    rawSlug ? "projects-overview" : null,
     getProjectsOverview,
     { revalidateOnFocus: false },
   );
+  const slug = resolveSessionProjectSlug({
+    resolvedSlug: rawSlug,
+    sessionId,
+    projects: overview?.projects ?? [],
+  });
   const { data: detail } = useSWR(
     slug ? ["project-detail", slug] : null,
     () => getProject(slug!),

--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/lib/api/projects";
 import {
   cardSummary,
+  resolveSessionProjectSlug,
   viewControllerSignal,
   viewMovingItems,
   viewOpenItems,
@@ -414,5 +415,71 @@ describe("viewOpenItems / viewControllerSignal", () => {
         status: "pending_user",
       },
     ]);
+  });
+});
+
+describe("resolveSessionProjectSlug", () => {
+  const sessionId = "20260814_224352_2a62eb";
+  const projects = [
+    {
+      slug: "verity-core",
+      title: "Verity",
+      conversation: { session_id: sessionId },
+    },
+    {
+      slug: "verity-lido",
+      title: "Lido SRv3 audit",
+      conversation: { session_id: "20260810_112100_35e1a0" },
+    },
+  ];
+
+  test("prefers the overview row bound to this session over an alias binding", () => {
+    expect(
+      resolveSessionProjectSlug({
+        resolvedSlug: "verity-roadmap",
+        sessionId,
+        projects,
+      }),
+    ).toBe("verity-core");
+  });
+
+  test("does not 404 a title-case slug when the roster title matches", () => {
+    expect(
+      resolveSessionProjectSlug({
+        resolvedSlug: "Verity",
+        sessionId: "unbound-session",
+        projects,
+      }),
+    ).toBe("verity-core");
+  });
+
+  test("matches a roster slug case-insensitively", () => {
+    expect(
+      resolveSessionProjectSlug({
+        resolvedSlug: "Verity-Core",
+        sessionId: "unbound-session",
+        projects,
+      }),
+    ).toBe("verity-core");
+  });
+
+  test("keeps an unknown slug so a new project can still load", () => {
+    expect(
+      resolveSessionProjectSlug({
+        resolvedSlug: "brand-new",
+        sessionId: "unbound-session",
+        projects,
+      }),
+    ).toBe("brand-new");
+  });
+
+  test("returns null when nothing resolved", () => {
+    expect(
+      resolveSessionProjectSlug({
+        resolvedSlug: null,
+        sessionId: "   ",
+        projects,
+      }),
+    ).toBeNull();
   });
 });

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -262,3 +262,56 @@ function nonblank(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
 }
+
+/** Overview row the session rail should load.
+ *
+ * `/api/projects/by-session` first-matches a binding slug. Alias bindings
+ * (`verity-roadmap`, title-case `Verity`) are not roster rows — the board
+ * folds them onto `verity-core`, and `GET /api/projects/Verity` 404s.
+ * Prefer the overview project bound to this session, then an exact /
+ * case-insensitive slug, then a title match. Fall back to the raw slug so
+ * a brand-new project still resolves after the roster catches up. */
+export function resolveSessionProjectSlug(args: {
+  resolvedSlug?: string | null;
+  sessionId: string;
+  projects: Array<{
+    slug: string;
+    title?: string | null;
+    conversation?: { session_id?: string } | null;
+  }>;
+}): string | null {
+  const sessionId = args.sessionId.trim();
+  const resolved = args.resolvedSlug?.trim() || null;
+  if (!sessionId && !resolved) {
+    return null;
+  }
+  const bound = sessionId
+    ? args.projects.find(
+        (project) => project.conversation?.session_id === sessionId,
+      )
+    : undefined;
+  if (bound) {
+    return bound.slug;
+  }
+  if (!resolved) {
+    return null;
+  }
+  const exact = args.projects.find((project) => project.slug === resolved);
+  if (exact) {
+    return exact.slug;
+  }
+  const folded = resolved.toLowerCase();
+  const caseMatch = args.projects.find(
+    (project) => project.slug.toLowerCase() === folded,
+  );
+  if (caseMatch) {
+    return caseMatch.slug;
+  }
+  const titleMatch = args.projects.find(
+    (project) => (project.title ?? "").trim().toLowerCase() === folded,
+  );
+  if (titleMatch) {
+    return titleMatch.slug;
+  }
+  return resolved;
+}

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -412,6 +412,10 @@ pub async fn project_by_session(
             format!("no project bound to session '{session_id}'"),
         ));
     };
+    // Bindings can name an alias (`verity-roadmap`) or a display title
+    // (`Verity`). The session rail then GET /api/projects/:slug — that
+    // must be the roster card, not a 404 nickname.
+    let slug = canonicalize_project_slug(&slug);
     Ok(Json(
         serde_json::json!({ "slug": slug, "session_id": session_id }),
     ))
@@ -427,6 +431,9 @@ pub async fn get_project(
     if !is_plain_key(&slug) {
         return Err(bad_slug());
     }
+    let Some(slug) = resolve_roster_slug(&state.projects, &slug).map_err(store_err)? else {
+        return Err((StatusCode::NOT_FOUND, format!("unknown project '{slug}'")));
+    };
     let project = state
         .projects
         .get_project(&slug)
@@ -2551,7 +2558,59 @@ pub fn canonicalize_project_slug_with(aliases: &HashMap<String, String>, slug: &
     if trimmed.is_empty() {
         return String::new();
     }
+    if let Some(canonical) = aliases.get(trimmed) {
+        return canonical.clone();
+    }
+    // Display titles (`Verity`) and mixed-case route keys must fold the
+    // same way as the lowercase nickname already in routes.json.
+    let lower = trimmed.to_ascii_lowercase();
+    if lower != trimmed {
+        if let Some(canonical) = aliases.get(&lower) {
+            return canonical.clone();
+        }
+    }
     resolve_alias(aliases, trimmed)
+}
+
+/// Roster keys to try for `GET /api/projects/:slug`, first hit wins.
+///
+/// Canonical alias first (`verity-roadmap` / `Verity` → `verity-core`),
+/// then ASCII-lower of the request, then the raw slug so a brand-new
+/// roster row is still reachable before `routes.json` knows about it.
+pub fn roster_lookup_keys_with(aliases: &HashMap<String, String>, requested: &str) -> Vec<String> {
+    let trimmed = requested.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    let canonical = canonicalize_project_slug_with(aliases, trimmed);
+    let lower = trimmed.to_ascii_lowercase();
+    let mut keys = Vec::new();
+    for key in [canonical, lower, trimmed.to_string()] {
+        if !key.is_empty() && !keys.iter().any(|seen| seen == &key) {
+            keys.push(key);
+        }
+    }
+    keys
+}
+
+fn resolve_roster_slug(
+    store: &super::projects_store::ProjectsStore,
+    requested: &str,
+) -> Result<Option<String>, String> {
+    for key in roster_lookup_keys_with(
+        &hermes_projects_dir()
+            .map(|dir| read_alias_map(&dir))
+            .unwrap_or_default(),
+        requested,
+    ) {
+        if !is_plain_key(&key) {
+            continue;
+        }
+        if store.get_project(&key)?.is_some() {
+            return Ok(Some(key));
+        }
+    }
+    Ok(None)
 }
 
 /// Mission `project` tags that belong on this project's item view.
@@ -3146,6 +3205,57 @@ mod tests {
         );
         assert_eq!(canonicalize_project_slug_with(&aliases, "verity"), "verity");
         assert_eq!(canonicalize_project_slug_with(&aliases, "   "), "");
+    }
+
+    #[test]
+    fn canonicalize_project_slug_folds_title_case_and_roadmap_aliases() {
+        // Prod routes.json (2026-08-15): display title + tracker nickname
+        // both point at the roster card the session rail must load.
+        let mut aliases = HashMap::new();
+        aliases.insert("verity".to_string(), "verity-core".to_string());
+        aliases.insert("verity-roadmap".to_string(), "verity-core".to_string());
+        aliases.insert("Verity".to_string(), "verity-core".to_string());
+        assert_eq!(
+            canonicalize_project_slug_with(&aliases, "verity-roadmap"),
+            "verity-core"
+        );
+        assert_eq!(
+            canonicalize_project_slug_with(&aliases, "Verity"),
+            "verity-core"
+        );
+        // Title-case still folds when only the lowercase nickname is mapped.
+        aliases.remove("Verity");
+        assert_eq!(
+            canonicalize_project_slug_with(&aliases, "Verity"),
+            "verity-core"
+        );
+        assert_eq!(
+            canonicalize_project_slug_with(&aliases, "verity-core"),
+            "verity-core"
+        );
+    }
+
+    #[test]
+    fn roster_lookup_keys_prefer_canonical_then_casefold() {
+        let mut aliases = HashMap::new();
+        aliases.insert("verity".to_string(), "verity-core".to_string());
+        aliases.insert("verity-roadmap".to_string(), "verity-core".to_string());
+        assert_eq!(
+            roster_lookup_keys_with(&aliases, "Verity"),
+            vec![
+                "verity-core".to_string(),
+                "verity".to_string(),
+                "Verity".to_string()
+            ]
+        );
+        assert_eq!(
+            roster_lookup_keys_with(&aliases, "verity-roadmap"),
+            vec!["verity-core".to_string(), "verity-roadmap".to_string()]
+        );
+        assert_eq!(
+            roster_lookup_keys_with(&HashMap::new(), "Verity"),
+            vec!["Verity".to_string(), "verity".to_string()]
+        );
     }
 
     #[test]

--- a/src/api/session_chain.rs
+++ b/src/api/session_chain.rs
@@ -228,4 +228,27 @@ mod tests {
             None
         );
     }
+
+    #[test]
+    fn an_alias_binding_is_the_first_match_the_handler_must_canonicalize() {
+        // Prod 2026-08-15: /by-session returned `verity-roadmap` because that
+        // binding is listed before `verity-core`. The HTTP handler folds it.
+        let (_dir, path) = db(&[("74bd9b", None), ("2a62eb", Some("74bd9b"))]);
+        let bindings = vec![
+            ("verity-roadmap".to_string(), "74bd9b".to_string()),
+            ("verity-core".to_string(), "74bd9b".to_string()),
+        ];
+        let chain = ancestry(&path, "2a62eb");
+        let raw = slug_for_bound_session("2a62eb", &bindings, &chain, |id| live_tip(&path, id));
+        assert_eq!(raw.as_deref(), Some("verity-roadmap"));
+        let mut aliases = std::collections::HashMap::new();
+        aliases.insert("verity-roadmap".to_string(), "verity-core".to_string());
+        assert_eq!(
+            crate::api::projects_overview::canonicalize_project_slug_with(
+                &aliases,
+                raw.as_deref().unwrap()
+            ),
+            "verity-core"
+        );
+    }
 }


### PR DESCRIPTION
## Why
The Verity session-right rail was a title link with no items / next_action / controller signal. Prod `/api/projects/by-session/20260814_224352_2a62eb` returned `verity-roadmap` (first binding match). The rail then looked up that slug on the overview (which only has `verity-core`) and `GET /api/projects/Verity` 404'd.

`routes.json` already maps `verity`, `verity-roadmap`, and `Verity` → `verity-core`. The handlers were not folding.

## What
- `project_by_session` canonicalizes the binding slug before returning.
- `get_project` walks `roster_lookup_keys` (canonical, lowercase, raw) so a nickname or display title loads the roster card.
- `canonicalize_project_slug_with` also folds ASCII title-case onto a lowercase alias.
- Dashboard `resolveSessionProjectSlug` prefers the overview row bound to this session (works against today's undeployed backend).

## Tests
- `canonicalize_project_slug_folds_title_case_and_roadmap_aliases`
- `roster_lookup_keys_prefer_canonical_then_casefold`
- `an_alias_binding_is_the_first_match_the_handler_must_canonicalize`
- vitest `resolveSessionProjectSlug` (alias binding, title-case, case-insensitive slug)

## Deploy
Do **not** redeploy prod for this PR tonight — writers have fresh heartbeats on `829a79a2`. The dashboard half is enough for the local session rail. Backend fold can ship with the next required deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path slug normalization and dashboard resolution only; no auth or data writes, with unit/vitest coverage for alias and title-case cases.
> 
> **Overview**
> Fixes the **session-right project rail** showing only a title link with no items, next action, or controller signal when bindings returned **alias or display-title slugs** (`verity-roadmap`, `Verity`) instead of the roster card (`verity-core`).
> 
> **Backend:** `project_by_session` now **canonicalizes** the binding slug via `routes.json` before responding. `GET /api/projects/:slug` resolves through **`roster_lookup_keys`** (canonical alias, lowercase, then raw) so nicknames load the real project. **`canonicalize_project_slug_with`** also folds ASCII title-case keys onto lowercase alias entries.
> 
> **Dashboard:** **`resolveSessionProjectSlug`** runs after overview load—prefers the overview row bound to the session, then exact/case-insensitive slug or title match, with fallback to the raw slug for new projects (helps before backend deploy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b23464ff27a11ad924280548f7781edfafc817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->