### PR TITLE
fix(dashboard): hide empty-tag [CTRL:] status lines

### DIFF
--- a/dashboard/src/lib/hermes-state-signature.test.ts
+++ b/dashboard/src/lib/hermes-state-signature.test.ts
@@ -55,6 +55,14 @@ describe("stripStateSignature", () => {
     expect(stripHermesControlTrailers(body)).toBe(body);
   });
 
+  it("removes a trailing empty-tag [CTRL:] line with prose outside the brackets", () => {
+    const body =
+      "Action Thomas : aucune pour l’instant.\n\n" +
+      "[CTRL:] #2332 repair active; both workers recovered after server restart; waiting for successor head or concrete blocker.\n\n" +
+      "[STATE_SIGNATURE: verity|pr2332|none|repair-active|source|successor-head-or-blocker]";
+    expect(stripHermesControlTrailers(body)).toBe("Action Thomas : aucune pour l’instant.");
+  });
+
   it("leaves a signature quoted mid-message intact", () => {
     const body = `The trailer looks like ${SIGNATURE} and routes the reply.`;
     expect(stripStateSignature(body)).toBe(body);

--- a/dashboard/src/lib/hermes-state-signature.ts
+++ b/dashboard/src/lib/hermes-state-signature.ts
@@ -17,15 +17,23 @@
 const TRAILING_CONTROL_TRAILER_RE =
   /\s*\[(?:STATE_SIGNATURE|CTRL|DECISION):[^\]]*\]\s*$/;
 
+// Empty-tag improvisation: `[CTRL:]` then prose *outside* the brackets.
+// Structured form is `[CTRL: project | mode=…]`; models sometimes emit
+// `[CTRL:] #2332 repair active; …` which the closer-inside-brackets
+// matcher cannot consume.
+const TRAILING_EMPTY_CTRL_LINE_RE = /\s*\[CTRL:\][^\n]*\s*$/i;
+
 const SIGNATURE_KEY_RE = /\[STATE_SIGNATURE:\s*([^|\]]+)/g;
 
 /** Remove trailing Hermes control-plane trailer(s) from a message body.
  * Only trailers are stripped — metadata quoted mid-text stays intact. */
 export function stripHermesControlTrailers(content: string): string {
   let out = content;
-  while (TRAILING_CONTROL_TRAILER_RE.test(out)) {
-    out = out.replace(TRAILING_CONTROL_TRAILER_RE, "");
-  }
+  let next = out;
+  do {
+    out = next;
+    next = out.replace(TRAILING_CONTROL_TRAILER_RE, "").replace(TRAILING_EMPTY_CTRL_LINE_RE, "");
+  } while (next !== out);
   return out;
 }
 


### PR DESCRIPTION
## Why
The Verity controller ended a status reply with `[CTRL:] #2332 repair active; …` — prose outside the brackets. The dashboard already strips `[CTRL: project | mode=…]`; this empty-tag shape slipped through.

## What
Strip a trailing `[CTRL:] …` line in `stripHermesControlTrailers`.

## Test
`bunx vitest run src/lib/hermes-state-signature.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only message sanitization for Hermes UI; no auth, API, or persistence changes.
> 
> **Overview**
> **Hermes transcript cleanup** now removes a trailing line that starts with **`[CTRL:]`** and continues with status prose *outside* the brackets (e.g. `[CTRL:] #2332 repair active; …`), which the existing in-bracket **`[CTRL: …]`** matcher could not eat.
> 
> `stripHermesControlTrailers` applies both the original trailing trailer regex and the new empty-tag line regex in a loop until the body stabilizes, so stacked trailers (empty **`CTRL`** line plus **`STATE_SIGNATURE`**) still strip down to user-visible prose only. A Vitest case mirrors the Verity controller reply that motivated the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ca3f1c378ff1064e65696a7d2bc631b8b62078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->