### PR TITLE
fix(dashboard): readable ACTIVE chip and unread count in light theme

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -385,8 +385,15 @@ select:focus-visible {
   [class~="text-indigo-400/60"],
   [class~="text-indigo-400/50"],
   [class~="text-indigo-300/80"],
+  [class~="text-indigo-300/70"],
   [class~="text-indigo-300/60"] {
-    color: rgb(79 70 229 / 0.86);
+    color: rgb(67 56 202);
+  }
+
+  [class~="text-indigo-200"],
+  [class~="text-indigo-200/90"],
+  [class~="text-indigo-200/80"] {
+    color: rgb(67 56 202);
   }
 
   [class~="text-emerald-400"] {

--- a/dashboard/tests/theme-regression.spec.ts
+++ b/dashboard/tests/theme-regression.spec.ts
@@ -36,6 +36,8 @@ async function mountThemeFixture(page: import("@playwright/test").Page) {
         <div class="mission-switcher-row-selected" data-testid="mission-row">
           Selected mission row
         </div>
+        <span class="text-[10px] uppercase text-indigo-300/70" data-testid="mode-chip-active">active</span>
+        <span class="rounded-full bg-indigo-500/20 text-[10px] font-semibold tabular-nums text-indigo-200" data-testid="unread-badge">9+</span>
       </div>
     `;
     document.body.appendChild(fixture);
@@ -143,6 +145,20 @@ test("semantic components switch to light theme via data-theme", async ({ page }
     expect(color[0]).toBeLessThan(90);
     expect(color[1]).toBeLessThan(90);
     expect(color[2]).toBeLessThan(160);
+  }
+
+  const modeChip = parseRgb(
+    await page.getByTestId("mode-chip-active").evaluate((el) => getComputedStyle(el).color),
+  );
+  const unread = parseRgb(
+    await page.getByTestId("unread-badge").evaluate((el) => getComputedStyle(el).color),
+  );
+  // Pale indigo-200 / indigo-300/70 are unreadable on white; remaps must land
+  // on a dark indigo (indigo-700-ish) so 10px labels stay above ~4.5:1.
+  for (const color of [modeChip, unread]) {
+    expect(color[0]).toBeLessThan(90);
+    expect(color[1]).toBeLessThan(80);
+    expect(color[2]).toBeGreaterThan(180);
   }
 });
 


### PR DESCRIPTION
## Why
Light theme left `text-indigo-300/70` (ACTIVE mode chip) and `text-indigo-200` (unread `9+` badge) as pale-on-white.

## What
Remap those utilities to indigo-700 in `:root[data-theme="light"]`, and lock the contrast in the existing theme regression test.

## Test
`PLAYWRIGHT_BASE_URL=http://localhost:3011 PLAYWRIGHT_PORT=3011 bunx playwright test tests/theme-regression.spec.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only light-theme utility remaps and test coverage; no auth, data, or runtime logic changes.
> 
> **Overview**
> Fixes **light-theme contrast** for small indigo labels that were effectively pale-on-white: the ACTIVE mode chip (`text-indigo-300/70`) and unread count badge (`text-indigo-200` on `bg-indigo-500/20`).
> 
> Under `:root[data-theme="light"]` in `globals.css`, those Tailwind utilities (plus related `text-indigo-300/*` and `text-indigo-200/*` variants) are remapped from light/semi-transparent indigo to **solid indigo-700** (`rgb(67 56 202)`), matching the existing light-theme pattern for other indigo text overrides.
> 
> The **theme regression** Playwright test adds fixture markup for those two UI patterns and asserts computed text color stays in a dark indigo range so ~10px uppercase labels stay readable (~4.5:1 on white).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 859713cff9c90adef690a5c18ac5f1de70c9d2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->