### PR TITLE
feat(projects): items are the only roadmap

### DIFF
--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -150,11 +150,18 @@ reach your project's row at all.**
 Before the two text trailers, record your state in the durable project store — the board
 and any live surface read *this*, not a parsed trailer. Once per tick:
 
-- `update_project_status(slug, mode, next_action, blocker)` with your exact project slug
-  (`verity`, `lido-audit`, `verity-benchmark`, `lean-silicon`, `coldcard-rng-cracker`).
-  Same mode vocabulary as the trailer; the store counts your consecutive-tick `wait`.
+- `update_project_status(slug, mode, next_action, blocker)` with your **canonical**
+  roster slug (`verity-core`, `verity-lido`, `verity-benchmark`, `lean-silicon`,
+  `coldcard-rng-cracker`). Nicknames (`verity`, `lido`, `lido-audit`) resolve, but
+  do not invent a new slug. Same mode vocabulary as the trailer; the store counts
+  your consecutive-tick `wait`.
+- The project's **items are the only roadmap**. `get_project` / `get_project_tasks`
+  return the same list (tracks + live attempts). `plan_project_tasks` upserts an
+  item (`project_tracks`). Do not create a second plan (no extra cron "roadmap
+  watcher", no `/goal` as the program, no new `project=` for a workstream — that
+  is a `track`).
 - For every mission you dispatch this tick, `link_mission_to_project(mission_id, slug,
-  track)` so it appears in the project's inventory. An unlinked worker is invisible.
+  track)` so it appears on that item. An unlinked worker is invisible.
 - At your first tick (or after the prompt changed), read `get_project_grant(slug)` — the
   merge authority, budget, and any PAUSED live there and outrank the prompt.
 - Each tick, `set_project_track` for every open in-scope PR and issue so the roadmap
@@ -266,6 +273,7 @@ repeated failure `repeat-loop-guard` · tool-call limits `context-budget`.
 - **Never cancel operator-relaunched missions without explicit confirmation.** If a mission you previously owned was relaunched or resumed by the operator, it is no longer yours to reap: do not cancel, pause, or supersede it unless the operator explicitly confirms. When in doubt, ask and keep your own work in a separate mission.
 - **Campaigns are one host-workspace mission with `track=campaign` — never hand-written systemd units.** Long-running or recurring campaign work runs as a single mission on a host workspace tagged `track=campaign`; do not create ad-hoc systemd services/timers for it. The API enforces campaign uniqueness and returns **409 Conflict** on a duplicate — treat a 409 as "the campaign already exists", not an error to retry around.
 - **STATE_SIGNATURE key = your project canonical roster slug, always.** Use exactly the slug of the project you drive (e.g. `verity-core`, `verity-lido`, `lean-silicon`, `verity-benchmark`, `coldcard-rng-cracker`). Never invent new keys (no camelCase names, phase names, or sub-tracks as keys — use the `track` field for that); a novel key creates a duplicate project on every surface. Nicknames (`coldcard`, `ec-defensive-research`) are aliases — they must resolve to the roster slug, never replace it.
+- **One list, one controller.** Do not add a second cron that "watches the roadmap". The bound conversation already is the project. A `/goal` is not a second roadmap.
 - **Deliver into the project session, never `origin` without an origin.** Cron jobs for a project use `deliver: project:<slug>`. `deliver: origin` with `origin: None` is a silent drop (Coldcard skip-scan watch, 2026-08-13). If you cannot capture origin, you must name the project.
 - **Do not delete the project's controller because it is noisy.** A repeating `blocked` trailer is a stall to escalate, not spam to silence. Removing the cron removes the only path that can write into the dedicated session.
 - **Acknowledge what you have absorbed.** When a failed/interrupted mission has been superseded (retry dispatched, work re-planned, or intentionally dropped), immediately mark it `acknowledged` — an unacknowledged terminal mission is an open operator alert. The attention surface only counts UNacknowledged failures; leaving absorbed failures unacknowledged cries wolf on every board.

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -9,7 +9,7 @@ description: >
 metadata:
   policy: chatgpt-ui-pool
   policy_version: 1.3.0
-version: 1.10.0
+version: 1.11.0
 ---
 
 # Hermes Mission Control
@@ -115,10 +115,16 @@ mission is `pending`/`active`, then stop. The result comes back here.
 
 ### Controller launch
 
-A cron tick with `deliver: project:<slug>`. Pass `project` (and track /
-intent as usual). Do **not** enroll a worker wakeup and do not wait.
-Report on the next tick or via the project route. A `cron_*` session
-dies with the tick; never stamp one as origin.
+A cron tick with `deliver: project:<canonical-slug>`. Pass `project` as
+the roster slug (`verity-core`, `verity-lido`, …) and `track` as the
+**item** this mission is an attempt on. Do **not** enroll a worker
+wakeup and do not wait. Report on the next tick or via the project
+route. A `cron_*` session dies with the tick; never stamp one as origin.
+
+The project's items **are** the roadmap (`get_project` / `get_project_tasks`
+are the same list). `plan_project_tasks` upserts an item. Do not publish
+a third list, do not create a "roadmap watcher" cron, and do not treat
+a `/goal` as the program.
 
 ### On callback
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4043,10 +4043,9 @@ impl ControlHub {
     }
 
     /// Board tasks across every store whose boss mission belongs to this
-    /// project family. Live stores answer through the trait; persisted SQLite
-    /// databases with no live control session (fresh restart, other users) are
-    /// read directly — otherwise the roadmap goes blank whenever nobody has a
-    /// session open. File stores have no boards and are skipped.
+    /// project family. Kept for boss-internal / debug reads. The public
+    /// project roadmap is the item list (`load_project_items`), not this.
+    #[allow(dead_code)]
     pub(crate) async fn collect_project_board_tasks(
         &self,
         project: &str,
@@ -10852,7 +10851,19 @@ pub async fn update_mission_project(
             })
         })
     };
-    let project = normalize(req.project);
+    let project = normalize(req.project).map(|inner| {
+        inner.map(|raw| {
+            let canonical = crate::api::projects_overview::canonicalize_project_slug(&raw);
+            if canonical != raw {
+                tracing::info!(
+                    from = %raw,
+                    to = %canonical,
+                    "canonicalized mission project patch via routes.json alias"
+                );
+            }
+            canonical
+        })
+    });
     let track = normalize(req.track);
     let intent = normalize(req.intent);
     let github_pr = normalize(req.github_pr);

--- a/src/api/mission_horizon.rs
+++ b/src/api/mission_horizon.rs
@@ -161,7 +161,7 @@ pub fn project_items(
                 kind: "track",
                 desired_state: track.desired_state.clone(),
                 status: track.status.clone(),
-                open: track.status.as_deref() != Some("done"),
+                open: !matches!(track.status.as_deref(), Some("done") | Some("cancelled")),
                 attempts: Vec::new(),
             },
         );
@@ -562,6 +562,16 @@ mod tests {
             .attempts
             .iter()
             .all(|attempt| attempt.id != live.id || item.key == "core")));
+
+        let cancelled = vec![ProjectTrack {
+            track: "old-pr46".to_string(),
+            desired_state: Some("certify PR 46".to_string()),
+            status: Some("cancelled".to_string()),
+            updated_at: "2026-08-01T00:00:00Z".to_string(),
+        }];
+        let closed = project_items(&cancelled, &[], &[]);
+        assert_eq!(closed.len(), 1);
+        assert!(!closed[0].open, "cancelled tracks are not open items");
         let historical = missions
             .iter()
             .filter(|mission| {

--- a/src/api/mission_horizon.rs
+++ b/src/api/mission_horizon.rs
@@ -130,8 +130,28 @@ pub struct ProjectItem {
     pub desired_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub acceptance_criteria: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
     pub open: bool,
+    /// True when a `project_tracks` or leftover proposal row declared this
+    /// item. Mission-only attention rows stay off the public roadmap.
+    #[serde(skip)]
+    pub declared: bool,
     pub attempts: Vec<ProjectItemAttempt>,
+}
+
+/// A declared track is open unless it is done, closed, or cancelled.
+/// Missing, empty, `running`, and `in-progress` all count as open — that is
+/// how `set_project_track` and existing store rows already behave.
+pub fn track_status_is_open(status: Option<&str>) -> bool {
+    !matches!(
+        status.map(str::trim).filter(|value| !value.is_empty()),
+        Some("done") | Some("closed") | Some("cancelled")
+    )
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -161,7 +181,11 @@ pub fn project_items(
                 kind: "track",
                 desired_state: track.desired_state.clone(),
                 status: track.status.clone(),
-                open: !matches!(track.status.as_deref(), Some("done") | Some("cancelled")),
+                title: track.title.clone(),
+                acceptance_criteria: track.acceptance_criteria.clone(),
+                depends_on: track.depends_on.clone(),
+                open: track_status_is_open(track.status.as_deref()),
+                declared: true,
                 attempts: Vec::new(),
             },
         );
@@ -172,9 +196,13 @@ pub fn project_items(
             .or_insert_with(|| ProjectItem {
                 key: proposal.task_key.clone(),
                 kind: "task",
-                desired_state: None,
+                desired_state: proposal.prompt.clone(),
                 status: Some("proposed".to_string()),
+                title: Some(proposal.title.clone()),
+                acceptance_criteria: proposal.acceptance_criteria.clone(),
+                depends_on: proposal.depends_on.clone(),
                 open: true,
+                declared: true,
                 attempts: Vec::new(),
             });
     }
@@ -195,7 +223,11 @@ pub fn project_items(
             kind: "track",
             desired_state: mission.project.desired_state.clone(),
             status: None,
+            title: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
             open: true,
+            declared: false,
             attempts: Vec::new(),
         });
         item.attempts.push(ProjectItemAttempt {
@@ -526,6 +558,9 @@ mod tests {
             track: "core".to_string(),
             desired_state: Some("landed".to_string()),
             status: Some("active".to_string()),
+            title: Some("Core".to_string()),
+            acceptance_criteria: vec!["merged".to_string()],
+            depends_on: Vec::new(),
             updated_at: "2026-08-14T00:00:00Z".to_string(),
         }];
         let proposals = vec![RoadmapProposal {
@@ -567,11 +602,37 @@ mod tests {
             track: "old-pr46".to_string(),
             desired_state: Some("certify PR 46".to_string()),
             status: Some("cancelled".to_string()),
+            title: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
             updated_at: "2026-08-01T00:00:00Z".to_string(),
         }];
         let closed = project_items(&cancelled, &[], &[]);
         assert_eq!(closed.len(), 1);
         assert!(!closed[0].open, "cancelled tracks are not open items");
+        assert!(core.declared);
+        assert_eq!(core.title.as_deref(), Some("Core"));
+        assert_eq!(core.acceptance_criteria, vec!["merged"]);
+        assert!(docs.declared);
+        assert!(!review.declared, "mission-only items are not declared");
+        let missing = project_items(
+            &[ProjectTrack {
+                track: "running-pr".to_string(),
+                desired_state: None,
+                status: Some("running".to_string()),
+                title: None,
+                acceptance_criteria: Vec::new(),
+                depends_on: Vec::new(),
+                updated_at: "2026-08-14T00:00:00Z".to_string(),
+            }],
+            &[],
+            &[],
+        );
+        assert!(missing[0].open, "running is an open track status");
+        assert!(track_status_is_open(None));
+        assert!(track_status_is_open(Some("")));
+        assert!(track_status_is_open(Some("in-progress")));
+        assert!(!track_status_is_open(Some("closed")));
         let historical = missions
             .iter()
             .filter(|mission| {

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1182,8 +1182,8 @@ fn merge_announcement_needles(delivery: &DeliveryUpdate, recorded_decided: bool)
 
 /// `GET /api/projects/:slug/tasks` — the project's roadmap.
 ///
-/// The list **is** the item inventory (`project_tracks` + leftover proposals
-/// + attention-horizon attempts). Boss `board_tasks` stay private to the
+/// The list **is** the item inventory: `project_tracks`, leftover proposals,
+/// and attention-horizon attempts. Boss `board_tasks` stay private to the
 /// mission that owns them; they are not a second plan. Aliases fold onto the
 /// canonical roster slug — hyphen prefix matching is deliberately not used,
 /// so `verity` never swallows `verity-lido`.

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -533,7 +533,7 @@ pub async fn get_project(
         .map_err(store_err)?
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("unknown project '{slug}'")))?;
     let grant = state.projects.get_grant(&slug).map_err(store_err)?;
-    let tracks = state.projects.tracks(&slug).map_err(store_err)?;
+    let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
     let decisions = state.projects.open_decisions(&slug).map_err(store_err)?;
     let recent = state
         .projects
@@ -544,10 +544,7 @@ pub async fn get_project(
         .binding(&slug)
         .map_err(store_err)?
         .map(follow_live_conversation);
-    let proposals = state
-        .projects
-        .list_open_proposals(&slug)
-        .map_err(store_err)?;
+    let items = load_project_items(&state, &slug).await?;
     let missions = match state
         .control
         .collect_attention_missions_for_project(&slug)
@@ -559,7 +556,6 @@ pub async fn get_project(
             Vec::new()
         }
     };
-    let items = super::mission_horizon::project_items(&tracks, &proposals, &missions);
     let mut project = project;
     if let Some(derived) = next_action_from_live_titles(
         missions
@@ -806,6 +802,9 @@ pub async fn set_project_track(
     if !is_plain_key(&slug) {
         return Err(bad_slug());
     }
+    let slug = resolve_roster_slug(&state.projects, &slug)
+        .map_err(store_err)?
+        .unwrap_or(slug);
     if req.track.trim().is_empty() {
         return Err((StatusCode::BAD_REQUEST, "track is required".to_string()));
     }
@@ -818,7 +817,7 @@ pub async fn set_project_track(
             req.status.as_deref(),
         )
         .map_err(store_err)?;
-    let tracks = state.projects.tracks(&slug).map_err(store_err)?;
+    let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
     Ok(Json(serde_json::json!({ "tracks": tracks })))
 }
 
@@ -1181,83 +1180,40 @@ fn merge_announcement_needles(delivery: &DeliveryUpdate, recorded_decided: bool)
     needles
 }
 
-/// `GET /api/projects/:slug/tasks` — the project's roadmap: every board task
-/// planned under a boss mission of this project family, in planning order,
-/// with the per-item detail (digest, PR link, worker mission) the drawer's
-/// checklist expands into.
+/// `GET /api/projects/:slug/tasks` — the project's roadmap.
+///
+/// The list **is** the item inventory (`project_tracks` + leftover proposals
+/// + attention-horizon attempts). Boss `board_tasks` stay private to the
+/// mission that owns them; they are not a second plan. Aliases fold onto the
+/// canonical roster slug — hyphen prefix matching is deliberately not used,
+/// so `verity` never swallows `verity-lido`.
 pub async fn project_tasks(
     State(state): State<Arc<AppState>>,
-    AxumPath(slug): AxumPath<String>,
+    AxumPath(requested): AxumPath<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    if !is_plain_key(&slug) {
+    if !is_plain_key(&requested) {
         return Err(bad_slug());
     }
-    let tasks = state
-        .control
-        .collect_project_board_tasks(&slug)
-        .await
-        .map_err(store_err)?;
+    let slug = resolve_roster_slug(&state.projects, &requested)
+        .map_err(store_err)?
+        .unwrap_or(requested);
+    let items = load_project_items(&state, &slug).await?;
     let mut done = 0usize;
     let mut running = 0usize;
     let mut failed = 0usize;
-    let mut rows: Vec<serde_json::Value> = tasks
+    let rows: Vec<serde_json::Value> = items
         .iter()
-        .map(|task| {
-            let status = task.status.to_string();
-            match status.as_str() {
+        .map(|item| {
+            let status = item_roadmap_status(item);
+            match status {
                 "accepted" => done += 1,
                 "running" | "settled" => running += 1,
                 "failed" => failed += 1,
                 _ => {}
             }
-            let pr_url = task
-                .result_digest
-                .as_deref()
-                .and_then(extract_pr_url)
-                .or_else(|| task.notes.as_deref().and_then(extract_pr_url));
-            serde_json::json!({
-                "id": task.id,
-                "task_key": task.task_key,
-                "title": task.title,
-                "status": status,
-                "outcome": task.outcome,
-                "depends_on": task.depends_on,
-                "acceptance_criteria": task.acceptance_criteria,
-                "result_digest": task.result_digest,
-                "pr_url": pr_url,
-                "worker_mission_id": task.worker_mission_id,
-                "boss_mission_id": task.boss_mission_id,
-                "attempts": task.attempts,
-                "updated_at": task.updated_at,
-            })
+            item_as_roadmap_task(item)
         })
         .collect();
-    // Chat-planned proposals ride the same list as `status: "proposed"`. A
-    // board task under the same key supersedes its proposal — the plan became
-    // real work, so the proposal row disappears from the read.
-    let planned: std::collections::HashSet<&str> =
-        tasks.iter().map(|task| task.task_key.as_str()).collect();
-    let proposals = state
-        .projects
-        .list_open_proposals(&slug)
-        .map_err(store_err)?;
-    rows.extend(
-        proposals
-            .iter()
-            .filter(|proposal| !planned.contains(proposal.task_key.as_str()))
-            .map(|proposal| {
-                serde_json::json!({
-                    "id": null,
-                    "task_key": proposal.task_key,
-                    "title": proposal.title,
-                    "prompt": proposal.prompt,
-                    "status": "proposed",
-                    "depends_on": proposal.depends_on,
-                    "acceptance_criteria": proposal.acceptance_criteria,
-                    "updated_at": proposal.updated_at,
-                })
-            }),
-    );
     Ok(Json(serde_json::json!({
         "slug": slug,
         "tasks": rows,
@@ -1287,29 +1243,29 @@ pub struct PlanTasksRequest {
     pub tasks: Vec<ProposalInput>,
 }
 
-/// `POST /api/projects/:slug/tasks` — plan roadmap items from chat. Proposals
-/// only: real board tasks stay writable solely by their boss mission, so a
-/// conversation can shape the plan without reaching into a running board.
+/// `POST /api/projects/:slug/tasks` — plan roadmap items from chat.
+///
+/// Writes the project's **item** table (`project_tracks`). This used to insert
+/// a third ledger (`project_roadmap_proposals`); that table is read only to
+/// surface leftover rows until they are absorbed into a track.
 pub async fn plan_project_tasks(
     State(state): State<Arc<AppState>>,
-    AxumPath(slug): AxumPath<String>,
+    AxumPath(requested): AxumPath<String>,
     Json(req): Json<PlanTasksRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    if !is_plain_key(&slug) {
+    if !is_plain_key(&requested) {
         return Err(bad_slug());
     }
-    if state
-        .projects
-        .get_project(&slug)
-        .map_err(store_err)?
-        .is_none()
-    {
-        return Err((StatusCode::NOT_FOUND, format!("unknown project '{slug}'")));
-    }
+    let Some(slug) = resolve_roster_slug(&state.projects, &requested).map_err(store_err)? else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("unknown project '{requested}'"),
+        ));
+    };
     if req.tasks.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "tasks is required".to_string()));
     }
-    let mut proposals = Vec::with_capacity(req.tasks.len());
+    let mut planned = 0usize;
     for task in &req.tasks {
         let task_key = task.task_key.trim();
         if !is_plain_key(task_key) {
@@ -1324,21 +1280,19 @@ pub async fn plan_project_tasks(
                 format!("task '{task_key}' needs a title"),
             ));
         }
-        proposals.push(crate::api::projects_store::NewProposal {
-            task_key: task_key.to_string(),
-            title: task.title.trim().to_string(),
-            prompt: task.prompt.clone(),
-            acceptance_criteria: task.acceptance_criteria.clone(),
-            depends_on: task.depends_on.clone(),
-        });
+        let desired = task
+            .prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(task.title.trim());
+        state
+            .projects
+            .set_track(&slug, task_key, Some(desired), Some("open"))
+            .map_err(store_err)?;
+        planned += 1;
     }
-    state
-        .projects
-        .upsert_proposals(&slug, &proposals)
-        .map_err(store_err)?;
-    Ok(Json(
-        serde_json::json!({ "ok": true, "proposed": proposals.len() }),
-    ))
+    Ok(Json(serde_json::json!({ "ok": true, "proposed": planned })))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1353,43 +1307,41 @@ pub struct UpdateProposalRequest {
     pub depends_on: Option<Vec<String>>,
 }
 
-/// A proposal whose key a boss mission has planned as a real board task is
-/// *adopted*: the roadmap read hides it, and editing/cancelling the hidden row
-/// would silently succeed while changing nothing the caller can see. Surface
-/// that as a conflict instead.
-async fn assert_not_adopted(
-    state: &Arc<AppState>,
-    slug: &str,
-    task_key: &str,
-) -> Result<(), (StatusCode, String)> {
-    let tasks = state
-        .control
-        .collect_project_board_tasks(slug)
-        .await
-        .map_err(store_err)?;
-    if tasks.iter().any(|task| task.task_key == task_key) {
-        return Err((
-            StatusCode::CONFLICT,
-            format!(
-                "proposal '{task_key}' was adopted as a board task — steer the boss mission instead"
-            ),
-        ));
-    }
-    Ok(())
-}
-
-/// `PATCH /api/projects/:slug/tasks/:task_key` — edit an open proposal.
-/// 404 covers "never proposed" and "cancelled"; an adopted key is 409 — once a
-/// board task owns the key, edits belong to the boss mission's flow.
+/// `PATCH /api/projects/:slug/tasks/:task_key` — edit an item (track).
+/// Leftover proposal rows are updated as a compatibility fallback.
 pub async fn update_project_task(
     State(state): State<Arc<AppState>>,
-    AxumPath((slug, task_key)): AxumPath<(String, String)>,
+    AxumPath((requested, task_key)): AxumPath<(String, String)>,
     Json(req): Json<UpdateProposalRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    if !is_plain_key(&slug) || !is_plain_key(&task_key) {
+    if !is_plain_key(&requested) || !is_plain_key(&task_key) {
         return Err(bad_slug());
     }
-    assert_not_adopted(&state, &slug, &task_key).await?;
+    let Some(slug) = resolve_roster_slug(&state.projects, &requested).map_err(store_err)? else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("unknown project '{requested}'"),
+        ));
+    };
+    let desired = req
+        .prompt
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            req.title
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        });
+    let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
+    if tracks.iter().any(|track| track.track == task_key) {
+        state
+            .projects
+            .set_track(&slug, &task_key, desired, None)
+            .map_err(store_err)?;
+        return Ok(Json(serde_json::json!({ "ok": true })));
+    }
     let updated = state
         .projects
         .update_proposal(
@@ -1407,21 +1359,34 @@ pub async fn update_project_task(
     if !updated {
         return Err((
             StatusCode::NOT_FOUND,
-            format!("no open proposal '{task_key}' for '{slug}'"),
+            format!("no open item '{task_key}' for '{slug}'"),
         ));
     }
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
-/// `DELETE /api/projects/:slug/tasks/:task_key` — cancel an open proposal.
+/// `DELETE /api/projects/:slug/tasks/:task_key` — cancel an item.
 pub async fn cancel_project_task(
     State(state): State<Arc<AppState>>,
-    AxumPath((slug, task_key)): AxumPath<(String, String)>,
+    AxumPath((requested, task_key)): AxumPath<(String, String)>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    if !is_plain_key(&slug) || !is_plain_key(&task_key) {
+    if !is_plain_key(&requested) || !is_plain_key(&task_key) {
         return Err(bad_slug());
     }
-    assert_not_adopted(&state, &slug, &task_key).await?;
+    let Some(slug) = resolve_roster_slug(&state.projects, &requested).map_err(store_err)? else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("unknown project '{requested}'"),
+        ));
+    };
+    let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
+    if tracks.iter().any(|track| track.track == task_key) {
+        state
+            .projects
+            .set_track(&slug, &task_key, None, Some("cancelled"))
+            .map_err(store_err)?;
+        return Ok(Json(serde_json::json!({ "ok": true })));
+    }
     let cancelled = state
         .projects
         .cancel_proposal(&slug, &task_key)
@@ -1429,7 +1394,7 @@ pub async fn cancel_project_task(
     if !cancelled {
         return Err((
             StatusCode::NOT_FOUND,
-            format!("no open proposal '{task_key}' for '{slug}'"),
+            format!("no open item '{task_key}' for '{slug}'"),
         ));
     }
     Ok(Json(serde_json::json!({ "ok": true })))
@@ -2897,6 +2862,120 @@ pub fn project_tag_keys_with(aliases: &HashMap<String, String>, slug: &str) -> V
     keys
 }
 
+fn collect_family_tracks(
+    store: &super::projects_store::ProjectsStore,
+    slug: &str,
+) -> Result<Vec<super::projects_store::ProjectTrack>, String> {
+    let mut collected = Vec::new();
+    let mut seen = HashSet::new();
+    for key in project_tag_keys(slug) {
+        for track in store.tracks(&key)? {
+            if seen.insert(track.track.clone()) {
+                collected.push(track);
+            }
+        }
+    }
+    Ok(collected)
+}
+
+fn collect_family_proposals(
+    store: &super::projects_store::ProjectsStore,
+    slug: &str,
+) -> Result<Vec<super::projects_store::RoadmapProposal>, String> {
+    let mut collected = Vec::new();
+    let mut seen = HashSet::new();
+    for key in project_tag_keys(slug) {
+        for proposal in store.list_open_proposals(&key)? {
+            if seen.insert(proposal.task_key.clone()) {
+                collected.push(proposal);
+            }
+        }
+    }
+    Ok(collected)
+}
+
+async fn load_project_items(
+    state: &Arc<AppState>,
+    slug: &str,
+) -> Result<Vec<super::mission_horizon::ProjectItem>, (StatusCode, String)> {
+    let tracks = collect_family_tracks(&state.projects, slug).map_err(store_err)?;
+    let proposals = collect_family_proposals(&state.projects, slug).map_err(store_err)?;
+    let missions = match state
+        .control
+        .collect_attention_missions_for_project(slug)
+        .await
+    {
+        Ok(missions) => missions,
+        Err(error) => {
+            tracing::warn!(project = %slug, %error, "project items: attention collect failed");
+            Vec::new()
+        }
+    };
+    Ok(super::mission_horizon::project_items(
+        &tracks, &proposals, &missions,
+    ))
+}
+
+fn item_attempt_is_live(status: &str) -> bool {
+    matches!(status, "active" | "pending" | "running" | "awaiting_user")
+}
+
+/// Map an item onto the existing `/tasks` row shape the desktop already
+/// renders. Status vocabulary stays the checklist's: accepted / running /
+/// failed / proposed / pending.
+fn item_roadmap_status(item: &super::mission_horizon::ProjectItem) -> &'static str {
+    if !item.open {
+        return "accepted";
+    }
+    if item
+        .attempts
+        .iter()
+        .any(|attempt| item_attempt_is_live(&attempt.status))
+    {
+        return "running";
+    }
+    if item.status.as_deref() == Some("proposed") {
+        return "proposed";
+    }
+    if !item.attempts.is_empty()
+        && item
+            .attempts
+            .iter()
+            .all(|attempt| matches!(attempt.status.as_str(), "failed" | "interrupted"))
+    {
+        return "failed";
+    }
+    "pending"
+}
+
+fn item_as_roadmap_task(item: &super::mission_horizon::ProjectItem) -> serde_json::Value {
+    let title = item
+        .desired_state
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            item.attempts
+                .iter()
+                .find_map(|attempt| attempt.title.clone().filter(|title| !title.is_empty()))
+        })
+        .unwrap_or_else(|| item.key.clone());
+    let latest = item.attempts.first();
+    serde_json::json!({
+        "id": null,
+        "task_key": item.key,
+        "title": title,
+        "status": item_roadmap_status(item),
+        "kind": item.kind,
+        "open": item.open,
+        "desired_state": item.desired_state,
+        "worker_mission_id": latest.map(|attempt| attempt.id.to_string()),
+        "attempts": item.attempts.len(),
+        "updated_at": latest.map(|attempt| attempt.updated_at.clone()),
+    })
+}
+
 /// True when every field of a state descriptor is an unfilled `<placeholder>`.
 ///
 /// Deliberately narrow: a descriptor is rejected only when it carries no real
@@ -3545,6 +3624,60 @@ mod tests {
             project_tag_keys_with(&aliases, "verity"),
             vec!["verity".to_string()]
         );
+    }
+
+    #[test]
+    fn sibling_verity_projects_do_not_share_a_hyphen_family() {
+        let mut aliases = HashMap::new();
+        aliases.insert("verity".to_string(), "verity-core".to_string());
+        aliases.insert("lido".to_string(), "verity-lido".to_string());
+        aliases.insert("lido-audit".to_string(), "verity-lido".to_string());
+        aliases.insert("lido-pdeposit1-tx".to_string(), "verity-lido".to_string());
+
+        let core = project_tag_keys_with(&aliases, "verity-core");
+        assert!(core.contains(&"verity-core".to_string()));
+        assert!(core.contains(&"verity".to_string()));
+        assert!(!core.iter().any(|key| key.contains("lido")));
+
+        let lido = project_tag_keys_with(&aliases, "lido-audit");
+        assert!(lido.contains(&"verity-lido".to_string()));
+        assert!(lido.contains(&"lido-pdeposit1-tx".to_string()));
+        assert!(!lido.contains(&"verity-core".to_string()));
+        assert!(!lido.contains(&"verity".to_string()));
+    }
+
+    #[test]
+    fn item_roadmap_status_follows_open_and_live_attempts() {
+        use crate::api::mission_horizon::{ProjectItem, ProjectItemAttempt};
+        use uuid::Uuid;
+
+        let open_live = ProjectItem {
+            key: "c5".into(),
+            kind: "track",
+            desired_state: Some("land #2332".into()),
+            status: Some("open".into()),
+            open: true,
+            attempts: vec![ProjectItemAttempt {
+                id: Uuid::nil(),
+                status: "active".into(),
+                title: Some("repair #2332".into()),
+                updated_at: "2026-08-15T00:00:00Z".into(),
+                role: None,
+            }],
+        };
+        assert_eq!(item_roadmap_status(&open_live), "running");
+        let row = item_as_roadmap_task(&open_live);
+        assert_eq!(row["task_key"], "c5");
+        assert_eq!(row["title"], "land #2332");
+        assert_eq!(row["status"], "running");
+
+        let done = ProjectItem {
+            open: false,
+            status: Some("done".into()),
+            attempts: Vec::new(),
+            ..open_live.clone()
+        };
+        assert_eq!(item_roadmap_status(&done), "accepted");
     }
 
     const SAMPLE: &str = "[Cron delivery: Verity two-phase Fable/Codex progression]\n\

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1263,11 +1263,26 @@ pub async fn plan_project_tasks(
             format!("unknown project '{requested}'"),
         ));
     };
-    if req.tasks.is_empty() {
+    let planned = planned_tracks_from_request(&req.tasks)?;
+    state
+        .projects
+        .upsert_planned_tracks(&slug, &planned)
+        .map_err(store_err)?;
+    Ok(Json(
+        serde_json::json!({ "ok": true, "proposed": planned.len() }),
+    ))
+}
+
+/// Validate the whole batch before any write so a later 400 cannot leave a
+/// prefix of tracks persisted.
+fn planned_tracks_from_request(
+    tasks: &[ProposalInput],
+) -> Result<Vec<super::projects_store::PlannedTrack>, (StatusCode, String)> {
+    if tasks.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "tasks is required".to_string()));
     }
-    let mut planned = 0usize;
-    for task in &req.tasks {
+    let mut planned = Vec::with_capacity(tasks.len());
+    for task in tasks {
         let task_key = task.task_key.trim();
         if !is_plain_key(task_key) {
             return Err((
@@ -1275,7 +1290,8 @@ pub async fn plan_project_tasks(
                 format!("invalid task_key '{}'", task.task_key),
             ));
         }
-        if task.title.trim().is_empty() {
+        let title = task.title.trim();
+        if title.is_empty() {
             return Err((
                 StatusCode::BAD_REQUEST,
                 format!("task '{task_key}' needs a title"),
@@ -1286,14 +1302,16 @@ pub async fn plan_project_tasks(
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .unwrap_or(task.title.trim());
-        state
-            .projects
-            .set_track(&slug, task_key, Some(desired), Some("open"))
-            .map_err(store_err)?;
-        planned += 1;
+            .unwrap_or(title);
+        planned.push(super::projects_store::PlannedTrack {
+            track: task_key.to_string(),
+            title: title.to_string(),
+            desired_state: desired.to_string(),
+            acceptance_criteria: task.acceptance_criteria.clone(),
+            depends_on: task.depends_on.clone(),
+        });
     }
-    Ok(Json(serde_json::json!({ "ok": true, "proposed": planned })))
+    Ok(planned)
 }
 
 #[derive(Debug, Deserialize)]
@@ -1335,23 +1353,47 @@ pub async fn update_project_task(
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
         });
-    let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
-    if tracks.iter().any(|track| track.track == task_key) {
+    let title = req
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let family = project_tag_keys(&slug);
+    if let Some(stored) = state
+        .projects
+        .find_track_slug(&family, &task_key)
+        .map_err(store_err)?
+    {
         state
             .projects
-            .set_track(&slug, &task_key, desired, None)
+            .patch_track(
+                &stored,
+                &task_key,
+                desired,
+                None,
+                title,
+                req.acceptance_criteria.as_deref(),
+                req.depends_on.as_deref(),
+            )
             .map_err(store_err)?;
         return Ok(Json(serde_json::json!({ "ok": true })));
     }
+    let Some(stored) = state
+        .projects
+        .find_open_proposal_slug(&family, &task_key)
+        .map_err(store_err)?
+    else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("no open item '{task_key}' for '{slug}'"),
+        ));
+    };
     let updated = state
         .projects
         .update_proposal(
-            &slug,
+            &stored,
             &task_key,
-            req.title
-                .as_deref()
-                .map(str::trim)
-                .filter(|t| !t.is_empty()),
+            title,
             req.prompt.as_deref(),
             req.acceptance_criteria.as_deref(),
             req.depends_on.as_deref(),
@@ -1380,17 +1422,31 @@ pub async fn cancel_project_task(
             format!("unknown project '{requested}'"),
         ));
     };
-    let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
-    if tracks.iter().any(|track| track.track == task_key) {
+    let family = project_tag_keys(&slug);
+    if let Some(stored) = state
+        .projects
+        .find_track_slug(&family, &task_key)
+        .map_err(store_err)?
+    {
         state
             .projects
-            .set_track(&slug, &task_key, None, Some("cancelled"))
+            .set_track(&stored, &task_key, None, Some("cancelled"))
             .map_err(store_err)?;
         return Ok(Json(serde_json::json!({ "ok": true })));
     }
+    let Some(stored) = state
+        .projects
+        .find_open_proposal_slug(&family, &task_key)
+        .map_err(store_err)?
+    else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("no open item '{task_key}' for '{slug}'"),
+        ));
+    };
     let cancelled = state
         .projects
-        .cancel_proposal(&slug, &task_key)
+        .cancel_proposal(&stored, &task_key)
         .map_err(store_err)?;
     if !cancelled {
         return Err((
@@ -2934,9 +2990,18 @@ fn item_belongs_on_roadmap(item: &super::mission_horizon::ProjectItem) -> bool {
     if item.kind == "task" {
         return item.open;
     }
-    matches!(
-        item.status.as_deref(),
-        Some("open") | Some("active") | Some("proposed") | Some("done")
+    if !item.declared {
+        return false;
+    }
+    // Declared tracks stay on the checklist unless cancelled/closed.
+    // `done` remains (as accepted). Missing, empty, running, in-progress
+    // match `project_items`: they are open.
+    !matches!(
+        item.status
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+        Some("cancelled") | Some("closed")
     )
 }
 
@@ -2970,11 +3035,18 @@ fn item_roadmap_status(item: &super::mission_horizon::ProjectItem) -> &'static s
 
 fn item_as_roadmap_task(item: &super::mission_horizon::ProjectItem) -> serde_json::Value {
     let title = item
-        .desired_state
+        .title
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+        .or_else(|| {
+            item.desired_state
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        })
         .or_else(|| {
             item.attempts
                 .iter()
@@ -2990,6 +3062,8 @@ fn item_as_roadmap_task(item: &super::mission_horizon::ProjectItem) -> serde_jso
         "kind": item.kind,
         "open": item.open,
         "desired_state": item.desired_state,
+        "acceptance_criteria": item.acceptance_criteria,
+        "depends_on": item.depends_on,
         "worker_mission_id": latest.map(|attempt| attempt.id.to_string()),
         "attempts": item.attempts.len(),
         "updated_at": latest.map(|attempt| attempt.updated_at.clone()),
@@ -3676,7 +3750,11 @@ mod tests {
             kind: "track",
             desired_state: Some("land #2332".into()),
             status: Some("open".into()),
+            title: Some("Land #2332".into()),
+            acceptance_criteria: vec!["CI green".into()],
+            depends_on: vec!["freeze".into()],
             open: true,
+            declared: true,
             attempts: vec![ProjectItemAttempt {
                 id: Uuid::nil(),
                 status: "active".into(),
@@ -3688,8 +3766,10 @@ mod tests {
         assert_eq!(item_roadmap_status(&open_live), "running");
         let row = item_as_roadmap_task(&open_live);
         assert_eq!(row["task_key"], "c5");
-        assert_eq!(row["title"], "land #2332");
+        assert_eq!(row["title"], "Land #2332");
         assert_eq!(row["status"], "running");
+        assert_eq!(row["acceptance_criteria"][0], "CI green");
+        assert_eq!(row["depends_on"][0], "freeze");
 
         let done = ProjectItem {
             open: false,
@@ -3704,6 +3784,8 @@ mod tests {
             open: true,
             status: None,
             desired_state: None,
+            title: None,
+            declared: false,
             attempts: vec![ProjectItemAttempt {
                 id: Uuid::nil(),
                 status: "failed".into(),
@@ -3716,6 +3798,116 @@ mod tests {
         assert!(
             !item_belongs_on_roadmap(&zombie),
             "unacknowledged failed attempts are not the roadmap"
+        );
+    }
+
+    #[test]
+    fn declared_open_tracks_stay_on_the_roadmap() {
+        use crate::api::mission_horizon::{track_status_is_open, ProjectItem};
+
+        let declared = |status: Option<&str>| ProjectItem {
+            key: "pr-48".into(),
+            kind: "track",
+            desired_state: None,
+            status: status.map(str::to_string),
+            title: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+            open: track_status_is_open(status),
+            declared: true,
+            attempts: Vec::new(),
+        };
+        for status in [
+            None,
+            Some(""),
+            Some("open"),
+            Some("running"),
+            Some("in-progress"),
+        ] {
+            assert!(
+                item_belongs_on_roadmap(&declared(status)),
+                "declared track status {status:?} belongs on the roadmap"
+            );
+        }
+        assert!(item_belongs_on_roadmap(&declared(Some("done"))));
+        assert!(!item_belongs_on_roadmap(&declared(Some("cancelled"))));
+        assert!(!item_belongs_on_roadmap(&declared(Some("closed"))));
+    }
+
+    #[test]
+    fn plan_request_validates_the_whole_batch_before_any_write() {
+        let ok = ProposalInput {
+            task_key: "land-2332".into(),
+            title: "Land #2332".into(),
+            prompt: Some("merge after certify".into()),
+            acceptance_criteria: vec!["CI green".into()],
+            depends_on: vec!["freeze-head".into()],
+        };
+        let planned = planned_tracks_from_request(&[ok]).expect("valid");
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].title, "Land #2332");
+        assert_eq!(planned[0].desired_state, "merge after certify");
+        assert_eq!(planned[0].acceptance_criteria, vec!["CI green"]);
+        assert_eq!(planned[0].depends_on, vec!["freeze-head"]);
+
+        let first = ProposalInput {
+            task_key: "ok-item".into(),
+            title: "Fine".into(),
+            prompt: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+        };
+        let bad_key = ProposalInput {
+            task_key: "not a key".into(),
+            title: "Bad".into(),
+            prompt: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+        };
+        let err = planned_tracks_from_request(&[first, bad_key]).expect_err("invalid key");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+
+        let empty_title = ProposalInput {
+            task_key: "second".into(),
+            title: "   ".into(),
+            prompt: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+        };
+        let first = ProposalInput {
+            task_key: "ok-item".into(),
+            title: "Fine".into(),
+            prompt: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+        };
+        let err = planned_tracks_from_request(&[first, empty_title]).expect_err("empty title");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.contains("needs a title"));
+
+        // The handler only writes after the whole batch validates.
+        let store = super::super::projects_store::ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity-core", None, None, None, None)
+            .expect("seed");
+        let valid = ProposalInput {
+            task_key: "first".into(),
+            title: "First".into(),
+            prompt: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+        };
+        let invalid = ProposalInput {
+            task_key: "".into(),
+            title: "Second".into(),
+            prompt: None,
+            acceptance_criteria: Vec::new(),
+            depends_on: Vec::new(),
+        };
+        assert!(planned_tracks_from_request(&[valid, invalid]).is_err());
+        assert!(
+            store.tracks("verity-core").expect("tracks").is_empty(),
+            "a rejected batch must not persist earlier entries"
         );
     }
 

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1203,6 +1203,7 @@ pub async fn project_tasks(
     let mut failed = 0usize;
     let rows: Vec<serde_json::Value> = items
         .iter()
+        .filter(|item| item_belongs_on_roadmap(item))
         .map(|item| {
             let status = item_roadmap_status(item);
             match status {
@@ -2920,6 +2921,25 @@ fn item_attempt_is_live(status: &str) -> bool {
     matches!(status, "active" | "pending" | "running" | "awaiting_user")
 }
 
+/// The public roadmap is the plan, not the unacknowledged graveyard.
+/// Controllers still see every attention item on `get_project`.
+fn item_belongs_on_roadmap(item: &super::mission_horizon::ProjectItem) -> bool {
+    if item
+        .attempts
+        .iter()
+        .any(|attempt| item_attempt_is_live(&attempt.status))
+    {
+        return true;
+    }
+    if item.kind == "task" {
+        return item.open;
+    }
+    matches!(
+        item.status.as_deref(),
+        Some("open") | Some("active") | Some("proposed") | Some("done")
+    )
+}
+
 /// Map an item onto the existing `/tasks` row shape the desktop already
 /// renders. Status vocabulary stays the checklist's: accepted / running /
 /// failed / proposed / pending.
@@ -3678,6 +3698,25 @@ mod tests {
             ..open_live.clone()
         };
         assert_eq!(item_roadmap_status(&done), "accepted");
+        assert!(item_belongs_on_roadmap(&open_live));
+        assert!(item_belongs_on_roadmap(&done));
+        let zombie = ProjectItem {
+            open: true,
+            status: None,
+            desired_state: None,
+            attempts: vec![ProjectItemAttempt {
+                id: Uuid::nil(),
+                status: "failed".into(),
+                title: Some("old cert".into()),
+                updated_at: "2026-08-01T00:00:00Z".into(),
+                role: None,
+            }],
+            ..open_live.clone()
+        };
+        assert!(
+            !item_belongs_on_roadmap(&zombie),
+            "unacknowledged failed attempts are not the roadmap"
+        );
     }
 
     const SAMPLE: &str = "[Cron delivery: Verity two-phase Fable/Codex progression]\n\

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -105,11 +105,14 @@ CREATE TABLE IF NOT EXISTS project_grant (
 -- One row per workstream. `desired_state` is what the track should reach;
 -- `status` is where it is. The controller sets these instead of editing prose.
 CREATE TABLE IF NOT EXISTS project_tracks (
-    slug          TEXT NOT NULL,
-    track         TEXT NOT NULL,
-    desired_state TEXT,
-    status        TEXT,
-    updated_at    TEXT NOT NULL,
+    slug                 TEXT NOT NULL,
+    track                TEXT NOT NULL,
+    desired_state        TEXT,
+    status               TEXT,
+    title                TEXT,
+    acceptance_criteria  TEXT,                             -- JSON array of strings
+    depends_on           TEXT,                             -- JSON array of task keys
+    updated_at           TEXT NOT NULL,
     PRIMARY KEY (slug, track)
 );
 
@@ -265,6 +268,21 @@ impl ProjectsStore {
              CASE WHEN answered = 1 THEN 'answered' ELSE 'pending_user' END \
              WHERE status IS NULL",
             [],
+        )?;
+        // 2026-08: planned items persist the submitted title/contract on the
+        // track itself so `plan_project_tasks` is not a silent title-only write.
+        Self::ensure_column(connection, "project_tracks", "title", "title TEXT")?;
+        Self::ensure_column(
+            connection,
+            "project_tracks",
+            "acceptance_criteria",
+            "acceptance_criteria TEXT",
+        )?;
+        Self::ensure_column(
+            connection,
+            "project_tracks",
+            "depends_on",
+            "depends_on TEXT",
         )?;
         Ok(())
     }
@@ -1045,22 +1063,46 @@ impl ProjectsStore {
         let connection = self.lock()?;
         let mut statement = connection
             .prepare(
-                "SELECT track, desired_state, status, updated_at \
+                "SELECT track, desired_state, status, title, acceptance_criteria, depends_on, updated_at \
                  FROM project_tracks WHERE slug = ?1 ORDER BY track",
             )
             .map_err(|e| e.to_string())?;
         let rows = statement
             .query_map(params![slug], |row| {
+                let criteria: Option<String> = row.get(4)?;
+                let depends: Option<String> = row.get(5)?;
                 Ok(ProjectTrack {
                     track: row.get(0)?,
                     desired_state: row.get(1)?,
                     status: row.get(2)?,
-                    updated_at: row.get(3)?,
+                    title: row.get(3)?,
+                    acceptance_criteria: parse_string_list(criteria),
+                    depends_on: parse_string_list(depends),
+                    updated_at: row.get(6)?,
                 })
             })
             .map_err(|e| e.to_string())?;
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| e.to_string())
+    }
+
+    /// Slug that actually owns this track among `slugs` (canonical + aliases).
+    pub fn find_track_slug(&self, slugs: &[String], track: &str) -> Result<Option<String>, String> {
+        let connection = self.lock()?;
+        for slug in slugs {
+            let found: Option<String> = connection
+                .query_row(
+                    "SELECT slug FROM project_tracks WHERE slug = ?1 AND track = ?2",
+                    params![slug, track],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| e.to_string())?;
+            if found.is_some() {
+                return Ok(found);
+            }
+        }
+        Ok(None)
     }
 
     pub fn set_track(
@@ -1070,20 +1112,93 @@ impl ProjectsStore {
         desired_state: Option<&str>,
         status: Option<&str>,
     ) -> Result<(), String> {
+        self.patch_track(slug, track, desired_state, status, None, None, None)
+    }
+
+    /// Partial update: NULL / omitted contract fields leave the stored values.
+    #[allow(clippy::too_many_arguments)]
+    pub fn patch_track(
+        &self,
+        slug: &str,
+        track: &str,
+        desired_state: Option<&str>,
+        status: Option<&str>,
+        title: Option<&str>,
+        acceptance_criteria: Option<&[String]>,
+        depends_on: Option<&[String]>,
+    ) -> Result<(), String> {
         let now = Utc::now().to_rfc3339();
+        let criteria = acceptance_criteria
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| e.to_string())?;
+        let depends = depends_on
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| e.to_string())?;
         let connection = self.lock()?;
         connection
             .execute(
-                "INSERT INTO project_tracks (slug, track, desired_state, status, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5) \
+                "INSERT INTO project_tracks \
+                   (slug, track, desired_state, status, title, acceptance_criteria, depends_on, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
                  ON CONFLICT(slug, track) DO UPDATE SET \
                    desired_state = COALESCE(excluded.desired_state, project_tracks.desired_state), \
                    status = COALESCE(excluded.status, project_tracks.status), \
+                   title = COALESCE(excluded.title, project_tracks.title), \
+                   acceptance_criteria = COALESCE(excluded.acceptance_criteria, project_tracks.acceptance_criteria), \
+                   depends_on = COALESCE(excluded.depends_on, project_tracks.depends_on), \
                    updated_at = excluded.updated_at",
-                params![slug, track, desired_state, status, now],
+                params![
+                    slug,
+                    track,
+                    desired_state,
+                    status,
+                    title,
+                    criteria,
+                    depends,
+                    now
+                ],
             )
             .map_err(|e| e.to_string())?;
         Ok(())
+    }
+
+    /// Plan items from chat: latest title + contract win, status stays `open`
+    /// unless a later `set_track` moved it. One transaction so a later invalid
+    /// caller never leaves a prefix of the batch persisted.
+    pub fn upsert_planned_tracks(&self, slug: &str, items: &[PlannedTrack]) -> Result<(), String> {
+        let now = Utc::now().to_rfc3339();
+        let mut connection = self.lock()?;
+        let tx = connection.transaction().map_err(|e| e.to_string())?;
+        for item in items {
+            let criteria =
+                serde_json::to_string(&item.acceptance_criteria).map_err(|e| e.to_string())?;
+            let depends = serde_json::to_string(&item.depends_on).map_err(|e| e.to_string())?;
+            tx.execute(
+                "INSERT INTO project_tracks \
+                   (slug, track, desired_state, status, title, acceptance_criteria, depends_on, updated_at) \
+                 VALUES (?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7) \
+                 ON CONFLICT(slug, track) DO UPDATE SET \
+                   desired_state = excluded.desired_state, \
+                   status = 'open', \
+                   title = excluded.title, \
+                   acceptance_criteria = excluded.acceptance_criteria, \
+                   depends_on = excluded.depends_on, \
+                   updated_at = excluded.updated_at",
+                params![
+                    slug,
+                    item.track,
+                    item.desired_state,
+                    item.title,
+                    criteria,
+                    depends,
+                    now
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+        }
+        tx.commit().map_err(|e| e.to_string())
     }
 
     pub fn get_grant(&self, slug: &str) -> Result<Option<ProjectGrant>, String> {
@@ -1272,6 +1387,30 @@ impl ProjectsStore {
             .map_err(|e| e.to_string())?;
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| e.to_string())
+    }
+
+    /// Slug that actually owns this leftover proposal among `slugs`.
+    pub fn find_open_proposal_slug(
+        &self,
+        slugs: &[String],
+        task_key: &str,
+    ) -> Result<Option<String>, String> {
+        let connection = self.lock()?;
+        for slug in slugs {
+            let found: Option<String> = connection
+                .query_row(
+                    "SELECT slug FROM project_roadmap_proposals \
+                     WHERE slug = ?1 AND task_key = ?2 AND status = 'proposed'",
+                    params![slug, task_key],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| e.to_string())?;
+            if found.is_some() {
+                return Ok(found);
+            }
+        }
+        Ok(None)
     }
 
     /// Record a decision and return its `at` key. The legacy `answered` flag is
@@ -1672,6 +1811,16 @@ pub struct NewProposal {
     pub depends_on: Vec<String>,
 }
 
+/// Input for `upsert_planned_tracks` — the chat-submitted item contract.
+#[derive(Debug, Clone)]
+pub struct PlannedTrack {
+    pub track: String,
+    pub title: String,
+    pub desired_state: String,
+    pub acceptance_criteria: Vec<String>,
+    pub depends_on: Vec<String>,
+}
+
 /// JSON-array column → Vec, treating NULL/garbage as empty rather than erroring
 /// the whole roadmap read.
 fn parse_string_list(raw: Option<String>) -> Vec<String> {
@@ -1709,6 +1858,12 @@ pub struct ProjectTrack {
     pub desired_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub acceptance_criteria: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
     pub updated_at: String,
 }
 
@@ -2886,5 +3041,120 @@ mod tests {
         // Newest first, and the oldest batch (including s1) was evicted.
         assert_eq!(rows[0].at, "2026-08-05T10:59:00Z");
         assert!(rows.iter().all(|row| row.session_id == "s2"));
+    }
+
+    #[test]
+    fn planned_tracks_persist_the_submitted_contract() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity-core", None, None, None, None)
+            .expect("seed");
+        store
+            .upsert_planned_tracks(
+                "verity-core",
+                &[PlannedTrack {
+                    track: "land-2332".into(),
+                    title: "Land #2332".into(),
+                    desired_state: "merge after certify".into(),
+                    acceptance_criteria: vec!["CI green".into(), "review resolved".into()],
+                    depends_on: vec!["freeze-head".into()],
+                }],
+            )
+            .expect("plan");
+        let tracks = store.tracks("verity-core").expect("tracks");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].title.as_deref(), Some("Land #2332"));
+        assert_eq!(
+            tracks[0].desired_state.as_deref(),
+            Some("merge after certify")
+        );
+        assert_eq!(tracks[0].status.as_deref(), Some("open"));
+        assert_eq!(
+            tracks[0].acceptance_criteria,
+            vec!["CI green", "review resolved"]
+        );
+        assert_eq!(tracks[0].depends_on, vec!["freeze-head"]);
+
+        store
+            .upsert_planned_tracks(
+                "verity-core",
+                &[PlannedTrack {
+                    track: "land-2332".into(),
+                    title: "Land #2332 (retry)".into(),
+                    desired_state: "merge after certify".into(),
+                    acceptance_criteria: vec!["exact-head clean".into()],
+                    depends_on: vec![],
+                }],
+            )
+            .expect("replan");
+        let tracks = store.tracks("verity-core").expect("re-read");
+        assert_eq!(tracks[0].title.as_deref(), Some("Land #2332 (retry)"));
+        assert_eq!(tracks[0].acceptance_criteria, vec!["exact-head clean"]);
+        assert!(tracks[0].depends_on.is_empty());
+    }
+
+    #[test]
+    fn find_open_proposal_slug_uses_the_stored_alias() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_proposals(
+                "verity",
+                &[NewProposal {
+                    task_key: "docs".into(),
+                    title: "Write the guide".into(),
+                    prompt: None,
+                    acceptance_criteria: vec!["published".into()],
+                    depends_on: vec![],
+                }],
+            )
+            .expect("seed alias proposal");
+        let keys = vec!["verity-core".into(), "verity".into()];
+        assert_eq!(
+            store
+                .find_open_proposal_slug(&keys, "docs")
+                .expect("lookup")
+                .as_deref(),
+            Some("verity")
+        );
+        assert!(store
+            .update_proposal(
+                "verity",
+                "docs",
+                Some("Write the core guide"),
+                None,
+                None,
+                None
+            )
+            .expect("update under alias"));
+        let open = store.list_open_proposals("verity").expect("list");
+        assert_eq!(open[0].title, "Write the core guide");
+        assert!(!store
+            .update_proposal("verity-core", "docs", Some("miss"), None, None, None)
+            .expect("canonical miss"));
+    }
+
+    #[test]
+    fn an_old_tracks_table_gains_the_plan_contract_columns() {
+        let connection = Connection::open_in_memory().expect("conn");
+        connection
+            .execute_batch(
+                "CREATE TABLE project_tracks (
+                    slug TEXT NOT NULL, track TEXT NOT NULL,
+                    desired_state TEXT, status TEXT, updated_at TEXT NOT NULL,
+                    PRIMARY KEY (slug, track));
+                 INSERT INTO project_tracks VALUES
+                    ('lido', 'P-ETH-1', 'proved', 'in-progress', '2026-08-01T00:00:00Z');",
+            )
+            .expect("old schema");
+        ProjectsStore::initialize(&connection).expect("migrate");
+        let store = ProjectsStore {
+            connection: Mutex::new(connection),
+        };
+        let tracks = store.tracks("lido").expect("read");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track, "P-ETH-1");
+        assert_eq!(tracks[0].status.as_deref(), Some("in-progress"));
+        assert!(tracks[0].title.is_none());
+        assert!(tracks[0].acceptance_criteria.is_empty());
     }
 }


### PR DESCRIPTION
## Why

Lido showed ROADMAP 5/5 done (fossil boss `board_tasks`) while live guarantee→tx work was still open. Verity showed « No planned tasks yet » while C5/#2332 was live. Same bug: the rail read a third ledger (`board_tasks` + `plan_project_tasks` proposals). Hyphen-prefix matching also made `verity` swallow `verity-lido`.

## What

- `GET /api/projects/:slug/tasks` returns the **item** inventory (declared tracks + leftover proposals + live attempts), not boss board tasks.
- Aliases resolve to the canonical roster slug (`lido` / `lido-audit` → `verity-lido`, `verity` → `verity-core`). No `slug-` prefix family.
- `plan_project_tasks` upserts `project_tracks` (the item table). Proposals are read-only leftovers.
- Public `/tasks` keeps the plan (live + declared). `get_project` still lists attention so controllers can acknowledge the graveyard.
- Mission project patches are canonicalized. Cancelled tracks are not open.
- Skills (`hermes-mission-control` 1.11, `controllers-policy`): one list, one controller, no roadmap watcher, no new slug for a workstream.

## Prod

Deployed `87ff88a06e59` to `sandboxed-sh-prod`. Verified:

| slug | resolves | `/tasks` |
|---|---|---|
| `lido`, `lido-audit`, `verity-lido` | `verity-lido` | 7 running (re-pin, P-DEPOSIT-1, P-ALLOC-2, P-SSZ-1, #69 cert) — not 5/5 |
| `verity`, `verity-core` | `verity-core` | 3 running (C5 #2332, #2330 audit, tier2-helpers) — not empty |

Companion: [hermes-agent#110](https://github.com/Th0rgal/hermes-agent/pull/110) (origin-wake) and the one-list desktop PR on the fork.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the authoritative roadmap source and slug resolution for all project UIs and controllers; wrong filtering or alias rules would mis-route work, though behavior is heavily covered by new unit tests.
> 
> **Overview**
> Fixes misleading project rails (e.g. “5/5 done” vs live work, or empty task lists while missions run) by making **`GET/POST/PATCH/DELETE /api/projects/:slug/tasks` and `get_project` use the same item inventory**—declared `project_tracks`, leftover proposals, and attention-horizon mission attempts—not boss `board_tasks`.
> 
> **API & store:** `plan_project_tasks` **upserts `project_tracks`** with title, acceptance criteria, and depends-on (schema migration + transactional batch validation). Task edit/cancel targets tracks first, with proposal fallback. Slugs resolve through **roster aliases** (`verity` → `verity-core`, `lido-audit` → `verity-lido`) without hyphen-prefix families swallowing siblings; mission project patches are canonicalized the same way. Public `/tasks` filters to the plan (live + declared items); mission-only zombie failures stay off the checklist while `get_project` still exposes full attention.
> 
> **Horizon model:** `ProjectItem` carries contract fields and `declared` vs mission-only rows; **cancelled/closed tracks are not open** (`track_status_is_open`).
> 
> **Skills:** `controllers-policy` and `hermes-mission-control` 1.11 document **one list, one controller**—no roadmap-watcher crons or `/goal` as a second program; canonical roster slugs and `track` as the item key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c16c0c8932c37b21a90c25f065d93e8cac8733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->