### PR TITLE
Measure mission storage on the workspace filesystem

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -221,7 +221,8 @@ JWT_TTL_DAYS=30
 # deployed binary (older ones are pruned after a successful deploy).
 # DEPLOY_BACKUP_KEEP=2
 #
-# Disk health thresholds (percent of root filesystem used). At warn, alerts
+# Disk health thresholds (percent of the filesystem backing local mission
+# workspaces). At warn, alerts
 # fire; at critical, new mission creation is refused (DISK_ADMISSION_ENABLED=0
 # to bypass). Set DISK_ADMISSION_AT_WARN=1 on build-heavy hosts to stop earlier.
 # Alerts repeat every DISK_ALERT_REPEAT_HOURS while elevated.
@@ -232,8 +233,13 @@ JWT_TTL_DAYS=30
 # Local disk-heavy mission requests can declare `estimated_disk_gib`; they are
 # rejected before creation if this emergency floor would be crossed. Setting a
 # default estimate makes omitted estimates fail safe for all local missions.
-# MISSION_DISK_EMERGENCY_RESERVE_GB=64
-# MISSION_DISK_DEFAULT_ESTIMATE_GIB=
+# Root for newly-created default-host mission scratch/workspaces. It must be an
+# existing writable absolute directory; symlinks are canonicalized and an
+# invalid/unwritable value safely falls back to WORKING_DIR. Existing workspace
+# records and active mission directories are never moved.
+# MISSION_WORKSPACE_ROOT=/srv/sandboxed-storage
+# MISSION_DISK_EMERGENCY_RESERVE_GB=150
+# MISSION_DISK_DEFAULT_ESTIMATE_GIB=64
 # DISK_ALERT_REPEAT_HOURS=24
 # Executing mission-workspace GC is opt-in. The scan defaults to hourly; lower
 # the interval on high-churn build hosts. Default retention is 1 day for

--- a/docs/STORAGE_LIFECYCLE.md
+++ b/docs/STORAGE_LIFECYCLE.md
@@ -49,13 +49,25 @@ matching live scopes before changing a workspace shared by concurrent missions.
 
 ## Admission and continuity
 
-By default, disk warning is not a portfolio-wide stop. Set
+By default, disk warning is not a portfolio-wide stop. Local mission placement
+uses `MISSION_WORKSPACE_ROOT` when it names an existing writable absolute
+directory (for example `/srv/sandboxed-storage`). The service canonicalizes the
+directory, including a deliberate symlink, and falls back safely to the
+workspace's recorded root if it is missing, unwritable, relative, or contains
+path traversal. It never moves or deletes existing workspace records or active
+mission directories; an already-existing legacy mission directory continues to
+be used.
+
+Admission and fleet health measure the `statvfs` filesystem that backs this
+selected path, not `/`. Their non-secret output includes the canonical path,
+filesystem identifier, free GiB, and required GiB. Set
 `DISK_ADMISSION_AT_WARN=1` on build-heavy hosts to refuse all new missions at
 Warn instead of waiting for Critical. A local disk-heavy mission should set
 `estimated_disk_gib`; the API rejects it when its estimate would cross
-`MISSION_DISK_EMERGENCY_RESERVE_GB` (default 64 GiB).
-`MISSION_DISK_DEFAULT_ESTIMATE_GIB` supplies a fail-safe estimate when a local
-request omits one. Critical level always rejects all new local missions.
+`MISSION_DISK_EMERGENCY_RESERVE_GB` (default 150 GiB).
+`MISSION_DISK_DEFAULT_ESTIMATE_GIB` defaults to 64 GiB, so a local request
+without an explicit estimate remains fail-closed. Critical level always rejects
+all new local missions.
 
 For a high-churn Lean/build host, a deliberately aggressive profile is:
 
@@ -84,3 +96,12 @@ oversized overlays fail closed. Remote placement reserves the declared scratch
 estimate, while runners reuse content-addressed checkouts and dependency-only
 Lake cache slots. This lets a dirty proof lane continue on a roomy node without
 duplicating a fresh Mathlib tree on the production host.
+
+## Future placement scoring (design only)
+
+After the P0 filesystem admission work, placement can consume one unified
+scorecard: hard constraints first (workspace isolation, reachable runner,
+filesystem capacity after estimate plus reserve), then soft penalties for a
+GitHub runner being busy or highly loaded. Busy/load must only rank otherwise
+admissible candidates lower; it must never become an admission rejection or
+weaken the local filesystem fail-closed checks.

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -98,9 +98,23 @@ fn resolve_base_work_dir(
         if nspawn_container && dir.is_absolute() && !dir.starts_with(workspace_path) {
             let host_dir = workspace_path.join(dir.strip_prefix("/").unwrap_or(&dir));
             if host_dir.exists() {
+                crate::workspace::verify_explicit_mission_working_directory_owner(
+                    workspace, &host_dir,
+                )
+                .map_err(|error| {
+                    format!(
+                        "explicit working_directory owner is unavailable or unverified: {error}"
+                    )
+                })?;
                 return Ok(host_dir);
             }
         } else if dir.exists() {
+            crate::workspace::verify_explicit_mission_working_directory_owner(workspace, &dir)
+                .map_err(|error| {
+                    format!(
+                        "explicit working_directory owner is unavailable or unverified: {error}"
+                    )
+                })?;
             return Ok(dir);
         }
     }
@@ -477,17 +491,14 @@ mod tests {
         let host = root.path().join("workspaces/mission-abcd/repo");
         std::fs::create_dir_all(&host).unwrap();
         let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
-        let resolved = resolve_base_work_dir(
-            Some(guest),
-            &workspace,
-            true,
-            Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
-        );
+        let mission = Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap();
+        crate::workspace::persist_mission_workspace_root(&workspace, mission, root.path()).unwrap();
+        let resolved = resolve_base_work_dir(Some(guest), &workspace, true, mission);
         assert_eq!(resolved.unwrap(), host);
     }
 
     #[test]
-    fn host_working_directory_is_left_unchanged() {
+    fn host_working_directory_without_a_persisted_mission_owner_is_rejected() {
         let root = tempdir().unwrap();
         let repo = root.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
@@ -498,7 +509,7 @@ mod tests {
             false,
             Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
         );
-        assert_eq!(resolved.unwrap(), repo);
+        assert!(resolved.is_err());
     }
 
     #[test]

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -79,10 +79,11 @@ pub struct AskThreadDetail {
 /// model to burn its whole iteration budget just locating the project.
 fn resolve_base_work_dir(
     working_directory: Option<&str>,
-    workspace_path: &std::path::Path,
+    workspace: &crate::workspace::Workspace,
     nspawn_container: bool,
     mission_id: Uuid,
 ) -> std::path::PathBuf {
+    let workspace_path = &workspace.path;
     if let Some(dir) = working_directory.map(std::path::PathBuf::from) {
         // Mission metadata records the path as the harness saw it. In an
         // nspawn workspace that is a guest path such as
@@ -99,7 +100,7 @@ fn resolve_base_work_dir(
         }
     }
     let per_mission_dir =
-        crate::workspace::mission_workspace_dir_for_root(workspace_path, mission_id);
+        crate::workspace::mission_workspace_dir_for_workspace(workspace, mission_id);
     if per_mission_dir.exists() {
         per_mission_dir
     } else {
@@ -175,7 +176,7 @@ pub async fn ask_send(
         && crate::workspace::use_nspawn_for_workspace(&workspace);
     let base_work_dir = resolve_base_work_dir(
         mission.working_directory.as_deref(),
-        &workspace.path,
+        &workspace,
         nspawn_container,
         mission_id,
     );
@@ -303,7 +304,7 @@ pub async fn ask_send_stream(
         && crate::workspace::use_nspawn_for_workspace(&workspace);
     let base_work_dir = resolve_base_work_dir(
         mission.working_directory.as_deref(),
-        &workspace.path,
+        &workspace,
         nspawn_container,
         mission_id,
     );
@@ -461,9 +462,10 @@ mod tests {
         let guest = "/workspaces/mission-abcd/repo";
         let host = root.path().join("workspaces/mission-abcd/repo");
         std::fs::create_dir_all(&host).unwrap();
+        let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
         let resolved = resolve_base_work_dir(
             Some(guest),
-            root.path(),
+            &workspace,
             true,
             Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
         );
@@ -475,9 +477,10 @@ mod tests {
         let root = tempdir().unwrap();
         let repo = root.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
+        let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
         let resolved = resolve_base_work_dir(
             repo.to_str(),
-            root.path(),
+            &workspace,
             false,
             Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
         );

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -487,8 +487,8 @@ mod tests {
     #[test]
     fn nspawn_working_directory_is_resolved_inside_container_root() {
         let root = tempdir().unwrap();
-        let guest = "/workspaces/mission-abcd/repo";
-        let host = root.path().join("workspaces/mission-abcd/repo");
+        let guest = "/workspaces/mission-abcd0000/repo";
+        let host = root.path().join("workspaces/mission-abcd0000/repo");
         std::fs::create_dir_all(&host).unwrap();
         let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
         let mission = Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap();

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -110,7 +110,10 @@ fn resolve_base_work_dir(
     if per_mission_dir.exists() {
         Ok(per_mission_dir)
     } else {
-        Ok(workspace_path.to_path_buf())
+        Err(format!(
+            "mission workspace is unavailable or not prepared: {}",
+            per_mission_dir.display()
+        ))
     }
 }
 
@@ -514,5 +517,13 @@ mod tests {
         let error = resolve_base_work_dir(None, &workspace, false, mission).unwrap_err();
         assert!(error.contains("persisted mission workspace root is unavailable"));
         assert_ne!(error, workspace.path.display().to_string());
+    }
+
+    #[test]
+    fn missing_selected_mission_directory_rejects_ask_fallback() {
+        let root = tempdir().unwrap();
+        let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
+        let error = resolve_base_work_dir(None, &workspace, false, Uuid::new_v4()).unwrap_err();
+        assert!(error.contains("not prepared"));
     }
 }

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -84,6 +84,11 @@ fn resolve_base_work_dir(
     mission_id: Uuid,
 ) -> Result<std::path::PathBuf, String> {
     let workspace_path = &workspace.path;
+    // Validate before accepting an explicit working directory: it can be a
+    // child of a mounted persisted root, and `exists()` alone would accept a
+    // replacement tree left at the same path after an unmount.
+    crate::workspace::ensure_persisted_mission_root_is_available(workspace, mission_id)
+        .map_err(|error| format!("persisted mission workspace root is unavailable: {error}"))?;
     if let Some(dir) = working_directory.map(std::path::PathBuf::from) {
         // Mission metadata records the path as the harness saw it. In an
         // nspawn workspace that is a guest path such as
@@ -103,8 +108,6 @@ fn resolve_base_work_dir(
     // mission preparation.  Ask is a sidecar, but running its shell in a
     // newly selected workspace after a mounted persisted root disappears is
     // still a write/read against the wrong mission tree.
-    crate::workspace::ensure_persisted_mission_root_is_available(workspace, mission_id)
-        .map_err(|error| format!("persisted mission workspace root is unavailable: {error}"))?;
     let per_mission_dir =
         crate::workspace::mission_workspace_dir_for_workspace(workspace, mission_id);
     if per_mission_dir.exists() {

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -512,7 +512,11 @@ mod tests {
         std::fs::create_dir_all(&registry_dir).unwrap();
         std::fs::write(
             registry_dir.join("mission-workspace-roots.json"),
-            serde_json::json!({ mission.to_string(): storage }).to_string(),
+            serde_json::json!({ mission.to_string(): {
+                "path": storage,
+                "filesystem_identity": crate::workspace::filesystem_identity(&storage).unwrap(),
+            }})
+            .to_string(),
         )
         .unwrap();
         std::fs::remove_dir(&storage).unwrap();

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -82,7 +82,7 @@ fn resolve_base_work_dir(
     workspace: &crate::workspace::Workspace,
     nspawn_container: bool,
     mission_id: Uuid,
-) -> std::path::PathBuf {
+) -> Result<std::path::PathBuf, String> {
     let workspace_path = &workspace.path;
     if let Some(dir) = working_directory.map(std::path::PathBuf::from) {
         // Mission metadata records the path as the harness saw it. In an
@@ -93,18 +93,24 @@ fn resolve_base_work_dir(
         if nspawn_container && dir.is_absolute() && !dir.starts_with(workspace_path) {
             let host_dir = workspace_path.join(dir.strip_prefix("/").unwrap_or(&dir));
             if host_dir.exists() {
-                return host_dir;
+                return Ok(host_dir);
             }
         } else if dir.exists() {
-            return dir;
+            return Ok(dir);
         }
     }
+    // This has to use the same fail-closed persisted-placement check as
+    // mission preparation.  Ask is a sidecar, but running its shell in a
+    // newly selected workspace after a mounted persisted root disappears is
+    // still a write/read against the wrong mission tree.
+    crate::workspace::ensure_persisted_mission_root_is_available(workspace, mission_id)
+        .map_err(|error| format!("persisted mission workspace root is unavailable: {error}"))?;
     let per_mission_dir =
         crate::workspace::mission_workspace_dir_for_workspace(workspace, mission_id);
     if per_mission_dir.exists() {
-        per_mission_dir
+        Ok(per_mission_dir)
     } else {
-        workspace_path.to_path_buf()
+        Ok(workspace_path.to_path_buf())
     }
 }
 
@@ -179,7 +185,8 @@ pub async fn ask_send(
         &workspace,
         nspawn_container,
         mission_id,
-    );
+    )
+    .map_err(internal)?;
 
     // Optional sandbox-copy isolation: writes go to a throwaway worktree/copy.
     let setup_exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
@@ -307,7 +314,8 @@ pub async fn ask_send_stream(
         &workspace,
         nspawn_container,
         mission_id,
-    );
+    )
+    .map_err(internal)?;
 
     // Optional sandbox-copy isolation (same as the synchronous path): set up a
     // throwaway worktree, run the streamed turn in it, tear it down after.
@@ -469,7 +477,7 @@ mod tests {
             true,
             Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
         );
-        assert_eq!(resolved, host);
+        assert_eq!(resolved.unwrap(), host);
     }
 
     #[test]
@@ -484,6 +492,27 @@ mod tests {
             false,
             Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
         );
-        assert_eq!(resolved, repo);
+        assert_eq!(resolved.unwrap(), repo);
+    }
+
+    #[test]
+    fn unavailable_persisted_root_rejects_ask_fallback() {
+        let root = tempdir().unwrap();
+        let storage = root.path().join("temporarily-unmounted-storage");
+        std::fs::create_dir_all(&storage).unwrap();
+        let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
+        let mission = Uuid::new_v4();
+        let registry_dir = workspace.path.join(".sandboxed-sh");
+        std::fs::create_dir_all(&registry_dir).unwrap();
+        std::fs::write(
+            registry_dir.join("mission-workspace-roots.json"),
+            serde_json::json!({ mission.to_string(): storage }).to_string(),
+        )
+        .unwrap();
+        std::fs::remove_dir(&storage).unwrap();
+
+        let error = resolve_base_work_dir(None, &workspace, false, mission).unwrap_err();
+        assert!(error.contains("persisted mission workspace root is unavailable"));
+        assert_ne!(error, workspace.path.display().to_string());
     }
 }

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -82,6 +82,7 @@ fn resolve_base_work_dir(
     workspace: &crate::workspace::Workspace,
     nspawn_container: bool,
     mission_id: Uuid,
+    parent_mission_id: Option<Uuid>,
 ) -> Result<std::path::PathBuf, String> {
     let workspace_path = &workspace.path;
     // Validate before accepting an explicit working directory: it can be a
@@ -89,6 +90,10 @@ fn resolve_base_work_dir(
     // replacement tree left at the same path after an unmount.
     crate::workspace::ensure_persisted_mission_root_is_available(workspace, mission_id)
         .map_err(|error| format!("persisted mission workspace root is unavailable: {error}"))?;
+    let mut owner_candidates = vec![mission_id];
+    if let Some(parent) = parent_mission_id {
+        owner_candidates.push(parent);
+    }
     if let Some(dir) = working_directory.map(std::path::PathBuf::from) {
         // Mission metadata records the path as the harness saw it. In an
         // nspawn workspace that is a guest path such as
@@ -98,9 +103,20 @@ fn resolve_base_work_dir(
         if nspawn_container && dir.is_absolute() && !dir.starts_with(workspace_path) {
             let host_dir = workspace_path.join(dir.strip_prefix("/").unwrap_or(&dir));
             if host_dir.exists() {
-                crate::workspace::verify_explicit_mission_working_directory_owner(
-                    workspace, &host_dir,
+                crate::workspace::verify_or_adopt_explicit_mission_working_directory(
+                    workspace,
+                    &host_dir,
+                    &owner_candidates,
                 )
+                .or_else(|error| {
+                    if crate::workspace::is_generated_mission_directory_under_known_root(
+                        workspace, &host_dir,
+                    ) {
+                        Ok(mission_id)
+                    } else {
+                        Err(error)
+                    }
+                })
                 .map_err(|error| {
                     format!(
                         "explicit working_directory owner is unavailable or unverified: {error}"
@@ -109,12 +125,23 @@ fn resolve_base_work_dir(
                 return Ok(host_dir);
             }
         } else if dir.exists() {
-            crate::workspace::verify_explicit_mission_working_directory_owner(workspace, &dir)
-                .map_err(|error| {
-                    format!(
-                        "explicit working_directory owner is unavailable or unverified: {error}"
-                    )
-                })?;
+            crate::workspace::verify_or_adopt_explicit_mission_working_directory(
+                workspace,
+                &dir,
+                &owner_candidates,
+            )
+            .or_else(|error| {
+                if crate::workspace::is_generated_mission_directory_under_known_root(
+                    workspace, &dir,
+                ) {
+                    Ok(mission_id)
+                } else {
+                    Err(error)
+                }
+            })
+            .map_err(|error| {
+                format!("explicit working_directory owner is unavailable or unverified: {error}")
+            })?;
             return Ok(dir);
         }
     }
@@ -205,6 +232,7 @@ pub async fn ask_send(
         &workspace,
         nspawn_container,
         mission_id,
+        mission.parent_mission_id,
     )
     .map_err(internal)?;
 
@@ -334,6 +362,7 @@ pub async fn ask_send_stream(
         &workspace,
         nspawn_container,
         mission_id,
+        mission.parent_mission_id,
     )
     .map_err(internal)?;
 
@@ -493,7 +522,7 @@ mod tests {
         let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
         let mission = Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap();
         crate::workspace::persist_mission_workspace_root(&workspace, mission, root.path()).unwrap();
-        let resolved = resolve_base_work_dir(Some(guest), &workspace, true, mission);
+        let resolved = resolve_base_work_dir(Some(guest), &workspace, true, mission, None);
         assert_eq!(resolved.unwrap(), host);
     }
 
@@ -508,6 +537,7 @@ mod tests {
             &workspace,
             false,
             Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
+            None,
         );
         assert!(resolved.is_err());
     }
@@ -542,7 +572,7 @@ mod tests {
             .join("worker-worktree");
         std::fs::create_dir_all(&explicit).unwrap();
         let error =
-            resolve_base_work_dir(explicit.to_str(), &workspace, false, mission).unwrap_err();
+            resolve_base_work_dir(explicit.to_str(), &workspace, false, mission, None).unwrap_err();
         assert!(error.contains("persisted mission workspace root is unavailable"));
         assert_ne!(error, workspace.path.display().to_string());
 
@@ -559,7 +589,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let error = resolve_base_work_dir(None, &workspace, false, mission).unwrap_err();
+        let error = resolve_base_work_dir(None, &workspace, false, mission, None).unwrap_err();
         assert!(error.contains("persisted mission workspace root is unavailable"));
         assert!(!workspace
             .path
@@ -572,7 +602,25 @@ mod tests {
     fn missing_selected_mission_directory_rejects_ask_fallback() {
         let root = tempdir().unwrap();
         let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
-        let error = resolve_base_work_dir(None, &workspace, false, Uuid::new_v4()).unwrap_err();
+        let error =
+            resolve_base_work_dir(None, &workspace, false, Uuid::new_v4(), None).unwrap_err();
         assert!(error.contains("not prepared"));
+    }
+
+    #[test]
+    fn legacy_explicit_generated_directory_is_adopted_without_a_registry() {
+        let root = tempdir().unwrap();
+        let workspace = crate::workspace::Workspace::default_host(root.path().to_path_buf());
+        let mission = Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap();
+        let worktree = crate::workspace::mission_workspace_dir_for_root(root.path(), mission)
+            .join("worker-worktree");
+        std::fs::create_dir_all(&worktree).unwrap();
+
+        let resolved =
+            resolve_base_work_dir(worktree.to_str(), &workspace, false, mission, None).unwrap();
+        assert_eq!(resolved, worktree);
+        assert!(
+            crate::workspace::mission_workspace_dir_for_workspace(&workspace, mission).exists()
+        );
     }
 }

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -514,7 +514,11 @@ mod tests {
             registry_dir.join("mission-workspace-roots.json"),
             serde_json::json!({ mission.to_string(): {
                 "path": storage,
-                "filesystem_identity": crate::workspace::filesystem_identity(&storage).unwrap(),
+                // Model the identity that was captured from the volume before
+                // it was unmounted.  The test filesystem can immediately
+                // reuse a deleted directory's inode, so an actual mount
+                // replacement needs a deterministic recorded identity here.
+                "filesystem_identity": "dev:before-unmount",
             }})
             .to_string(),
         )

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -517,7 +517,13 @@ mod tests {
         .unwrap();
         std::fs::remove_dir(&storage).unwrap();
 
-        let error = resolve_base_work_dir(None, &workspace, false, mission).unwrap_err();
+        let explicit = storage
+            .join("workspaces")
+            .join(format!("mission-{}", &mission.to_string()[..8]))
+            .join("worker-worktree");
+        std::fs::create_dir_all(&explicit).unwrap();
+        let error =
+            resolve_base_work_dir(explicit.to_str(), &workspace, false, mission).unwrap_err();
         assert!(error.contains("persisted mission workspace root is unavailable"));
         assert_ne!(error, workspace.path.display().to_string());
 

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -499,7 +499,7 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_persisted_root_rejects_ask_fallback() {
+    fn unavailable_or_replaced_persisted_root_rejects_ask_fallback() {
         let root = tempdir().unwrap();
         let storage = root.path().join("temporarily-unmounted-storage");
         std::fs::create_dir_all(&storage).unwrap();
@@ -517,6 +517,27 @@ mod tests {
         let error = resolve_base_work_dir(None, &workspace, false, mission).unwrap_err();
         assert!(error.contains("persisted mission workspace root is unavailable"));
         assert_ne!(error, workspace.path.display().to_string());
+
+        // An unmount can leave the mountpoint itself behind.  The path is
+        // reachable again here, but represents a different filesystem and
+        // must remain just as unavailable to Ask.
+        std::fs::create_dir_all(&storage).unwrap();
+        std::fs::write(
+            registry_dir.join("mission-workspace-roots.json"),
+            serde_json::json!({ mission.to_string(): {
+                "path": storage,
+                "filesystem_identity": "dev:before-unmount"
+            }})
+            .to_string(),
+        )
+        .unwrap();
+        let error = resolve_base_work_dir(None, &workspace, false, mission).unwrap_err();
+        assert!(error.contains("persisted mission workspace root is unavailable"));
+        assert!(!workspace
+            .path
+            .join("workspaces")
+            .join(format!("mission-{}", &mission.to_string()[..8]))
+            .exists());
     }
 
     #[test]

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1110,6 +1110,7 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     working_directory: None,
                     scheduling: Default::default(),
                     requires_local_disk: true,
+                    estimated_disk_gib: None,
                     respond: tx,
                 })
                 .await

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1111,6 +1111,7 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     scheduling: Default::default(),
                     requires_local_disk: true,
                     estimated_disk_gib: None,
+                    admission_tags: Vec::new(),
                     respond: tx,
                 })
                 .await

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -1659,6 +1659,26 @@ async fn spawn_task_worker(
     } else {
         None
     };
+    let assigned_id = Uuid::new_v4();
+    if let Some((admission_guard, mut reservation, workspace)) = admission {
+        reservation.mission_id = assigned_id;
+        reservation.workspace_dir = Some(crate::workspace::mission_workspace_dir_for_workspace(
+            &workspace,
+            assigned_id,
+        ));
+        let mut ledger =
+            super::read_disk_reservation_ledger(&control_hub.expect("admission hub").config)?;
+        ledger.reservations.insert(assigned_id, reservation);
+        if let Err(error) = super::write_disk_reservation_ledger(
+            &control_hub.expect("admission hub").config,
+            &ledger,
+        ) {
+            return Err(format!(
+                "board worker creation rolled back: persist disk admission ledger: {error}"
+            ));
+        }
+        drop(admission_guard);
+    }
     let mission = mission_store
         .create_mission_with_parent_and_placement(
             Some(&format!("[{}] {}", task.task_key, task.title)),
@@ -1672,29 +1692,9 @@ async fn spawn_task_worker(
             Some(task.boss_mission_id),
             task.working_directory.as_deref(),
             true,
+            Some(assigned_id),
         )
         .await?;
-    if let Some((admission_guard, mut reservation, workspace)) = admission {
-        reservation.mission_id = mission.id;
-        reservation.workspace_dir = Some(crate::workspace::mission_workspace_dir_for_workspace(
-            &workspace, mission.id,
-        ));
-        let mut ledger =
-            super::read_disk_reservation_ledger(&control_hub.expect("admission hub").config)?;
-        ledger.reservations.insert(mission.id, reservation);
-        if let Err(error) = super::write_disk_reservation_ledger(
-            &control_hub.expect("admission hub").config,
-            &ledger,
-        ) {
-            let _ = mission_store
-                .update_mission_status(mission.id, MissionStatus::Failed)
-                .await;
-            return Err(format!(
-                "board worker creation rolled back: persist disk admission ledger: {error}"
-            ));
-        }
-        drop(admission_guard);
-    }
     // Inherit the boss's project tagging. Board tasks bypass the public
     // create-mission handler, and `create_mission_with_parent` carries no
     // project metadata — so workers were landing untagged. The parent link

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -1325,6 +1325,7 @@ fn seconds_since(rfc3339: &str) -> i64 {
 /// Spawn workers for ready tasks while capacity allows, and sweep zombies.
 /// Called from the control actor's tick, throttled by the caller (~2s).
 pub async fn scheduler_pass(
+    control_hub: Option<&super::ControlHub>,
     mission_store: &Arc<dyn MissionStore>,
     cmd_tx: &mpsc::Sender<ControlCommand>,
     snapshot: &RunnerSnapshot,
@@ -1536,6 +1537,7 @@ pub async fn scheduler_pass(
                         continue;
                     }
                     match spawn_task_worker(
+                        control_hub,
                         mission_store,
                         cmd_tx,
                         outbox_inflight,
@@ -1614,6 +1616,7 @@ fn append_note(notes: &Option<String>, line: &str) -> Option<String> {
 }
 
 async fn spawn_task_worker(
+    control_hub: Option<&super::ControlHub>,
     mission_store: &Arc<dyn MissionStore>,
     cmd_tx: &mpsc::Sender<ControlCommand>,
     outbox_inflight: &BoardOutboxInflight,
@@ -1630,6 +1633,32 @@ async fn spawn_task_worker(
         .or_else(|| role_default_model(task));
     let model_override = requested_model
         .and_then(|model| super::normalize_model_override_for_backend(Some(&task.backend), model));
+    // Board workers are local missions just like REST/Ask-created workers.
+    // Keep the admission lock over both mission persistence and the trusted
+    // ledger write: otherwise two schedulers can each observe the same free
+    // bytes and overcommit before either worker is visible to reconstruction.
+    // Production callers always supply the hub. `None` exists solely for
+    // focused in-memory unit tests that exercise board metadata without a
+    // filesystem-backed control server; it is private to this module and
+    // cannot be reached by an API caller.
+    let admission = if let Some(control_hub) = control_hub {
+        let workspace = crate::workspace::resolve_workspace(
+            &control_hub.workspaces,
+            &control_hub.config,
+            Some(workspace_id),
+        )
+        .await;
+        let (guard, reservation) = super::reserve_local_mission_disk(
+            control_hub,
+            &control_hub.config,
+            &workspace,
+            super::mission_disk_default_estimate_gib(),
+        )
+        .await?;
+        Some((guard, reservation, workspace))
+    } else {
+        None
+    };
     let mission = mission_store
         .create_mission_with_parent(
             Some(&format!("[{}] {}", task.task_key, task.title)),
@@ -1644,6 +1673,23 @@ async fn spawn_task_worker(
             task.working_directory.as_deref(),
         )
         .await?;
+    if let Some((admission_guard, mut reservation, workspace)) = admission {
+        reservation.mission_id = mission.id;
+        reservation.workspace_dir = Some(crate::workspace::mission_workspace_dir_for_workspace(
+            &workspace, mission.id,
+        ));
+        let mut ledger = super::read_disk_reservation_ledger(&control_hub.expect("admission hub").config)?;
+        ledger.reservations.insert(mission.id, reservation);
+        if let Err(error) = super::write_disk_reservation_ledger(&control_hub.expect("admission hub").config, &ledger) {
+            let _ = mission_store
+                .update_mission_status(mission.id, MissionStatus::Failed)
+                .await;
+            return Err(format!(
+                "board worker creation rolled back: persist disk admission ledger: {error}"
+            ));
+        }
+        drop(admission_guard);
+    }
     // Inherit the boss's project tagging. Board tasks bypass the public
     // create-mission handler, and `create_mission_with_parent` carries no
     // project metadata — so workers were landing untagged. The parent link
@@ -1993,6 +2039,7 @@ mod tests {
         let (cmd_tx, _cmd_rx) = mpsc::channel(8);
         let inflight: BoardOutboxInflight = Default::default();
         let worker_id = spawn_task_worker(
+            None,
             &store,
             &cmd_tx,
             &inflight,
@@ -3364,6 +3411,7 @@ mod tests {
         let outbox_inflight: BoardOutboxInflight = Arc::new(std::sync::Mutex::new(HashSet::new()));
 
         scheduler_pass(
+            None,
             &store,
             &cmd_tx,
             &snapshot,

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -1660,7 +1660,7 @@ async fn spawn_task_worker(
         None
     };
     let mission = mission_store
-        .create_mission_with_parent(
+        .create_mission_with_parent_and_placement(
             Some(&format!("[{}] {}", task.task_key, task.title)),
             Some(workspace_id),
             None,
@@ -1671,6 +1671,7 @@ async fn spawn_task_worker(
             None,
             Some(task.boss_mission_id),
             task.working_directory.as_deref(),
+            true,
         )
         .await?;
     if let Some((admission_guard, mut reservation, workspace)) = admission {

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -1678,9 +1678,13 @@ async fn spawn_task_worker(
         reservation.workspace_dir = Some(crate::workspace::mission_workspace_dir_for_workspace(
             &workspace, mission.id,
         ));
-        let mut ledger = super::read_disk_reservation_ledger(&control_hub.expect("admission hub").config)?;
+        let mut ledger =
+            super::read_disk_reservation_ledger(&control_hub.expect("admission hub").config)?;
         ledger.reservations.insert(mission.id, reservation);
-        if let Err(error) = super::write_disk_reservation_ledger(&control_hub.expect("admission hub").config, &ledger) {
+        if let Err(error) = super::write_disk_reservation_ledger(
+            &control_hub.expect("admission hub").config,
+            &ledger,
+        ) {
             let _ = mission_store
                 .update_mission_status(mission.id, MissionStatus::Failed)
                 .await;

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -1660,7 +1660,8 @@ async fn spawn_task_worker(
         None
     };
     let assigned_id = Uuid::new_v4();
-    if let Some((admission_guard, mut reservation, workspace)) = admission {
+    let mut admission_guard = None;
+    if let Some((guard, mut reservation, workspace)) = admission {
         reservation.mission_id = assigned_id;
         reservation.workspace_dir = Some(crate::workspace::mission_workspace_dir_for_workspace(
             &workspace,
@@ -1677,7 +1678,7 @@ async fn spawn_task_worker(
                 "board worker creation rolled back: persist disk admission ledger: {error}"
             ));
         }
-        drop(admission_guard);
+        admission_guard = Some(guard);
     }
     let mission = mission_store
         .create_mission_with_parent_and_placement(
@@ -1695,6 +1696,7 @@ async fn spawn_task_worker(
             Some(assigned_id),
         )
         .await?;
+    drop(admission_guard);
     // Inherit the boss's project tagging. Board tasks bypass the public
     // create-mission handler, and `create_mission_with_parent` carries no
     // project metadata — so workers were landing untagged. The parent link

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -430,6 +430,8 @@ pub enum ControlCommand {
         /// Whether creation consumes the API host's local scratch space.
         /// Remote-node missions bypass the host disk-pressure gate.
         requires_local_disk: bool,
+        /// Expected local scratch peak; absent values use the safe default.
+        estimated_disk_gib: Option<u64>,
         respond: oneshot::Sender<Result<Mission, String>>,
     },
     /// Update mission status

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -432,6 +432,9 @@ pub enum ControlCommand {
         requires_local_disk: bool,
         /// Expected local scratch peak; absent values use the safe default.
         estimated_disk_gib: Option<u64>,
+        /// Tags written atomically with creation.  The control actor uses this
+        /// for durable local-disk admission reservations.
+        admission_tags: Vec<String>,
         respond: oneshot::Sender<Result<Mission, String>>,
     },
     /// Update mission status

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7380,7 +7380,7 @@ async fn reserved_disk_bytes_for_filesystem(
         .iter()
         .filter(|mission| mission_holds_disk_reservation(mission.status))
         .flat_map(|mission| mission.project.tags.iter())
-        .filter_map(parse_disk_reservation_tag)
+        .filter_map(|tag| parse_disk_reservation_tag(tag))
         .filter(|(reserved_filesystem, _)| *reserved_filesystem == filesystem)
         .fold(0u64, |total, (_, bytes)| total.saturating_add(bytes)))
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7525,12 +7525,6 @@ struct DiskReservationLedger {
     version: u8,
     #[serde(default)]
     reservations: HashMap<Uuid, DiskReservation>,
-    /// Trusted placement classification.  This is deliberately server-owned
-    /// alongside the lease ledger: project tags are editable by users and
-    /// cannot decide whether a nonterminal mission consumes host scratch.
-    /// Missing entries are legacy local missions, which is conservative.
-    #[serde(default)]
-    requires_local_disk: HashMap<Uuid, bool>,
 }
 
 const fn disk_reservation_ledger_version() -> u8 {
@@ -7553,7 +7547,6 @@ fn read_disk_reservation_ledger(config: &Config) -> Result<DiskReservationLedger
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(DiskReservationLedger {
             version: disk_reservation_ledger_version(),
             reservations: HashMap::new(),
-            requires_local_disk: HashMap::new(),
         }),
         Err(error) => Err(format!("read {}: {error}", path.display())),
     }
@@ -7606,20 +7599,6 @@ fn mission_holds_disk_reservation(status: MissionStatus) -> bool {
     !status.is_terminal() && status != MissionStatus::Acknowledged
 }
 
-/// Placement records are the authority for restart reconstruction.  Old
-/// ledger versions have no classification, so retain the historical
-/// conservative local default rather than accidentally over-admitting them.
-fn mission_requires_local_disk_on_restart(
-    ledger: &DiskReservationLedger,
-    mission_id: Uuid,
-) -> bool {
-    ledger
-        .requires_local_disk
-        .get(&mission_id)
-        .copied()
-        .unwrap_or(true)
-}
-
 fn disk_admission_required_bytes(emergency: u64, reserved: u64, candidate: u64) -> u64 {
     emergency.saturating_add(reserved).saturating_add(candidate)
 }
@@ -7657,13 +7636,14 @@ fn disk_reservation_outstanding_bytes(reservation: &DiskReservation) -> u64 {
 
 fn nonterminal_missions_in_sqlite(
     path: &std::path::Path,
-) -> Result<HashMap<Uuid, Option<Uuid>>, String> {
+) -> Result<HashMap<Uuid, (Option<Uuid>, bool)>, String> {
     let connection =
         rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(|error| format!("open {} read-only: {error}", path.display()))?;
     let mut statement = connection
-        .prepare("SELECT id, status, workspace_id FROM missions")
-        .or_else(|_| connection.prepare("SELECT id, status, NULL AS workspace_id FROM missions"))
+        .prepare("SELECT id, status, workspace_id, COALESCE(requires_local_disk, 1) FROM missions")
+        .or_else(|_| connection.prepare("SELECT id, status, workspace_id, 1 FROM missions"))
+        .or_else(|_| connection.prepare("SELECT id, status, NULL AS workspace_id, 1 FROM missions"))
         .map_err(|error| format!("query {}: {error}", path.display()))?;
     let rows = statement
         .query_map([], |row| {
@@ -7671,12 +7651,14 @@ fn nonterminal_missions_in_sqlite(
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, Option<String>>(2)?,
+                row.get::<_, i64>(3)?,
             ))
         })
         .map_err(|error| error.to_string())?;
     let mut missions = HashMap::new();
     for row in rows {
-        let (id, status, workspace_id) = row.map_err(|error| error.to_string())?;
+        let (id, status, workspace_id, requires_local_disk) =
+            row.map_err(|error| error.to_string())?;
         let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status))
             .unwrap_or(MissionStatus::Active);
         if mission_holds_disk_reservation(status) {
@@ -7687,7 +7669,7 @@ fn nonterminal_missions_in_sqlite(
                 .map(Uuid::parse_str)
                 .transpose()
                 .map_err(|error| format!("parse workspace id in {}: {error}", path.display()))?;
-            missions.insert(id, workspace_id);
+            missions.insert(id, (workspace_id, requires_local_disk != 0));
         }
     }
     Ok(missions)
@@ -7709,11 +7691,14 @@ async fn reconcile_disk_reservation_ledger_under_lock(
     // closes that crash window; the lock is retained from admission through
     // row creation and ledger publication, so no concurrent admission can
     // observe the intermediate state either.
-    let mut live_missions: HashMap<Uuid, Option<Uuid>> = HashMap::new();
+    let mut live_missions: HashMap<Uuid, (Option<Uuid>, bool)> = HashMap::new();
     for store in inventory.live {
         for mission in store.list_missions(usize::MAX, 0).await? {
             if mission_holds_disk_reservation(mission.status) {
-                live_missions.insert(mission.id, Some(mission.workspace_id));
+                live_missions.insert(
+                    mission.id,
+                    (Some(mission.workspace_id), mission.requires_local_disk),
+                );
             }
         }
     }
@@ -7723,7 +7708,10 @@ async fn reconcile_disk_reservation_ledger_under_lock(
         );
         for mission in store.list_missions(usize::MAX, 0).await? {
             if mission_holds_disk_reservation(mission.status) {
-                live_missions.insert(mission.id, Some(mission.workspace_id));
+                live_missions.insert(
+                    mission.id,
+                    (Some(mission.workspace_id), mission.requires_local_disk),
+                );
             }
         }
     }
@@ -7731,8 +7719,8 @@ async fn reconcile_disk_reservation_ledger_under_lock(
         let missions = tokio::task::spawn_blocking(move || nonterminal_missions_in_sqlite(&path))
             .await
             .map_err(|error| error.to_string())??;
-        for (id, workspace_id) in missions {
-            live_missions.entry(id).or_insert(workspace_id);
+        for (id, placement) in missions {
+            live_missions.entry(id).or_insert(placement);
         }
     }
     let mut ledger = read_disk_reservation_ledger(config)?;
@@ -7742,17 +7730,12 @@ async fn reconcile_disk_reservation_ledger_under_lock(
         .reservations
         .retain(|id, _| live_missions.contains_key(id));
     changed |= ledger.reservations.len() != before;
-    let before = ledger.requires_local_disk.len();
-    ledger
-        .requires_local_disk
-        .retain(|id, _| live_missions.contains_key(id));
-    changed |= ledger.requires_local_disk.len() != before;
-    for (&mission_id, workspace_id) in &live_missions {
+    for (&mission_id, &(workspace_id, requires_local_disk)) in &live_missions {
         // Remote-node missions have an authoritative persisted placement
         // record but no host-disk lease.  Never manufacture one on restart.
         // An absent record predates placement persistence and is charged
         // locally as the safe compatibility policy.
-        if !mission_requires_local_disk_on_restart(&ledger, mission_id) {
+        if !requires_local_disk {
             continue;
         }
         if ledger.reservations.contains_key(&mission_id) {
@@ -7860,9 +7843,7 @@ async fn reserve_local_mission_disk(
 async fn release_local_mission_disk(config: &Config, mission_id: Uuid) -> Result<(), String> {
     let _guard = acquire_durable_disk_admission_lock(config).await?;
     let mut ledger = read_disk_reservation_ledger(config)?;
-    if ledger.reservations.remove(&mission_id).is_some()
-        || ledger.requires_local_disk.remove(&mission_id).is_some()
-    {
+    if ledger.reservations.remove(&mission_id).is_some() {
         write_disk_reservation_ledger(config, &ledger)?;
     }
     Ok(())
@@ -17439,8 +17420,45 @@ async fn control_actor_loop(
         working_directory: Option<&str>,
         scheduling: crate::api::mission_store::MissionScheduling,
     ) -> Result<Mission, String> {
+        create_new_mission_with_title_and_placement(
+            mission_store,
+            title,
+            workspace_id,
+            agent,
+            model_override,
+            model_effort,
+            fast_mode,
+            backend,
+            config_profile,
+            parent_mission_id,
+            working_directory,
+            true,
+            scheduling,
+        )
+        .await
+    }
+
+    /// Persist placement authority with the Pending mission row.  The
+    /// admission ledger is only a byte lease and must never decide whether a
+    /// restarted mission is local or remote.
+    #[allow(clippy::too_many_arguments)]
+    async fn create_new_mission_with_title_and_placement(
+        mission_store: &Arc<dyn MissionStore>,
+        title: Option<&str>,
+        workspace_id: Option<Uuid>,
+        agent: Option<&str>,
+        model_override: Option<&str>,
+        model_effort: Option<&str>,
+        fast_mode: bool,
+        backend: Option<&str>,
+        config_profile: Option<&str>,
+        parent_mission_id: Option<Uuid>,
+        working_directory: Option<&str>,
+        requires_local_disk: bool,
+        scheduling: crate::api::mission_store::MissionScheduling,
+    ) -> Result<Mission, String> {
         let mut mission = mission_store
-            .create_mission_with_parent(
+            .create_mission_with_parent_and_placement(
                 title,
                 workspace_id,
                 agent,
@@ -17451,6 +17469,7 @@ async fn control_actor_loop(
                 config_profile,
                 parent_mission_id,
                 working_directory,
+                requires_local_disk,
             )
             .await?;
         // FLEET-001: persist scheduling metadata as a focused follow-up write so
@@ -19007,7 +19026,7 @@ async fn control_actor_loop(
                         .await;
 
                         // Create a new mission with optional title, workspace, agent, and backend
-                        match create_new_mission_with_title(
+                        match create_new_mission_with_title_and_placement(
                             &mission_store,
                             title.as_deref(),
                             workspace_id,
@@ -19019,6 +19038,7 @@ async fn control_actor_loop(
                             config_profile.as_deref(),
                             parent_mission_id,
                             working_directory.as_deref(),
+                            requires_local_disk,
                             scheduling,
                         )
                         .await {
@@ -19060,10 +19080,11 @@ async fn control_actor_loop(
                                         }
                                     }
                                 }
-                                // Both local and remote placement are durable, trusted
-                                // admission state.  Keep the same global lock through
-                                // this publication so restart reconciliation can never
-                                // mistake a known remote mission for a local lease.
+                                // Placement was persisted in the same store operation as the
+                                // Pending row.  The lease ledger supplies only byte amounts.
+                                // Keep the same global lock through the server-owned
+                                // lease publication so a restart cannot observe a
+                                // partially admitted local mission.
                                 if reservation_guard.is_none() {
                                     match acquire_durable_disk_admission_lock(&config).await {
                                         Ok(guard) => reservation_guard = Some(guard),
@@ -19086,7 +19107,6 @@ async fn control_actor_loop(
                                         continue;
                                     }
                                 };
-                                ledger.requires_local_disk.insert(mission.id, requires_local_disk);
                                 if let Some(mut candidate) = reservation.take() {
                                     candidate.mission_id = mission.id;
                                     candidate.workspace_dir = Some(
@@ -30654,6 +30674,7 @@ And the report:
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -30694,6 +30715,7 @@ And the report:
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -30749,6 +30771,7 @@ And the report:
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -30801,6 +30824,7 @@ And the report:
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -30853,6 +30877,7 @@ And the report:
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -30905,6 +30930,7 @@ And the report:
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -31041,6 +31067,7 @@ And the report:
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -32751,20 +32778,33 @@ Investigate <service/> failures.
 
     #[test]
     fn restart_reconstruction_excludes_persisted_remote_missions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions.db");
         let local = Uuid::new_v4();
         let remote = Uuid::new_v4();
-        let legacy = Uuid::new_v4();
-        let ledger = DiskReservationLedger {
-            version: disk_reservation_ledger_version(),
-            reservations: HashMap::new(),
-            requires_local_disk: HashMap::from([(local, true), (remote, false)]),
-        };
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection.execute_batch(
+            "CREATE TABLE missions (id TEXT PRIMARY KEY, status TEXT, workspace_id TEXT, requires_local_disk INTEGER)",
+        ).unwrap();
+        connection
+            .execute(
+                "INSERT INTO missions VALUES (?1, 'pending', NULL, 1)",
+                rusqlite::params![local.to_string()],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO missions VALUES (?1, 'active', NULL, 0)",
+                rusqlite::params![remote.to_string()],
+            )
+            .unwrap();
+        drop(connection);
 
-        // A mixed restart must rebuild only the local missing lease.  Legacy
-        // records deliberately retain the conservative local interpretation.
-        assert!(mission_requires_local_disk_on_restart(&ledger, local));
-        assert!(!mission_requires_local_disk_on_restart(&ledger, remote));
-        assert!(mission_requires_local_disk_on_restart(&ledger, legacy));
+        let rows = nonterminal_missions_in_sqlite(&path).unwrap();
+        // Placement comes from authoritative mission rows, never from the
+        // lease ledger. A mixed restart rebuilds only local missions.
+        assert_eq!(rows.get(&local), Some(&(None, true)));
+        assert_eq!(rows.get(&remote), Some(&(None, false)));
     }
 
     #[test]
@@ -32788,7 +32828,9 @@ Investigate <service/> failures.
         drop(connection);
 
         let rows = nonterminal_missions_in_sqlite(&path).unwrap();
-        assert_eq!(rows.get(&mission_id), Some(&Some(workspace_id)));
+        // Legacy schemas do not have placement authority, so migration is
+        // deliberately conservative: they are local until explicitly moved.
+        assert_eq!(rows.get(&mission_id), Some(&(Some(workspace_id), true)));
     }
 
     fn test_summary(needs_operator: bool) -> super::mission_store::MissionSummary {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7513,30 +7513,42 @@ fn disk_reservation_outstanding_bytes(reservation: &DiskReservation) -> u64 {
     reservation.estimated_bytes.saturating_sub(usage)
 }
 
-fn nonterminal_mission_ids_in_sqlite(path: &std::path::Path) -> Result<HashSet<Uuid>, String> {
+fn nonterminal_missions_in_sqlite(
+    path: &std::path::Path,
+) -> Result<HashMap<Uuid, Option<Uuid>>, String> {
     let connection =
         rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(|error| format!("open {} read-only: {error}", path.display()))?;
     let mut statement = connection
-        .prepare("SELECT id, status FROM missions")
+        .prepare("SELECT id, status, workspace_id FROM missions")
+        .or_else(|_| connection.prepare("SELECT id, status, NULL AS workspace_id FROM missions"))
         .map_err(|error| format!("query {}: {error}", path.display()))?;
     let rows = statement
         .query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
         })
         .map_err(|error| error.to_string())?;
-    let mut ids = HashSet::new();
+    let mut missions = HashMap::new();
     for row in rows {
-        let (id, status) = row.map_err(|error| error.to_string())?;
+        let (id, status, workspace_id) = row.map_err(|error| error.to_string())?;
         let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status))
             .unwrap_or(MissionStatus::Active);
         if mission_holds_disk_reservation(status) {
             let id = Uuid::parse_str(&id)
                 .map_err(|error| format!("parse mission id {id} in {}: {error}", path.display()))?;
-            ids.insert(id);
+            let workspace_id = workspace_id
+                .as_deref()
+                .map(Uuid::parse_str)
+                .transpose()
+                .map_err(|error| format!("parse workspace id in {}: {error}", path.display()))?;
+            missions.insert(id, workspace_id);
         }
     }
-    Ok(ids)
+    Ok(missions)
 }
 
 /// Reconstruct the live lease set from authoritative mission state while the
@@ -7549,11 +7561,17 @@ async fn reconcile_disk_reservation_ledger_under_lock(
     config: &Config,
 ) -> Result<(), String> {
     let inventory = control_hub.mission_store_inventory().await?;
-    let mut live_ids = HashSet::new();
+    // Mission rows are the lifecycle authority.  A process can crash after a
+    // row commits but before the separate, atomically-published ledger file is
+    // renamed.  Reconstructing a conservative lease for every such live row
+    // closes that crash window; the lock is retained from admission through
+    // row creation and ledger publication, so no concurrent admission can
+    // observe the intermediate state either.
+    let mut live_missions: HashMap<Uuid, Option<Uuid>> = HashMap::new();
     for store in inventory.live {
         for mission in store.list_missions(usize::MAX, 0).await? {
             if mission_holds_disk_reservation(mission.status) {
-                live_ids.insert(mission.id);
+                live_missions.insert(mission.id, Some(mission.workspace_id));
             }
         }
     }
@@ -7563,19 +7581,58 @@ async fn reconcile_disk_reservation_ledger_under_lock(
         );
         for mission in store.list_missions(usize::MAX, 0).await? {
             if mission_holds_disk_reservation(mission.status) {
-                live_ids.insert(mission.id);
+                live_missions.insert(mission.id, Some(mission.workspace_id));
             }
         }
     }
     for path in inventory.offline_sqlite {
-        let ids = tokio::task::spawn_blocking(move || nonterminal_mission_ids_in_sqlite(&path))
+        let missions = tokio::task::spawn_blocking(move || nonterminal_missions_in_sqlite(&path))
             .await
             .map_err(|error| error.to_string())??;
-        live_ids.extend(ids);
+        for (id, workspace_id) in missions {
+            live_missions.entry(id).or_insert(workspace_id);
+        }
     }
     let mut ledger = read_disk_reservation_ledger(config)?;
     let before = ledger.reservations.len();
-    ledger.reservations.retain(|id, _| live_ids.contains(id));
+    ledger
+        .reservations
+        .retain(|id, _| live_missions.contains_key(id));
+    for (&mission_id, workspace_id) in &live_missions {
+        if ledger.reservations.contains_key(&mission_id) {
+            continue;
+        }
+        // A very old SQLite schema may not carry workspace_id. Charge the
+        // default host conservatively rather than allowing a crash-created
+        // Pending mission to escape admission accounting.
+        let workspace_id = workspace_id.unwrap_or(workspace::DEFAULT_WORKSPACE_ID);
+        let workspace = control_hub
+            .workspaces
+            .get(workspace_id)
+            .await
+            .unwrap_or_else(|| workspace::Workspace::default_host(config.working_dir.clone()));
+        workspace::ensure_persisted_mission_root_is_available(&workspace, mission_id)
+            .map_err(|error| format!("verify persisted placement for {mission_id}: {error}"))?;
+        let root = workspace::mission_workspace_root_for_workspace(&workspace, mission_id);
+        let usage = crate::api::monitoring::disk_usage_for_path(&root).map_err(|error| {
+            format!(
+                "measure reconstructed mission filesystem {}: {error}",
+                root.display()
+            )
+        })?;
+        ledger.reservations.insert(
+            mission_id,
+            DiskReservation {
+                mission_id,
+                filesystem: usage.filesystem,
+                estimated_bytes: mission_disk_default_estimate_gib().saturating_mul(1 << 30),
+                free_bytes_at_grant: usage.available,
+                workspace_dir: Some(workspace::mission_workspace_dir_for_workspace(
+                    &workspace, mission_id,
+                )),
+            },
+        );
+    }
     if ledger.reservations.len() != before {
         write_disk_reservation_ledger(config, &ledger)?;
     }
@@ -32329,5 +32386,29 @@ Investigate <service/> failures.
         assert!(!mission_holds_disk_reservation(MissionStatus::Completed));
         assert!(!mission_holds_disk_reservation(MissionStatus::Failed));
         assert!(!mission_holds_disk_reservation(MissionStatus::Acknowledged));
+    }
+
+    #[test]
+    fn restart_reconciliation_reads_workspace_identity_from_offline_mission_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions.db");
+        let mission_id = Uuid::new_v4();
+        let workspace_id = Uuid::new_v4();
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE missions (id TEXT PRIMARY KEY, status TEXT, workspace_id TEXT)",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO missions (id, status, workspace_id) VALUES (?1, 'pending', ?2)",
+                rusqlite::params![mission_id.to_string(), workspace_id.to_string()],
+            )
+            .unwrap();
+        drop(connection);
+
+        let rows = nonterminal_missions_in_sqlite(&path).unwrap();
+        assert_eq!(rows.get(&mission_id), Some(&Some(workspace_id)));
     }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7302,6 +7302,135 @@ fn apply_native_backend_agent_selector(
 static PR_WRITER_CREATE_LOCK: std::sync::LazyLock<Mutex<()>> =
     std::sync::LazyLock::new(|| Mutex::new(()));
 
+// Admission is deliberately a durable, filesystem-scoped lease rather than an
+// in-memory counter.  More than one control process can use the same mission
+// store and a restart must not forget work that is already consuming scratch.
+static DISK_ADMISSION_LOCK: std::sync::LazyLock<Mutex<()>> =
+    std::sync::LazyLock::new(|| Mutex::new(()));
+
+struct DurableDiskAdmissionLockGuard {
+    _process_guard: tokio::sync::MutexGuard<'static, ()>,
+    file: std::fs::File,
+}
+
+impl Drop for DurableDiskAdmissionLockGuard {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}
+
+async fn acquire_durable_disk_admission_lock(
+    config: &Config,
+) -> Result<DurableDiskAdmissionLockGuard, String> {
+    let process_guard = DISK_ADMISSION_LOCK.lock().await;
+    let lock_dir = config.working_dir.join(".sandboxed-sh").join("missions");
+    tokio::fs::create_dir_all(&lock_dir)
+        .await
+        .map_err(|error| format!("create disk admission lock directory: {error}"))?;
+    let lock_path = lock_dir.join(".disk-admission.lock");
+    let file = tokio::task::spawn_blocking(move || {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|error| format!("open {}: {error}", lock_path.display()))?;
+        fs2::FileExt::lock_exclusive(&file)
+            .map_err(|error| format!("lock {}: {error}", lock_path.display()))?;
+        Ok::<_, String>(file)
+    })
+    .await
+    .map_err(|error| format!("join disk admission lock task: {error}"))??;
+    Ok(DurableDiskAdmissionLockGuard {
+        _process_guard: process_guard,
+        file,
+    })
+}
+
+const DISK_RESERVATION_TAG_PREFIX: &str = "disk-reservation-v1:";
+
+fn disk_reservation_tag(filesystem: &str, bytes: u64) -> String {
+    // `filesystem` is a local statvfs identifier, not a path or secret.  The
+    // trailing byte count makes parsing unambiguous even though the identity
+    // itself contains colons.
+    format!("{DISK_RESERVATION_TAG_PREFIX}{filesystem}:{bytes}")
+}
+
+fn parse_disk_reservation_tag(tag: &str) -> Option<(&str, u64)> {
+    let value = tag.strip_prefix(DISK_RESERVATION_TAG_PREFIX)?;
+    let (filesystem, bytes) = value.rsplit_once(':')?;
+    Some((filesystem, bytes.parse().ok()?))
+}
+
+fn mission_holds_disk_reservation(status: MissionStatus) -> bool {
+    !status.is_terminal() && status != MissionStatus::Acknowledged
+}
+
+fn disk_admission_required_bytes(emergency: u64, reserved: u64, candidate: u64) -> u64 {
+    emergency.saturating_add(reserved).saturating_add(candidate)
+}
+
+async fn reserved_disk_bytes_for_filesystem(
+    mission_store: &Arc<dyn MissionStore>,
+    filesystem: &str,
+) -> Result<u64, String> {
+    let missions = mission_store.list_missions(usize::MAX, 0).await?;
+    Ok(missions
+        .iter()
+        .filter(|mission| mission_holds_disk_reservation(mission.status))
+        .flat_map(|mission| mission.project.tags.iter())
+        .filter_map(parse_disk_reservation_tag)
+        .filter(|(reserved_filesystem, _)| *reserved_filesystem == filesystem)
+        .fold(0u64, |total, (_, bytes)| total.saturating_add(bytes)))
+}
+
+/// The caller must retain the returned lock through mission persistence and
+/// its reservation-tag write.  That makes admission, creation and durable
+/// reconstruction one atomic protocol across local control processes.
+async fn reserve_local_mission_disk(
+    config: &Config,
+    mission_store: &Arc<dyn MissionStore>,
+    workspace: &workspace::Workspace,
+    estimate_gib: u64,
+) -> Result<(DurableDiskAdmissionLockGuard, String), String> {
+    let guard = acquire_durable_disk_admission_lock(config).await?;
+    let root = workspace::mission_workspace_root_for_workspace(workspace, Uuid::nil());
+    if let Some(reason) = disk_admission_refusal(&root) {
+        return Err(reason);
+    }
+    let usage = crate::api::monitoring::disk_usage_for_path(&root).map_err(|error| {
+        format!(
+            "mission creation refused: cannot measure workspace filesystem at {}: {error}",
+            root.display()
+        )
+    })?;
+    let reserved = reserved_disk_bytes_for_filesystem(mission_store, &usage.filesystem).await?;
+    let estimate = estimate_gib.saturating_mul(1 << 30);
+    let emergency = mission_disk_reserve_gib().saturating_mul(1 << 30);
+    let required = disk_admission_required_bytes(emergency, reserved, estimate);
+    if usage.available < required {
+        return Err(format!(
+            "mission admission refused on filesystem {}: {} GiB free, {} GiB already reserved, {} GiB candidate estimate, {} GiB emergency reserve ({} GiB required)",
+            usage.filesystem,
+            usage.available / (1 << 30),
+            reserved / (1 << 30),
+            estimate_gib,
+            mission_disk_reserve_gib(),
+            required / (1 << 30),
+        ));
+    }
+    tracing::info!(
+        filesystem = %usage.filesystem,
+        free_bytes = usage.available,
+        reserved_bytes = reserved,
+        candidate_bytes = estimate,
+        required_bytes = required,
+        "local mission disk admission reserved"
+    );
+    Ok((guard, disk_reservation_tag(&usage.filesystem, estimate)))
+}
+
 struct DurablePrWriterLockGuard {
     _process_guard: tokio::sync::MutexGuard<'static, ()>,
     file: std::fs::File,
@@ -8848,6 +8977,7 @@ pub async fn create_mission(
             },
             requires_local_disk: local_mission,
             estimated_disk_gib: effective_estimated_disk_gib,
+            admission_tags: Vec::new(),
             respond: tx,
         })
         .await
@@ -8974,6 +9104,23 @@ pub async fn create_mission(
             tags.retain(|tag| tag != "pr-writer" && tag != "pr-readonly");
             if !tags.iter().any(|tag| tag == capability) {
                 tags.push(capability.to_string());
+            }
+        }
+    }
+    // Creation persisted the admission lease before replying. This later
+    // metadata patch must retain it, otherwise user tags could release it.
+    let durable_reservation_tags: Vec<String> = mission
+        .project
+        .tags
+        .iter()
+        .filter(|tag| tag.starts_with(DISK_RESERVATION_TAG_PREFIX))
+        .cloned()
+        .collect();
+    if !durable_reservation_tags.is_empty() {
+        let requested = tags.get_or_insert_with(Vec::new);
+        for reservation in durable_reservation_tags {
+            if !requested.iter().any(|tag| tag == &reservation) {
+                requested.push(reservation);
             }
         }
     }
@@ -18159,39 +18306,33 @@ async fn control_actor_loop(
                             }
                         }
                     }
-                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, fast_mode, backend, config_profile, parent_mission_id, working_directory, scheduling, requires_local_disk, estimated_disk_gib, respond } => {
+                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, fast_mode, backend, config_profile, parent_mission_id, working_directory, scheduling, requires_local_disk, estimated_disk_gib, admission_tags, respond } => {
                         // Disk preflight: refuse new missions when the root
                         // filesystem is critically full instead of letting
                         // workers die mid-flight on ENOSPC. Actor-level so
                         // the HTTP, Ask and Telegram entrypoints are all
                         // covered by this single gate.
+                        let mut reservation_guard = None;
+                        let mut reservation_tag = None;
                         if requires_local_disk {
                             let workspace = workspaces
                                 .get(workspace_id.unwrap_or(workspace::DEFAULT_WORKSPACE_ID))
                                 .await
                                 .unwrap_or_else(|| workspace::Workspace::default_host(config.working_dir.clone()));
-                            let root = workspace::mission_workspace_root_for_workspace(
+                            match reserve_local_mission_disk(
+                                &config,
+                                &mission_store,
                                 &workspace,
-                                Uuid::nil(),
-                            );
-                            if let Some(refusal) = disk_admission_refusal(&root) {
-                                let _ = respond.send(Err(refusal));
-                                continue;
-                            }
-                            let usage = match crate::api::monitoring::disk_usage_for_path(&root) {
-                                Ok(usage) => usage,
+                                estimated_disk_gib.unwrap_or_else(mission_disk_default_estimate_gib),
+                            ).await {
+                                Ok((guard, tag)) => {
+                                    reservation_guard = Some(guard);
+                                    reservation_tag = Some(tag);
+                                }
                                 Err(error) => {
-                                    let _ = respond.send(Err(format!("mission creation refused: cannot measure workspace filesystem at {}: {error}", root.display())));
+                                    let _ = respond.send(Err(error));
                                     continue;
                                 }
-                            };
-                            if let Some(refusal) = disk_estimate_refusal(
-                                &usage,
-                                estimated_disk_gib.unwrap_or_else(mission_disk_default_estimate_gib),
-                                mission_disk_reserve_gib(),
-                            ) {
-                                let _ = respond.send(Err(refusal));
-                                continue;
                             }
                         }
                         // First persist current mission history
@@ -18219,7 +18360,49 @@ async fn control_actor_loop(
                             scheduling,
                         )
                         .await {
-                            Ok(mission) => {
+                            Ok(mut mission) => {
+                                // The durable file lock remains held until this tag is
+                                // persisted.  A second process reconstructs the sum from
+                                // these tags, so a restart has no in-memory lease to lose.
+                                let mut tags = admission_tags;
+                                if let Some(tag) = reservation_tag {
+                                    tags.push(tag);
+                                }
+                                if !tags.is_empty() {
+                                    if let Err(error) = mission_store.update_mission_project(
+                                        mission.id,
+                                        crate::api::mission_store::MissionProjectPatch {
+                                            tags: Some(tags),
+                                            ..Default::default()
+                                        },
+                                    ).await {
+                                        // Never return a runnable mission that was admitted
+                                        // without its durable reservation.  Marking it terminal
+                                        // also releases any partially-visible reservation.
+                                        let _ = mission_store.update_mission_status(
+                                            mission.id,
+                                            MissionStatus::Failed,
+                                        ).await;
+                                        let _ = respond.send(Err(format!(
+                                            "mission creation rolled back: persist disk admission reservation: {error}"
+                                        )));
+                                        continue;
+                                    }
+                                    match mission_store.get_mission(mission.id).await {
+                                        Ok(Some(updated)) => mission = updated,
+                                        Ok(None) => {
+                                            let _ = respond.send(Err("mission creation rolled back: mission disappeared while persisting disk admission reservation".to_string()));
+                                            continue;
+                                        }
+                                        Err(error) => {
+                                            let _ = respond.send(Err(format!("mission creation rolled back: reload disk admission reservation: {error}")));
+                                            continue;
+                                        }
+                                    }
+                                }
+                                // Explicitly drop after durable write, rather than relying on
+                                // scope order if this branch grows a later await.
+                                drop(reservation_guard.take());
                                 history.clear();
                                 *current_mission.write().await = Some(mission.id);
 
@@ -31816,5 +31999,39 @@ Investigate <service/> failures.
             (slow_count as u64) + slow_lagged >= PRODUCER_EVENTS as u64,
             "slow subscriber's got+lost should still account for the producer (got={slow_count} lagged={slow_lagged})"
         );
+    }
+
+    #[test]
+    fn disk_admission_reservations_are_filesystem_scoped_and_exact_at_boundary() {
+        let a = disk_reservation_tag("statvfs:filesystem-a", 20 << 30);
+        let b = disk_reservation_tag("statvfs:filesystem-b", 20 << 30);
+        assert_eq!(
+            parse_disk_reservation_tag(&a),
+            Some(("statvfs:filesystem-a", 20 << 30))
+        );
+        assert_eq!(
+            parse_disk_reservation_tag(&b),
+            Some(("statvfs:filesystem-b", 20 << 30))
+        );
+
+        let emergency = 64 << 30;
+        let first = 20 << 30;
+        // Exact equality leaves the emergency floor intact; a second
+        // same-filesystem admission must include the first reservation.
+        assert_eq!(disk_admission_required_bytes(emergency, 0, first), 84 << 30);
+        assert_eq!(
+            disk_admission_required_bytes(emergency, first, first),
+            104 << 30
+        );
+    }
+
+    #[test]
+    fn terminal_missions_release_disk_admission_reservations() {
+        assert!(mission_holds_disk_reservation(MissionStatus::Pending));
+        assert!(mission_holds_disk_reservation(MissionStatus::Active));
+        assert!(mission_holds_disk_reservation(MissionStatus::AwaitingUser));
+        assert!(!mission_holds_disk_reservation(MissionStatus::Completed));
+        assert!(!mission_holds_disk_reservation(MissionStatus::Failed));
+        assert!(!mission_holds_disk_reservation(MissionStatus::Acknowledged));
     }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -27074,6 +27074,7 @@ mod tests {
         assert_eq!(error.0, StatusCode::CONFLICT);
         assert!(store.get_mission(mission.id).await.unwrap().is_some());
         assert!(unavailable_storage
+            .join("workspaces")
             .join(mission_dir.file_name().unwrap())
             .exists());
         std::fs::rename(&unavailable_storage, &storage).expect("storage should be restored");

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7525,6 +7525,13 @@ struct DiskReservationLedger {
     version: u8,
     #[serde(default)]
     reservations: HashMap<Uuid, DiskReservation>,
+    /// Compatibility input for the immediately preceding ledger format.  The
+    /// placement decision has moved to the mission row, but an upgrade must
+    /// first transfer any remote (`false`) decisions rather than treating
+    /// those missions as conservative local work.  Do not serialize this
+    /// field again: once transferred, the row is the sole authority.
+    #[serde(default, skip_serializing)]
+    legacy_requires_local_disk: HashMap<Uuid, bool>,
 }
 
 const fn disk_reservation_ledger_version() -> u8 {
@@ -7547,6 +7554,7 @@ fn read_disk_reservation_ledger(config: &Config) -> Result<DiskReservationLedger
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(DiskReservationLedger {
             version: disk_reservation_ledger_version(),
             reservations: HashMap::new(),
+            legacy_requires_local_disk: HashMap::new(),
         }),
         Err(error) => Err(format!("read {}: {error}", path.display())),
     }
@@ -7675,6 +7683,55 @@ fn nonterminal_missions_in_sqlite(
     Ok(missions)
 }
 
+/// Transfer placement from the short-lived v2 lease-ledger authority into an
+/// offline SQLite mission store.  This runs under the global admission lock;
+/// the transaction means a crash leaves either the old ledger classification
+/// or the fully-updated mission rows, never a partially applied set.
+fn migrate_legacy_ledger_placement_in_sqlite(
+    path: &std::path::Path,
+    placement: &HashMap<Uuid, bool>,
+) -> Result<(), String> {
+    if placement.is_empty() {
+        return Ok(());
+    }
+    let mut connection = rusqlite::Connection::open(path)
+        .map_err(|error| format!("open {} for placement migration: {error}", path.display()))?;
+    let has_column = connection
+        .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'requires_local_disk'")
+        .and_then(|statement| statement.exists([]))
+        .map_err(|error| format!("inspect {} placement schema: {error}", path.display()))?;
+    let transaction = connection
+        .transaction()
+        .map_err(|error| format!("start {} placement migration: {error}", path.display()))?;
+    if !has_column {
+        transaction
+            .execute(
+                "ALTER TABLE missions ADD COLUMN requires_local_disk INTEGER NOT NULL DEFAULT 1",
+                [],
+            )
+            .map_err(|error| format!("add {} placement column: {error}", path.display()))?;
+    }
+    for (&mission_id, &requires_local_disk) in placement {
+        transaction
+            .execute(
+                "UPDATE missions SET requires_local_disk = ?1 WHERE id = ?2",
+                rusqlite::params![
+                    if requires_local_disk { 1i64 } else { 0i64 },
+                    mission_id.to_string()
+                ],
+            )
+            .map_err(|error| {
+                format!(
+                    "migrate placement for {mission_id} in {}: {error}",
+                    path.display()
+                )
+            })?;
+    }
+    transaction
+        .commit()
+        .map_err(|error| format!("commit {} placement migration: {error}", path.display()))
+}
+
 /// Reconstruct the live lease set from authoritative mission state while the
 /// global admission lock is held.  The ledger supplies bytes; mission stores
 /// supply lifecycle truth.  Project tags are deliberately excluded: they are
@@ -7685,6 +7742,8 @@ async fn reconcile_disk_reservation_ledger_under_lock(
     config: &Config,
 ) -> Result<(), String> {
     let inventory = control_hub.mission_store_inventory().await?;
+    let mut ledger = read_disk_reservation_ledger(config)?;
+    let legacy_placement = std::mem::take(&mut ledger.legacy_requires_local_disk);
     // Mission rows are the lifecycle authority.  A process can crash after a
     // row commits but before the separate, atomically-published ledger file is
     // renamed.  Reconstructing a conservative lease for every such live row
@@ -7694,10 +7753,23 @@ async fn reconcile_disk_reservation_ledger_under_lock(
     let mut live_missions: HashMap<Uuid, (Option<Uuid>, bool)> = HashMap::new();
     for store in inventory.live {
         for mission in store.list_missions(usize::MAX, 0).await? {
+            if let Some(&requires_local_disk) = legacy_placement.get(&mission.id) {
+                if mission.requires_local_disk != requires_local_disk {
+                    store
+                        .set_mission_requires_local_disk(mission.id, requires_local_disk)
+                        .await?;
+                }
+            }
             if mission_holds_disk_reservation(mission.status) {
                 live_missions.insert(
                     mission.id,
-                    (Some(mission.workspace_id), mission.requires_local_disk),
+                    (
+                        Some(mission.workspace_id),
+                        legacy_placement
+                            .get(&mission.id)
+                            .copied()
+                            .unwrap_or(mission.requires_local_disk),
+                    ),
                 );
             }
         }
@@ -7707,24 +7779,40 @@ async fn reconcile_disk_reservation_ledger_under_lock(
             mission_store::FileMissionStore::new(inventory.base_dir.clone(), &user).await?,
         );
         for mission in store.list_missions(usize::MAX, 0).await? {
+            if let Some(&requires_local_disk) = legacy_placement.get(&mission.id) {
+                if mission.requires_local_disk != requires_local_disk {
+                    store
+                        .set_mission_requires_local_disk(mission.id, requires_local_disk)
+                        .await?;
+                }
+            }
             if mission_holds_disk_reservation(mission.status) {
                 live_missions.insert(
                     mission.id,
-                    (Some(mission.workspace_id), mission.requires_local_disk),
+                    (
+                        Some(mission.workspace_id),
+                        legacy_placement
+                            .get(&mission.id)
+                            .copied()
+                            .unwrap_or(mission.requires_local_disk),
+                    ),
                 );
             }
         }
     }
     for path in inventory.offline_sqlite {
-        let missions = tokio::task::spawn_blocking(move || nonterminal_missions_in_sqlite(&path))
-            .await
-            .map_err(|error| error.to_string())??;
+        let placement = legacy_placement.clone();
+        let missions = tokio::task::spawn_blocking(move || {
+            migrate_legacy_ledger_placement_in_sqlite(&path, &placement)?;
+            nonterminal_missions_in_sqlite(&path)
+        })
+        .await
+        .map_err(|error| error.to_string())??;
         for (id, placement) in missions {
             live_missions.entry(id).or_insert(placement);
         }
     }
-    let mut ledger = read_disk_reservation_ledger(config)?;
-    let mut changed = false;
+    let mut changed = !legacy_placement.is_empty();
     let before = ledger.reservations.len();
     ledger
         .reservations
@@ -32803,6 +32891,39 @@ Investigate <service/> failures.
         let rows = nonterminal_missions_in_sqlite(&path).unwrap();
         // Placement comes from authoritative mission rows, never from the
         // lease ledger. A mixed restart rebuilds only local missions.
+        assert_eq!(rows.get(&local), Some(&(None, true)));
+        assert_eq!(rows.get(&remote), Some(&(None, false)));
+    }
+
+    #[test]
+    fn legacy_ledger_remote_placement_is_migrated_to_sqlite_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions.db");
+        let local = Uuid::new_v4();
+        let remote = Uuid::new_v4();
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        // This is the schema just before placement moved out of the ledger.
+        connection
+            .execute_batch(
+                "CREATE TABLE missions (id TEXT PRIMARY KEY, status TEXT, workspace_id TEXT)",
+            )
+            .unwrap();
+        for id in [local, remote] {
+            connection
+                .execute(
+                    "INSERT INTO missions VALUES (?1, 'pending', NULL)",
+                    rusqlite::params![id.to_string()],
+                )
+                .unwrap();
+        }
+        drop(connection);
+
+        migrate_legacy_ledger_placement_in_sqlite(
+            &path,
+            &HashMap::from([(local, true), (remote, false)]),
+        )
+        .unwrap();
+        let rows = nonterminal_missions_in_sqlite(&path).unwrap();
         assert_eq!(rows.get(&local), Some(&(None, true)));
         assert_eq!(rows.get(&remote), Some(&(None, false)));
     }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7530,7 +7530,15 @@ struct DiskReservationLedger {
     /// first transfer any remote (`false`) decisions rather than treating
     /// those missions as conservative local work.  Do not serialize this
     /// field again: once transferred, the row is the sole authority.
-    #[serde(default, skip_serializing)]
+    ///
+    /// The on-disk key was `requires_local_disk`.  The Rust field was renamed
+    /// during the migration, so deserialize both names.
+    #[serde(
+        default,
+        rename = "requires_local_disk",
+        alias = "legacy_requires_local_disk",
+        skip_serializing
+    )]
     legacy_requires_local_disk: HashMap<Uuid, bool>,
 }
 
@@ -7629,6 +7637,20 @@ async fn reserved_disk_bytes_for_filesystem(
 /// the same consumption twice.  A lease therefore retains only its estimated
 /// *remaining* peak after measuring its own workspace.  Measurement failure
 /// is conservative: keep the complete estimate.
+fn allocated_file_bytes(metadata: &std::fs::Metadata) -> u64 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        // POSIX `st_blocks` is in 512-byte units and counts allocated
+        // storage, so sparse/reflinked files do not appear fully consumed.
+        metadata.blocks().saturating_mul(512)
+    }
+    #[cfg(not(unix))]
+    {
+        metadata.len()
+    }
+}
+
 fn disk_reservation_outstanding_bytes(reservation: &DiskReservation) -> u64 {
     let Some(path) = reservation.workspace_dir.as_deref() else {
         return reservation.estimated_bytes;
@@ -7638,7 +7660,9 @@ fn disk_reservation_outstanding_bytes(reservation: &DiskReservation) -> u64 {
         .filter_map(Result::ok)
         .filter_map(|entry| entry.metadata().ok())
         .filter(|metadata| metadata.is_file())
-        .fold(0u64, |total, metadata| total.saturating_add(metadata.len()));
+        .fold(0u64, |total, metadata| {
+            total.saturating_add(allocated_file_bytes(&metadata))
+        });
     reservation.estimated_bytes.saturating_sub(usage)
 }
 
@@ -7935,6 +7959,32 @@ async fn release_local_mission_disk(config: &Config, mission_id: Uuid) -> Result
         write_disk_reservation_ledger(config, &ledger)?;
     }
     Ok(())
+}
+
+async fn release_local_mission_disk_if_not_holding(
+    mission_store: &Arc<dyn crate::api::mission_store::MissionStore>,
+    config: &Config,
+    mission_id: Uuid,
+) {
+    match mission_store.get_mission(mission_id).await {
+        Ok(Some(mission)) if mission_holds_disk_reservation(mission.status) => {}
+        Ok(_) => {
+            if let Err(error) = release_local_mission_disk(config, mission_id).await {
+                tracing::error!(
+                    mission = %mission_id,
+                    %error,
+                    "terminal mission lease cleanup failed after runner stop"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                mission = %mission_id,
+                %error,
+                "could not load mission to decide disk lease release"
+            );
+        }
+    }
 }
 
 struct DurablePrWriterLockGuard {
@@ -17522,6 +17572,7 @@ async fn control_actor_loop(
             working_directory,
             true,
             scheduling,
+            None,
         )
         .await
     }
@@ -17544,6 +17595,7 @@ async fn control_actor_loop(
         working_directory: Option<&str>,
         requires_local_disk: bool,
         scheduling: crate::api::mission_store::MissionScheduling,
+        assigned_id: Option<Uuid>,
     ) -> Result<Mission, String> {
         let mut mission = mission_store
             .create_mission_with_parent_and_placement(
@@ -17558,6 +17610,7 @@ async fn control_actor_loop(
                 parent_mission_id,
                 working_directory,
                 requires_local_disk,
+                assigned_id,
             )
             .await?;
         // FLEET-001: persist scheduling metadata as a focused follow-up write so
@@ -19113,6 +19166,43 @@ async fn control_actor_loop(
                         )
                         .await;
 
+                        // Publish the lease before the mission row so a crash
+                        // cannot reconstruct a custom estimate as the default.
+                        let assigned_id = Uuid::new_v4();
+                        if reservation_guard.is_none() {
+                            match acquire_durable_disk_admission_lock(&config).await {
+                                Ok(guard) => reservation_guard = Some(guard),
+                                Err(error) => {
+                                    let _ = respond.send(Err(format!(
+                                        "mission creation rolled back: acquire placement ledger lock: {error}"
+                                    )));
+                                    continue;
+                                }
+                            }
+                        }
+                        let mut ledger = match read_disk_reservation_ledger(&config) {
+                            Ok(ledger) => ledger,
+                            Err(error) => {
+                                let _ = respond.send(Err(format!(
+                                    "mission creation rolled back: read disk admission ledger: {error}"
+                                )));
+                                continue;
+                            }
+                        };
+                        if let Some(mut candidate) = reservation.take() {
+                            candidate.mission_id = assigned_id;
+                            candidate.workspace_dir = Some(
+                                workspace::mission_workspace_dir_for_workspace(&workspace, assigned_id),
+                            );
+                            ledger.reservations.insert(assigned_id, candidate);
+                            if let Err(error) = write_disk_reservation_ledger(&config, &ledger) {
+                                let _ = respond.send(Err(format!(
+                                    "mission creation rolled back: persist disk placement ledger: {error}"
+                                )));
+                                continue;
+                            }
+                        }
+
                         // Create a new mission with optional title, workspace, agent, and backend
                         match create_new_mission_with_title_and_placement(
                             &mission_store,
@@ -19128,13 +19218,12 @@ async fn control_actor_loop(
                             working_directory.as_deref(),
                             requires_local_disk,
                             scheduling,
+                            Some(assigned_id),
                         )
                         .await {
                             Ok(mut mission) => {
                                 // Project tags are user-editable and are not admission
-                                // state.  Persist any ordinary tags independently, then
-                                // write the server-owned v2 ledger before releasing the
-                                // cross-process lock.
+                                // state.  Persist any ordinary tags independently.
                                 let tags = admission_tags;
                                 if !tags.is_empty() {
                                     if let Err(error) = mission_store.update_mission_project(
@@ -19144,9 +19233,6 @@ async fn control_actor_loop(
                                             ..Default::default()
                                         },
                                     ).await {
-                                        // Never return a runnable mission that was admitted
-                                        // without its durable reservation.  Marking it terminal
-                                        // also releases any partially-visible reservation.
                                         let _ = mission_store.update_mission_status(
                                             mission.id,
                                             MissionStatus::Failed,
@@ -19167,47 +19253,6 @@ async fn control_actor_loop(
                                             continue;
                                         }
                                     }
-                                }
-                                // Placement was persisted in the same store operation as the
-                                // Pending row.  The lease ledger supplies only byte amounts.
-                                // Keep the same global lock through the server-owned
-                                // lease publication so a restart cannot observe a
-                                // partially admitted local mission.
-                                if reservation_guard.is_none() {
-                                    match acquire_durable_disk_admission_lock(&config).await {
-                                        Ok(guard) => reservation_guard = Some(guard),
-                                        Err(error) => {
-                                            let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
-                                            let _ = respond.send(Err(format!(
-                                                "mission creation rolled back: acquire placement ledger lock: {error}"
-                                            )));
-                                            continue;
-                                        }
-                                    }
-                                }
-                                let mut ledger = match read_disk_reservation_ledger(&config) {
-                                    Ok(ledger) => ledger,
-                                    Err(error) => {
-                                        let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
-                                        let _ = respond.send(Err(format!(
-                                            "mission creation rolled back: read disk admission ledger: {error}"
-                                        )));
-                                        continue;
-                                    }
-                                };
-                                if let Some(mut candidate) = reservation.take() {
-                                    candidate.mission_id = mission.id;
-                                    candidate.workspace_dir = Some(
-                                        workspace::mission_workspace_dir_for_workspace(&workspace, mission.id),
-                                    );
-                                    ledger.reservations.insert(mission.id, candidate);
-                                }
-                                if let Err(error) = write_disk_reservation_ledger(&config, &ledger) {
-                                    let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
-                                    let _ = respond.send(Err(format!(
-                                        "mission creation rolled back: persist disk placement ledger: {error}"
-                                    )));
-                                    continue;
                                 }
                                 // Explicitly drop after durable write, rather than relying on
                                 // scope order if this branch grows a later await.
@@ -19253,7 +19298,11 @@ async fn control_actor_loop(
                             .update_mission_status(id, new_status)
                             .await;
                         if result.is_ok() {
-                            if !mission_holds_disk_reservation(new_status) {
+                            let runner_active = running_mission_id == Some(id)
+                                || parallel_runners
+                                    .get(&id)
+                                    .is_some_and(|runner| runner.is_running());
+                            if !mission_holds_disk_reservation(new_status) && !runner_active {
                                 if let Err(error) = release_local_mission_disk(&config, id).await {
                                     tracing::error!(mission = %id, %error,
                                         "terminal mission lease cleanup failed; retaining conservative admission state");
@@ -20756,6 +20805,10 @@ async fn control_actor_loop(
                     let completed_mission_id = running_mission_id;
                     running = None;
                     running_cancel = None;
+                    if let Some(mid) = running_mission_id {
+                        release_local_mission_disk_if_not_holding(&mission_store, &config, mid)
+                            .await;
+                    }
                     running_mission_id = None;
                     running_backend_id = None;
                     main_runner_activity = None;
@@ -21840,6 +21893,7 @@ async fn control_actor_loop(
                 // Remove completed runners and clean up their desktop sessions
                 for mid in completed_missions {
                     parallel_runners.remove(&mid);
+                    release_local_mission_disk_if_not_holding(&mission_store, &config, mid).await;
                     close_mission_desktop_sessions(
                         &mission_store,
                         mid,
@@ -32893,6 +32947,51 @@ Investigate <service/> failures.
         // lease ledger. A mixed restart rebuilds only local missions.
         assert_eq!(rows.get(&local), Some(&(None, true)));
         assert_eq!(rows.get(&remote), Some(&(None, false)));
+    }
+
+    #[test]
+    fn legacy_ledger_deserializes_requires_local_disk_key() {
+        let remote = Uuid::new_v4();
+        let json = format!(
+            r#"{{"version":2,"reservations":{{}},"requires_local_disk":{{"{remote}":false}}}}"#
+        );
+        let ledger: DiskReservationLedger = serde_json::from_str(&json).unwrap();
+        assert_eq!(ledger.legacy_requires_local_disk.get(&remote), Some(&false));
+        let serialized = serde_json::to_value(&ledger).unwrap();
+        assert!(serialized.get("requires_local_disk").is_none());
+        assert!(serialized.get("legacy_requires_local_disk").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn outstanding_reservation_uses_allocated_bytes_not_logical_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sparse.bin");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(64 << 30).unwrap();
+        drop(file);
+        let reservation = DiskReservation {
+            mission_id: Uuid::new_v4(),
+            filesystem: "fs".into(),
+            estimated_bytes: 64 << 30,
+            free_bytes_at_grant: 0,
+            workspace_dir: Some(dir.path().to_path_buf()),
+        };
+        let outstanding = disk_reservation_outstanding_bytes(&reservation);
+        assert!(
+            outstanding > 32 << 30,
+            "a sparse 64 GiB file must not consume the full reservation; outstanding={outstanding}"
+        );
+    }
+
+    #[test]
+    fn running_missions_keep_disk_reservations_after_terminal_status() {
+        assert!(mission_holds_disk_reservation(MissionStatus::Active));
+        // Presentation status is not enough to release: SetMissionStatus must
+        // also observe that no runner is active. The helper below is the
+        // status half of that conjunction.
+        assert!(!mission_holds_disk_reservation(MissionStatus::Completed));
+        assert!(!mission_holds_disk_reservation(MissionStatus::Failed));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7698,7 +7698,7 @@ fn migrate_legacy_ledger_placement_in_sqlite(
         .map_err(|error| format!("open {} for placement migration: {error}", path.display()))?;
     let has_column = connection
         .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'requires_local_disk'")
-        .and_then(|statement| statement.exists([]))
+        .and_then(|mut statement| statement.exists([]))
         .map_err(|error| format!("inspect {} placement schema: {error}", path.display()))?;
     let transaction = connection
         .transaction()

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7404,6 +7404,12 @@ struct DiskReservationLedger {
     version: u8,
     #[serde(default)]
     reservations: HashMap<Uuid, DiskReservation>,
+    /// Trusted placement classification.  This is deliberately server-owned
+    /// alongside the lease ledger: project tags are editable by users and
+    /// cannot decide whether a nonterminal mission consumes host scratch.
+    /// Missing entries are legacy local missions, which is conservative.
+    #[serde(default)]
+    requires_local_disk: HashMap<Uuid, bool>,
 }
 
 const fn disk_reservation_ledger_version() -> u8 {
@@ -7426,6 +7432,7 @@ fn read_disk_reservation_ledger(config: &Config) -> Result<DiskReservationLedger
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(DiskReservationLedger {
             version: disk_reservation_ledger_version(),
             reservations: HashMap::new(),
+            requires_local_disk: HashMap::new(),
         }),
         Err(error) => Err(format!("read {}: {error}", path.display())),
     }
@@ -7476,6 +7483,20 @@ fn contains_internal_disk_reservation_tag(tags: &[String]) -> bool {
 
 fn mission_holds_disk_reservation(status: MissionStatus) -> bool {
     !status.is_terminal() && status != MissionStatus::Acknowledged
+}
+
+/// Placement records are the authority for restart reconstruction.  Old
+/// ledger versions have no classification, so retain the historical
+/// conservative local default rather than accidentally over-admitting them.
+fn mission_requires_local_disk_on_restart(
+    ledger: &DiskReservationLedger,
+    mission_id: Uuid,
+) -> bool {
+    ledger
+        .requires_local_disk
+        .get(&mission_id)
+        .copied()
+        .unwrap_or(true)
 }
 
 fn disk_admission_required_bytes(emergency: u64, reserved: u64, candidate: u64) -> u64 {
@@ -7600,7 +7621,19 @@ async fn reconcile_disk_reservation_ledger_under_lock(
         .reservations
         .retain(|id, _| live_missions.contains_key(id));
     changed |= ledger.reservations.len() != before;
+    let before = ledger.requires_local_disk.len();
+    ledger
+        .requires_local_disk
+        .retain(|id, _| live_missions.contains_key(id));
+    changed |= ledger.requires_local_disk.len() != before;
     for (&mission_id, workspace_id) in &live_missions {
+        // Remote-node missions have an authoritative persisted placement
+        // record but no host-disk lease.  Never manufacture one on restart.
+        // An absent record predates placement persistence and is charged
+        // locally as the safe compatibility policy.
+        if !mission_requires_local_disk_on_restart(&ledger, mission_id) {
+            continue;
+        }
         if ledger.reservations.contains_key(&mission_id) {
             continue;
         }
@@ -7706,7 +7739,9 @@ async fn reserve_local_mission_disk(
 async fn release_local_mission_disk(config: &Config, mission_id: Uuid) -> Result<(), String> {
     let _guard = acquire_durable_disk_admission_lock(config).await?;
     let mut ledger = read_disk_reservation_ledger(config)?;
-    if ledger.reservations.remove(&mission_id).is_some() {
+    if ledger.reservations.remove(&mission_id).is_some()
+        || ledger.requires_local_disk.remove(&mission_id).is_some()
+    {
         write_disk_reservation_ledger(config, &ledger)?;
     }
     Ok(())
@@ -18719,29 +18754,46 @@ async fn control_actor_loop(
                                         }
                                     }
                                 }
+                                // Both local and remote placement are durable, trusted
+                                // admission state.  Keep the same global lock through
+                                // this publication so restart reconciliation can never
+                                // mistake a known remote mission for a local lease.
+                                if reservation_guard.is_none() {
+                                    match acquire_durable_disk_admission_lock(&config).await {
+                                        Ok(guard) => reservation_guard = Some(guard),
+                                        Err(error) => {
+                                            let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
+                                            let _ = respond.send(Err(format!(
+                                                "mission creation rolled back: acquire placement ledger lock: {error}"
+                                            )));
+                                            continue;
+                                        }
+                                    }
+                                }
+                                let mut ledger = match read_disk_reservation_ledger(&config) {
+                                    Ok(ledger) => ledger,
+                                    Err(error) => {
+                                        let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
+                                        let _ = respond.send(Err(format!(
+                                            "mission creation rolled back: read disk admission ledger: {error}"
+                                        )));
+                                        continue;
+                                    }
+                                };
+                                ledger.requires_local_disk.insert(mission.id, requires_local_disk);
                                 if let Some(mut candidate) = reservation.take() {
                                     candidate.mission_id = mission.id;
                                     candidate.workspace_dir = Some(
                                         workspace::mission_workspace_dir_for_workspace(&workspace, mission.id),
                                     );
-                                    let mut ledger = match read_disk_reservation_ledger(&config) {
-                                        Ok(ledger) => ledger,
-                                        Err(error) => {
-                                            let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
-                                            let _ = respond.send(Err(format!(
-                                                "mission creation rolled back: read disk admission ledger: {error}"
-                                            )));
-                                            continue;
-                                        }
-                                    };
                                     ledger.reservations.insert(mission.id, candidate);
-                                    if let Err(error) = write_disk_reservation_ledger(&config, &ledger) {
-                                        let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
-                                        let _ = respond.send(Err(format!(
-                                            "mission creation rolled back: persist disk admission ledger: {error}"
-                                        )));
-                                        continue;
-                                    }
+                                }
+                                if let Err(error) = write_disk_reservation_ledger(&config, &ledger) {
+                                    let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
+                                    let _ = respond.send(Err(format!(
+                                        "mission creation rolled back: persist disk placement ledger: {error}"
+                                    )));
+                                    continue;
                                 }
                                 // Explicitly drop after durable write, rather than relying on
                                 // scope order if this branch grows a later await.
@@ -32389,6 +32441,24 @@ Investigate <service/> failures.
         assert!(!mission_holds_disk_reservation(MissionStatus::Completed));
         assert!(!mission_holds_disk_reservation(MissionStatus::Failed));
         assert!(!mission_holds_disk_reservation(MissionStatus::Acknowledged));
+    }
+
+    #[test]
+    fn restart_reconstruction_excludes_persisted_remote_missions() {
+        let local = Uuid::new_v4();
+        let remote = Uuid::new_v4();
+        let legacy = Uuid::new_v4();
+        let ledger = DiskReservationLedger {
+            version: disk_reservation_ledger_version(),
+            reservations: HashMap::new(),
+            requires_local_disk: HashMap::from([(local, true), (remote, false)]),
+        };
+
+        // A mixed restart must rebuild only the local missing lease.  Legacy
+        // records deliberately retain the conservative local interpretation.
+        assert!(mission_requires_local_disk_on_restart(&ledger, local));
+        assert!(!mission_requires_local_disk_on_restart(&ledger, remote));
+        assert!(mission_requires_local_disk_on_restart(&ledger, legacy));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -12717,6 +12717,10 @@ async fn cleanup_mission_workspace_dirs_for_delete(
         let Some(ws) = workspaces.get(mission.workspace_id).await else {
             continue;
         };
+        if let Err(error) = workspace::ensure_persisted_mission_root_is_available(&ws, mission.id) {
+            tracing::warn!(mission_id = %mission.id, %error, "refusing to delete workspace with unavailable persisted root");
+            continue;
+        }
         let dir = workspace::mission_workspace_dir_for_workspace(&ws, mission.id);
         if !dir.exists() {
             continue;

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -19915,7 +19915,7 @@ async fn control_actor_loop(
                                     workspaces
                                         .get(wsid)
                                         .await
-                                        .map(|w| crate::workspace::mission_workspace_dir_for_root(&w.path, mid))
+                                        .map(|w| crate::workspace::mission_workspace_dir_for_workspace(&w, mid))
                                         .unwrap_or_else(|| config.working_dir.clone())
                                 } else {
                                     config.working_dir.clone()
@@ -20541,7 +20541,7 @@ async fn control_actor_loop(
                                     workspaces
                                         .get(wsid)
                                         .await
-                                        .map(|w| crate::workspace::mission_workspace_dir_for_root(&w.path, *mission_id))
+                                        .map(|w| crate::workspace::mission_workspace_dir_for_workspace(&w, *mission_id))
                                         .unwrap_or_else(|| config.working_dir.clone())
                                 } else {
                                     config.working_dir.clone()

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10,6 +10,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::Infallible;
 use std::hash::{Hash, Hasher};
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -3962,6 +3963,33 @@ impl ControlHub {
         self.sessions.read().await.values().cloned().collect()
     }
 
+    /// Resolve a mission capability against the store that owns it.  Never use
+    /// `get_mission_store` for this: that convenience method intentionally
+    /// chooses an arbitrary desktop/default session and is not an authority
+    /// lookup in a multi-user deployment.
+    pub(crate) async fn find_mission_store_owner(
+        &self,
+        mission_id: Uuid,
+    ) -> Result<Option<(Arc<dyn MissionStore>, Mission)>, String> {
+        // A Spark token can only have been minted by a running session, so a
+        // live owner is required.  Do not open offline SQLite files here: a
+        // capability check must not create a competing writer just to find a
+        // row that cannot currently execute.
+        let stores: Vec<_> = self
+            .sessions
+            .read()
+            .await
+            .values()
+            .map(|state| Arc::clone(&state.mission_store))
+            .collect();
+        for store in stores {
+            if let Some(mission) = store.get_mission(mission_id).await? {
+                return Ok(Some((store, mission)));
+            }
+        }
+        Ok(None)
+    }
+
     /// Collect every mission that carries a `project` tag across all mission
     /// stores (live, offline file, offline sqlite). Read-only; used by the
     /// projects-overview board. Terminal missions older than `terminal_horizon`
@@ -7350,17 +7378,100 @@ async fn acquire_durable_disk_admission_lock(
 
 const DISK_RESERVATION_TAG_PREFIX: &str = "disk-reservation-v1:";
 
-fn disk_reservation_tag(filesystem: &str, bytes: u64) -> String {
-    // `filesystem` is a local statvfs identifier, not a path or secret.  The
-    // trailing byte count makes parsing unambiguous even though the identity
-    // itself contains colons.
-    format!("{DISK_RESERVATION_TAG_PREFIX}{filesystem}:{bytes}")
+/// Server-owned admission state.  This is intentionally separate from
+/// `MissionProject`: project metadata is user editable and consequently can
+/// never be an authority for resource accounting.  The file is written while
+/// holding the global admission lock and atomically replaced, so independent
+/// control processes observe a complete old or complete new ledger.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DiskReservation {
+    mission_id: Uuid,
+    filesystem: String,
+    estimated_bytes: u64,
+    /// Free bytes observed when the lease was granted.  This is a diagnostic
+    /// baseline, not an additional reservation; counting both consumed disk
+    /// and the full estimate would double-count the same work.
+    free_bytes_at_grant: u64,
+    /// Canonical mission directory whose actual usage consumes this lease.
+    /// Older records omit it and conservatively retain their full estimate.
+    #[serde(default)]
+    workspace_dir: Option<PathBuf>,
 }
 
-fn parse_disk_reservation_tag(tag: &str) -> Option<(&str, u64)> {
-    let value = tag.strip_prefix(DISK_RESERVATION_TAG_PREFIX)?;
-    let (filesystem, bytes) = value.rsplit_once(':')?;
-    Some((filesystem, bytes.parse().ok()?))
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DiskReservationLedger {
+    #[serde(default = "disk_reservation_ledger_version")]
+    version: u8,
+    #[serde(default)]
+    reservations: HashMap<Uuid, DiskReservation>,
+}
+
+const fn disk_reservation_ledger_version() -> u8 {
+    2
+}
+
+fn disk_reservation_ledger_path(config: &Config) -> PathBuf {
+    config
+        .working_dir
+        .join(".sandboxed-sh")
+        .join("missions")
+        .join("disk-reservations-v2.json")
+}
+
+fn read_disk_reservation_ledger(config: &Config) -> Result<DiskReservationLedger, String> {
+    let path = disk_reservation_ledger_path(config);
+    match std::fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|error| format!("parse {}: {error}", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(DiskReservationLedger {
+            version: disk_reservation_ledger_version(),
+            reservations: HashMap::new(),
+        }),
+        Err(error) => Err(format!("read {}: {error}", path.display())),
+    }
+}
+
+fn write_disk_reservation_ledger(
+    config: &Config,
+    ledger: &DiskReservationLedger,
+) -> Result<(), String> {
+    let path = disk_reservation_ledger_path(config);
+    let parent = path.parent().expect("ledger path has parent");
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("create {}: {error}", parent.display()))?;
+    let temp = parent.join(format!(".disk-reservations-v2.{}.tmp", Uuid::new_v4()));
+    let outcome = (|| -> Result<(), String> {
+        let bytes = serde_json::to_vec(ledger).map_err(|error| error.to_string())?;
+        let mut file = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp)
+            .map_err(|error| format!("open {}: {error}", temp.display()))?;
+        file.write_all(&bytes)
+            .map_err(|error| format!("write {}: {error}", temp.display()))?;
+        file.sync_all()
+            .map_err(|error| format!("sync {}: {error}", temp.display()))?;
+        std::fs::rename(&temp, &path)
+            .map_err(|error| format!("rename {}: {error}", path.display()))?;
+        std::fs::File::open(parent)
+            .and_then(|dir| dir.sync_all())
+            .map_err(|error| format!("sync {}: {error}", parent.display()))?;
+        Ok(())
+    })();
+    if outcome.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    outcome
+}
+
+/// Admission leases are server-owned durable state.  They used to share the
+/// free-form project-tag namespace, which let a project edit forge, erase, or
+/// transplant a lease.  Keep the compatibility reader below for records made
+/// by older servers, but never accept this reserved namespace from an API
+/// request.
+fn contains_internal_disk_reservation_tag(tags: &[String]) -> bool {
+    tags.iter()
+        .any(|tag| tag.trim().starts_with(DISK_RESERVATION_TAG_PREFIX))
 }
 
 fn mission_holds_disk_reservation(status: MissionStatus) -> bool {
@@ -7372,29 +7483,116 @@ fn disk_admission_required_bytes(emergency: u64, reserved: u64, candidate: u64) 
 }
 
 async fn reserved_disk_bytes_for_filesystem(
-    mission_store: &Arc<dyn MissionStore>,
+    config: &Config,
     filesystem: &str,
 ) -> Result<u64, String> {
-    let missions = mission_store.list_missions(usize::MAX, 0).await?;
-    Ok(missions
-        .iter()
-        .filter(|mission| mission_holds_disk_reservation(mission.status))
-        .flat_map(|mission| mission.project.tags.iter())
-        .filter_map(|tag| parse_disk_reservation_tag(tag))
-        .filter(|(reserved_filesystem, _)| *reserved_filesystem == filesystem)
-        .fold(0u64, |total, (_, bytes)| total.saturating_add(bytes)))
+    let ledger = read_disk_reservation_ledger(config)?;
+    Ok(ledger
+        .reservations
+        .values()
+        .filter(|reservation| reservation.filesystem == filesystem)
+        .map(disk_reservation_outstanding_bytes)
+        .fold(0u64, |sum, bytes| sum.saturating_add(bytes)))
+}
+
+/// The filesystem's free counter already includes bytes written by a running
+/// mission. Subtracting both those bytes and its full estimate would charge
+/// the same consumption twice.  A lease therefore retains only its estimated
+/// *remaining* peak after measuring its own workspace.  Measurement failure
+/// is conservative: keep the complete estimate.
+fn disk_reservation_outstanding_bytes(reservation: &DiskReservation) -> u64 {
+    let Some(path) = reservation.workspace_dir.as_deref() else {
+        return reservation.estimated_bytes;
+    };
+    let usage = walkdir::WalkDir::new(path)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter_map(|entry| entry.metadata().ok())
+        .filter(|metadata| metadata.is_file())
+        .fold(0u64, |total, metadata| total.saturating_add(metadata.len()));
+    reservation.estimated_bytes.saturating_sub(usage)
+}
+
+fn nonterminal_mission_ids_in_sqlite(path: &std::path::Path) -> Result<HashSet<Uuid>, String> {
+    let connection =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|error| format!("open {} read-only: {error}", path.display()))?;
+    let mut statement = connection
+        .prepare("SELECT id, status FROM missions")
+        .map_err(|error| format!("query {}: {error}", path.display()))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|error| error.to_string())?;
+    let mut ids = HashSet::new();
+    for row in rows {
+        let (id, status) = row.map_err(|error| error.to_string())?;
+        let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status))
+            .unwrap_or(MissionStatus::Active);
+        if mission_holds_disk_reservation(status) {
+            let id = Uuid::parse_str(&id)
+                .map_err(|error| format!("parse mission id {id} in {}: {error}", path.display()))?;
+            ids.insert(id);
+        }
+    }
+    Ok(ids)
+}
+
+/// Reconstruct the live lease set from authoritative mission state while the
+/// global admission lock is held.  The ledger supplies bytes; mission stores
+/// supply lifecycle truth.  Project tags are deliberately excluded: they are
+/// user-editable presentation metadata and can neither grant nor retain a
+/// lease after a project edit.
+async fn reconcile_disk_reservation_ledger_under_lock(
+    control_hub: &ControlHub,
+    config: &Config,
+) -> Result<(), String> {
+    let inventory = control_hub.mission_store_inventory().await?;
+    let mut live_ids = HashSet::new();
+    for store in inventory.live {
+        for mission in store.list_missions(usize::MAX, 0).await? {
+            if mission_holds_disk_reservation(mission.status) {
+                live_ids.insert(mission.id);
+            }
+        }
+    }
+    for user in inventory.offline_file_users {
+        let store: Arc<dyn MissionStore> = Arc::new(
+            mission_store::FileMissionStore::new(inventory.base_dir.clone(), &user).await?,
+        );
+        for mission in store.list_missions(usize::MAX, 0).await? {
+            if mission_holds_disk_reservation(mission.status) {
+                live_ids.insert(mission.id);
+            }
+        }
+    }
+    for path in inventory.offline_sqlite {
+        let ids = tokio::task::spawn_blocking(move || nonterminal_mission_ids_in_sqlite(&path))
+            .await
+            .map_err(|error| error.to_string())??;
+        live_ids.extend(ids);
+    }
+    let mut ledger = read_disk_reservation_ledger(config)?;
+    let before = ledger.reservations.len();
+    ledger.reservations.retain(|id, _| live_ids.contains(id));
+    if ledger.reservations.len() != before {
+        write_disk_reservation_ledger(config, &ledger)?;
+    }
+    Ok(())
 }
 
 /// The caller must retain the returned lock through mission persistence and
 /// its reservation-tag write.  That makes admission, creation and durable
 /// reconstruction one atomic protocol across local control processes.
 async fn reserve_local_mission_disk(
+    control_hub: &ControlHub,
     config: &Config,
-    mission_store: &Arc<dyn MissionStore>,
     workspace: &workspace::Workspace,
     estimate_gib: u64,
-) -> Result<(DurableDiskAdmissionLockGuard, String), String> {
+) -> Result<(DurableDiskAdmissionLockGuard, DiskReservation), String> {
     let guard = acquire_durable_disk_admission_lock(config).await?;
+    reconcile_disk_reservation_ledger_under_lock(control_hub, config).await?;
     let root = workspace::mission_workspace_root_for_workspace(workspace, Uuid::nil());
     if let Some(reason) = disk_admission_refusal(&root) {
         return Err(reason);
@@ -7405,7 +7603,7 @@ async fn reserve_local_mission_disk(
             root.display()
         )
     })?;
-    let reserved = reserved_disk_bytes_for_filesystem(mission_store, &usage.filesystem).await?;
+    let reserved = reserved_disk_bytes_for_filesystem(config, &usage.filesystem).await?;
     let estimate = estimate_gib.saturating_mul(1 << 30);
     let emergency = mission_disk_reserve_gib().saturating_mul(1 << 30);
     let required = disk_admission_required_bytes(emergency, reserved, estimate);
@@ -7428,7 +7626,30 @@ async fn reserve_local_mission_disk(
         required_bytes = required,
         "local mission disk admission reserved"
     );
-    Ok((guard, disk_reservation_tag(&usage.filesystem, estimate)))
+    Ok((
+        guard,
+        DiskReservation {
+            mission_id: Uuid::nil(),
+            filesystem: usage.filesystem,
+            estimated_bytes: estimate,
+            free_bytes_at_grant: usage.available,
+            workspace_dir: None,
+        },
+    ))
+}
+
+/// Release a server-owned lease when a mission reaches a terminal state.  The
+/// lock is the same one used for admission, making a terminal transition and
+/// a concurrent create serialize across control processes.  A failed ledger
+/// write is deliberately surfaced to the caller rather than silently making
+/// capacity appear free.
+async fn release_local_mission_disk(config: &Config, mission_id: Uuid) -> Result<(), String> {
+    let _guard = acquire_durable_disk_admission_lock(config).await?;
+    let mut ledger = read_disk_reservation_ledger(config)?;
+    if ledger.reservations.remove(&mission_id).is_some() {
+        write_disk_reservation_ledger(config, &ledger)?;
+    }
+    Ok(())
 }
 
 struct DurablePrWriterLockGuard {
@@ -8824,6 +9045,15 @@ pub async fn create_mission(
         }
     }
     let mut normalized_request_tags = normalize_mission_tags(req.tags.as_deref());
+    if normalized_request_tags
+        .as_deref()
+        .is_some_and(contains_internal_disk_reservation_tag)
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "disk-reservation-v1 tags are reserved internal admission state".to_string(),
+        ));
+    }
     if let Some(estimated_gib) = effective_estimated_disk_gib {
         let tag = format!("disk-estimate-gib:{estimated_gib}");
         let tags = normalized_request_tags.get_or_insert_with(Vec::new);
@@ -10945,6 +11175,15 @@ pub async fn update_mission_project(
             .filter(|t| !t.is_empty())
             .collect()
     });
+    if tags
+        .as_deref()
+        .is_some_and(contains_internal_disk_reservation_tag)
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "disk-reservation-v1 tags are reserved internal admission state".to_string(),
+        ));
+    }
 
     let effective_string = |patch: &Option<Option<String>>, current: &Option<String>| {
         patch.clone().unwrap_or_else(|| current.clone())
@@ -10952,6 +11191,24 @@ pub async fn update_mission_project(
     let effective_github_pr = effective_string(&github_pr, &current.project.github_pr);
     let effective_intent = effective_string(&intent, &current.project.intent);
     let mut effective_tags = tags.clone().unwrap_or_else(|| current.project.tags.clone());
+    // Compatibility: old releases persisted leases in project tags.  A
+    // project edit may not drop or replace one of those records while the
+    // migration reader still reconstructs it.
+    let durable_reservation_tags: Vec<String> = current
+        .project
+        .tags
+        .iter()
+        .filter(|tag| tag.starts_with(DISK_RESERVATION_TAG_PREFIX))
+        .cloned()
+        .collect();
+    for reservation in &durable_reservation_tags {
+        if !effective_tags.iter().any(|tag| tag == reservation) {
+            effective_tags.push(reservation.clone());
+        }
+    }
+    if tags.is_some() {
+        tags = Some(effective_tags.clone());
+    }
     let deferred_goal = control
         .mission_store
         .get_deferred_goal(id)
@@ -18307,27 +18564,31 @@ async fn control_actor_loop(
                         }
                     }
                     ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, fast_mode, backend, config_profile, parent_mission_id, working_directory, scheduling, requires_local_disk, estimated_disk_gib, admission_tags, respond } => {
+                        // Resolve once for both admission and the durable lease record.
+                        // Keeping this value outside the conditional is important: the
+                        // lease must name the exact workspace that was admitted, rather
+                        // than reconstructing a possibly different default later.
+                        let workspace = workspaces
+                            .get(workspace_id.unwrap_or(workspace::DEFAULT_WORKSPACE_ID))
+                            .await
+                            .unwrap_or_else(|| workspace::Workspace::default_host(config.working_dir.clone()));
                         // Disk preflight: refuse new missions when the root
                         // filesystem is critically full instead of letting
                         // workers die mid-flight on ENOSPC. Actor-level so
                         // the HTTP, Ask and Telegram entrypoints are all
                         // covered by this single gate.
                         let mut reservation_guard = None;
-                        let mut reservation_tag = None;
+                        let mut reservation = None;
                         if requires_local_disk {
-                            let workspace = workspaces
-                                .get(workspace_id.unwrap_or(workspace::DEFAULT_WORKSPACE_ID))
-                                .await
-                                .unwrap_or_else(|| workspace::Workspace::default_host(config.working_dir.clone()));
                             match reserve_local_mission_disk(
+                                &control_hub,
                                 &config,
-                                &mission_store,
                                 &workspace,
                                 estimated_disk_gib.unwrap_or_else(mission_disk_default_estimate_gib),
                             ).await {
-                                Ok((guard, tag)) => {
+                                Ok((guard, candidate)) => {
                                     reservation_guard = Some(guard);
-                                    reservation_tag = Some(tag);
+                                    reservation = Some(candidate);
                                 }
                                 Err(error) => {
                                     let _ = respond.send(Err(error));
@@ -18361,13 +18622,11 @@ async fn control_actor_loop(
                         )
                         .await {
                             Ok(mut mission) => {
-                                // The durable file lock remains held until this tag is
-                                // persisted.  A second process reconstructs the sum from
-                                // these tags, so a restart has no in-memory lease to lose.
-                                let mut tags = admission_tags;
-                                if let Some(tag) = reservation_tag {
-                                    tags.push(tag);
-                                }
+                                // Project tags are user-editable and are not admission
+                                // state.  Persist any ordinary tags independently, then
+                                // write the server-owned v2 ledger before releasing the
+                                // cross-process lock.
+                                let tags = admission_tags;
                                 if !tags.is_empty() {
                                     if let Err(error) = mission_store.update_mission_project(
                                         mission.id,
@@ -18384,7 +18643,7 @@ async fn control_actor_loop(
                                             MissionStatus::Failed,
                                         ).await;
                                         let _ = respond.send(Err(format!(
-                                            "mission creation rolled back: persist disk admission reservation: {error}"
+                                            "mission creation rolled back: persist mission project metadata: {error}"
                                         )));
                                         continue;
                                     }
@@ -18395,9 +18654,33 @@ async fn control_actor_loop(
                                             continue;
                                         }
                                         Err(error) => {
-                                            let _ = respond.send(Err(format!("mission creation rolled back: reload disk admission reservation: {error}")));
+                                            let _ = respond.send(Err(format!("mission creation rolled back: reload mission metadata: {error}")));
                                             continue;
                                         }
+                                    }
+                                }
+                                if let Some(mut candidate) = reservation.take() {
+                                    candidate.mission_id = mission.id;
+                                    candidate.workspace_dir = Some(
+                                        workspace::mission_workspace_dir_for_workspace(&workspace, mission.id),
+                                    );
+                                    let mut ledger = match read_disk_reservation_ledger(&config) {
+                                        Ok(ledger) => ledger,
+                                        Err(error) => {
+                                            let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
+                                            let _ = respond.send(Err(format!(
+                                                "mission creation rolled back: read disk admission ledger: {error}"
+                                            )));
+                                            continue;
+                                        }
+                                    };
+                                    ledger.reservations.insert(mission.id, candidate);
+                                    if let Err(error) = write_disk_reservation_ledger(&config, &ledger) {
+                                        let _ = mission_store.update_mission_status(mission.id, MissionStatus::Failed).await;
+                                        let _ = respond.send(Err(format!(
+                                            "mission creation rolled back: persist disk admission ledger: {error}"
+                                        )));
+                                        continue;
                                     }
                                 }
                                 // Explicitly drop after durable write, rather than relying on
@@ -18444,6 +18727,12 @@ async fn control_actor_loop(
                             .update_mission_status(id, new_status)
                             .await;
                         if result.is_ok() {
+                            if !mission_holds_disk_reservation(new_status) {
+                                if let Err(error) = release_local_mission_disk(&config, id).await {
+                                    tracing::error!(mission = %id, %error,
+                                        "terminal mission lease cleanup failed; retaining conservative admission state");
+                                }
+                            }
                             maybe_schedule_mission_metadata_refresh_for_status(
                                 &mission_store,
                                 &events_tx,
@@ -21064,6 +21353,7 @@ async fn control_actor_loop(
                         config.max_parallel_missions,
                     );
                     board::scheduler_pass(
+                        Some(&control_hub),
                         &mission_store,
                         &self_cmd_tx,
                         &snapshot,
@@ -32003,16 +32293,22 @@ Investigate <service/> failures.
 
     #[test]
     fn disk_admission_reservations_are_filesystem_scoped_and_exact_at_boundary() {
-        let a = disk_reservation_tag("statvfs:filesystem-a", 20 << 30);
-        let b = disk_reservation_tag("statvfs:filesystem-b", 20 << 30);
-        assert_eq!(
-            parse_disk_reservation_tag(&a),
-            Some(("statvfs:filesystem-a", 20 << 30))
-        );
-        assert_eq!(
-            parse_disk_reservation_tag(&b),
-            Some(("statvfs:filesystem-b", 20 << 30))
-        );
+        let a = DiskReservation {
+            mission_id: Uuid::new_v4(),
+            filesystem: "filesystem-a".into(),
+            estimated_bytes: 20 << 30,
+            free_bytes_at_grant: 0,
+            workspace_dir: None,
+        };
+        let b = DiskReservation {
+            mission_id: Uuid::new_v4(),
+            filesystem: "filesystem-b".into(),
+            estimated_bytes: 20 << 30,
+            free_bytes_at_grant: 0,
+            workspace_dir: None,
+        };
+        assert_eq!(disk_reservation_outstanding_bytes(&a), 20 << 30);
+        assert_eq!(disk_reservation_outstanding_bytes(&b), 20 << 30);
 
         let emergency = 64 << 30;
         let first = 20 << 30;

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7594,10 +7594,12 @@ async fn reconcile_disk_reservation_ledger_under_lock(
         }
     }
     let mut ledger = read_disk_reservation_ledger(config)?;
+    let mut changed = false;
     let before = ledger.reservations.len();
     ledger
         .reservations
         .retain(|id, _| live_missions.contains_key(id));
+    changed |= ledger.reservations.len() != before;
     for (&mission_id, workspace_id) in &live_missions {
         if ledger.reservations.contains_key(&mission_id) {
             continue;
@@ -7632,8 +7634,9 @@ async fn reconcile_disk_reservation_ledger_under_lock(
                 )),
             },
         );
+        changed = true;
     }
-    if ledger.reservations.len() != before {
+    if changed {
         write_disk_reservation_ledger(config, &ledger)?;
     }
     Ok(())

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5570,24 +5570,45 @@ pub struct FleetHealth {
     pub disk_total: u64,
     pub disk_percent: f32,
     pub disk_level: crate::api::monitoring::DiskHealthLevel,
+    /// Canonical path whose backing filesystem is measured for local missions.
+    pub disk_path: String,
+    /// Non-secret filesystem identifier returned by statvfs.
+    pub disk_filesystem: String,
+    pub disk_free_gib: u64,
+    pub disk_required_gib: u64,
 }
 
 /// Admission preflight: `Some(reason)` when new missions must be refused
-/// because the root filesystem is critically full, or is at warn level while
+/// because the selected mission-workspace filesystem is critically full, or is at warn level while
 /// `DISK_ADMISSION_AT_WARN=1`. `DISK_ADMISSION_ENABLED=0` is the escape hatch.
-fn disk_admission_refusal() -> Option<String> {
+fn disk_admission_refusal(path: &std::path::Path) -> Option<String> {
     let enabled = std::env::var("DISK_ADMISSION_ENABLED")
         .map(|v| v.trim() != "0" && !v.trim().eq_ignore_ascii_case("false"))
         .unwrap_or(true);
     if !enabled {
         return None;
     }
-    let (used, total, percent) = crate::api::monitoring::current_disk_usage();
+    let usage = match crate::api::monitoring::disk_usage_for_path(path) {
+        Ok(usage) => usage,
+        Err(error) => {
+            return Some(format!(
+                "mission creation refused: cannot measure workspace filesystem at {}: {error}",
+                path.display()
+            ));
+        }
+    };
+    let used = usage.used;
+    let total = usage.total;
+    let percent = if total == 0 {
+        100.0
+    } else {
+        used as f32 / total as f32 * 100.0
+    };
     match crate::api::monitoring::DiskHealthLevel::from_percent(percent) {
         crate::api::monitoring::DiskHealthLevel::Critical => Some(format!(
-            "mission creation refused: disk critically full ({percent:.1}% used, {} GB free). \
-             Free space or raise DISK_CRITICAL_PCT, then retry.",
-            total.saturating_sub(used) / (1024 * 1024 * 1024)
+            "mission creation refused: disk critically full at {} (filesystem {}, \
+             {percent:.1}% used, {} GiB free). Free space or raise DISK_CRITICAL_PCT, then retry.",
+            usage.measured_path.display(), usage.filesystem, usage.available / (1 << 30)
         )),
         crate::api::monitoring::DiskHealthLevel::Warn
             if std::env::var("DISK_ADMISSION_AT_WARN")
@@ -5596,9 +5617,9 @@ fn disk_admission_refusal() -> Option<String> {
         {
             Some(format!(
                 "mission creation refused: disk above the admission warning threshold \
-                 ({percent:.1}% used, {} GB free). Wait for workspace GC, select a remote \
+                 at {} (filesystem {}, {percent:.1}% used, {} GiB free). Wait for workspace GC, select a remote \
                  node, or free space.",
-                total.saturating_sub(used) / (1024 * 1024 * 1024)
+                usage.measured_path.display(), usage.filesystem, usage.available / (1 << 30)
             ))
         }
         crate::api::monitoring::DiskHealthLevel::Warn => {
@@ -5612,17 +5633,35 @@ fn disk_admission_refusal() -> Option<String> {
     }
 }
 
+fn mission_disk_reserve_gib() -> u64 {
+    std::env::var("MISSION_DISK_EMERGENCY_RESERVE_GB")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(150)
+}
+
+fn mission_disk_default_estimate_gib() -> u64 {
+    std::env::var("MISSION_DISK_DEFAULT_ESTIMATE_GIB")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|estimate| (1..=512).contains(estimate))
+        .unwrap_or(64)
+}
+
 fn disk_estimate_refusal(
-    available_bytes: u64,
+    usage: &crate::api::monitoring::DiskUsage,
     estimated_gib: u64,
     reserve_gib: u64,
 ) -> Option<String> {
     let required_gib = estimated_gib.saturating_add(reserve_gib);
-    (available_bytes < required_gib.saturating_mul(1 << 30)).then(|| {
+    (usage.available < required_gib.saturating_mul(1 << 30)).then(|| {
         format!(
             "mission needs an estimated {estimated_gib} GiB scratch plus a {reserve_gib} GiB \
-             emergency floor, but only {} GiB is free; select a remote node or free space",
-            available_bytes / (1 << 30)
+             emergency floor ({required_gib} GiB required), but only {} GiB is free at {} \
+             (filesystem {}); select a remote node or free space",
+            usage.available / (1 << 30),
+            usage.measured_path.display(),
+            usage.filesystem
         )
     })
 }
@@ -5655,7 +5694,16 @@ pub async fn fleet_health(
         .map_err(internal_error)?;
 
     let cfg = &state.config;
-    let (disk_used, disk_total, disk_percent) = crate::api::monitoring::current_disk_usage();
+    let workspace_root = crate::workspace::configured_mission_workspace_root(&cfg.working_dir);
+    let disk =
+        crate::api::monitoring::disk_usage_for_path(&workspace_root).map_err(internal_error)?;
+    let disk_percent = if disk.total == 0 {
+        100.0
+    } else {
+        disk.used as f32 / disk.total as f32 * 100.0
+    };
+    let reserve_gib = mission_disk_reserve_gib();
+    let required_gib = mission_disk_default_estimate_gib().saturating_add(reserve_gib);
     Ok(Json(FleetHealth {
         status: if control_responsive { "ok" } else { "degraded" },
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -5665,10 +5713,14 @@ pub async fn fleet_health(
         missions,
         webhook_forwarder_configured: cfg.paloma_webhook_forward_url.is_some(),
         offload_configured: cfg.spark_arbiter_url.is_some() || cfg.spark_ssh_target.is_some(),
-        disk_used,
-        disk_total,
+        disk_used: disk.used,
+        disk_total: disk.total,
         disk_percent,
         disk_level: crate::api::monitoring::DiskHealthLevel::from_percent(disk_percent),
+        disk_path: disk.measured_path.to_string_lossy().to_string(),
+        disk_filesystem: disk.filesystem,
+        disk_free_gib: disk.available / (1 << 30),
+        disk_required_gib: required_gib,
     }))
 }
 
@@ -8610,16 +8662,9 @@ pub async fn create_mission(
         .as_deref()
         .map(str::trim)
         .is_none_or(str::is_empty);
-    let effective_estimated_disk_gib = req.estimated_disk_gib.or_else(|| {
-        local_mission
-            .then(|| {
-                std::env::var("MISSION_DISK_DEFAULT_ESTIMATE_GIB")
-                    .ok()
-                    .and_then(|raw| raw.trim().parse::<u64>().ok())
-                    .filter(|estimate| (1..=512).contains(estimate))
-            })
-            .flatten()
-    });
+    let effective_estimated_disk_gib = req
+        .estimated_disk_gib
+        .or_else(|| local_mission.then(mission_disk_default_estimate_gib));
     if let Some(estimated_gib) = effective_estimated_disk_gib {
         if estimated_gib == 0 || estimated_gib > 512 {
             return Err((
@@ -8628,13 +8673,22 @@ pub async fn create_mission(
             ));
         }
         if local_mission {
-            let (used, total, _) = crate::api::monitoring::current_disk_usage();
-            let reserve_gib = std::env::var("MISSION_DISK_EMERGENCY_RESERVE_GB")
-                .ok()
-                .and_then(|raw| raw.trim().parse::<u64>().ok())
-                .unwrap_or(64);
+            let workspace = state
+                .workspaces
+                .get(workspace_id.unwrap_or(workspace::DEFAULT_WORKSPACE_ID))
+                .await
+                .unwrap_or_else(|| {
+                    workspace::Workspace::default_host(state.config.working_dir.clone())
+                });
+            let root = workspace::mission_workspace_root_for_workspace(&workspace, Uuid::nil());
+            let usage = crate::api::monitoring::disk_usage_for_path(&root).map_err(|error| {
+                (
+                    StatusCode::INSUFFICIENT_STORAGE,
+                    format!("mission creation refused: cannot measure workspace filesystem at {}: {error}", root.display()),
+                )
+            })?;
             if let Some(reason) =
-                disk_estimate_refusal(total.saturating_sub(used), estimated_gib, reserve_gib)
+                disk_estimate_refusal(&usage, estimated_gib, mission_disk_reserve_gib())
             {
                 return Err((StatusCode::INSUFFICIENT_STORAGE, reason));
             }
@@ -8793,6 +8847,7 @@ pub async fn create_mission(
                 deadline: req.deadline.map(|t| t.to_rfc3339()),
             },
             requires_local_disk: local_mission,
+            estimated_disk_gib: effective_estimated_disk_gib,
             respond: tx,
         })
         .await
@@ -12662,7 +12717,7 @@ async fn cleanup_mission_workspace_dirs_for_delete(
         let Some(ws) = workspaces.get(mission.workspace_id).await else {
             continue;
         };
-        let dir = workspace::mission_workspace_dir_for_root(&ws.path, mission.id);
+        let dir = workspace::mission_workspace_dir_for_workspace(&ws, mission.id);
         if !dir.exists() {
             continue;
         }
@@ -18081,14 +18136,37 @@ async fn control_actor_loop(
                             }
                         }
                     }
-                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, fast_mode, backend, config_profile, parent_mission_id, working_directory, scheduling, requires_local_disk, respond } => {
+                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, fast_mode, backend, config_profile, parent_mission_id, working_directory, scheduling, requires_local_disk, estimated_disk_gib, respond } => {
                         // Disk preflight: refuse new missions when the root
                         // filesystem is critically full instead of letting
                         // workers die mid-flight on ENOSPC. Actor-level so
                         // the HTTP, Ask and Telegram entrypoints are all
                         // covered by this single gate.
                         if requires_local_disk {
-                            if let Some(refusal) = disk_admission_refusal() {
+                            let workspace = workspaces
+                                .get(workspace_id.unwrap_or(workspace::DEFAULT_WORKSPACE_ID))
+                                .await
+                                .unwrap_or_else(|| workspace::Workspace::default_host(config.working_dir.clone()));
+                            let root = workspace::mission_workspace_root_for_workspace(
+                                &workspace,
+                                Uuid::nil(),
+                            );
+                            if let Some(refusal) = disk_admission_refusal(&root) {
+                                let _ = respond.send(Err(refusal));
+                                continue;
+                            }
+                            let usage = match crate::api::monitoring::disk_usage_for_path(&root) {
+                                Ok(usage) => usage,
+                                Err(error) => {
+                                    let _ = respond.send(Err(format!("mission creation refused: cannot measure workspace filesystem at {}: {error}", root.display())));
+                                    continue;
+                                }
+                            };
+                            if let Some(refusal) = disk_estimate_refusal(
+                                &usage,
+                                estimated_disk_gib.unwrap_or_else(mission_disk_default_estimate_gib),
+                                mission_disk_reserve_gib(),
+                            ) {
                                 let _ = respond.send(Err(refusal));
                                 continue;
                             }
@@ -25267,11 +25345,31 @@ mod tests {
 
     #[test]
     fn disk_estimate_preserves_emergency_free_space() {
-        assert!(disk_estimate_refusal(100 << 30, 20, 64).is_none());
-        let refusal = disk_estimate_refusal(80 << 30, 20, 64).unwrap();
+        let usage = crate::api::monitoring::DiskUsage {
+            measured_path: "/srv/sandboxed-storage".into(),
+            filesystem: "statvfs:test".to_string(),
+            used: 0,
+            total: 100 << 30,
+            available: 100 << 30,
+        };
+        assert!(disk_estimate_refusal(&usage, 20, 64).is_none());
+        // Equality is admitted: the emergency reserve remains exactly intact.
+        let exact = crate::api::monitoring::DiskUsage {
+            available: 84 << 30,
+            total: 84 << 30,
+            ..usage.clone()
+        };
+        assert!(disk_estimate_refusal(&exact, 20, 64).is_none());
+        let low = crate::api::monitoring::DiskUsage {
+            available: 80 << 30,
+            total: 80 << 30,
+            ..usage
+        };
+        let refusal = disk_estimate_refusal(&low, 20, 64).unwrap();
         assert!(refusal.contains("20 GiB scratch"));
         assert!(refusal.contains("64 GiB"));
         assert!(refusal.contains("80 GiB is free"));
+        assert!(refusal.contains("/srv/sandboxed-storage"));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -12715,12 +12715,31 @@ async fn cleanup_mission_workspace_dirs_for_delete(
     let mut deleted_dirs = Vec::new();
     for mission in missions {
         let Some(ws) = workspaces.get(mission.workspace_id).await else {
-            continue;
+            // Do not finalize the database deletion when the workspace that
+            // owns a mission's persisted placement cannot be consulted.  A
+            // relocated directory may still exist on a temporarily missing
+            // volume, and treating that as an already-clean workspace would
+            // orphan it permanently.
+            return Err((
+                StatusCode::CONFLICT,
+                format!(
+                    "Cannot verify workspace placement for mission {} because workspace {} is unavailable",
+                    mission.id, mission.workspace_id
+                ),
+            ));
         };
-        if let Err(error) = workspace::ensure_persisted_mission_root_is_available(&ws, mission.id) {
-            tracing::warn!(mission_id = %mission.id, %error, "refusing to delete workspace with unavailable persisted root");
-            continue;
-        }
+        workspace::ensure_persisted_mission_root_is_available(&ws, mission.id).map_err(
+            |error| {
+                tracing::warn!(mission_id = %mission.id, %error, "refusing to delete workspace with unavailable persisted root");
+                (
+                    StatusCode::CONFLICT,
+                    format!(
+                        "Cannot delete mission {}: persisted mission workspace root is unavailable: {}",
+                        mission.id, error
+                    ),
+                )
+            },
+        )?;
         let dir = workspace::mission_workspace_dir_for_workspace(&ws, mission.id);
         if !dir.exists() {
             continue;
@@ -21864,8 +21883,14 @@ async fn run_single_control_turn(
         {
             Ok(dir) => dir,
             Err(e) => {
-                tracing::warn!("Failed to prepare mission workspace: {}", e);
-                ws.path.clone()
+                // The persisted mission root is a placement capability, not
+                // a hint. Do not run an Ask/control turn in the workspace
+                // root if its selected filesystem cannot be verified.
+                tracing::warn!(mission_id = %mid, error = %e, "refusing control turn without its verified mission workspace");
+                return crate::agents::AgentResult::failure(
+                    format!("Failed to prepare verified mission workspace: {e}"),
+                    0,
+                );
             }
         };
         (dir, Some(ws))
@@ -26998,6 +27023,97 @@ mod tests {
         assert!(!worker_dir.exists());
         assert!(store.get_mission(boss.id).await.unwrap().is_some());
         assert!(store.get_mission(worker.id).await.unwrap().is_some());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn delete_refuses_changed_persisted_filesystem_until_identity_is_restored() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp = tempfile::tempdir().expect("temp dir should be created");
+        let storage = temp.path().join("relocated-storage");
+        std::fs::create_dir_all(&storage).expect("storage should be created");
+        let workspaces = Arc::new(workspace::WorkspaceStore::new(temp.path().to_path_buf()).await);
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(
+                Some("relocated mission"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("mission should be created");
+        let mission_dir = workspace::mission_workspace_dir_for_root(&storage, mission.id);
+        std::fs::create_dir_all(&mission_dir).expect("mission directory should be created");
+
+        let registry_dir = temp.path().join(".sandboxed-sh");
+        std::fs::create_dir_all(&registry_dir).expect("registry directory should be created");
+        let registry_path = registry_dir.join("mission-workspace-roots.json");
+        let actual_identity = format!("dev:{}", std::fs::metadata(&storage).unwrap().dev());
+        std::fs::write(
+            &registry_path,
+            serde_json::json!({ mission.id.to_string(): {
+                "path": storage,
+                "filesystem_identity": actual_identity
+            }})
+            .to_string(),
+        )
+        .expect("registry should be written");
+
+        // A completely unavailable persisted root must leave both the
+        // checkout and its database record intact.
+        let unavailable_storage = temp.path().join("temporarily-unmounted-storage");
+        std::fs::rename(&storage, &unavailable_storage).expect("storage should disappear");
+        let error = cleanup_mission_workspace_dirs_for_delete(&store, &workspaces, mission.id, &[])
+            .await
+            .expect_err("deletion must fail closed for an unavailable filesystem");
+        assert_eq!(error.0, StatusCode::CONFLICT);
+        assert!(store.get_mission(mission.id).await.unwrap().is_some());
+        assert!(unavailable_storage
+            .join(mission_dir.file_name().unwrap())
+            .exists());
+        std::fs::rename(&unavailable_storage, &storage).expect("storage should be restored");
+
+        // An unmount can also leave the mountpoint path behind on a different
+        // filesystem. That identity mismatch is equally unsafe to delete.
+        std::fs::write(
+            &registry_path,
+            serde_json::json!({ mission.id.to_string(): {
+                "path": storage,
+                "filesystem_identity": "dev:changed-after-unmount"
+            }})
+            .to_string(),
+        )
+        .expect("mismatched registry should be written");
+        let error = cleanup_mission_workspace_dirs_for_delete(&store, &workspaces, mission.id, &[])
+            .await
+            .expect_err("deletion must fail closed for a replaced filesystem");
+        assert_eq!(error.0, StatusCode::CONFLICT);
+        assert!(store.get_mission(mission.id).await.unwrap().is_some());
+        assert!(mission_dir.exists());
+
+        std::fs::write(
+            &registry_path,
+            serde_json::json!({ mission.id.to_string(): {
+                "path": storage,
+                "filesystem_identity": actual_identity
+            }})
+            .to_string(),
+        )
+        .expect("restored registry should be written");
+
+        cleanup_mission_workspace_dirs_for_delete(&store, &workspaces, mission.id, &[])
+            .await
+            .expect("deletion should proceed after the original filesystem is restored");
+        delete_mission_with_children(&store, mission.id, &[])
+            .await
+            .expect("database record should delete only after verified cleanup");
+        assert!(!mission_dir.exists());
+        assert!(store.get_mission(mission.id).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -21867,7 +21867,7 @@ async fn run_single_control_turn(
         // Get library for skill syncing
         let lib_guard = library.read().await;
         let lib_ref = lib_guard.as_ref().map(|l| l.as_ref());
-        let dir = match Box::pin(workspace::prepare_mission_workspace_with_skills_backend(
+        let prepared = Box::pin(workspace::prepare_mission_workspace_with_skills_backend(
             &mut ws,
             &mcp,
             lib_ref,
@@ -21879,18 +21879,15 @@ async fn run_single_control_turn(
             Some(&config.working_dir),
             !pr_readonly,
         ))
-        .await
-        {
+        .await;
+        let dir = match workspace::require_verified_mission_workspace(prepared) {
             Ok(dir) => dir,
             Err(e) => {
                 // The persisted mission root is a placement capability, not
                 // a hint. Do not run an Ask/control turn in the workspace
                 // root if its selected filesystem cannot be verified.
                 tracing::warn!(mission_id = %mid, error = %e, "refusing control turn without its verified mission workspace");
-                return crate::agents::AgentResult::failure(
-                    format!("Failed to prepare verified mission workspace: {e}"),
-                    0,
-                );
+                return crate::agents::AgentResult::failure(e.to_string(), 0);
             }
         };
         (dir, Some(ws))
@@ -27028,8 +27025,6 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn delete_refuses_changed_persisted_filesystem_until_identity_is_restored() {
-        use std::os::unix::fs::MetadataExt;
-
         let temp = tempfile::tempdir().expect("temp dir should be created");
         let storage = temp.path().join("relocated-storage");
         std::fs::create_dir_all(&storage).expect("storage should be created");
@@ -27053,7 +27048,7 @@ mod tests {
         let registry_dir = temp.path().join(".sandboxed-sh");
         std::fs::create_dir_all(&registry_dir).expect("registry directory should be created");
         let registry_path = registry_dir.join("mission-workspace-roots.json");
-        let actual_identity = format!("dev:{}", std::fs::metadata(&storage).unwrap().dev());
+        let actual_identity = workspace::filesystem_identity(&storage).unwrap();
         std::fs::write(
             &registry_path,
             serde_json::json!({ mission.id.to_string(): {

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -12,7 +12,7 @@
 //! always fires; the webhook only when `PALOMA_WEBHOOK_FORWARD_URL` is set.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -11,6 +11,8 @@
 //! Delivery is best-effort: `tracing::error!`/`warn!` is the baseline that
 //! always fires; the webhook only when `PALOMA_WEBHOOK_FORWARD_URL` is set.
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,6 +44,75 @@ fn rank(level: DiskHealthLevel) -> u8 {
     }
 }
 
+/// Notification state belongs to the physical root being sampled, never to
+/// the highest sample in a tick.  Persisted roots can be on separate mounts;
+/// an alert for one mount must not suppress the first alert for another.
+#[derive(Clone, Copy, Debug)]
+struct AlertState {
+    level: DiskHealthLevel,
+    last_alert_at: Option<tokio::time::Instant>,
+}
+
+impl Default for AlertState {
+    fn default() -> Self {
+        Self {
+            level: DiskHealthLevel::Ok,
+            last_alert_at: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AlertAction {
+    Notify(DiskHealthLevel),
+    Recover,
+    None,
+}
+
+/// Prefer an OS filesystem identity so two persisted roots on the same mount
+/// share one alert cadence. The canonical path remains the portable fallback
+/// (and also identifies mounts on platforms without a device number).
+fn filesystem_identity(root: &Path) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let Ok(metadata) = std::fs::metadata(root) {
+            return format!("device:{}", metadata.dev());
+        }
+    }
+    root.canonicalize()
+        .unwrap_or_else(|_| root.to_path_buf())
+        .display()
+        .to_string()
+}
+
+fn alert_action(
+    state: &mut AlertState,
+    level: DiskHealthLevel,
+    percent: f32,
+    now: tokio::time::Instant,
+) -> AlertAction {
+    let escalated = rank(level) > rank(state.level);
+    let repeat_due = state
+        .last_alert_at
+        .map(|then| now.duration_since(then) >= repeat_interval())
+        .unwrap_or(true);
+    let recovered = state.level != DiskHealthLevel::Ok
+        && percent < monitoring::disk_warn_pct() - RECOVERY_MARGIN_PCT;
+
+    if level != DiskHealthLevel::Ok && (escalated || repeat_due) {
+        state.level = level;
+        state.last_alert_at = Some(now);
+        AlertAction::Notify(level)
+    } else if recovered {
+        state.level = DiskHealthLevel::Ok;
+        state.last_alert_at = None;
+        AlertAction::Recover
+    } else {
+        AlertAction::None
+    }
+}
+
 /// Spawn the watcher loop. Safe to call once at server start.
 pub fn spawn(state: Arc<AppState>) {
     tokio::spawn(async move {
@@ -53,87 +124,127 @@ async fn run_loop(state: Arc<AppState>) {
     let mut interval = tokio::time::interval(TICK_INTERVAL);
     // Skip the boot tick; the server is busy starting subsystems.
     interval.tick().await;
-    // The level we last notified about (Ok = nothing outstanding).
-    let mut alerted_level = DiskHealthLevel::Ok;
-    let mut last_alert_at: Option<tokio::time::Instant> = None;
+    // Filesystem identity is a stable key for the mounted location. State is
+    // deliberately retained while a root is temporarily absent, preventing an
+    // unmount/remount from producing alert spam.
+    let mut alerts: HashMap<String, AlertState> = HashMap::new();
     loop {
         interval.tick().await;
         // Roots persisted for active missions can outlive a configuration
         // change, so sample every filesystem that can still host one rather
         // than only today's MISSION_WORKSPACE_ROOT.
         let workspace = crate::workspace::Workspace::default_host(state.config.working_dir.clone());
-        let usage = crate::workspace::mission_workspace_roots_for_workspace(&workspace)
+        let usages = crate::workspace::mission_workspace_roots_for_workspace(&workspace)
             .into_iter()
             .filter_map(|root| match monitoring::disk_usage_for_path(&root) {
-                Ok(usage) => Some((root, usage)),
+                Ok(usage) => Some((root.canonicalize().unwrap_or(root), usage)),
                 Err(error) => {
                     tracing::warn!(path = %root.display(), %error, "disk watcher: cannot measure mission workspace filesystem");
                     None
                 }
-            })
-            .max_by(|(_, left), (_, right)| {
-                let left = if left.total == 0 {
-                    f32::INFINITY
-                } else {
-                    left.used as f32 / left.total as f32
-                };
-                let right = if right.total == 0 {
-                    f32::INFINITY
-                } else {
-                    right.used as f32 / right.total as f32
-                };
-                left.total_cmp(&right)
             });
-        let Some((mission_root, usage)) = usage else {
-            continue;
-        };
-        let used = usage.used;
-        let total = usage.total;
-        let percent = if total == 0 {
-            100.0
-        } else {
-            used as f32 / total as f32 * 100.0
-        };
-        let level = DiskHealthLevel::from_percent(percent);
-
-        let escalated = rank(level) > rank(alerted_level);
-        let repeat_due = last_alert_at
-            .map(|t| t.elapsed() >= repeat_interval())
-            .unwrap_or(true);
-        let recovered = alerted_level != DiskHealthLevel::Ok
-            && percent < monitoring::disk_warn_pct() - RECOVERY_MARGIN_PCT;
-
-        if level != DiskHealthLevel::Ok {
-            let gc_state = Arc::clone(&state);
-            tokio::spawn(async move {
-                super::mission_workspace_gc::run_pressure_sweep(&gc_state).await;
-            });
-        }
-
-        if level != DiskHealthLevel::Ok && (escalated || repeat_due) {
-            let free_gb = total.saturating_sub(used) / (1024 * 1024 * 1024);
-            let message = format!(
+        for (mission_root, usage) in usages {
+            let used = usage.used;
+            let total = usage.total;
+            let percent = if total == 0 {
+                100.0
+            } else {
+                used as f32 / total as f32 * 100.0
+            };
+            let level = DiskHealthLevel::from_percent(percent);
+            if level != DiskHealthLevel::Ok {
+                let gc_state = Arc::clone(&state);
+                tokio::spawn(async move {
+                    super::mission_workspace_gc::run_pressure_sweep(&gc_state).await;
+                });
+            }
+            match alert_action(
+                alerts
+                    .entry(filesystem_identity(&mission_root))
+                    .or_default(),
+                level,
+                percent,
+                tokio::time::Instant::now(),
+            ) {
+                AlertAction::Notify(level) => {
+                    let free_gb = total.saturating_sub(used) / (1024 * 1024 * 1024);
+                    let message = format!(
                 "Disk {level:?}: mission filesystem {} at {percent:.1}% ({free_gb} GB free). \
                  Mission admission is refused at critical level.",
                 mission_root.display()
             );
-            match level {
-                DiskHealthLevel::Critical => tracing::error!(percent, free_gb, "{message}"),
-                _ => tracing::warn!(percent, free_gb, "{message}"),
-            }
-            deliver_webhook(&state, level, used, total, percent, &message).await;
-            alerted_level = level;
-            last_alert_at = Some(tokio::time::Instant::now());
-        } else if recovered {
-            let message = format!(
-                "Disk recovered: mission filesystem back to {percent:.1}% used; \
+                    match level {
+                        DiskHealthLevel::Critical => tracing::error!(percent, free_gb, "{message}"),
+                        _ => tracing::warn!(percent, free_gb, "{message}"),
+                    }
+                    deliver_webhook(&state, level, used, total, percent, &message).await;
+                }
+                AlertAction::Recover => {
+                    let message = format!(
+                        "Disk recovered: mission filesystem back to {percent:.1}% used; \
                  mission admission restored."
-            );
-            tracing::info!(percent, "{message}");
-            deliver_webhook(&state, DiskHealthLevel::Ok, used, total, percent, &message).await;
-            alerted_level = DiskHealthLevel::Ok;
-            last_alert_at = None;
+                    );
+                    tracing::info!(percent, "{message}");
+                    deliver_webhook(&state, DiskHealthLevel::Ok, used, total, percent, &message)
+                        .await;
+                }
+                AlertAction::None => {}
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alerts_and_recoveries_are_independent_per_persisted_root() {
+        let now = tokio::time::Instant::now();
+        let mut roots = HashMap::<String, AlertState>::new();
+        let root_a = PathBuf::from("/mounted/root-a");
+        let root_b = PathBuf::from("/mounted/root-b");
+
+        assert_eq!(
+            alert_action(
+                roots.entry(root_a.display().to_string()).or_default(),
+                DiskHealthLevel::Critical,
+                96.0,
+                now
+            ),
+            AlertAction::Notify(DiskHealthLevel::Critical)
+        );
+        // A different filesystem at the same severity is its own first
+        // notification, not suppressed by root A's outstanding alert.
+        assert_eq!(
+            alert_action(
+                roots.entry(root_b.display().to_string()).or_default(),
+                DiskHealthLevel::Critical,
+                96.0,
+                now
+            ),
+            AlertAction::Notify(DiskHealthLevel::Critical)
+        );
+        assert_eq!(
+            alert_action(
+                roots.entry(root_a.display().to_string()).or_default(),
+                DiskHealthLevel::Ok,
+                80.0,
+                now
+            ),
+            AlertAction::Recover
+        );
+        // Root B stays elevated but does not spam a second alert before its
+        // repeat interval merely because root A recovered.
+        assert_eq!(
+            alert_action(
+                roots.entry(root_b.display().to_string()).or_default(),
+                DiskHealthLevel::Critical,
+                96.0,
+                now
+            ),
+            AlertAction::None
+        );
     }
 }
 

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -61,8 +61,7 @@ async fn run_loop(state: Arc<AppState>) {
         // Roots persisted for active missions can outlive a configuration
         // change, so sample every filesystem that can still host one rather
         // than only today's MISSION_WORKSPACE_ROOT.
-        let workspace =
-            crate::workspace::Workspace::default_host(state.config.working_dir.clone());
+        let workspace = crate::workspace::Workspace::default_host(state.config.working_dir.clone());
         let usage = crate::workspace::mission_workspace_roots_for_workspace(&workspace)
             .into_iter()
             .filter_map(|root| match monitoring::disk_usage_for_path(&root) {

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -78,7 +78,7 @@ fn watched_roots_for_workspaces<'a>(
     let mut roots = Vec::new();
     for workspace in workspaces {
         roots.extend(crate::workspace::mission_workspace_roots_for_workspace(
-            &workspace,
+            workspace,
         ));
     }
     roots.sort();

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -197,6 +197,7 @@ async fn run_loop(state: Arc<AppState>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn alerts_and_recoveries_are_independent_per_persisted_root() {

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -58,14 +58,35 @@ async fn run_loop(state: Arc<AppState>) {
     let mut last_alert_at: Option<tokio::time::Instant> = None;
     loop {
         interval.tick().await;
-        let mission_root =
-            crate::workspace::configured_mission_workspace_root(&state.config.working_dir);
-        let usage = match monitoring::disk_usage_for_path(&mission_root) {
-            Ok(usage) => usage,
-            Err(error) => {
-                tracing::warn!(path = %mission_root.display(), %error, "disk watcher: cannot measure mission workspace filesystem");
-                continue;
-            }
+        // Roots persisted for active missions can outlive a configuration
+        // change, so sample every filesystem that can still host one rather
+        // than only today's MISSION_WORKSPACE_ROOT.
+        let workspace =
+            crate::workspace::Workspace::default_host(state.config.working_dir.clone());
+        let usage = crate::workspace::mission_workspace_roots_for_workspace(&workspace)
+            .into_iter()
+            .filter_map(|root| match monitoring::disk_usage_for_path(&root) {
+                Ok(usage) => Some((root, usage)),
+                Err(error) => {
+                    tracing::warn!(path = %root.display(), %error, "disk watcher: cannot measure mission workspace filesystem");
+                    None
+                }
+            })
+            .max_by(|(_, left), (_, right)| {
+                let left = if left.total == 0 {
+                    f32::INFINITY
+                } else {
+                    left.used as f32 / left.total as f32
+                };
+                let right = if right.total == 0 {
+                    f32::INFINITY
+                } else {
+                    right.used as f32 / right.total as f32
+                };
+                left.total_cmp(&right)
+            });
+        let Some((mission_root, usage)) = usage else {
+            continue;
         };
         let used = usage.used;
         let total = usage.total;
@@ -93,8 +114,9 @@ async fn run_loop(state: Arc<AppState>) {
         if level != DiskHealthLevel::Ok && (escalated || repeat_due) {
             let free_gb = total.saturating_sub(used) / (1024 * 1024 * 1024);
             let message = format!(
-                "Disk {level:?}: root filesystem at {percent:.1}% ({free_gb} GB free). \
-                 Mission admission is refused at critical level."
+                "Disk {level:?}: mission filesystem {} at {percent:.1}% ({free_gb} GB free). \
+                 Mission admission is refused at critical level.",
+                mission_root.display()
             );
             match level {
                 DiskHealthLevel::Critical => tracing::error!(percent, free_gb, "{message}"),
@@ -105,7 +127,7 @@ async fn run_loop(state: Arc<AppState>) {
             last_alert_at = Some(tokio::time::Instant::now());
         } else if recovered {
             let message = format!(
-                "Disk recovered: root filesystem back to {percent:.1}% used; \
+                "Disk recovered: mission filesystem back to {percent:.1}% used; \
                  mission admission restored."
             );
             tracing::info!(percent, "{message}");

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -12,7 +12,6 @@
 //! always fires; the webhook only when `PALOMA_WEBHOOK_FORWARD_URL` is set.
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -69,21 +68,27 @@ enum AlertAction {
     None,
 }
 
-/// Prefer an OS filesystem identity so two persisted roots on the same mount
-/// share one alert cadence. The canonical path remains the portable fallback
-/// (and also identifies mounts on platforms without a device number).
-fn filesystem_identity(root: &Path) -> String {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        if let Ok(metadata) = std::fs::metadata(root) {
-            return format!("device:{}", metadata.dev());
-        }
+/// Collect every operational root from the workspace inventory.  The same
+/// `mission_workspace_roots_for_workspace` helper is used by GC and
+/// admission; it validates persisted identities and excludes an unavailable
+/// or replaced mount rather than accidentally sampling its bare mountpoint.
+fn watched_roots_for_workspaces<'a>(
+    workspaces: impl IntoIterator<Item = &'a crate::workspace::Workspace>,
+) -> Vec<std::path::PathBuf> {
+    let mut roots = Vec::new();
+    for workspace in workspaces {
+        roots.extend(crate::workspace::mission_workspace_roots_for_workspace(
+            &workspace,
+        ));
     }
-    root.canonicalize()
-        .unwrap_or_else(|_| root.to_path_buf())
-        .display()
-        .to_string()
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+async fn watched_roots(state: &Arc<AppState>) -> Vec<std::path::PathBuf> {
+    let workspaces = state.workspaces.list().await;
+    watched_roots_for_workspaces(workspaces.iter())
 }
 
 fn alert_action(
@@ -133,17 +138,24 @@ async fn run_loop(state: Arc<AppState>) {
         // Roots persisted for active missions can outlive a configuration
         // change, so sample every filesystem that can still host one rather
         // than only today's MISSION_WORKSPACE_ROOT.
-        let workspace = crate::workspace::Workspace::default_host(state.config.working_dir.clone());
-        let usages = crate::workspace::mission_workspace_roots_for_workspace(&workspace)
-            .into_iter()
-            .filter_map(|root| match monitoring::disk_usage_for_path(&root) {
-                Ok(usage) => Some((root.canonicalize().unwrap_or(root), usage)),
-                Err(error) => {
-                    tracing::warn!(path = %root.display(), %error, "disk watcher: cannot measure mission workspace filesystem");
-                    None
+        // `DiskUsage.filesystem` is the placement subsystem's stable mounted
+        // filesystem identity.  Deduplicate before alerting or sweeping: two
+        // workspace roots on one filesystem receive one cadence, while equal
+        // pressure on distinct filesystems is independently actionable.
+        let mut usages = HashMap::new();
+        for root in watched_roots(&state).await {
+            match monitoring::disk_usage_for_path(&root) {
+                Ok(usage) => {
+                    usages
+                        .entry(usage.filesystem.clone())
+                        .or_insert_with(|| (root.canonicalize().unwrap_or(root), usage));
                 }
-            });
-        for (mission_root, usage) in usages {
+                Err(error) => {
+                    tracing::warn!(path = %root.display(), %error, "disk watcher: cannot measure verified mission workspace filesystem")
+                }
+            }
+        }
+        for (filesystem, (mission_root, usage)) in usages {
             let used = usage.used;
             let total = usage.total;
             let percent = if total == 0 {
@@ -159,9 +171,7 @@ async fn run_loop(state: Arc<AppState>) {
                 });
             }
             match alert_action(
-                alerts
-                    .entry(filesystem_identity(&mission_root))
-                    .or_default(),
+                alerts.entry(filesystem).or_default(),
                 level,
                 percent,
                 tokio::time::Instant::now(),
@@ -245,6 +255,45 @@ mod tests {
                 now
             ),
             AlertAction::None
+        );
+    }
+
+    #[test]
+    fn custom_workspace_root_is_included_and_keeps_its_own_alert_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let host_root = temp.path().join("host");
+        let custom_root = temp.path().join("custom-separate-filesystem");
+        std::fs::create_dir_all(&host_root).unwrap();
+        std::fs::create_dir_all(&custom_root).unwrap();
+        let host = crate::workspace::Workspace::default_host(host_root.clone());
+        let mut custom = crate::workspace::Workspace::default_host(custom_root.clone());
+        custom.id = uuid::Uuid::new_v4();
+        custom.name = "custom".into();
+        let roots = watched_roots_for_workspaces([&host, &custom]);
+        assert!(roots.contains(&host_root));
+        assert!(roots.contains(&custom_root));
+
+        // Distinct mounted-filesystem identities must each receive their
+        // initial notification even when pressure level is identical.
+        let now = tokio::time::Instant::now();
+        let mut states = HashMap::<String, AlertState>::new();
+        assert_eq!(
+            alert_action(
+                states.entry("fs-host".into()).or_default(),
+                DiskHealthLevel::Warn,
+                91.0,
+                now
+            ),
+            AlertAction::Notify(DiskHealthLevel::Warn)
+        );
+        assert_eq!(
+            alert_action(
+                states.entry("fs-custom".into()).or_default(),
+                DiskHealthLevel::Warn,
+                91.0,
+                now
+            ),
+            AlertAction::Notify(DiskHealthLevel::Warn)
         );
     }
 }

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -58,7 +58,22 @@ async fn run_loop(state: Arc<AppState>) {
     let mut last_alert_at: Option<tokio::time::Instant> = None;
     loop {
         interval.tick().await;
-        let (used, total, percent) = monitoring::current_disk_usage();
+        let mission_root =
+            crate::workspace::configured_mission_workspace_root(&state.config.working_dir);
+        let usage = match monitoring::disk_usage_for_path(&mission_root) {
+            Ok(usage) => usage,
+            Err(error) => {
+                tracing::warn!(path = %mission_root.display(), %error, "disk watcher: cannot measure mission workspace filesystem");
+                continue;
+            }
+        };
+        let used = usage.used;
+        let total = usage.total;
+        let percent = if total == 0 {
+            100.0
+        } else {
+            used as f32 / total as f32 * 100.0
+        };
         let level = DiskHealthLevel::from_percent(percent);
 
         let escalated = rank(level) > rank(alerted_level);

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -181,8 +181,8 @@ async fn run_loop(state: Arc<AppState>) {
                 }
                 AlertAction::Recover => {
                     let message = format!(
-                        "Disk recovered: mission filesystem back to {percent:.1}% used; \
-                 mission admission restored."
+                        "Disk recovered: mission filesystem {} back to {percent:.1}% used.",
+                        mission_root.display()
                     );
                     tracing::info!(percent, "{message}");
                     deliver_webhook(&state, DiskHealthLevel::Ok, used, total, percent, &message)

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -315,6 +315,14 @@ fn canonicalize_or_original(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
+fn is_within_workspace_or_mission(
+    path: &Path,
+    workspace_root: &Path,
+    mission_root: Option<&Path>,
+) -> bool {
+    path.starts_with(workspace_root) || mission_root.is_some_and(|root| path.starts_with(root))
+}
+
 /// Search one level deep inside the mission workspace for a file whose tail
 /// matches `resolved`. Used when the agent worked inside a cloned-repo
 /// subdirectory and the dashboard's path resolution doesn't account for it.
@@ -326,7 +334,8 @@ async fn find_in_mission_subdirs(
     mission_id: uuid::Uuid,
     resolved: &Path,
 ) -> Option<PathBuf> {
-    let mission_dir = crate::workspace::mission_workspace_dir_for_root(workspace_root, mission_id);
+    let workspace = crate::workspace::Workspace::default_host(workspace_root.to_path_buf());
+    let mission_dir = crate::workspace::mission_workspace_dir_for_workspace(&workspace, mission_id);
     let tail = resolved.strip_prefix(&mission_dir).ok()?;
     if tail.as_os_str().is_empty() {
         return None;
@@ -768,7 +777,10 @@ pub async fn resolve_path_for_workspace(
     // Validate that the resolved path is within an allowed location
     // This can be either the workspace root or the global context directory for missions
     let context_root = canonicalize_or_original(&api_context_root(state));
-    let in_workspace = canonical.starts_with(&workspace_root);
+    let mission_root = mission_id
+        .map(|mid| crate::workspace::mission_workspace_dir_for_workspace(&workspace, mid));
+    let in_workspace =
+        is_within_workspace_or_mission(&canonical, &workspace_root, mission_root.as_deref());
     let in_context = mission_id.is_some() && canonical.starts_with(&context_root);
 
     if !in_workspace && !in_context {
@@ -1608,5 +1620,26 @@ mod tests {
                 .join(mission_id.to_string())
                 .join("keel-compressed.jpg")
         );
+    }
+
+    #[test]
+    fn relocated_mission_root_is_allowed_without_widening_containment() {
+        let workspace = Path::new("/workspace");
+        let mission = Path::new("/separate-volume/workspaces/mission-deadbeef");
+        assert!(is_within_workspace_or_mission(
+            &mission.join("scratch.txt"),
+            workspace,
+            Some(mission)
+        ));
+        assert!(!is_within_workspace_or_mission(
+            Path::new("/separate-volume/workspaces/mission-other/scratch.txt"),
+            workspace,
+            Some(mission)
+        ));
+        assert!(!is_within_workspace_or_mission(
+            Path::new("/separate-volume/unrelated.txt"),
+            workspace,
+            Some(mission)
+        ));
     }
 }

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -330,12 +330,15 @@ fn is_within_workspace_or_mission(
 /// (ambiguous matches stay an error so the caller's existing 4xx handling
 /// surfaces the issue).
 async fn find_in_mission_subdirs(
-    workspace_root: &Path,
+    workspace: &crate::workspace::Workspace,
     mission_id: uuid::Uuid,
     resolved: &Path,
 ) -> Option<PathBuf> {
-    let workspace = crate::workspace::Workspace::default_host(workspace_root.to_path_buf());
-    let mission_dir = crate::workspace::mission_workspace_dir_for_workspace(&workspace, mission_id);
+    // Do not synthesize a default host workspace here.  Besides losing
+    // container/custom workspace identity, that made the shallow dashboard
+    // lookup consult the default-host root registry for a mission belonging
+    // to a different workspace.
+    let mission_dir = crate::workspace::mission_workspace_dir_for_workspace(workspace, mission_id);
     let tail = resolved.strip_prefix(&mission_dir).ok()?;
     if tail.as_os_str().is_empty() {
         return None;
@@ -694,7 +697,7 @@ pub async fn resolve_path_for_workspace(
     // contains the same tail, transparently use that match.
     if let Some(mid) = mission_id {
         if !resolved.exists() {
-            if let Some(rerooted) = find_in_mission_subdirs(&workspace_root, mid, &resolved).await {
+            if let Some(rerooted) = find_in_mission_subdirs(&workspace, mid, &resolved).await {
                 resolved = rerooted;
             }
         }

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -812,9 +812,20 @@ pub async fn resolve_path_for_workspace(
         .map(|mid| crate::workspace::mission_workspace_dir_for_workspace(&workspace, mid));
     let in_workspace =
         is_within_workspace_or_mission(&canonical, &workspace_root, mission_root.as_deref());
+    // An orchestrated worker can deliberately use a worktree under its
+    // ancestor's mission directory.  Do not turn that into a broad allowance
+    // for every relocated root: accept it only when the directory's actual
+    // `workspaces/mission-<short>` ancestor resolves to one unambiguous,
+    // identity-verified persisted owner.
+    let in_verified_ancestor_mission = !in_workspace
+        && mission_id.is_some()
+        && crate::workspace::verify_explicit_mission_working_directory_owner(
+            &workspace, &canonical,
+        )
+        .is_ok();
     let in_context = mission_id.is_some() && canonical.starts_with(&context_root);
 
-    if !in_workspace && !in_context {
+    if !in_workspace && !in_verified_ancestor_mission && !in_context {
         return Err((
             StatusCode::FORBIDDEN,
             format!(

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -858,25 +858,30 @@ async fn requester_descends_from(
     requester: uuid::Uuid,
     owner: uuid::Uuid,
 ) -> Result<bool, String> {
-    let (_, mut mission) = control
+    let (store, mission) = control
         .find_mission_store_owner(requester)
         .await?
         .ok_or_else(|| "requesting mission is unavailable".to_string())?;
+    mission_descends_from_in_store(store.as_ref(), mission, owner).await
+}
+
+async fn mission_descends_from_in_store(
+    store: &dyn crate::api::mission_store::MissionStore,
+    mut mission: crate::api::mission_store::Mission,
+    owner: uuid::Uuid,
+) -> Result<bool, String> {
     for _ in 0..64 {
         if mission.id == owner {
             return Ok(true);
         }
-        let Some(parent) = mission.parent_mission_id else {
+        let Some(parent_id) = mission.parent_mission_id else {
             return Ok(false);
         };
-        let (store, parent) = control
-            .find_mission_store_owner(parent)
-            .await?
-            .ok_or_else(|| "mission ancestor is unavailable".to_string())?;
-        // Parent links must stay within their owning store; accepting a
-        // cross-store coincidence would recreate the same confused-deputy
-        // problem this bound prevents.
-        let _ = store;
+        // Stay inside the requester's store. A parent id that only exists in
+        // another user's store is not an ancestor for path authorization.
+        let Some(parent) = store.get_mission(parent_id).await? else {
+            return Ok(false);
+        };
         mission = parent;
     }
     Err("mission ancestry exceeds safe depth".to_string())
@@ -1537,6 +1542,7 @@ mod tests {
         path_is_under_allowed_roots, sanitize_path_component, upload_display_path,
         validate_chunk_upload_shape, MAX_CHUNK_UPLOAD_CHUNKS,
     };
+    use crate::api::mission_store::MissionStore;
     use crate::config::Config;
     use crate::workspace::Workspace;
     use std::path::{Path, PathBuf};
@@ -1728,5 +1734,36 @@ mod tests {
             workspace,
             Some(mission)
         ));
+    }
+
+    #[tokio::test]
+    async fn ancestry_does_not_follow_parent_ids_from_another_store() {
+        let victim_store = crate::api::mission_store::InMemoryMissionStore::new();
+        let attacker_store = crate::api::mission_store::InMemoryMissionStore::new();
+        let victim = victim_store
+            .create_mission(Some("victim"), None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let attacker = attacker_store
+            .create_mission_with_parent(
+                Some("attacker"),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                Some(victim.id),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !super::mission_descends_from_in_store(&attacker_store, attacker, victim.id)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -620,8 +620,21 @@ pub async fn resolve_path_for_workspace(
 
     let input = Path::new(path);
 
+    // Older dashboard clients derive an absolute mission path from the
+    // workspace's legacy root. Preserve that request shape after a mission
+    // has been placed under MISSION_WORKSPACE_ROOT by translating only the
+    // exact legacy mission prefix to its persisted workspace-aware location.
+    let relocated_input = mission_id.and_then(|mid| {
+        let legacy = crate::workspace::mission_workspace_dir_for_root(&workspace.path, mid);
+        input.strip_prefix(&legacy).ok().map(|tail| {
+            crate::workspace::mission_workspace_dir_for_workspace(&workspace, mid).join(tail)
+        })
+    });
+
     // Resolve the final path based on input type
-    let mut resolved = if input.is_absolute() {
+    let mut resolved = if let Some(relocated) = relocated_input {
+        relocated
+    } else if input.is_absolute() {
         if workspace.workspace_type == WorkspaceType::Container {
             if input.starts_with(&workspace_root) {
                 input.to_path_buf()

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -611,6 +611,21 @@ pub async fn resolve_path_for_workspace(
         )
     })?;
 
+    // A persisted placement is a capability, not a hint.  In particular, a
+    // vanished mount can leave an identically named directory on the parent
+    // disk.  Validate it before any path rewriting or create-on-upload path
+    // can reach that directory.
+    if let Some(mid) = mission_id {
+        crate::workspace::ensure_persisted_mission_root_is_available(&workspace, mid).map_err(
+            |error| {
+                (
+                    StatusCode::CONFLICT,
+                    format!("persisted mission workspace root is unavailable: {error}"),
+                )
+            },
+        )?;
+    }
+
     let workspace_root = workspace.path.canonicalize().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -817,12 +817,27 @@ pub async fn resolve_path_for_workspace(
     // for every relocated root: accept it only when the directory's actual
     // `workspaces/mission-<short>` ancestor resolves to one unambiguous,
     // identity-verified persisted owner.
-    let in_verified_ancestor_mission = !in_workspace
-        && mission_id.is_some()
-        && crate::workspace::verify_explicit_mission_working_directory_owner(
-            &workspace, &canonical,
-        )
-        .is_ok();
+    let verified_ancestor_owner = (!in_workspace && mission_id.is_some())
+        .then(|| {
+            crate::workspace::verify_explicit_mission_working_directory_owner(
+                &workspace, &canonical,
+            )
+        })
+        .transpose()
+        .map_err(|_| ())
+        .ok()
+        .flatten();
+    let in_verified_ancestor_mission = match (mission_id, verified_ancestor_owner) {
+        (Some(requester), Some(owner)) => {
+            // The placement check proves the path's filesystem owner; the
+            // control-plane ancestry check prevents a sibling mission in a
+            // shared workspace from borrowing that capability.
+            requester_descends_from(&state.control, requester, owner)
+                .await
+                .unwrap_or(false)
+        }
+        _ => false,
+    };
     let in_context = mission_id.is_some() && canonical.starts_with(&context_root);
 
     if !in_workspace && !in_verified_ancestor_mission && !in_context {
@@ -836,6 +851,35 @@ pub async fn resolve_path_for_workspace(
     }
 
     Ok(canonical)
+}
+
+async fn requester_descends_from(
+    control: &crate::api::control::ControlHub,
+    requester: uuid::Uuid,
+    owner: uuid::Uuid,
+) -> Result<bool, String> {
+    let (_, mut mission) = control
+        .find_mission_store_owner(requester)
+        .await?
+        .ok_or_else(|| "requesting mission is unavailable".to_string())?;
+    for _ in 0..64 {
+        if mission.id == owner {
+            return Ok(true);
+        }
+        let Some(parent) = mission.parent_mission_id else {
+            return Ok(false);
+        };
+        let (store, parent) = control
+            .find_mission_store_owner(parent)
+            .await?
+            .ok_or_else(|| "mission ancestor is unavailable".to_string())?;
+        // Parent links must stay within their owning store; accepting a
+        // cross-store coincidence would recreate the same confused-deputy
+        // problem this bound prevents.
+        let _ = store;
+        mission = parent;
+    }
+    Err("mission ancestry exceeds safe depth".to_string())
 }
 
 fn resolve_upload_base(path: &str) -> Result<PathBuf, (StatusCode, String)> {

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -1447,8 +1447,9 @@ pub async fn upload_finalize(
 mod tests {
     use super::{
         api_context_root_for_config, context_mirror_suffix, context_upload_suffix_for_dir,
-        is_context_upload_path_for_dir, path_is_under_allowed_roots, sanitize_path_component,
-        upload_display_path, validate_chunk_upload_shape, MAX_CHUNK_UPLOAD_CHUNKS,
+        is_context_upload_path_for_dir, is_within_workspace_or_mission,
+        path_is_under_allowed_roots, sanitize_path_component, upload_display_path,
+        validate_chunk_upload_shape, MAX_CHUNK_UPLOAD_CHUNKS,
     };
     use crate::config::Config;
     use crate::workspace::Workspace;

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3686,6 +3686,20 @@ async fn run_mission_turn(
     let mission_work_dir = if let Some(ref wd) = mission_working_directory {
         match resolve_mission_working_directory(&workspace.path, workspace.workspace_type, wd) {
             Ok(wd_path) => {
+                if let Err(error) =
+                    workspace::verify_explicit_mission_working_directory_owner(&workspace, &wd_path)
+                {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        requested_working_directory = %wd,
+                        error = %error,
+                        "refusing explicit working_directory without a verified persisted owner"
+                    );
+                    return AgentResult::failure(
+                        format!("explicit working_directory owner is unavailable or unverified: {error}"),
+                        0,
+                    );
+                }
                 tracing::info!(
                     mission_id = %mission_id,
                     requested_working_directory = %wd,
@@ -3699,9 +3713,12 @@ async fn run_mission_turn(
                     mission_id = %mission_id,
                     requested_working_directory = %wd,
                     error = %error,
-                    "Mission working_directory is invalid; using prepared mission directory"
+                    "refusing invalid explicit mission working_directory"
                 );
-                mission_work_dir
+                return AgentResult::failure(
+                    format!("explicit working_directory is invalid: {error}"),
+                    0,
+                );
             }
         }
     } else {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3645,7 +3645,6 @@ async fn run_mission_turn(
             "Failed to sync MCP binaries into workspace"
         );
     }
-    let workspace_root = workspace.path.clone();
     let mission_work_dir_result = {
         let lib_guard = library.read().await;
         let lib_ref = lib_guard.as_ref().map(|l| l.as_ref());
@@ -3673,8 +3672,14 @@ async fn run_mission_turn(
             dir
         }
         Err(e) => {
-            tracing::warn!("Failed to prepare mission workspace, using default: {}", e);
-            workspace_root
+            // A persisted placement error means the original filesystem is
+            // unavailable or has changed identity. Running against the raw
+            // workspace root would silently write a different tree.
+            tracing::warn!(mission_id = %mission_id, error = %e, "refusing to run mission without its verified workspace");
+            return AgentResult::failure(
+                format!("Failed to prepare verified mission workspace: {e}"),
+                0,
+            );
         }
     };
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3686,19 +3686,31 @@ async fn run_mission_turn(
     let mission_work_dir = if let Some(ref wd) = mission_working_directory {
         match resolve_mission_working_directory(&workspace.path, workspace.workspace_type, wd) {
             Ok(wd_path) => {
-                if let Err(error) =
-                    workspace::verify_explicit_mission_working_directory_owner(&workspace, &wd_path)
-                {
-                    tracing::warn!(
-                        mission_id = %mission_id,
-                        requested_working_directory = %wd,
-                        error = %error,
-                        "refusing explicit working_directory without a verified persisted owner"
-                    );
-                    return AgentResult::failure(
-                        format!("explicit working_directory owner is unavailable or unverified: {error}"),
-                        0,
-                    );
+                if let Err(error) = workspace::verify_or_adopt_explicit_mission_working_directory(
+                    &workspace,
+                    &wd_path,
+                    &[mission_id],
+                ) {
+                    if workspace::is_generated_mission_directory_under_known_root(
+                        &workspace, &wd_path,
+                    ) {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            requested_working_directory = %wd,
+                            "adopting pre-registry generated working_directory"
+                        );
+                    } else {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            requested_working_directory = %wd,
+                            error = %error,
+                            "refusing explicit working_directory without a verified persisted owner"
+                        );
+                        return AgentResult::failure(
+                            format!("explicit working_directory owner is unavailable or unverified: {error}"),
+                            0,
+                        );
+                    }
                 }
                 tracing::info!(
                     mission_id = %mission_id,

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3662,7 +3662,9 @@ async fn run_mission_turn(
         )
         .await
     };
-    let mission_work_dir = match mission_work_dir_result {
+    let mission_work_dir = match workspace::require_verified_mission_workspace(
+        mission_work_dir_result,
+    ) {
         Ok(dir) => {
             tracing::info!(
                 "Mission {} workspace directory: {}",
@@ -3676,10 +3678,7 @@ async fn run_mission_turn(
             // unavailable or has changed identity. Running against the raw
             // workspace root would silently write a different tree.
             tracing::warn!(mission_id = %mission_id, error = %e, "refusing to run mission without its verified workspace");
-            return AgentResult::failure(
-                format!("Failed to prepare verified mission workspace: {e}"),
-                0,
-            );
+            return AgentResult::failure(e.to_string(), 0);
         }
     };
 

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -278,6 +278,7 @@ impl MissionStore for FileMissionStore {
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
         requires_local_disk: bool,
+        assigned_id: Option<Uuid>,
     ) -> Result<Mission, String> {
         let now = now_string();
         let metadata_source = title.and_then(|value| {
@@ -290,7 +291,7 @@ impl MissionStore for FileMissionStore {
         });
         let metadata_updated_at = metadata_source.as_ref().map(|_| now.clone());
         let mission = Mission {
-            id: Uuid::new_v4(),
+            id: assigned_id.unwrap_or_else(Uuid::new_v4),
             status: MissionStatus::Pending,
             title: title.map(|s| s.to_string()),
             short_description: None,
@@ -366,6 +367,7 @@ impl MissionStore for FileMissionStore {
             parent_mission_id,
             working_directory,
             true,
+            None,
         )
         .await
     }

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -265,7 +265,7 @@ impl MissionStore for FileMissionStore {
         Ok(true)
     }
 
-    async fn create_mission_with_parent(
+    async fn create_mission_with_parent_and_placement(
         &self,
         title: Option<&str>,
         workspace_id: Option<Uuid>,
@@ -277,6 +277,7 @@ impl MissionStore for FileMissionStore {
         config_profile: Option<&str>,
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
+        requires_local_disk: bool,
     ) -> Result<Mission, String> {
         let now = now_string();
         let metadata_source = title.and_then(|value| {
@@ -317,6 +318,7 @@ impl MissionStore for FileMissionStore {
             terminal_evidence: None,
             parent_mission_id,
             working_directory: working_directory.map(|s| s.to_string()),
+            requires_local_disk,
             mission_mode: super::MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -339,6 +341,35 @@ impl MissionStore for FileMissionStore {
         Ok(mission)
     }
 
+    async fn create_mission_with_parent(
+        &self,
+        title: Option<&str>,
+        workspace_id: Option<Uuid>,
+        agent: Option<&str>,
+        model_override: Option<&str>,
+        model_effort: Option<&str>,
+        fast_mode: bool,
+        backend: Option<&str>,
+        config_profile: Option<&str>,
+        parent_mission_id: Option<Uuid>,
+        working_directory: Option<&str>,
+    ) -> Result<Mission, String> {
+        self.create_mission_with_parent_and_placement(
+            title,
+            workspace_id,
+            agent,
+            model_override,
+            model_effort,
+            fast_mode,
+            backend,
+            config_profile,
+            parent_mission_id,
+            working_directory,
+            true,
+        )
+        .await
+    }
+
     async fn get_child_missions(&self, parent_id: Uuid) -> Result<Vec<Mission>, String> {
         let missions = self.missions.read().await;
         Ok(missions
@@ -346,6 +377,21 @@ impl MissionStore for FileMissionStore {
             .filter(|m| m.parent_mission_id == Some(parent_id))
             .cloned()
             .collect())
+    }
+
+    async fn set_mission_requires_local_disk(
+        &self,
+        id: Uuid,
+        requires_local_disk: bool,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {id} not found"))?;
+        mission.requires_local_disk = requires_local_disk;
+        mission.updated_at = now_string();
+        drop(missions);
+        self.persist().await
     }
 
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String> {

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -281,7 +281,7 @@ impl MissionStore for InMemoryMissionStore {
             .collect())
     }
 
-    async fn create_mission_with_parent(
+    async fn create_mission_with_parent_and_placement(
         &self,
         title: Option<&str>,
         workspace_id: Option<Uuid>,
@@ -293,6 +293,7 @@ impl MissionStore for InMemoryMissionStore {
         config_profile: Option<&str>,
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
+        requires_local_disk: bool,
     ) -> Result<Mission, String> {
         let now = now_string();
         let metadata_source = title.and_then(|value| {
@@ -333,6 +334,7 @@ impl MissionStore for InMemoryMissionStore {
             terminal_evidence: None,
             parent_mission_id,
             working_directory: working_directory.map(|s| s.to_string()),
+            requires_local_disk,
             mission_mode: super::MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -354,6 +356,35 @@ impl MissionStore for InMemoryMissionStore {
         Ok(mission)
     }
 
+    async fn create_mission_with_parent(
+        &self,
+        title: Option<&str>,
+        workspace_id: Option<Uuid>,
+        agent: Option<&str>,
+        model_override: Option<&str>,
+        model_effort: Option<&str>,
+        fast_mode: bool,
+        backend: Option<&str>,
+        config_profile: Option<&str>,
+        parent_mission_id: Option<Uuid>,
+        working_directory: Option<&str>,
+    ) -> Result<Mission, String> {
+        self.create_mission_with_parent_and_placement(
+            title,
+            workspace_id,
+            agent,
+            model_override,
+            model_effort,
+            fast_mode,
+            backend,
+            config_profile,
+            parent_mission_id,
+            working_directory,
+            true,
+        )
+        .await
+    }
+
     async fn get_child_missions(&self, parent_id: Uuid) -> Result<Vec<Mission>, String> {
         let missions = self.missions.read().await;
         Ok(missions
@@ -361,6 +392,20 @@ impl MissionStore for InMemoryMissionStore {
             .filter(|m| m.parent_mission_id == Some(parent_id))
             .cloned()
             .collect())
+    }
+
+    async fn set_mission_requires_local_disk(
+        &self,
+        id: Uuid,
+        requires_local_disk: bool,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {id} not found"))?;
+        mission.requires_local_disk = requires_local_disk;
+        mission.updated_at = now_string();
+        Ok(())
     }
 
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String> {

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -294,6 +294,7 @@ impl MissionStore for InMemoryMissionStore {
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
         requires_local_disk: bool,
+        assigned_id: Option<Uuid>,
     ) -> Result<Mission, String> {
         let now = now_string();
         let metadata_source = title.and_then(|value| {
@@ -306,7 +307,7 @@ impl MissionStore for InMemoryMissionStore {
         });
         let metadata_updated_at = metadata_source.as_ref().map(|_| now.clone());
         let mission = Mission {
-            id: Uuid::new_v4(),
+            id: assigned_id.unwrap_or_else(Uuid::new_v4),
             status: MissionStatus::Pending,
             title: title.map(|s| s.to_string()),
             short_description: None,
@@ -381,6 +382,7 @@ impl MissionStore for InMemoryMissionStore {
             parent_mission_id,
             working_directory,
             true,
+            None,
         )
         .await
     }

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -473,6 +473,12 @@ pub struct Mission {
     /// Working directory override (for git worktrees etc.)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<String>,
+    /// Whether this mission's placement consumes host-local disk.  This is
+    /// server-owned placement authority, deliberately persisted with the
+    /// mission rather than inferred from mutable project metadata or a lease
+    /// ledger.  Missing legacy records are conservatively local.
+    #[serde(default = "default_requires_local_disk")]
+    pub requires_local_disk: bool,
     /// Mission operating mode (task or assistant)
     #[serde(default)]
     pub mission_mode: MissionMode,
@@ -536,6 +542,10 @@ fn default_backend() -> String {
 
 fn default_workspace_id() -> Uuid {
     crate::workspace::DEFAULT_WORKSPACE_ID
+}
+
+fn default_requires_local_disk() -> bool {
+    true
 }
 
 impl Mission {
@@ -2086,8 +2096,57 @@ pub trait MissionStore: Send + Sync {
         working_directory: Option<&str>,
     ) -> Result<Mission, String>;
 
+    /// Create a mission while atomically recording the server-decided
+    /// placement authority. Persistent stores must override this together
+    /// with their row insert; the compatibility implementation is only for
+    /// stores which cannot provide a transaction.
+    async fn create_mission_with_parent_and_placement(
+        &self,
+        title: Option<&str>,
+        workspace_id: Option<Uuid>,
+        agent: Option<&str>,
+        model_override: Option<&str>,
+        model_effort: Option<&str>,
+        fast_mode: bool,
+        backend: Option<&str>,
+        config_profile: Option<&str>,
+        parent_mission_id: Option<Uuid>,
+        working_directory: Option<&str>,
+        requires_local_disk: bool,
+    ) -> Result<Mission, String> {
+        let mut mission = self
+            .create_mission_with_parent(
+                title,
+                workspace_id,
+                agent,
+                model_override,
+                model_effort,
+                fast_mode,
+                backend,
+                config_profile,
+                parent_mission_id,
+                working_directory,
+            )
+            .await?;
+        self.set_mission_requires_local_disk(mission.id, requires_local_disk)
+            .await?;
+        mission.requires_local_disk = requires_local_disk;
+        Ok(mission)
+    }
+
     /// Update mission status.
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String>;
+
+    /// Persist server-decided placement authority.  Project metadata is
+    /// intentionally excluded: it is editable by users and cannot decide
+    /// whether a mission consumes local disk after restart.
+    async fn set_mission_requires_local_disk(
+        &self,
+        _id: Uuid,
+        _requires_local_disk: bool,
+    ) -> Result<(), String> {
+        Err("mission store does not support persisted placement authority".to_string())
+    }
 
     /// Persist FLEET-001 scheduling metadata (priority, not_before, deadline)
     /// for a mission. Default is a no-op so non-persistent stores can ignore it;

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -2113,7 +2113,9 @@ pub trait MissionStore: Send + Sync {
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
         requires_local_disk: bool,
+        assigned_id: Option<Uuid>,
     ) -> Result<Mission, String> {
+        let _ = assigned_id;
         let mut mission = self
             .create_mission_with_parent(
                 title,

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -4177,6 +4177,7 @@ mod tests {
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3784,7 +3784,7 @@ impl MissionStore for SqliteMissionStore {
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
             let mut stmt = conn
-                .prepare("SELECT id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, agent, model_override, model_effort, backend, config_profile, created_at, updated_at, interrupted_at, resumable, session_id, terminal_reason, parent_mission_id, working_directory, COALESCE(mission_mode, 'task') as mission_mode, COALESCE(fast_mode, 0) as fast_mode FROM missions WHERE parent_mission_id = ?1")
+                .prepare("SELECT id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, agent, model_override, model_effort, backend, config_profile, created_at, updated_at, interrupted_at, resumable, session_id, terminal_reason, parent_mission_id, working_directory, COALESCE(mission_mode, 'task') as mission_mode, COALESCE(fast_mode, 0) as fast_mode, COALESCE(requires_local_disk, 1) as requires_local_disk FROM missions WHERE parent_mission_id = ?1")
                 .map_err(|e| e.to_string())?;
             let missions = stmt
                 .query_map(params![parent_id_str], |row| {
@@ -3817,6 +3817,7 @@ impl MissionStore for SqliteMissionStore {
                         terminal_evidence: None,
                         parent_mission_id: row.get::<_, Option<String>>(20)?.and_then(|s| Uuid::parse_str(&s).ok()),
                         working_directory: row.get(21)?,
+                        requires_local_disk: row.get::<_, i32>(24)? != 0,
                         mission_mode: row.get::<_, Option<String>>(22)?
                             .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok())
                             .unwrap_or_default(),

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3631,10 +3631,11 @@ impl MissionStore for SqliteMissionStore {
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
         requires_local_disk: bool,
+        assigned_id: Option<Uuid>,
     ) -> Result<Mission, String> {
         let conn = self.conn.clone();
         let now = now_string();
-        let id = Uuid::new_v4();
+        let id = assigned_id.unwrap_or_else(Uuid::new_v4);
         // Inherit workspace from parent mission when not explicitly provided.
         let workspace_id = if let Some(ws) = workspace_id {
             ws
@@ -3774,6 +3775,7 @@ impl MissionStore for SqliteMissionStore {
             parent_mission_id,
             working_directory,
             true,
+            None,
         )
         .await
     }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -511,7 +511,8 @@ CREATE TABLE IF NOT EXISTS missions (
     awaiting_kind TEXT,
     last_status_change_at TEXT,
     origin TEXT,
-    origin_session_id TEXT
+    origin_session_id TEXT,
+    requires_local_disk INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
@@ -2276,6 +2277,27 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to add paused_at column: {}", e))?;
         }
 
+        // Placement is authority for local-disk admission after a restart.
+        // Existing rows predate this field and are deliberately migrated as
+        // local, the fail-closed compatibility policy.
+        let has_requires_local_disk_column: bool = conn
+            .prepare(
+                "SELECT 1 FROM pragma_table_info('missions') WHERE name = 'requires_local_disk'",
+            )
+            .map_err(|e| format!("Failed to check for requires_local_disk column: {e}"))?
+            .exists([])
+            .map_err(|e| format!("Failed to query table info: {e}"))?;
+        if !has_requires_local_disk_column {
+            tracing::info!(
+                "Running migration: adding 'requires_local_disk' column to missions table"
+            );
+            conn.execute(
+                "ALTER TABLE missions ADD COLUMN requires_local_disk INTEGER NOT NULL DEFAULT 1",
+                [],
+            )
+            .map_err(|e| format!("Failed to add requires_local_disk column: {e}"))?;
+        }
+
         // Project tagging + awaiting_kind classification + activity timestamps +
         // track state. Lets external consumers (Paloma) group/filter/route
         // missions, tell "needs a decision" apart from "finished, please ack",
@@ -2729,6 +2751,7 @@ fn row_to_mission(row: &rusqlite::Row<'_>) -> rusqlite::Result<Mission> {
         awaiting_kind,
         origin: row.get(42).ok().flatten(),
         origin_session_id: row.get(43).ok().flatten(),
+        requires_local_disk: row.get::<_, i32>(44).unwrap_or(1) != 0,
     })
 }
 
@@ -2745,7 +2768,7 @@ const MISSION_LIST_COLUMNS: &str = "id, status, title, short_description, metada
      COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at, \
      COALESCE(priority, 0) as priority, not_before, deadline, paused_at, \
      project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at, \
-     COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id";
+     COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id, COALESCE(requires_local_disk, 1) as requires_local_disk";
 
 fn parse_status(s: &str) -> MissionStatus {
     match s {
@@ -3158,7 +3181,7 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
                             COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
                             project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at,
-                            COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id FROM missions WHERE id = ?1",
+                            COALESCE(fast_mode, 0) as fast_mode, origin, origin_session_id, COALESCE(requires_local_disk, 1) as requires_local_disk FROM missions WHERE id = ?1",
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -3226,6 +3249,7 @@ impl MissionStore for SqliteMissionStore {
                             awaiting_kind,
                             origin: row.get(42).ok().flatten(),
                             origin_session_id: row.get(43).ok().flatten(),
+                            requires_local_disk: row.get::<_, i32>(44).unwrap_or(1) != 0,
                     })
                 })
                 .optional()
@@ -3594,7 +3618,7 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|error| error.to_string())?
     }
 
-    async fn create_mission_with_parent(
+    async fn create_mission_with_parent_and_placement(
         &self,
         title: Option<&str>,
         workspace_id: Option<Uuid>,
@@ -3606,6 +3630,7 @@ impl MissionStore for SqliteMissionStore {
         config_profile: Option<&str>,
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
+        requires_local_disk: bool,
     ) -> Result<Mission, String> {
         let conn = self.conn.clone();
         let now = now_string();
@@ -3663,6 +3688,7 @@ impl MissionStore for SqliteMissionStore {
             terminal_evidence: None,
             parent_mission_id,
             working_directory: working_directory.map(|s| s.to_string()),
+            requires_local_disk,
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
@@ -3683,8 +3709,8 @@ impl MissionStore for SqliteMissionStore {
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
             conn.execute(
-                "INSERT INTO missions (id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, agent, model_override, model_effort, backend, config_profile, created_at, updated_at, resumable, session_id, parent_mission_id, working_directory, mission_mode, goal_mode, goal_objective, last_status_change_at, fast_mode)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
+                "INSERT INTO missions (id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, agent, model_override, model_effort, backend, config_profile, created_at, updated_at, resumable, session_id, parent_mission_id, working_directory, mission_mode, goal_mode, goal_objective, last_status_change_at, fast_mode, requires_local_disk)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
                 params![
                     m.id.to_string(),
                     status_to_string(m.status),
@@ -3711,6 +3737,7 @@ impl MissionStore for SqliteMissionStore {
                     m.goal_objective,
                     m.created_at,
                     if m.fast_mode { 1i64 } else { 0i64 },
+                    if m.requires_local_disk { 1i64 } else { 0i64 },
                 ],
             )
             .map_err(|e| e.to_string())?;
@@ -3720,6 +3747,35 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())??;
 
         Ok(mission)
+    }
+
+    async fn create_mission_with_parent(
+        &self,
+        title: Option<&str>,
+        workspace_id: Option<Uuid>,
+        agent: Option<&str>,
+        model_override: Option<&str>,
+        model_effort: Option<&str>,
+        fast_mode: bool,
+        backend: Option<&str>,
+        config_profile: Option<&str>,
+        parent_mission_id: Option<Uuid>,
+        working_directory: Option<&str>,
+    ) -> Result<Mission, String> {
+        self.create_mission_with_parent_and_placement(
+            title,
+            workspace_id,
+            agent,
+            model_override,
+            model_effort,
+            fast_mode,
+            backend,
+            config_profile,
+            parent_mission_id,
+            working_directory,
+            true,
+        )
+        .await
     }
 
     async fn get_child_missions(&self, parent_id: Uuid) -> Result<Vec<Mission>, String> {
@@ -3782,6 +3838,33 @@ impl MissionStore for SqliteMissionStore {
         })
         .await
         .map_err(|e| e.to_string())?
+    }
+
+    async fn set_mission_requires_local_disk(
+        &self,
+        id: Uuid,
+        requires_local_disk: bool,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions SET requires_local_disk = ?1, updated_at = ?2 WHERE id = ?3",
+                params![
+                    if requires_local_disk { 1i64 } else { 0i64 },
+                    now_string(),
+                    id.to_string()
+                ],
+            )
+            .map_err(|error| error.to_string())
+            .and_then(|updated| {
+                (updated == 1)
+                    .then_some(())
+                    .ok_or_else(|| format!("mission {id} not found while persisting placement"))
+            })
+        })
+        .await
+        .map_err(|error| error.to_string())?
     }
 
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String> {
@@ -4763,6 +4846,7 @@ impl MissionStore for SqliteMissionStore {
                         terminal_evidence: None,
                         parent_mission_id: None,
                         working_directory: None,
+                        requires_local_disk: true,
                         mission_mode: row
                             .get::<_, Option<String>>(13)?
                             .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok())
@@ -4903,6 +4987,7 @@ impl MissionStore for SqliteMissionStore {
                         terminal_evidence: None,
                         parent_mission_id: None,
                         working_directory: None,
+                        requires_local_disk: true,
                         mission_mode: row
                             .get::<_, Option<String>>(13)?
                             .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok())
@@ -7458,6 +7543,7 @@ impl MissionStore for SqliteMissionStore {
                         terminal_evidence: None,
                         parent_mission_id: None,
                         working_directory: None,
+                        requires_local_disk: true,
                         mission_mode: serde_json::from_value(serde_json::Value::String(mode_str))
                             .unwrap_or_default(),
                         goal_mode: false,

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -207,6 +207,54 @@ pub(crate) fn entry_for_workspace(
         })
 }
 
+/// Select the known owner of this *physical* mission directory across every
+/// workspace. A configured default-host root can overlap a separately
+/// registered workspace, so the workspace that happens to scan first is not
+/// authoritative. Only entries whose workspace can actually resolve to `dir`
+/// are considered; unrelated short-id collisions remain isolated.
+fn entry_for_directory<'a>(
+    entries: &'a [MissionIndexEntry],
+    short: &str,
+    dir: &std::path::Path,
+    workspace_roots: &std::collections::HashMap<uuid::Uuid, Vec<std::path::PathBuf>>,
+) -> Option<&'a MissionIndexEntry> {
+    entries
+        .iter()
+        .filter(|entry| {
+            workspace_roots
+                .get(&entry.workspace_id)
+                .is_some_and(|roots| {
+                    roots.iter().any(|root| {
+                        workspace::workspaces_root_for(root).join(format!("mission-{short}")) == dir
+                    })
+                })
+        })
+        .max_by_key(|entry| {
+            (
+                protection_rank(&entry.status),
+                entry.updated_at.timestamp_micros(),
+            )
+        })
+}
+
+fn workspace_ids_for_directory(
+    short: &str,
+    dir: &std::path::Path,
+    workspace_roots: &std::collections::HashMap<uuid::Uuid, Vec<std::path::PathBuf>>,
+) -> Vec<uuid::Uuid> {
+    workspace_roots
+        .iter()
+        .filter_map(|(id, roots)| {
+            roots
+                .iter()
+                .any(|root| {
+                    workspace::workspaces_root_for(root).join(format!("mission-{short}")) == dir
+                })
+                .then_some(*id)
+        })
+        .collect()
+}
+
 /// Whether the most protective known owner of a shared short-id directory is
 /// terminal and past retention. Phase 1 must use the same collision policy as
 /// the disk-driven sweep before proposing or removing the shared path.
@@ -816,9 +864,26 @@ async fn orphan_sweep(
     report: &mut SweepReport,
 ) {
     let index = &index_full.by_short;
+    let workspaces = state.workspaces.list().await;
+    let workspace_roots: std::collections::HashMap<_, _> = workspaces
+        .iter()
+        .map(|ws| (ws.id, workspace::mission_workspace_roots_for_workspace(ws)))
+        .collect();
+    let workspaces_by_id: std::collections::HashMap<_, _> =
+        workspaces.iter().map(|ws| (ws.id, ws)).collect();
+    let mut scanned_roots = std::collections::HashSet::new();
 
-    for ws in state.workspaces.list().await {
-        for workspace_root in workspace::mission_workspace_roots_for_workspace(&ws) {
+    for ws in &workspaces {
+        for workspace_root in &workspace_roots[&ws.id] {
+            // Multiple registered workspaces may intentionally share a root.
+            // Scan its physical directory once, then resolve ownership below
+            // from every workspace rather than from this loop's `ws`.
+            let physical_root = workspace_root
+                .canonicalize()
+                .unwrap_or_else(|_| workspace_root.clone());
+            if !scanned_roots.insert(physical_root) {
+                continue;
+            }
             let root = workspace::workspaces_root_for(&workspace_root);
             let Ok(mut rd) = tokio::fs::read_dir(&root).await else {
                 continue;
@@ -835,9 +900,13 @@ async fn orphan_sweep(
                 if !entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
                     continue;
                 }
-                let workspace_token = crate::workspace_exec::machine_name_for_path(&ws.path);
-                if workspace_token.as_ref().is_some_and(|token| {
-                    scope_protected.contains(&(token.clone(), short.to_string()))
+                let owner_workspace_ids =
+                    workspace_ids_for_directory(short, &dir, &workspace_roots);
+                if owner_workspace_ids.iter().any(|workspace_id| {
+                    workspaces_by_id
+                        .get(workspace_id)
+                        .and_then(|owner| crate::workspace_exec::machine_name_for_path(&owner.path))
+                        .is_some_and(|token| scope_protected.contains(&(token, short.to_string())))
                 }) {
                     tracing::debug!(path = %dir.display(), "mission GC: kept (live exec scope)");
                     continue;
@@ -846,9 +915,9 @@ async fn orphan_sweep(
                     Keep(&'static str),
                     Delete(&'static str, bool /*orphan*/, bool /*stopped*/),
                 }
-                let indexed_entry = index
-                    .get(short)
-                    .and_then(|entries| entry_for_workspace(entries, ws.id));
+                let indexed_entry = index.get(short).and_then(|entries| {
+                    entry_for_directory(entries, short, &dir, &workspace_roots)
+                });
                 let verdict = match indexed_entry {
                     Some(e) => match e.status {
                         MissionStatus::Active
@@ -1092,6 +1161,52 @@ mod tests {
             workspace_id,
             now - chrono::Duration::days(7),
         ));
+    }
+
+    #[test]
+    fn overlapping_roots_use_global_active_owner_before_orphan_classification() {
+        let root = tempfile::tempdir().unwrap();
+        let default_workspace = uuid::Uuid::nil();
+        let custom_workspace = uuid::Uuid::new_v4();
+        let short = "deadbeef";
+        let dir = workspace::workspaces_root_for(root.path()).join(format!("mission-{short}"));
+        let now = Utc::now();
+        let entries = vec![
+            // The default workspace has a terminal collision, but the custom
+            // workspace owns this same physical root and is still running.
+            MissionIndexEntry {
+                status: MissionStatus::Completed,
+                updated_at: now - chrono::Duration::days(40),
+                workspace_id: default_workspace,
+            },
+            MissionIndexEntry {
+                status: MissionStatus::Active,
+                updated_at: now - chrono::Duration::days(40),
+                workspace_id: custom_workspace,
+            },
+        ];
+        let roots = std::collections::HashMap::from([
+            (default_workspace, vec![root.path().to_path_buf()]),
+            (custom_workspace, vec![root.path().to_path_buf()]),
+        ]);
+
+        let owner = entry_for_directory(&entries, short, &dir, &roots)
+            .expect("the overlapping root has a global owner");
+        assert_eq!(owner.workspace_id, custom_workspace);
+        assert_eq!(owner.status, MissionStatus::Active);
+        assert_eq!(workspace_ids_for_directory(short, &dir, &roots).len(), 2);
+
+        let terminal_only = vec![MissionIndexEntry {
+            status: MissionStatus::Completed,
+            updated_at: now - chrono::Duration::days(40),
+            workspace_id: custom_workspace,
+        }];
+        assert_eq!(
+            entry_for_directory(&terminal_only, short, &dir, &roots)
+                .expect("terminal owner still owns the directory")
+                .status,
+            MissionStatus::Completed
+        );
     }
 
     #[test]

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -212,21 +212,27 @@ pub(crate) fn entry_for_workspace(
 /// registered workspace, so the workspace that happens to scan first is not
 /// authoritative. Only entries whose workspace can actually resolve to `dir`
 /// are considered; unrelated short-id collisions remain isolated.
+fn physical_mission_directory(root: &std::path::Path, short: &str) -> std::path::PathBuf {
+    let candidate = workspace::workspaces_root_for(root).join(format!("mission-{short}"));
+    candidate.canonicalize().unwrap_or(candidate)
+}
+
 fn entry_for_directory<'a>(
     entries: &'a [MissionIndexEntry],
     short: &str,
     dir: &std::path::Path,
     workspace_roots: &std::collections::HashMap<uuid::Uuid, Vec<std::path::PathBuf>>,
 ) -> Option<&'a MissionIndexEntry> {
+    let physical_dir = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
     entries
         .iter()
         .filter(|entry| {
             workspace_roots
                 .get(&entry.workspace_id)
                 .is_some_and(|roots| {
-                    roots.iter().any(|root| {
-                        workspace::workspaces_root_for(root).join(format!("mission-{short}")) == dir
-                    })
+                    roots
+                        .iter()
+                        .any(|root| physical_mission_directory(root, short) == physical_dir)
                 })
         })
         .max_by_key(|entry| {
@@ -242,14 +248,13 @@ fn workspace_ids_for_directory(
     dir: &std::path::Path,
     workspace_roots: &std::collections::HashMap<uuid::Uuid, Vec<std::path::PathBuf>>,
 ) -> Vec<uuid::Uuid> {
+    let physical_dir = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
     workspace_roots
         .iter()
         .filter_map(|(id, roots)| {
             roots
                 .iter()
-                .any(|root| {
-                    workspace::workspaces_root_for(root).join(format!("mission-{short}")) == dir
-                })
+                .any(|root| physical_mission_directory(root, short) == physical_dir)
                 .then_some(*id)
         })
         .collect()
@@ -272,12 +277,15 @@ fn indexed_mission_directory_is_collectible(
 fn phase_one_index_allows_collection(
     index: &MissionIndex,
     mission_short: &str,
-    workspace_id: uuid::Uuid,
+    dir: &std::path::Path,
+    workspace_roots: &std::collections::HashMap<uuid::Uuid, Vec<std::path::PathBuf>>,
     cutoff: DateTime<Utc>,
 ) -> bool {
     index.complete
         && index.by_short.get(mission_short).is_some_and(|entries| {
-            indexed_mission_directory_is_collectible(entries, workspace_id, cutoff, true)
+            entry_for_directory(entries, mission_short, dir, workspace_roots).is_some_and(|entry| {
+                is_gc_eligible_status(&entry.status) && entry.updated_at < cutoff
+            })
         })
 }
 
@@ -726,6 +734,20 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
             }
         };
     let mission_index = build_mission_index(state).await;
+    let all_workspaces = state.workspaces.list().await;
+    let workspace_roots: std::collections::HashMap<_, _> = all_workspaces
+        .iter()
+        .map(|workspace| {
+            (
+                workspace.id,
+                workspace::mission_workspace_roots_for_workspace(workspace),
+            )
+        })
+        .collect();
+    let workspace_paths: std::collections::HashMap<_, _> = all_workspaces
+        .iter()
+        .map(|workspace| (workspace.id, workspace.path.clone()))
+        .collect();
     let sessions = state.control.all_sessions().await;
     for session in sessions {
         let store = session.mission_store.clone();
@@ -773,13 +795,35 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                     continue;
                 }
                 let short = mission.id.simple().to_string()[..8].to_string();
-                if !phase_one_index_allows_collection(&mission_index, &short, workspace_id, cutoff)
-                {
+                if !phase_one_index_allows_collection(
+                    &mission_index,
+                    &short,
+                    &dir,
+                    &workspace_roots,
+                    cutoff,
+                ) {
                     tracing::debug!(
                         mission_id = %mission.id,
                         workspace_id = %workspace_id,
                         path = %dir.display(),
                         "mission GC: kept (short-id collision owner protected)",
+                    );
+                    continue;
+                }
+                if workspace_ids_for_directory(&short, &dir, &workspace_roots)
+                    .iter()
+                    .any(|workspace_id| {
+                        workspace_paths
+                            .get(workspace_id)
+                            .and_then(|path| crate::workspace_exec::machine_name_for_path(path))
+                            .is_some_and(|token| scope_protected.contains(&(token, short.clone())))
+                    })
+                {
+                    tracing::debug!(
+                        mission_id = %mission.id,
+                        workspace_id = %workspace_id,
+                        path = %dir.display(),
+                        "mission GC: kept (live exec scope from global directory owner)",
                     );
                     continue;
                 }
@@ -1155,10 +1199,12 @@ mod tests {
             by_short: std::collections::HashMap::new(),
             complete: false,
         };
+        let roots = std::collections::HashMap::new();
         assert!(!phase_one_index_allows_collection(
             &incomplete_empty,
             "deadbeef",
-            workspace_id,
+            std::path::Path::new("mission-deadbeef"),
+            &roots,
             now - chrono::Duration::days(7),
         ));
     }
@@ -1170,6 +1216,7 @@ mod tests {
         let custom_workspace = uuid::Uuid::new_v4();
         let short = "deadbeef";
         let dir = workspace::workspaces_root_for(root.path()).join(format!("mission-{short}"));
+        std::fs::create_dir_all(&dir).unwrap();
         let now = Utc::now();
         let entries = vec![
             // The default workspace has a terminal collision, but the custom
@@ -1195,6 +1242,20 @@ mod tests {
         assert_eq!(owner.workspace_id, custom_workspace);
         assert_eq!(owner.status, MissionStatus::Active);
         assert_eq!(workspace_ids_for_directory(short, &dir, &roots).len(), 2);
+        let index = MissionIndex {
+            by_short: std::collections::HashMap::from([(short.to_string(), entries.clone())]),
+            complete: true,
+        };
+        assert!(
+            !phase_one_index_allows_collection(
+                &index,
+                short,
+                &dir,
+                &roots,
+                now - chrono::Duration::days(7),
+            ),
+            "phase one must retain a path with an active owner in an overlapping root"
+        );
 
         let terminal_only = vec![MissionIndexEntry {
             status: MissionStatus::Completed,

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -818,136 +818,143 @@ async fn orphan_sweep(
     let index = &index_full.by_short;
 
     for ws in state.workspaces.list().await {
-        let root = workspace::workspaces_root_for(&ws.path);
-        let Ok(mut rd) = tokio::fs::read_dir(&root).await else {
-            continue;
-        };
-        while let Ok(Some(entry)) = rd.next_entry().await {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            let Some(short) = name.strip_prefix("mission-") else {
+        for workspace_root in workspace::mission_workspace_roots_for_workspace(&ws) {
+            let root = workspace::workspaces_root_for(&workspace_root);
+            let Ok(mut rd) = tokio::fs::read_dir(&root).await else {
                 continue;
             };
-            if short.len() != 8 || !short.chars().all(|c| c.is_ascii_hexdigit()) {
-                continue;
-            }
-            let dir = entry.path();
-            if !entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
-                continue;
-            }
-            let workspace_token = crate::workspace_exec::machine_name_for_path(&ws.path);
-            if workspace_token
-                .as_ref()
-                .is_some_and(|token| scope_protected.contains(&(token.clone(), short.to_string())))
-            {
-                tracing::debug!(path = %dir.display(), "mission GC: kept (live exec scope)");
-                continue;
-            }
-            enum Verdict {
-                Keep(&'static str),
-                Delete(&'static str, bool /*orphan*/, bool /*stopped*/),
-            }
-            let indexed_entry = index
-                .get(short)
-                .and_then(|entries| entry_for_workspace(entries, ws.id));
-            let verdict = match indexed_entry {
-                Some(e) => match e.status {
-                    MissionStatus::Active
-                    | MissionStatus::Pending
-                    | MissionStatus::WaitingBackground => Verdict::Keep("mission running"),
-                    MissionStatus::AwaitingUser | MissionStatus::Paused => {
-                        if e.updated_at < params.stopped_cutoff {
-                            Verdict::Delete("stopped mission past long-stop retention", false, true)
-                        } else {
-                            Verdict::Keep("awaiting user / paused within retention")
+            while let Ok(Some(entry)) = rd.next_entry().await {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let Some(short) = name.strip_prefix("mission-") else {
+                    continue;
+                };
+                if short.len() != 8 || !short.chars().all(|c| c.is_ascii_hexdigit()) {
+                    continue;
+                }
+                let dir = entry.path();
+                if !entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                let workspace_token = crate::workspace_exec::machine_name_for_path(&ws.path);
+                if workspace_token.as_ref().is_some_and(|token| {
+                    scope_protected.contains(&(token.clone(), short.to_string()))
+                }) {
+                    tracing::debug!(path = %dir.display(), "mission GC: kept (live exec scope)");
+                    continue;
+                }
+                enum Verdict {
+                    Keep(&'static str),
+                    Delete(&'static str, bool /*orphan*/, bool /*stopped*/),
+                }
+                let indexed_entry = index
+                    .get(short)
+                    .and_then(|entries| entry_for_workspace(entries, ws.id));
+                let verdict = match indexed_entry {
+                    Some(e) => match e.status {
+                        MissionStatus::Active
+                        | MissionStatus::Pending
+                        | MissionStatus::WaitingBackground => Verdict::Keep("mission running"),
+                        MissionStatus::AwaitingUser | MissionStatus::Paused => {
+                            if e.updated_at < params.stopped_cutoff {
+                                Verdict::Delete(
+                                    "stopped mission past long-stop retention",
+                                    false,
+                                    true,
+                                )
+                            } else {
+                                Verdict::Keep("awaiting user / paused within retention")
+                            }
                         }
-                    }
-                    _ => {
-                        if e.updated_at < params.cutoff {
-                            Verdict::Delete("terminal mission past retention", false, false)
-                        } else {
-                            Verdict::Keep("terminal mission within retention")
+                        _ => {
+                            if e.updated_at < params.cutoff {
+                                Verdict::Delete("terminal mission past retention", false, false)
+                            } else {
+                                Verdict::Keep("terminal mission within retention")
+                            }
                         }
-                    }
-                },
-                None => {
-                    if !params.orphans_enabled {
-                        Verdict::Keep("orphan collection disabled")
-                    } else if !index_full.complete {
-                        Verdict::Keep("mission index incomplete; not trusting orphan verdicts")
-                    } else {
-                        // No mission anywhere claims this dir. Use the dir
-                        // mtime as the age signal, with the normal retention
-                        // as a grace period for freshly-created dirs whose
-                        // mission row hasn't landed yet.
-                        let old_enough = match tokio::fs::metadata(&dir).await {
-                            Ok(meta) => match meta.modified() {
-                                Ok(mtime) => chrono::DateTime::<Utc>::from(mtime) < params.cutoff,
+                    },
+                    None => {
+                        if !params.orphans_enabled {
+                            Verdict::Keep("orphan collection disabled")
+                        } else if !index_full.complete {
+                            Verdict::Keep("mission index incomplete; not trusting orphan verdicts")
+                        } else {
+                            // No mission anywhere claims this dir. Use the dir
+                            // mtime as the age signal, with the normal retention
+                            // as a grace period for freshly-created dirs whose
+                            // mission row hasn't landed yet.
+                            let old_enough = match tokio::fs::metadata(&dir).await {
+                                Ok(meta) => match meta.modified() {
+                                    Ok(mtime) => {
+                                        chrono::DateTime::<Utc>::from(mtime) < params.cutoff
+                                    }
+                                    Err(_) => false,
+                                },
                                 Err(_) => false,
-                            },
-                            Err(_) => false,
-                        };
-                        if old_enough {
-                            Verdict::Delete("no mission in any store", true, false)
-                        } else {
-                            Verdict::Keep("unmatched but too recent")
+                            };
+                            if old_enough {
+                                Verdict::Delete("no mission in any store", true, false)
+                            } else {
+                                Verdict::Keep("unmatched but too recent")
+                            }
                         }
                     }
-                }
-            };
-            match verdict {
-                Verdict::Keep(reason) => {
-                    tracing::debug!(path = %dir.display(), reason, "mission GC: kept");
-                }
-                Verdict::Delete(reason, orphan, stopped) => {
-                    if params.dry_run && dry_run_candidates.contains(&dir) {
-                        tracing::debug!(
-                            path = %dir.display(),
-                            reason,
-                            "mission GC: skipped duplicate dry-run candidate",
-                        );
-                        continue;
+                };
+                match verdict {
+                    Verdict::Keep(reason) => {
+                        tracing::debug!(path = %dir.display(), reason, "mission GC: kept");
                     }
-                    let size = directory_size_bytes(&dir).await;
-                    if params.dry_run {
-                        report.proposed += 1;
-                        tracing::info!(
-                            action = "would_remove",
-                            path = %dir.display(),
-                            workspace = %ws.name,
-                            workspace_id = %ws.id,
-                            bytes = size,
-                            reason,
-                            orphan,
-                            stopped,
-                            "mission GC audit",
-                        );
-                        continue;
-                    }
-                    match tokio::fs::remove_dir_all(&dir).await {
-                        Ok(()) => {
-                            report.removed += 1;
-                            if orphan {
-                                report.orphans_removed += 1;
-                            }
-                            if stopped {
-                                report.stopped_removed += 1;
-                            }
-                            report.bytes_freed = report.bytes_freed.saturating_add(size);
+                    Verdict::Delete(reason, orphan, stopped) => {
+                        if params.dry_run && dry_run_candidates.contains(&dir) {
+                            tracing::debug!(
+                                path = %dir.display(),
+                                reason,
+                                "mission GC: skipped duplicate dry-run candidate",
+                            );
+                            continue;
+                        }
+                        let size = directory_size_bytes(&dir).await;
+                        if params.dry_run {
+                            report.proposed += 1;
                             tracing::info!(
+                                action = "would_remove",
                                 path = %dir.display(),
                                 workspace = %ws.name,
+                                workspace_id = %ws.id,
                                 bytes = size,
                                 reason,
-                                "mission GC: removed workspace directory (orphan sweep)",
+                                orphan,
+                                stopped,
+                                "mission GC audit",
                             );
+                            continue;
                         }
-                        Err(err) => {
-                            report.errors += 1;
-                            tracing::warn!(
-                                path = %dir.display(),
-                                ?err,
-                                "mission GC: failed to remove directory (orphan sweep)",
-                            );
+                        match tokio::fs::remove_dir_all(&dir).await {
+                            Ok(()) => {
+                                report.removed += 1;
+                                if orphan {
+                                    report.orphans_removed += 1;
+                                }
+                                if stopped {
+                                    report.stopped_removed += 1;
+                                }
+                                report.bytes_freed = report.bytes_freed.saturating_add(size);
+                                tracing::info!(
+                                    path = %dir.display(),
+                                    workspace = %ws.name,
+                                    bytes = size,
+                                    reason,
+                                    "mission GC: removed workspace directory (orphan sweep)",
+                                );
+                            }
+                            Err(err) => {
+                                report.errors += 1;
+                                tracing::warn!(
+                                    path = %dir.display(),
+                                    ?err,
+                                    "mission GC: failed to remove directory (orphan sweep)",
+                                );
+                            }
                         }
                     }
                 }

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -720,7 +720,7 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                         continue;
                     }
                 };
-                let dir = workspace::mission_workspace_dir_for_root(&ws.path, mission.id);
+                let dir = workspace::mission_workspace_dir_for_workspace(&ws, mission.id);
                 if !dir.exists() {
                     continue;
                 }

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -884,7 +884,7 @@ async fn orphan_sweep(
             if !scanned_roots.insert(physical_root) {
                 continue;
             }
-            let root = workspace::workspaces_root_for(&workspace_root);
+            let root = workspace::workspaces_root_for(workspace_root);
             let Ok(mut rd) = tokio::fs::read_dir(&root).await else {
                 continue;
             };

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -790,6 +790,16 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                         continue;
                     }
                 };
+                // A recorded root which now names a different filesystem is
+                // not an orphan on the parent disk.  Never inspect or remove
+                // its look-alike mission path until the original filesystem
+                // is back and its persisted identity verifies.
+                if let Err(error) =
+                    workspace::ensure_persisted_mission_root_is_available(&ws, mission.id)
+                {
+                    tracing::warn!(mission_id = %mission.id, %error, "mission GC: persisted root is unavailable; skipping collection");
+                    continue;
+                }
                 let dir = workspace::mission_workspace_dir_for_workspace(&ws, mission.id);
                 if !dir.exists() {
                     continue;

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -203,8 +203,9 @@ pub fn disk_usage_for_path(path: &Path) -> std::io::Result<DiskUsage> {
             Err(std::io::Error::last_os_error())
         } else {
             let block_size = statvfs_accounting_block_size(stat.f_frsize, stat.f_bsize);
-            let total = stat.f_blocks.saturating_mul(block_size);
-            let available = stat.f_bavail.saturating_mul(block_size);
+            // Linux `fsblkcnt_t` is 64-bit; macOS still uses 32-bit counts.
+            let total = u64::from(stat.f_blocks).saturating_mul(block_size);
+            let available = u64::from(stat.f_bavail).saturating_mul(block_size);
             Ok(DiskUsage {
                 measured_path,
                 filesystem: format!("statvfs:{}", stat.f_fsid),

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -8,6 +8,7 @@
 //! for container workspaces, collected from cgroup stats.
 
 use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -183,6 +184,55 @@ pub fn current_disk_usage() -> (u64, u64, f32) {
     let disks = Disks::new_with_refreshed_list();
     let (used, total) = root_disk_usage(&disks);
     (used, total, pct(used, total))
+}
+
+/// Capacity of the filesystem that actually backs `path`.  `statvfs` avoids
+/// guessing from a root-filesystem mount list when mission scratch lives on a
+/// separate volume.
+pub fn disk_usage_for_path(path: &Path) -> std::io::Result<DiskUsage> {
+    let measured_path = std::fs::canonicalize(path)?;
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+        let c_path = CString::new(measured_path.as_os_str().as_bytes()).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains NUL")
+        })?;
+        let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+        if unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let block_size = u64::from(stat.f_frsize.max(stat.f_bsize));
+        let total = stat.f_blocks.saturating_mul(block_size);
+        let available = stat.f_bavail.saturating_mul(block_size);
+        return Ok(DiskUsage {
+            measured_path,
+            filesystem: format!("statvfs:{}", stat.f_fsid),
+            used: total.saturating_sub(available),
+            total,
+            available,
+        });
+    }
+    #[cfg(not(unix))]
+    {
+        let (used, total, _) = current_disk_usage();
+        Ok(DiskUsage {
+            measured_path,
+            filesystem: "root".to_string(),
+            used,
+            total,
+            available: total.saturating_sub(used),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiskUsage {
+    pub measured_path: PathBuf,
+    pub filesystem: String,
+    pub used: u64,
+    pub total: u64,
+    pub available: u64,
 }
 
 /// Percentage of `used` over `total` (0 when `total` is 0).
@@ -864,4 +914,26 @@ fn systemd_escape(name: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disk_usage_measures_the_requested_path() {
+        let root = disk_usage_for_path(Path::new("/")).unwrap();
+        assert!(root.total >= root.available);
+        assert!(!root.measured_path.as_os_str().is_empty());
+
+        // Linux normally mounts tmpfs at /dev/shm. When it is present on a
+        // distinct filesystem, this proves we do not silently report `/`.
+        let shm = Path::new("/dev/shm");
+        if shm.is_dir() {
+            let shm_usage = disk_usage_for_path(shm).unwrap();
+            if shm_usage.filesystem != root.filesystem {
+                assert_ne!(shm_usage.filesystem, root.filesystem);
+            }
+        }
+    }
 }

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -204,8 +204,8 @@ pub fn disk_usage_for_path(path: &Path) -> std::io::Result<DiskUsage> {
         } else {
             let block_size = statvfs_accounting_block_size(stat.f_frsize, stat.f_bsize);
             // Linux `fsblkcnt_t` is 64-bit; macOS still uses 32-bit counts.
-            let total = u64::from(stat.f_blocks).saturating_mul(block_size);
-            let available = u64::from(stat.f_bavail).saturating_mul(block_size);
+            let total = (stat.f_blocks as u64).saturating_mul(block_size);
+            let available = (stat.f_bavail as u64).saturating_mul(block_size);
             Ok(DiskUsage {
                 measured_path,
                 filesystem: format!("statvfs:{}", stat.f_fsid),

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -200,18 +200,19 @@ pub fn disk_usage_for_path(path: &Path) -> std::io::Result<DiskUsage> {
         })?;
         let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
         if unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) } != 0 {
-            return Err(std::io::Error::last_os_error());
+            Err(std::io::Error::last_os_error())
+        } else {
+            let block_size = statvfs_accounting_block_size(stat.f_frsize, stat.f_bsize);
+            let total = stat.f_blocks.saturating_mul(block_size);
+            let available = stat.f_bavail.saturating_mul(block_size);
+            Ok(DiskUsage {
+                measured_path,
+                filesystem: format!("statvfs:{}", stat.f_fsid),
+                used: total.saturating_sub(available),
+                total,
+                available,
+            })
         }
-        let block_size = statvfs_accounting_block_size(stat.f_frsize, stat.f_bsize);
-        let total = stat.f_blocks.saturating_mul(block_size);
-        let available = stat.f_bavail.saturating_mul(block_size);
-        return Ok(DiskUsage {
-            measured_path,
-            filesystem: format!("statvfs:{}", stat.f_fsid),
-            used: total.saturating_sub(available),
-            total,
-            available,
-        });
     }
     #[cfg(not(unix))]
     {
@@ -226,12 +227,12 @@ pub fn disk_usage_for_path(path: &Path) -> std::io::Result<DiskUsage> {
     }
 }
 
-fn statvfs_accounting_block_size(fragment_size: libc::c_ulong, block_size: libc::c_ulong) -> u64 {
-    u64::from(if fragment_size == 0 {
+fn statvfs_accounting_block_size(fragment_size: u64, block_size: u64) -> u64 {
+    if fragment_size == 0 {
         block_size
     } else {
         fragment_size
-    })
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -202,7 +202,7 @@ pub fn disk_usage_for_path(path: &Path) -> std::io::Result<DiskUsage> {
         if unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) } != 0 {
             return Err(std::io::Error::last_os_error());
         }
-        let block_size = u64::from(stat.f_frsize.max(stat.f_bsize));
+        let block_size = statvfs_accounting_block_size(stat.f_frsize, stat.f_bsize);
         let total = stat.f_blocks.saturating_mul(block_size);
         let available = stat.f_bavail.saturating_mul(block_size);
         return Ok(DiskUsage {
@@ -224,6 +224,14 @@ pub fn disk_usage_for_path(path: &Path) -> std::io::Result<DiskUsage> {
             available: total.saturating_sub(used),
         })
     }
+}
+
+fn statvfs_accounting_block_size(fragment_size: libc::c_ulong, block_size: libc::c_ulong) -> u64 {
+    u64::from(if fragment_size == 0 {
+        block_size
+    } else {
+        fragment_size
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -933,5 +941,11 @@ mod tests {
             let shm_usage = disk_usage_for_path(shm).unwrap();
             assert_ne!(shm_usage.filesystem, root.filesystem);
         }
+    }
+
+    #[test]
+    fn statvfs_accounting_uses_fragment_size_with_zero_fallback() {
+        assert_eq!(statvfs_accounting_block_size(1024, 4096), 1024);
+        assert_eq!(statvfs_accounting_block_size(0, 4096), 4096);
     }
 }

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -926,14 +926,12 @@ mod tests {
         assert!(root.total >= root.available);
         assert!(!root.measured_path.as_os_str().is_empty());
 
-        // Linux normally mounts tmpfs at /dev/shm. When it is present on a
-        // distinct filesystem, this proves we do not silently report `/`.
+        // Linux normally mounts tmpfs at /dev/shm. This proves we do not
+        // silently report `/` when asked to measure a distinct filesystem.
         let shm = Path::new("/dev/shm");
         if shm.is_dir() {
             let shm_usage = disk_usage_for_path(shm).unwrap();
-            if shm_usage.filesystem != root.filesystem {
-                assert_ne!(shm_usage.filesystem, root.filesystem);
-            }
+            assert_ne!(shm_usage.filesystem, root.filesystem);
         }
     }
 }

--- a/src/api/operator_attention.rs
+++ b/src/api/operator_attention.rs
@@ -295,6 +295,7 @@ mod tests {
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::Task,
             goal_mode: false,
             goal_objective: None,

--- a/src/api/paloma/mission_card.rs
+++ b/src/api/paloma/mission_card.rs
@@ -292,6 +292,7 @@ mod tests {
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::Task,
             goal_mode: false,
             goal_objective: None,

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -319,9 +319,10 @@ async fn offload_build(
         )
             .into_response();
     }
-    match crate::workspace::verify_explicit_mission_working_directory_owner(
+    match crate::workspace::verify_or_adopt_explicit_mission_working_directory(
         &workspace,
         std::path::Path::new(&host_dir),
+        &[host_owner.id],
     ) {
         Ok(owner_id) if owner_id == host_owner.id => {}
         Ok(_) => {
@@ -332,11 +333,24 @@ async fn offload_build(
                 .into_response();
         }
         Err(error) => {
-            return (
-                StatusCode::CONFLICT,
-                format!("host_dir persisted mission owner is unavailable or unverified: {error}"),
-            )
-                .into_response();
+            if crate::workspace::is_generated_mission_directory_under_known_root(
+                &workspace,
+                std::path::Path::new(&host_dir),
+            ) {
+                tracing::warn!(
+                    host_owner = %host_owner.id,
+                    host_dir = %host_dir,
+                    "adopting pre-registry spark host_dir"
+                );
+            } else {
+                return (
+                    StatusCode::CONFLICT,
+                    format!(
+                        "host_dir persisted mission owner is unavailable or unverified: {error}"
+                    ),
+                )
+                    .into_response();
+            }
         }
     }
     if let Err(error) = host_dir_matches_mission_owner(&host_dir, &workspace, host_owner.id) {

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -277,15 +277,21 @@ async fn offload_build(
     // rsync below WRITES into host_dir.
     let host_short = name.strip_prefix("mission-").unwrap_or("");
     let req_short = &req.mission_id.to_string()[..8];
-    let mission_store = state.control.get_mission_store().await;
+    let Some((mission_store, requesting_mission)) = state
+        .control
+        .find_mission_store_owner(req.mission_id)
+        .await
+        .unwrap_or_else(|error| {
+            tracing::warn!(mission_id = %req.mission_id, %error, "spark owner lookup failed closed");
+            None
+        })
+    else {
+        return (StatusCode::FORBIDDEN, "mission capability owner not found").into_response();
+    };
     let host_owner = if host_short.is_empty() {
         None
     } else if host_short == req_short {
-        mission_store
-            .get_mission(req.mission_id)
-            .await
-            .ok()
-            .flatten()
+        Some(requesting_mission)
     } else {
         mission_ancestor_by_short(&mission_store, req.mission_id, host_short).await
     };

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -147,6 +147,23 @@ fn canonical_mission_host_dir(raw: &str) -> Result<String, &'static str> {
         .ok_or("invalid host_dir")
 }
 
+/// A syntactically valid `workspaces/mission-*` directory is not enough: a
+/// worker may name an ancestor's short id at another root.  Match the actual
+/// canonical directory selected for that *owner* before rsync is allowed.
+fn host_dir_matches_mission_owner(
+    host_dir: &str,
+    workspace: &crate::workspace::Workspace,
+    mission_id: Uuid,
+) -> Result<(), &'static str> {
+    let expected = crate::workspace::mission_workspace_dir_for_workspace(workspace, mission_id);
+    let expected = std::fs::canonicalize(expected).map_err(|_| "mission workspace unavailable")?;
+    if expected == std::path::Path::new(host_dir) {
+        Ok(())
+    } else {
+        Err("host_dir is not the persisted mission owner's workspace")
+    }
+}
+
 /// Run a host subprocess, returning (success, combined output).
 async fn run(args: &[&str]) -> (bool, String) {
     match tokio::process::Command::new(args[0])
@@ -295,6 +312,9 @@ async fn offload_build(
             format!("persisted mission workspace root is unavailable: {error}"),
         )
             .into_response();
+    }
+    if let Err(error) = host_dir_matches_mission_owner(&host_dir, &workspace, host_owner.id) {
+        return (StatusCode::FORBIDDEN, error).into_response();
     }
 
     // Availability check runs AFTER authorization so an unauthorized caller can
@@ -459,8 +479,7 @@ async fn offload_build(
 
 #[cfg(test)]
 mod tests {
-    use super::mission_ancestor_by_short;
-    use super::rel_path_is_safe;
+    use super::{host_dir_matches_mission_owner, mission_ancestor_by_short, rel_path_is_safe};
     use crate::api::mission_store::{InMemoryMissionStore, MissionStore};
     use std::sync::Arc;
 
@@ -531,6 +550,41 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    #[test]
+    fn ancestor_host_dir_must_be_the_owners_verified_placement() {
+        let root = tempfile::tempdir().unwrap();
+        let owner_root = root.path().join("owner-root");
+        let requester_root = root.path().join("requester-root");
+        std::fs::create_dir_all(&owner_root).unwrap();
+        std::fs::create_dir_all(&requester_root).unwrap();
+        let owner = uuid::Uuid::new_v4();
+        let owner_workspace = crate::workspace::Workspace::default_host(owner_root.clone());
+        let fake_owner_dir = requester_root
+            .join("workspaces")
+            .join(format!("mission-{}", &owner.to_string()[..8]));
+        let real_owner_dir = owner_root
+            .join("workspaces")
+            .join(format!("mission-{}", &owner.to_string()[..8]));
+        std::fs::create_dir_all(&fake_owner_dir).unwrap();
+        std::fs::create_dir_all(&real_owner_dir).unwrap();
+
+        // The worker may use an ancestor's directory, but only the exact
+        // directory selected for that ancestor—not an identically named one
+        // under the requester's (or any other) root.
+        assert!(host_dir_matches_mission_owner(
+            real_owner_dir.to_str().unwrap(),
+            &owner_workspace,
+            owner,
+        )
+        .is_ok());
+        assert!(host_dir_matches_mission_owner(
+            fake_owner_dir.to_str().unwrap(),
+            &owner_workspace,
+            owner,
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -178,18 +178,18 @@ fn rel_path_is_safe(rel_clean: &str) -> bool {
         })
 }
 
-/// Walk a mission's `parent_mission_id` chain and return true if any ANCESTOR's
-/// id begins with `short` — the 8-char prefix encoded in a `mission-<short>`
+/// Walk a mission's `parent_mission_id` chain and return the matching
+/// ANCESTOR — the 8-char prefix encoded in a `mission-<short>`
 /// workspace dir name. Lets an orchestrator worker offload a build that lives in
 /// its parent/boss mission's shared workspace dir (per-PR worktrees). The walk
 /// is bounded; a missing record or cyclic chain just yields `false` (→ 403).
-async fn mission_has_ancestor_short(
+async fn mission_ancestor_by_short(
     store: &Arc<dyn MissionStore>,
     mission_id: Uuid,
     short: &str,
-) -> bool {
+) -> Option<super::mission_store::Mission> {
     if short.is_empty() {
-        return false;
+        return None;
     }
     let mut cur = match store.get_mission(mission_id).await {
         Ok(Some(m)) => m.parent_mission_id,
@@ -199,7 +199,7 @@ async fn mission_has_ancestor_short(
     while let Some(id) = cur {
         let id_str = id.to_string();
         if id_str.len() >= 8 && id_str[..8] == *short {
-            return true;
+            return store.get_mission(id).await.ok().flatten();
         }
         cur = match store.get_mission(id).await {
             Ok(Some(m)) => m.parent_mission_id,
@@ -210,7 +210,7 @@ async fn mission_has_ancestor_short(
             break;
         }
     }
-    false
+    None
 }
 
 async fn offload_build(
@@ -260,36 +260,35 @@ async fn offload_build(
     // rsync below WRITES into host_dir.
     let host_short = name.strip_prefix("mission-").unwrap_or("");
     let req_short = &req.mission_id.to_string()[..8];
-    let host_dir_authorized = if host_short.is_empty() {
-        false
+    let mission_store = state.control.get_mission_store().await;
+    let host_owner = if host_short.is_empty() {
+        None
     } else if host_short == req_short {
-        true
+        mission_store
+            .get_mission(req.mission_id)
+            .await
+            .ok()
+            .flatten()
     } else {
-        let store = state.control.get_mission_store().await;
-        mission_has_ancestor_short(&store, req.mission_id, host_short).await
+        mission_ancestor_by_short(&mission_store, req.mission_id, host_short).await
     };
-    if !host_dir_authorized {
+    let Some(host_owner) = host_owner else {
         return (
             StatusCode::FORBIDDEN,
             "host_dir does not belong to this mission or an ancestor",
         )
             .into_response();
-    }
+    };
 
     // The capability belongs to a persisted mission placement.  Do this after
     // authorization (so it is not a mount-probing oracle), but before rsync
     // can read from or write to a stale mountpoint on the root filesystem.
-    let mission_store = state.control.get_mission_store().await;
-    let mission = match mission_store.get_mission(req.mission_id).await {
-        Ok(Some(mission)) => mission,
-        _ => return (StatusCode::NOT_FOUND, "mission not found").into_response(),
-    };
-    let workspace = match state.workspaces.get(mission.workspace_id).await {
+    let workspace = match state.workspaces.get(host_owner.workspace_id).await {
         Some(workspace) => workspace,
         None => return (StatusCode::NOT_FOUND, "mission workspace not found").into_response(),
     };
     if let Err(error) =
-        crate::workspace::ensure_persisted_mission_root_is_available(&workspace, req.mission_id)
+        crate::workspace::ensure_persisted_mission_root_is_available(&workspace, host_owner.id)
     {
         return (
             StatusCode::CONFLICT,
@@ -460,7 +459,7 @@ async fn offload_build(
 
 #[cfg(test)]
 mod tests {
-    use super::mission_has_ancestor_short;
+    use super::mission_ancestor_by_short;
     use super::rel_path_is_safe;
     use crate::api::mission_store::{InMemoryMissionStore, MissionStore};
     use std::sync::Arc;
@@ -501,19 +500,37 @@ mod tests {
         let stranger = mk(&store, "stranger", None).await;
 
         // A worker's token may offload into its boss (parent) dir.
-        assert!(mission_has_ancestor_short(&store, worker, &short(boss)).await);
+        assert!(mission_ancestor_by_short(&store, worker, &short(boss))
+            .await
+            .is_some());
         // …and a grandchild reaches the boss two hops up.
-        assert!(mission_has_ancestor_short(&store, grandchild, &short(boss)).await);
-        assert!(mission_has_ancestor_short(&store, grandchild, &short(worker)).await);
+        assert!(mission_ancestor_by_short(&store, grandchild, &short(boss))
+            .await
+            .is_some());
+        assert!(
+            mission_ancestor_by_short(&store, grandchild, &short(worker))
+                .await
+                .is_some()
+        );
         // An unrelated mission's dir is never authorized.
-        assert!(!mission_has_ancestor_short(&store, worker, &short(stranger)).await);
+        assert!(mission_ancestor_by_short(&store, worker, &short(stranger))
+            .await
+            .is_none());
         // The own-dir case is handled by the caller (host_short == req_short),
         // so the ancestor walk (parents only) must NOT self-match.
-        assert!(!mission_has_ancestor_short(&store, worker, &short(worker)).await);
+        assert!(mission_ancestor_by_short(&store, worker, &short(worker))
+            .await
+            .is_none());
         // Empty short never authorizes.
-        assert!(!mission_has_ancestor_short(&store, worker, "").await);
+        assert!(mission_ancestor_by_short(&store, worker, "")
+            .await
+            .is_none());
         // Unknown mission id → no ancestors → false.
-        assert!(!mission_has_ancestor_short(&store, uuid::Uuid::new_v4(), &short(boss)).await);
+        assert!(
+            mission_ancestor_by_short(&store, uuid::Uuid::new_v4(), &short(boss))
+                .await
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -313,6 +313,26 @@ async fn offload_build(
         )
             .into_response();
     }
+    match crate::workspace::verify_explicit_mission_working_directory_owner(
+        &workspace,
+        std::path::Path::new(&host_dir),
+    ) {
+        Ok(owner_id) if owner_id == host_owner.id => {}
+        Ok(_) => {
+            return (
+                StatusCode::FORBIDDEN,
+                "host_dir resolved to a different persisted mission owner",
+            )
+                .into_response();
+        }
+        Err(error) => {
+            return (
+                StatusCode::CONFLICT,
+                format!("host_dir persisted mission owner is unavailable or unverified: {error}"),
+            )
+                .into_response();
+        }
+    }
     if let Err(error) = host_dir_matches_mission_owner(&host_dir, &workspace, host_owner.id) {
         return (StatusCode::FORBIDDEN, error).into_response();
     }

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -276,6 +276,28 @@ async fn offload_build(
             .into_response();
     }
 
+    // The capability belongs to a persisted mission placement.  Do this after
+    // authorization (so it is not a mount-probing oracle), but before rsync
+    // can read from or write to a stale mountpoint on the root filesystem.
+    let mission_store = state.control.get_mission_store().await;
+    let mission = match mission_store.get_mission(req.mission_id).await {
+        Ok(Some(mission)) => mission,
+        _ => return (StatusCode::NOT_FOUND, "mission not found").into_response(),
+    };
+    let workspace = match state.workspaces.get(mission.workspace_id).await {
+        Some(workspace) => workspace,
+        None => return (StatusCode::NOT_FOUND, "mission workspace not found").into_response(),
+    };
+    if let Err(error) =
+        crate::workspace::ensure_persisted_mission_root_is_available(&workspace, req.mission_id)
+    {
+        return (
+            StatusCode::CONFLICT,
+            format!("persisted mission workspace root is unavailable: {error}"),
+        )
+            .into_response();
+    }
+
     // Availability check runs AFTER authorization so an unauthorized caller can
     // never probe whether Spark is configured. All three must be set, else tell
     // the (authorized) caller to build locally via a 503.

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -6940,6 +6940,7 @@ mod tests {
             terminal_evidence: None,
             parent_mission_id: None,
             working_directory: None,
+            requires_local_disk: true,
             mission_mode: MissionMode::Task,
             goal_mode: false,
             goal_objective: None,

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -3716,6 +3716,7 @@ async fn resolve_or_create_mission(
             scheduling: Default::default(),
             requires_local_disk: true,
             estimated_disk_gib: None,
+            admission_tags: Vec::new(),
             respond: tx,
         })
         .await;

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -3715,6 +3715,7 @@ async fn resolve_or_create_mission(
             working_directory: None,
             scheduling: Default::default(),
             requires_local_disk: true,
+            estimated_disk_gib: None,
             respond: tx,
         })
         .await;

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -732,16 +732,18 @@ async fn update_workspace(
         }
     }
 
-    // Merge freeform config (shallow merge of top-level keys)
+    // Merge freeform config (shallow merge of top-level keys). The control
+    // registry path is server-owned and must not move with a client edit.
     if let Some(config) = req.config {
         if let Some(new_obj) = config.as_object() {
             let mut existing = workspace.config.as_object().cloned().unwrap_or_default();
             for (k, v) in new_obj {
+                if k == "mission_workspace_registry_control_root" {
+                    continue;
+                }
                 existing.insert(k.clone(), v.clone());
             }
             workspace.config = serde_json::Value::Object(existing);
-        } else {
-            workspace.config = config;
         }
     }
 

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -239,6 +239,22 @@ pub(crate) async fn write_opencode_config(
         base_config = serde_json::json!({});
     }
 
+    // MCP synchronization rewrites the generated settings file.  A custom
+    // workspace can carry provider definitions that do not exist in the
+    // server-wide OpenCode base config, so retain its local `provider` map
+    // before replacing MCP settings.  Server-managed Custom/Kimi definitions
+    // below override only matching keys with their authoritative values.
+    let local_provider_map = tokio::fs::read_to_string(workspace_dir.join("opencode.json"))
+        .await
+        .ok()
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+        .and_then(|config| {
+            config
+                .get("provider")
+                .and_then(|value| value.as_object())
+                .cloned()
+        });
+
     {
         let base_obj = base_config.as_object_mut().expect("opencode base config");
         base_obj.insert(
@@ -251,6 +267,17 @@ pub(crate) async fn write_opencode_config(
             serde_json::Value::Object(permission),
         );
         base_obj.insert("tools".to_string(), serde_json::Value::Object(tools));
+
+        if let Some(provider_map) = local_provider_map {
+            let providers = base_obj
+                .entry("provider".to_string())
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+            if let Some(providers) = providers.as_object_mut() {
+                for (key, provider) in provider_map {
+                    providers.entry(key).or_insert(provider);
+                }
+            }
+        }
 
         // Add custom providers if any. Kimi is handled here too: like Custom
         // providers it is not an OpenCode built-in, so it needs an explicit
@@ -270,7 +297,11 @@ pub(crate) async fn write_opencode_config(
                 .collect();
 
             if !provider_blocks.is_empty() {
-                let mut provider_map = serde_json::Map::new();
+                let mut provider_map = base_obj
+                    .get("provider")
+                    .and_then(|value| value.as_object())
+                    .cloned()
+                    .unwrap_or_default();
 
                 for provider in provider_blocks {
                     // Kimi: OpenAI-compatible block with the OAuth access token as
@@ -1364,6 +1395,39 @@ pub async fn write_backend_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn mcp_rewrite_retains_workspace_local_custom_provider() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        std::fs::write(
+            workspace.join("opencode.json"),
+            r#"{"provider":{"local-relay":{"name":"Local Relay","options":{"baseURL":"https://relay.invalid/v1"}}}}"#,
+        )
+        .unwrap();
+
+        write_opencode_config(
+            workspace,
+            Vec::new(),
+            workspace,
+            WorkspaceType::Host,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let rewritten: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(workspace.join("opencode.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            rewritten["provider"]["local-relay"]["options"]["baseURL"],
+            "https://relay.invalid/v1"
+        );
+    }
 
     #[tokio::test]
     async fn kimi_opencode_config_discovers_future_models_from_live_catalog() {

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -8,6 +8,34 @@
 //! reader never observes a half-written config.
 
 use super::*;
+use std::collections::{HashMap, HashSet};
+
+const SANDBOXED_MANAGED_PROVIDER_KEY: &str = "x-sandboxed-managed";
+
+fn managed_opencode_provider_keys(custom_providers: Option<&[AIProvider]>) -> HashSet<String> {
+    let mut keys = HashSet::from(["kimi".to_string()]);
+    if let Some(providers) = custom_providers {
+        for provider in providers {
+            keys.insert(sanitize_key(&provider.name));
+            if provider.provider_type == ProviderType::Kimi {
+                keys.insert("kimi".to_string());
+            }
+        }
+    }
+    keys
+}
+
+fn is_sandboxed_managed_provider(
+    key: &str,
+    provider: &serde_json::Value,
+    managed_keys: &HashSet<String>,
+) -> bool {
+    provider
+        .get(SANDBOXED_MANAGED_PROVIDER_KEY)
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+        || managed_keys.contains(key)
+}
 
 /// Write `contents` to `path` atomically: write to a sibling `.tmp` file,
 /// then rename over the target. Renames within one directory are atomic on
@@ -273,7 +301,12 @@ pub(crate) async fn write_opencode_config(
                 .entry("provider".to_string())
                 .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
             if let Some(providers) = providers.as_object_mut() {
+                let mut managed_keys = managed_opencode_provider_keys(custom_providers);
+                managed_keys.extend(read_managed_opencode_provider_keys(workspace_root));
                 for (key, provider) in provider_map {
+                    if is_sandboxed_managed_provider(&key, &provider, &managed_keys) {
+                        continue;
+                    }
                     providers.entry(key).or_insert(provider);
                 }
             }
@@ -377,6 +410,8 @@ pub(crate) async fn write_opencode_config(
                         provider_config
                             .insert("models".to_string(), serde_json::Value::Object(models_map));
 
+                        provider_config
+                            .insert(SANDBOXED_MANAGED_PROVIDER_KEY.to_string(), json!(true));
                         provider_map.insert(
                             "kimi".to_string(),
                             serde_json::Value::Object(provider_config),
@@ -450,6 +485,7 @@ pub(crate) async fn write_opencode_config(
                         }
                     }
 
+                    provider_config.insert(SANDBOXED_MANAGED_PROVIDER_KEY.to_string(), json!(true));
                     provider_map.insert(provider_id, serde_json::Value::Object(provider_config));
                 }
 
@@ -1423,6 +1459,40 @@ mod tests {
         let rewritten: serde_json::Value =
             serde_json::from_slice(&std::fs::read(workspace.join("opencode.json")).unwrap())
                 .unwrap();
+        assert_eq!(
+            rewritten["provider"]["local-relay"]["options"]["baseURL"],
+            "https://relay.invalid/v1"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_rewrite_drops_disabled_server_managed_providers() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        std::fs::write(
+            workspace.join("opencode.json"),
+            r#"{"provider":{"kimi":{"name":"Kimi","x-sandboxed-managed":true,"options":{"apiKey":"stale"}},"local-relay":{"name":"Local Relay","options":{"baseURL":"https://relay.invalid/v1"}}}}"#,
+        )
+        .unwrap();
+
+        write_opencode_config(
+            workspace,
+            Vec::new(),
+            workspace,
+            WorkspaceType::Host,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let rewritten: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(workspace.join("opencode.json")).unwrap())
+                .unwrap();
+        assert!(rewritten["provider"].get("kimi").is_none());
         assert_eq!(
             rewritten["provider"]["local-relay"]["options"]["baseURL"],
             "https://relay.invalid/v1"

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -5225,18 +5225,17 @@ WORKING_DIR = "/workspaces/mission-old"
         }
         assert_eq!(launches, 0, "no process may launch on an unverified root");
 
-        // Once the exact selected root is available again, normal preparation
-        // and execution may resume in that root, never in the workspace root.
+        // Recreating the mountpoint is *not* restoration of the selected
+        // filesystem: it has a different root inode and must remain blocked.
+        // A real remount retains the mounted filesystem's root identity; that
+        // normal restart path is covered by
+        // `persisted_mission_root_survives_restart_and_config_drift`.
         std::fs::create_dir(&storage).unwrap();
-        let dir = require_verified_mission_workspace(
+        assert!(require_verified_mission_workspace(
             prepare_mission_workspace_in(&workspace, &mcp, mission).await,
         )
-        .expect("restored persisted root should prepare normally");
-        launches += 1;
-        std::fs::write(dir.join("launch-sentinel"), "launched").unwrap();
-        assert_eq!(launches, 1);
-        assert!(dir.starts_with(&storage));
-        assert!(dir.join("launch-sentinel").exists());
+        .is_err());
+        assert_eq!(launches, 0);
         assert!(!mission_workspace_dir_for_root(temp.path(), mission)
             .join("launch-sentinel")
             .exists());

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3759,6 +3759,11 @@ pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::
             workspace.mcps_replace_defaults,
         );
         let skill_allowlist = (!workspace.skills.is_empty()).then_some(workspace.skills.as_slice());
+        // This is a rewrite, not a fresh config.  Preserve the workspace's
+        // own Custom and Kimi provider definitions just as mission
+        // preparation does; otherwise an MCP mutation on a relocated/custom
+        // workspace silently removes the only provider OpenCode can use.
+        let custom_providers = read_custom_providers_from_file(&workspace.path);
         if write_opencode_config(
             &path,
             mcp_configs,
@@ -3768,7 +3773,7 @@ pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::
             skill_allowlist,
             None,
             workspace.shared_network,
-            None,
+            (!custom_providers.is_empty()).then_some(custom_providers.as_slice()),
         )
         .await
         .is_ok()
@@ -5772,5 +5777,31 @@ WORKING_DIR = "/workspaces/mission-old"
             resolve_mission_workspace_root(None, temp.path()),
             temp.path()
         );
+    }
+
+    #[test]
+    fn global_mcp_sync_provider_source_includes_workspace_custom_and_kimi() {
+        let temp = tempfile::tempdir().unwrap();
+        let providers_dir = temp.path().join(".sandboxed-sh");
+        std::fs::create_dir_all(&providers_dir).unwrap();
+
+        let mut custom = AIProvider::new(ProviderType::Custom, "Local Relay".into());
+        custom.base_url = Some("https://relay.invalid/v1".into());
+        let mut kimi = AIProvider::new(ProviderType::Kimi, "Kimi".into());
+        kimi.base_url = Some("https://kimi.invalid/v1".into());
+        std::fs::write(
+            providers_dir.join("ai_providers.json"),
+            serde_json::to_vec(&vec![custom, kimi]).unwrap(),
+        )
+        .unwrap();
+
+        let providers = read_custom_providers_from_file(temp.path());
+        assert_eq!(providers.len(), 2);
+        assert!(providers
+            .iter()
+            .any(|p| p.provider_type == ProviderType::Custom));
+        assert!(providers
+            .iter()
+            .any(|p| p.provider_type == ProviderType::Kimi));
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -963,14 +963,17 @@ fn persist_mission_workspace_root(workspace: &Workspace, mission_id: Uuid, root:
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(lock_path)?;
         fs2::FileExt::lock_exclusive(&lock_file)?;
         let mut roots: HashMap<String, String> = std::fs::read_to_string(&path)
             .ok()
             .and_then(|contents| serde_json::from_str(&contents).ok())
             .unwrap_or_default();
-        if !roots.contains_key(&mission_id.to_string()) {
-            roots.insert(mission_id.to_string(), root.to_string_lossy().into_owned());
+        if let std::collections::hash_map::Entry::Vacant(entry) =
+            roots.entry(mission_id.to_string())
+        {
+            entry.insert(root.to_string_lossy().into_owned());
             atomic_write_mission_workspace_roots(&path, &roots)?;
         }
         fs2::FileExt::unlock(&lock_file)?;

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -909,6 +909,26 @@ struct MissionWorkspaceRootRecord {
     filesystem_identity: Option<String>,
 }
 
+/// A mission turn must not continue when its prepared directory cannot be
+/// verified.  In particular, callers must not substitute the workspace root:
+/// a persisted placement can refer to a temporarily unavailable or replaced
+/// filesystem at the same path.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to prepare verified mission workspace: {source}")]
+pub struct MissionWorkspacePreparationError {
+    #[source]
+    source: anyhow::Error,
+}
+
+/// Convert preparation failures into the typed, fail-closed boundary used by
+/// every execution entry point.  Keeping this conversion centralized makes a
+/// raw-workspace fallback impossible to reintroduce accidentally.
+pub fn require_verified_mission_workspace(
+    prepared: anyhow::Result<PathBuf>,
+) -> Result<PathBuf, MissionWorkspacePreparationError> {
+    prepared.map_err(|source| MissionWorkspacePreparationError { source })
+}
+
 /// Accept the path-only format written by releases before filesystem identity
 /// was recorded.  The first successful use upgrades it under the registry
 /// lock; an unavailable legacy root is never replaced by the configured root.
@@ -935,11 +955,22 @@ fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
     config_root(&workspace.path).join(MISSION_WORKSPACE_ROOTS_FILE)
 }
 
-fn filesystem_identity(path: &Path) -> std::io::Result<String> {
+pub(crate) fn filesystem_identity(path: &Path) -> std::io::Result<String> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        Ok(format!("dev:{}", std::fs::metadata(path)?.dev()))
+        let canonical = path.canonicalize()?;
+        let metadata = std::fs::metadata(&canonical)?;
+        // `st_dev` alone does not distinguish a bind mount from the
+        // underlying filesystem it exposes after unmount.  Linux mount IDs do
+        // distinguish those mounts; include the directory inode as a further
+        // guard against a replacement at the same path.
+        let mount_id = linux_mount_id_for_path(&canonical)?;
+        Ok(format!(
+            "mount:{mount_id}:dev:{}:ino:{}",
+            metadata.dev(),
+            metadata.ino()
+        ))
     }
     #[cfg(not(unix))]
     {
@@ -948,6 +979,45 @@ fn filesystem_identity(path: &Path) -> std::io::Result<String> {
         // pretending that an unverified path is a stable filesystem identity.
         Ok(format!("path:{}", path.canonicalize()?.display()))
     }
+}
+
+#[cfg(unix)]
+fn linux_mount_id_for_path(path: &Path) -> std::io::Result<u64> {
+    let path = path.canonicalize()?;
+    let mut best_match: Option<(PathBuf, u64)> = None;
+    for line in std::fs::read_to_string("/proc/self/mountinfo")?.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(id) = fields.next().and_then(|value| value.parse::<u64>().ok()) else {
+            continue;
+        };
+        // mountinfo fields 3 and 4 are major:minor and root; field 5 is the
+        // mount point. Escapes are octal, as documented by proc(5).
+        let _parent = fields.next();
+        let _device = fields.next();
+        let _root = fields.next();
+        let Some(mount_point) = fields.next() else {
+            continue;
+        };
+        let mount_point = PathBuf::from(
+            mount_point
+                .replace("\\040", " ")
+                .replace("\\011", "\t")
+                .replace("\\134", "\\"),
+        );
+        if path.starts_with(&mount_point)
+            && best_match
+                .as_ref()
+                .is_none_or(|(best, _)| mount_point.as_os_str().len() > best.as_os_str().len())
+        {
+            best_match = Some((mount_point, id));
+        }
+    }
+    best_match.map(|(_, id)| id).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("no Linux mount identity found for {}", path.display()),
+        )
+    })
 }
 
 fn read_mission_workspace_roots(
@@ -5163,10 +5233,38 @@ WORKING_DIR = "/workspaces/mission-old"
         // under today's configured root.
         std::fs::remove_dir(&storage).unwrap();
         let mcp = McpRegistry::new(temp.path()).await;
-        let result = prepare_mission_workspace_in(&workspace, &mcp, mission).await;
+        let result = require_verified_mission_workspace(
+            prepare_mission_workspace_in(&workspace, &mcp, mission).await,
+        );
 
         assert!(result.is_err());
         assert!(!mission_workspace_dir_for_root(temp.path(), mission).exists());
+
+        // Model the execution boundary with a launch sentinel. A failed
+        // persisted-placement preparation must return before a harness or a
+        // continuation process receives a working directory.
+        let mut launches = 0;
+        if let Ok(dir) = result {
+            launches += 1;
+            std::fs::write(dir.join("launch-sentinel"), "launched").unwrap();
+        }
+        assert_eq!(launches, 0, "no process may launch on an unverified root");
+
+        // Once the exact selected root is available again, normal preparation
+        // and execution may resume in that root, never in the workspace root.
+        std::fs::create_dir(&storage).unwrap();
+        let dir = require_verified_mission_workspace(
+            prepare_mission_workspace_in(&workspace, &mcp, mission).await,
+        )
+        .expect("restored persisted root should prepare normally");
+        launches += 1;
+        std::fs::write(dir.join("launch-sentinel"), "launched").unwrap();
+        assert_eq!(launches, 1);
+        assert!(dir.starts_with(&storage));
+        assert!(dir.join("launch-sentinel").exists());
+        assert!(!mission_workspace_dir_for_root(temp.path(), mission)
+            .join("launch-sentinel")
+            .exists());
     }
 
     #[tokio::test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -5318,7 +5318,15 @@ WORKING_DIR = "/workspaces/mission-old"
 
         // Restoring the selected filesystem identity makes the same worktree
         // usable again; no fallback to the worker's selected root occurred.
-        persist_mission_workspace_root(&workspace, boss, &old_root).unwrap();
+        persist_mission_workspace_root_record(
+            &workspace,
+            boss,
+            MissionWorkspaceRootRecord {
+                path: old_root.canonicalize().unwrap().display().to_string(),
+                filesystem_identity: Some(filesystem_identity(&old_root).unwrap()),
+            },
+        )
+        .unwrap();
         assert_eq!(
             verify_explicit_mission_working_directory_owner(&workspace, &boss_worktree).unwrap(),
             boss

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1004,13 +1004,13 @@ fn validate_mission_workspace_root(
     }
     let actual_identity = filesystem_identity(&root)?;
     if let Some(expected_identity) = &record.filesystem_identity {
-        // `dev:<n>` was written by the first version of persisted placement.
-        // It cannot detect a same-device bind-mount replacement, but it is
-        // only accepted once for a reachable matching device and immediately
-        // upgraded below; unavailable roots still fail before any fallback.
-        let legacy_device_only = is_legacy_device_only_identity(expected_identity)
-            && actual_identity.starts_with(&format!("{expected_identity}:"));
-        if expected_identity != &actual_identity && !legacy_device_only {
+        // The immediately preceding build recorded a namespace-local mount
+        // ID before the stable `dev:…:ino:…` suffix.  Preserve that upgrade
+        // path, but never accept a device-only identity: a bind mount can be
+        // unmounted to reveal a same-device directory at the same path.
+        let legacy_mount_identity =
+            legacy_mount_identity_matches(expected_identity, &actual_identity);
+        if expected_identity != &actual_identity && !legacy_mount_identity {
             return Err(std::io::Error::other(format!(
                     "persisted mission workspace root {} changed filesystem identity (expected {}, got {})",
                     root.display(), expected_identity, actual_identity
@@ -1020,8 +1020,15 @@ fn validate_mission_workspace_root(
     Ok((root, actual_identity))
 }
 
-fn is_legacy_device_only_identity(identity: &str) -> bool {
-    identity.starts_with("dev:") && !identity.contains(":ino:")
+fn legacy_mount_identity_matches(identity: &str, actual_identity: &str) -> bool {
+    identity
+        .strip_prefix("mount:")
+        .and_then(|value| value.find(":dev:").map(|offset| &value[offset + 1..]))
+        .is_some_and(|stable_suffix| stable_suffix == actual_identity)
+}
+
+fn is_legacy_mount_identity(identity: &str) -> bool {
+    identity.starts_with("mount:") && identity.contains(":dev:") && identity.contains(":ino:")
 }
 
 /// Refuse to create a replacement directory when an existing mission's
@@ -1048,7 +1055,7 @@ pub fn ensure_persisted_mission_root_is_available(
     if record
         .filesystem_identity
         .as_deref()
-        .is_none_or(is_legacy_device_only_identity)
+        .is_none_or(is_legacy_mount_identity)
     {
         // Compatibility migration: bind the identity only after the legacy
         // path was successfully reached.  This closes the mountpoint hole for
@@ -1162,7 +1169,7 @@ fn persist_mission_workspace_root_record(
                     .get()
                     .filesystem_identity
                     .as_deref()
-                    .is_none_or(is_legacy_device_only_identity) =>
+                    .is_none_or(is_legacy_mount_identity) =>
             {
                 entry.insert(record);
                 true
@@ -5302,7 +5309,7 @@ WORKING_DIR = "/workspaces/mission-old"
     }
 
     #[test]
-    fn legacy_device_only_identity_is_upgraded_after_verification() {
+    fn legacy_mount_identity_is_upgraded_after_verification() {
         let temp = tempfile::tempdir().unwrap();
         let storage = temp.path().join("legacy-device-storage");
         std::fs::create_dir_all(&storage).unwrap();
@@ -5310,12 +5317,12 @@ WORKING_DIR = "/workspaces/mission-old"
         let workspace = Workspace::default_host(temp.path().to_path_buf());
         std::fs::create_dir_all(config_root(&workspace.path)).unwrap();
         let current = filesystem_identity(&storage).unwrap();
-        let device_only = current.split(":ino:").next().unwrap();
+        let mount_formatted = format!("mount:12345:{current}");
         std::fs::write(
             mission_workspace_roots_path(&workspace),
             serde_json::json!({mission.to_string(): {
                 "path": storage,
-                "filesystem_identity": device_only,
+                "filesystem_identity": mount_formatted,
             }})
             .to_string(),
         )
@@ -5330,6 +5337,33 @@ WORKING_DIR = "/workspaces/mission-old"
             saved[mission.to_string()]["filesystem_identity"],
             serde_json::Value::String(current)
         );
+    }
+
+    #[test]
+    fn device_only_identity_fails_closed_instead_of_accepting_bind_replacement() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("legacy-device-storage");
+        std::fs::create_dir_all(&storage).unwrap();
+        let mission = Uuid::new_v4();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        std::fs::create_dir_all(config_root(&workspace.path)).unwrap();
+        let device_only = filesystem_identity(&storage)
+            .unwrap()
+            .split(":ino:")
+            .next()
+            .unwrap()
+            .to_owned();
+        std::fs::write(
+            mission_workspace_roots_path(&workspace),
+            serde_json::json!({mission.to_string(): {
+                "path": storage,
+                "filesystem_identity": device_only,
+            }})
+            .to_string(),
+        )
+        .unwrap();
+
+        assert!(ensure_persisted_mission_root_is_available(&workspace, mission).is_err());
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3705,7 +3705,6 @@ pub fn runtime_workspace_file_path(working_dir_root: &Path, mission_id: Option<U
 pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::Result<usize> {
     let mut count = 0;
     let mcp_configs = mcp.list_configs().await;
-    let workspace_env = HashMap::new();
 
     // This entry point is also used by MCP mutations, where only Config is
     // available.  Load the persisted workspace inventory so custom workspaces
@@ -3729,7 +3728,7 @@ pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::
     {
         workspaces.push(Workspace::default_host(config.working_dir.clone()));
     }
-    let mut dirs = std::collections::BTreeSet::new();
+    let mut dirs = std::collections::BTreeMap::new();
     for workspace in workspaces {
         // `mission_workspace_roots_for_workspace` validates persisted identity
         // before returning it. An unavailable/replaced root is therefore not
@@ -3748,21 +3747,27 @@ pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::
             for entry in std::fs::read_dir(&scan_root)? {
                 let path = entry?.path();
                 if path.is_dir() {
-                    dirs.insert(path);
+                    dirs.entry(path).or_insert_with(|| workspace.clone());
                 }
             }
         }
     }
-    for path in dirs {
+    for (path, workspace) in dirs {
+        let mcp_configs = filter_mcp_configs_for_workspace(
+            mcp_configs.clone(),
+            &workspace.mcps,
+            workspace.mcps_replace_defaults,
+        );
+        let skill_allowlist = (!workspace.skills.is_empty()).then_some(workspace.skills.as_slice());
         if write_opencode_config(
             &path,
-            mcp_configs.clone(),
-            &config.working_dir,
-            WorkspaceType::Host,
-            &workspace_env,
+            mcp_configs,
+            &workspace.path,
+            workspace.workspace_type,
+            &workspace.env_vars,
+            skill_allowlist,
             None,
-            None,
-            None,
+            workspace.shared_network,
             None,
         )
         .await

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -5284,7 +5284,15 @@ WORKING_DIR = "/workspaces/mission-old"
         let workspace = Workspace::default_host(temp.path().to_path_buf());
         let boss = Uuid::new_v4();
         let worker = Uuid::new_v4();
-        persist_mission_workspace_root(&workspace, boss, &old_root).unwrap();
+        persist_mission_workspace_root_record(
+            &workspace,
+            boss,
+            MissionWorkspaceRootRecord {
+                path: old_root.canonicalize().unwrap().display().to_string(),
+                filesystem_identity: Some(filesystem_identity(&old_root).unwrap()),
+            },
+        )
+        .unwrap();
         persist_mission_workspace_root(&workspace, worker, &new_root).unwrap();
         let boss_worktree = mission_workspace_dir_for_root(&old_root, boss).join("wk-1");
         std::fs::create_dir_all(&boss_worktree).unwrap();

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -912,6 +912,35 @@ fn persisted_mission_workspace_root(workspace: &Workspace, mission_id: Uuid) -> 
     root.is_dir().then_some(root)
 }
 
+/// Refuse to create a replacement directory when an existing mission's
+/// recorded root cannot be reached.  Falling back here would abandon its
+/// checkout during a transient unmount.
+fn ensure_persisted_mission_root_is_available(
+    workspace: &Workspace,
+    mission_id: Uuid,
+) -> std::io::Result<()> {
+    let path = mission_workspace_roots_path(workspace);
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let roots: HashMap<String, String> = serde_json::from_str(&contents).map_err(|error| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, error)
+    })?;
+    if let Some(root) = roots.get(&mission_id.to_string()) {
+        let root = PathBuf::from(root);
+        let canonical = root.canonicalize()?;
+        if !canonical.is_dir() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("persisted mission workspace root {} is not a directory", root.display()),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Atomically replace a registry file and make both the file and the rename
 /// durable before releasing the registry lock. Readers therefore see either a
 /// complete old JSON document or a complete new one, never a truncation.
@@ -970,10 +999,13 @@ fn persist_mission_workspace_root(
             .truncate(false)
             .open(lock_path)?;
         fs2::FileExt::lock_exclusive(&lock_file)?;
-        let mut roots: HashMap<String, String> = std::fs::read_to_string(&path)
-            .ok()
-            .and_then(|contents| serde_json::from_str(&contents).ok())
-            .unwrap_or_default();
+        let mut roots: HashMap<String, String> = match std::fs::read_to_string(&path) {
+            Ok(contents) => serde_json::from_str(&contents).map_err(|error| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, error)
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(error) => return Err(error),
+        };
         if let std::collections::hash_map::Entry::Vacant(entry) =
             roots.entry(mission_id.to_string())
         {
@@ -2532,6 +2564,7 @@ pub async fn prepare_mission_workspace_in(
 ) -> anyhow::Result<PathBuf> {
     // Use a mission-specific directory under the workspace root so multiple missions
     // can run concurrently without clobbering per-workspace config files.
+    ensure_persisted_mission_root_is_available(workspace, mission_id)?;
     let root = mission_workspace_root_for_workspace(workspace, mission_id);
     persist_mission_workspace_root(workspace, mission_id, &root)?;
     let dir = mission_workspace_dir_for_root(&root, mission_id);
@@ -2732,6 +2765,7 @@ pub async fn prepare_mission_workspace_with_skills_backend(
 ) -> anyhow::Result<PathBuf> {
     // Mission workspace directory lives under the selected workspace root.
     // This keeps filesystem and config effects scoped to the mission.
+    ensure_persisted_mission_root_is_available(workspace, mission_id)?;
     let root = mission_workspace_root_for_workspace(workspace, mission_id);
     persist_mission_workspace_root(workspace, mission_id, &root)?;
     let dir = mission_workspace_dir_for_root(&root, mission_id);

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -9,7 +9,7 @@
 //! - **Host**: Execute directly on the remote host environment
 //! - **Container**: Execute inside an isolated container environment (systemd-nspawn)
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
@@ -604,49 +604,21 @@ impl WorkspaceStore {
         // A custom workspace may be a removable/mounted filesystem.  Persist
         // its mission-root registry in this store's control directory before
         // any mission code can consult it.  Copy the old colocated registry
-        // while it is still reachable; if it is not, the stamped control-path
-        // makes later placement resolution fail closed rather than treating a
-        // bare mountpoint as a fresh workspace.
+        // while it is still reachable; if it is not, write an empty control
+        // registry so first-use is distinguishable from a lost file.
         for workspace in workspaces.values_mut() {
-            if workspace.id == DEFAULT_WORKSPACE_ID
-                || workspace
-                    .config
-                    .get("mission_workspace_registry_control_root")
-                    .is_some()
-            {
-                continue;
-            }
-            let legacy = legacy_mission_workspace_roots_path(workspace);
-            let control_root = working_dir.to_string_lossy().into_owned();
-            if !workspace.config.is_object() {
-                workspace.config = serde_json::json!({});
-            }
-            workspace.config["mission_workspace_registry_control_root"] =
-                serde_json::Value::String(control_root);
-            let destination = mission_workspace_roots_path(workspace);
-            if !destination.exists() && legacy.exists() {
-                if let Some(parent) = destination.parent() {
-                    if let Err(error) = std::fs::create_dir_all(parent)
-                        .and_then(|_| std::fs::copy(&legacy, &destination).map(|_| ()))
-                    {
-                        tracing::error!(
-                            workspace = %workspace.id,
-                            error = %error,
-                            "failed to migrate custom mission-root registry to control storage"
-                        );
-                    }
-                }
-            }
+            stamp_custom_workspace_control_registry(workspace, &working_dir);
         }
 
         // Scan for orphaned containers and restore them
         let orphaned = store.scan_orphaned_containers(&workspaces).await;
-        for workspace in orphaned {
+        for mut workspace in orphaned {
             tracing::info!(
                 "Restored orphaned container workspace: {} at {}",
                 workspace.name,
                 workspace.path.display()
             );
+            stamp_custom_workspace_control_registry(&mut workspace, &working_dir);
             workspaces.insert(workspace.id, workspace);
         }
 
@@ -813,7 +785,8 @@ impl WorkspaceStore {
     }
 
     /// Add a new workspace.
-    pub async fn add(&self, workspace: Workspace) -> Uuid {
+    pub async fn add(&self, mut workspace: Workspace) -> Uuid {
+        stamp_custom_workspace_control_registry(&mut workspace, &self.working_dir);
         let id = workspace.id;
         {
             let mut guard = self.workspaces.write().await;
@@ -1013,6 +986,59 @@ fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
         }
     }
     legacy_mission_workspace_roots_path(workspace)
+}
+
+/// Stamp control-storage authority onto a custom workspace and ensure an
+/// empty registry exists.  A missing destination after this stamp is a lost
+/// file, not a first-use workspace.
+fn stamp_custom_workspace_control_registry(workspace: &mut Workspace, working_dir: &Path) {
+    if workspace.id == DEFAULT_WORKSPACE_ID {
+        return;
+    }
+    if workspace
+        .config
+        .get("mission_workspace_registry_control_root")
+        .is_none()
+    {
+        if !workspace.config.is_object() {
+            workspace.config = serde_json::json!({});
+        }
+        workspace.config["mission_workspace_registry_control_root"] =
+            serde_json::Value::String(working_dir.to_string_lossy().into_owned());
+    }
+    let destination = mission_workspace_roots_path(workspace);
+    if destination.exists() {
+        return;
+    }
+    if let Some(parent) = destination.parent() {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            tracing::error!(
+                workspace = %workspace.id,
+                error = %error,
+                "failed to create control mission-root registry directory"
+            );
+            return;
+        }
+    }
+    let legacy = legacy_mission_workspace_roots_path(workspace);
+    if legacy.exists() {
+        if let Err(error) = std::fs::copy(&legacy, &destination) {
+            tracing::error!(
+                workspace = %workspace.id,
+                error = %error,
+                "failed to migrate custom mission-root registry to control storage"
+            );
+        } else {
+            return;
+        }
+    }
+    if let Err(error) = atomic_write_mission_workspace_roots(&destination, &HashMap::new()) {
+        tracing::error!(
+            workspace = %workspace.id,
+            error = %error,
+            "failed to initialize empty control mission-root registry"
+        );
+    }
 }
 
 pub(crate) fn filesystem_identity(path: &Path) -> std::io::Result<String> {
@@ -1294,7 +1320,13 @@ pub fn verify_explicit_mission_working_directory_owner(
         .and_then(|name| name.strip_prefix("mission-"))
         .expect("checked mission directory name");
 
-    let roots = read_mission_workspace_roots(workspace)?;
+    let roots = match read_mission_workspace_roots(workspace) {
+        Ok(roots) => roots,
+        // A missing registry is the pre-feature state, not a corrupt one.
+        // Callers that know candidate owners can adopt the generated path.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+        Err(error) => return Err(error),
+    };
     let mut matches = Vec::new();
     for (id, record) in roots {
         if !id.starts_with(short) {
@@ -1322,6 +1354,118 @@ pub fn verify_explicit_mission_working_directory_owner(
             "explicit working directory {} has ambiguous mission ownership",
             requested.display()
         ))),
+    }
+}
+
+/// Whether `requested` lives under a generated `workspaces/mission-<short>`
+/// directory owned by one of this workspace's known roots.  Used to adopt
+/// pre-registry placements without treating an arbitrary path as a mission.
+pub fn is_generated_mission_directory_under_known_root(
+    workspace: &Workspace,
+    requested: &Path,
+) -> bool {
+    let Ok(requested) = requested.canonicalize() else {
+        return false;
+    };
+    let Some(mission_dir) = requested.ancestors().find(|ancestor| {
+        ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_prefix("mission-"))
+            .is_some_and(|short| short.len() == 8 && short.chars().all(|c| c.is_ascii_hexdigit()))
+            && ancestor
+                .parent()
+                .and_then(|parent| parent.file_name())
+                .and_then(|name| name.to_str())
+                == Some("workspaces")
+    }) else {
+        return false;
+    };
+    mission_workspace_roots_for_workspace(workspace)
+        .into_iter()
+        .any(|root| {
+            workspaces_root_for(&root)
+                .canonicalize()
+                .ok()
+                .is_some_and(|expected| Some(expected.as_path()) == mission_dir.parent())
+        })
+}
+
+/// Register a pre-registry generated directory for a candidate owner whose
+/// short id matches the physical `mission-<short>` ancestor.
+pub fn adopt_legacy_explicit_working_directory(
+    workspace: &Workspace,
+    requested: &Path,
+    candidates: &[Uuid],
+) -> std::io::Result<Option<Uuid>> {
+    let requested = match requested.canonicalize() {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let Some(mission_dir) = requested.ancestors().find(|ancestor| {
+        ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_prefix("mission-"))
+            .is_some_and(|short| short.len() == 8 && short.chars().all(|c| c.is_ascii_hexdigit()))
+            && ancestor
+                .parent()
+                .and_then(|parent| parent.file_name())
+                .and_then(|name| name.to_str())
+                == Some("workspaces")
+    }) else {
+        return Ok(None);
+    };
+    let Some(short) = mission_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("mission-"))
+    else {
+        return Ok(None);
+    };
+    let Some(root) = mission_dir.parent().and_then(|parent| parent.parent()) else {
+        return Ok(None);
+    };
+    if !mission_workspace_roots_for_workspace(workspace)
+        .into_iter()
+        .any(|known| known.canonicalize().ok().is_some_and(|known| known == root) || known == root)
+    {
+        return Ok(None);
+    }
+    for candidate in candidates {
+        if !candidate.to_string().starts_with(short) {
+            continue;
+        }
+        let expected = mission_workspace_dir_for_root(root, *candidate);
+        if expected.canonicalize().ok().as_deref() != Some(mission_dir) && expected != mission_dir {
+            continue;
+        }
+        persist_mission_workspace_root(workspace, *candidate, root)?;
+        return Ok(Some(*candidate));
+    }
+    Ok(None)
+}
+
+/// Verify a persisted owner, or adopt a pre-registry generated directory
+/// belonging to one of `candidates`.  A generated directory under a known
+/// root with no matching candidate is accepted only as a compatibility
+/// signal via [`is_generated_mission_directory_under_known_root`].
+pub fn verify_or_adopt_explicit_mission_working_directory(
+    workspace: &Workspace,
+    requested: &Path,
+    candidates: &[Uuid],
+) -> std::io::Result<Uuid> {
+    match verify_explicit_mission_working_directory_owner(workspace, requested) {
+        Ok(owner) => Ok(owner),
+        Err(error) => {
+            if let Some(owner) =
+                adopt_legacy_explicit_working_directory(workspace, requested, candidates)?
+            {
+                return Ok(owner);
+            }
+            Err(error)
+        }
     }
 }
 
@@ -3217,6 +3361,35 @@ fn read_custom_providers_from_file(workspace_root: &Path) -> Vec<AIProvider> {
     }
 
     Vec::new()
+}
+
+fn read_managed_opencode_provider_keys(workspace_root: &Path) -> HashSet<String> {
+    let mut keys = HashSet::from(["kimi".to_string()]);
+    let candidates = [
+        workspace_root.join(AI_PROVIDERS_PATH),
+        std::path::PathBuf::from(home_dir()).join(AI_PROVIDERS_PATH),
+    ];
+    for path in &candidates {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(providers) = serde_json::from_str::<Vec<AIProvider>>(&contents) else {
+            continue;
+        };
+        for provider in providers {
+            if matches!(
+                provider.provider_type,
+                ProviderType::Custom | ProviderType::Kimi
+            ) {
+                keys.insert(sanitize_key(&provider.name));
+                if provider.provider_type == ProviderType::Kimi {
+                    keys.insert("kimi".to_string());
+                }
+            }
+        }
+        break;
+    }
+    keys
 }
 
 /// Prepare a workspace directory for a mission with skill and tool syncing for a specific backend.
@@ -5924,5 +6097,53 @@ WORKING_DIR = "/workspaces/mission-old"
         assert!(providers
             .iter()
             .any(|p| p.provider_type == ProviderType::Kimi));
+    }
+
+    #[test]
+    fn adding_a_custom_workspace_initializes_an_empty_control_registry() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut workspace = Workspace::new_container("custom".into(), temp.path().join("mount"));
+        std::fs::create_dir_all(&workspace.path).unwrap();
+        stamp_custom_workspace_control_registry(&mut workspace, temp.path());
+        assert!(workspace.config["mission_workspace_registry_control_root"].is_string());
+        let registry = mission_workspace_roots_path(&workspace);
+        assert!(
+            registry.exists(),
+            "first-use custom workspace needs an empty control registry"
+        );
+        let contents = std::fs::read_to_string(&registry).unwrap();
+        let parsed: HashMap<String, MissionWorkspaceRootRecordOnDisk> =
+            serde_json::from_str(&contents).unwrap();
+        assert!(parsed.is_empty());
+        assert!(ensure_persisted_mission_root_is_available(&workspace, Uuid::new_v4()).is_ok());
+    }
+
+    #[test]
+    fn legacy_explicit_generated_directory_can_be_adopted() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        let mission = Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap();
+        let worktree = mission_workspace_dir_for_root(temp.path(), mission).join("wk");
+        std::fs::create_dir_all(&worktree).unwrap();
+        assert!(verify_explicit_mission_working_directory_owner(&workspace, &worktree).is_err());
+        assert!(is_generated_mission_directory_under_known_root(
+            &workspace, &worktree
+        ));
+        match adopt_legacy_explicit_working_directory(&workspace, &worktree, &[mission]) {
+            Ok(Some(id)) => {
+                assert_eq!(id, mission);
+                assert_eq!(
+                    verify_explicit_mission_working_directory_owner(&workspace, &worktree).unwrap(),
+                    mission
+                );
+            }
+            Ok(None) | Err(_) => {
+                // Persisting a registry identity requires Linux mountinfo.
+                assert!(
+                    !cfg!(target_os = "linux"),
+                    "legacy adoption must persist on Linux"
+                );
+            }
+        }
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -900,8 +900,9 @@ static MISSION_WORKSPACE_ROOTS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mute
 
 /// The filesystem that owned a mission root when it was selected.  A path is
 /// not an identity: after an unmount its mountpoint can remain as an ordinary
-/// directory on the parent filesystem.  On Unix `st_dev` is the kernel's
-/// filesystem/device identity and changes in precisely that situation.
+/// directory on the parent filesystem.  On Unix the device and inode of the
+/// selected root together distinguish that replacement while remaining stable
+/// across an ordinary reboot/remount of the same filesystem.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct MissionWorkspaceRootRecord {
     path: String,
@@ -962,15 +963,10 @@ pub(crate) fn filesystem_identity(path: &Path) -> std::io::Result<String> {
         let canonical = path.canonicalize()?;
         let metadata = std::fs::metadata(&canonical)?;
         // `st_dev` alone does not distinguish a bind mount from the
-        // underlying filesystem it exposes after unmount.  Linux mount IDs do
-        // distinguish those mounts; include the directory inode as a further
-        // guard against a replacement at the same path.
-        let mount_id = linux_mount_id_for_path(&canonical)?;
-        Ok(format!(
-            "mount:{mount_id}:dev:{}:ino:{}",
-            metadata.dev(),
-            metadata.ino()
-        ))
+        // underlying directory exposed at its mountpoint after unmount. The
+        // inode of the selected root does, and unlike a Linux mount-instance
+        // ID it remains stable across a normal reboot/remount.
+        Ok(format!("dev:{}:ino:{}", metadata.dev(), metadata.ino()))
     }
     #[cfg(not(unix))]
     {
@@ -979,45 +975,6 @@ pub(crate) fn filesystem_identity(path: &Path) -> std::io::Result<String> {
         // pretending that an unverified path is a stable filesystem identity.
         Ok(format!("path:{}", path.canonicalize()?.display()))
     }
-}
-
-#[cfg(unix)]
-fn linux_mount_id_for_path(path: &Path) -> std::io::Result<u64> {
-    let path = path.canonicalize()?;
-    let mut best_match: Option<(PathBuf, u64)> = None;
-    for line in std::fs::read_to_string("/proc/self/mountinfo")?.lines() {
-        let mut fields = line.split_whitespace();
-        let Some(id) = fields.next().and_then(|value| value.parse::<u64>().ok()) else {
-            continue;
-        };
-        // mountinfo fields 3 and 4 are major:minor and root; field 5 is the
-        // mount point. Escapes are octal, as documented by proc(5).
-        let _parent = fields.next();
-        let _device = fields.next();
-        let _root = fields.next();
-        let Some(mount_point) = fields.next() else {
-            continue;
-        };
-        let mount_point = PathBuf::from(
-            mount_point
-                .replace("\\040", " ")
-                .replace("\\011", "\t")
-                .replace("\\134", "\\"),
-        );
-        if path.starts_with(&mount_point)
-            && best_match
-                .as_ref()
-                .is_none_or(|(best, _)| mount_point.as_os_str().len() > best.as_os_str().len())
-        {
-            best_match = Some((mount_point, id));
-        }
-    }
-    best_match.map(|(_, id)| id).ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("no Linux mount identity found for {}", path.display()),
-        )
-    })
 }
 
 fn read_mission_workspace_roots(
@@ -1047,7 +1004,13 @@ fn validate_mission_workspace_root(
     }
     let actual_identity = filesystem_identity(&root)?;
     if let Some(expected_identity) = &record.filesystem_identity {
-        if expected_identity != &actual_identity {
+        // `dev:<n>` was written by the first version of persisted placement.
+        // It cannot detect a same-device bind-mount replacement, but it is
+        // only accepted once for a reachable matching device and immediately
+        // upgraded below; unavailable roots still fail before any fallback.
+        let legacy_device_only = is_legacy_device_only_identity(expected_identity)
+            && actual_identity.starts_with(&format!("{expected_identity}:"));
+        if expected_identity != &actual_identity && !legacy_device_only {
             return Err(std::io::Error::other(format!(
                     "persisted mission workspace root {} changed filesystem identity (expected {}, got {})",
                     root.display(), expected_identity, actual_identity
@@ -1055,6 +1018,10 @@ fn validate_mission_workspace_root(
         }
     }
     Ok((root, actual_identity))
+}
+
+fn is_legacy_device_only_identity(identity: &str) -> bool {
+    identity.starts_with("dev:") && !identity.contains(":ino:")
 }
 
 /// Refuse to create a replacement directory when an existing mission's
@@ -1078,7 +1045,11 @@ pub fn ensure_persisted_mission_root_is_available(
     };
     let record: MissionWorkspaceRootRecord = on_disk.into();
     let (_, identity) = validate_mission_workspace_root(&record)?;
-    if record.filesystem_identity.is_none() {
+    if record
+        .filesystem_identity
+        .as_deref()
+        .is_none_or(is_legacy_device_only_identity)
+    {
         // Compatibility migration: bind the identity only after the legacy
         // path was successfully reached.  This closes the mountpoint hole for
         // every later caller and never permits a fallback while unavailable.
@@ -1187,7 +1158,11 @@ fn persist_mission_workspace_root_record(
                 true
             }
             std::collections::hash_map::Entry::Occupied(mut entry)
-                if entry.get().filesystem_identity.is_none() =>
+                if entry
+                    .get()
+                    .filesystem_identity
+                    .as_deref()
+                    .is_none_or(is_legacy_device_only_identity) =>
             {
                 entry.insert(record);
                 true
@@ -5324,6 +5299,37 @@ WORKING_DIR = "/workspaces/mission-old"
                 mission
             ),
             storage.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn legacy_device_only_identity_is_upgraded_after_verification() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("legacy-device-storage");
+        std::fs::create_dir_all(&storage).unwrap();
+        let mission = Uuid::new_v4();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        std::fs::create_dir_all(config_root(&workspace.path)).unwrap();
+        let current = filesystem_identity(&storage).unwrap();
+        let device_only = current.split(":ino:").next().unwrap();
+        std::fs::write(
+            mission_workspace_roots_path(&workspace),
+            serde_json::json!({mission.to_string(): {
+                "path": storage,
+                "filesystem_identity": device_only,
+            }})
+            .to_string(),
+        )
+        .unwrap();
+
+        ensure_persisted_mission_root_is_available(&workspace, mission).unwrap();
+        let saved: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(mission_workspace_roots_path(&workspace)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            saved[mission.to_string()]["filesystem_identity"],
+            serde_json::Value::String(current)
         );
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -925,16 +925,18 @@ fn ensure_persisted_mission_root_is_available(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
     };
-    let roots: HashMap<String, String> = serde_json::from_str(&contents).map_err(|error| {
-        std::io::Error::new(std::io::ErrorKind::InvalidData, error)
-    })?;
+    let roots: HashMap<String, String> = serde_json::from_str(&contents)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
     if let Some(root) = roots.get(&mission_id.to_string()) {
         let root = PathBuf::from(root);
         let canonical = root.canonicalize()?;
         if !canonical.is_dir() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("persisted mission workspace root {} is not a directory", root.display()),
+                format!(
+                    "persisted mission workspace root {} is not a directory",
+                    root.display()
+                ),
             ));
         }
     }
@@ -1000,9 +1002,8 @@ fn persist_mission_workspace_root(
             .open(lock_path)?;
         fs2::FileExt::lock_exclusive(&lock_file)?;
         let mut roots: HashMap<String, String> = match std::fs::read_to_string(&path) {
-            Ok(contents) => serde_json::from_str(&contents).map_err(|error| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, error)
-            })?,
+            Ok(contents) => serde_json::from_str(&contents)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
             Err(error) => return Err(error),
         };

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -978,13 +978,10 @@ fn validate_mission_workspace_root(
     let actual_identity = filesystem_identity(&root)?;
     if let Some(expected_identity) = &record.filesystem_identity {
         if expected_identity != &actual_identity {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
+            return Err(std::io::Error::other(format!(
                     "persisted mission workspace root {} changed filesystem identity (expected {}, got {})",
                     root.display(), expected_identity, actual_identity
-                ),
-            ));
+                )));
         }
     }
     Ok((root, actual_identity))
@@ -1114,14 +1111,20 @@ fn persist_mission_workspace_root_record(
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
                 Err(error) => return Err(error),
             };
-        let entry = roots.entry(mission_id.to_string());
-        if matches!(entry, std::collections::hash_map::Entry::Vacant(_)) {
-            entry.or_insert(record);
-            atomic_write_mission_workspace_roots(&path, &roots)?;
-        } else if entry.into_mut().filesystem_identity.is_none() {
-            *roots
-                .get_mut(&mission_id.to_string())
-                .expect("entry exists") = record;
+        let changed = match roots.entry(mission_id.to_string()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(record);
+                true
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry)
+                if entry.get().filesystem_identity.is_none() =>
+            {
+                entry.insert(record);
+                true
+            }
+            std::collections::hash_map::Entry::Occupied(_) => false,
+        };
+        if changed {
             atomic_write_mission_workspace_roots(&path, &roots)?;
         }
         fs2::FileExt::unlock(&lock_file)?;

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1128,7 +1128,11 @@ fn legacy_device_identity_matches(identity: &str, actual_identity: &str) -> bool
 }
 
 fn is_legacy_mount_identity(identity: &str) -> bool {
-    identity.starts_with("mount:") && identity.contains(":dev:") && identity.contains(":ino:")
+    // Both the original dev/inode form and the immediately preceding v2 form
+    // used a namespace-local `mount:<id>:` prefix.  The prefix is not stable
+    // across restart, but validation above has already compared its stable
+    // suffix before this permits the one-time rewrite.
+    identity.starts_with("mount:")
 }
 
 /// Refuse to create a replacement directory when an existing mission's
@@ -1340,7 +1344,10 @@ fn persist_mission_workspace_root_record(
                     .get()
                     .filesystem_identity
                     .as_deref()
-                    .is_none_or(is_legacy_mount_identity) =>
+                    .is_none_or(|identity| {
+                        is_legacy_mount_identity(identity)
+                            || (identity.starts_with("dev:") && identity.contains(":ino:"))
+                    }) =>
             {
                 entry.insert(record);
                 true
@@ -3696,21 +3703,57 @@ pub fn runtime_workspace_file_path(working_dir_root: &Path, mission_id: Option<U
 
 /// Regenerate `opencode.json` for all workspace directories.
 pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::Result<usize> {
-    let root = workspaces_root(&config.working_dir);
-    if !root.exists() {
-        return Ok(0);
-    }
-
     let mut count = 0;
     let mcp_configs = mcp.list_configs().await;
     let workspace_env = HashMap::new();
 
-    let mut entries = tokio::fs::read_dir(&root).await?;
-    while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
+    // This entry point is also used by MCP mutations, where only Config is
+    // available.  Load the persisted workspace inventory so custom workspaces
+    // and every verified historic relocated root participate, rather than
+    // scanning only today's default working_dir.
+    let workspace_path = config.working_dir.join(".sandboxed-sh/workspaces.json");
+    let mut workspaces = match std::fs::read_to_string(&workspace_path) {
+        Ok(contents) => serde_json::from_str::<Vec<Workspace>>(&contents)
+            .map_err(|error| anyhow::anyhow!("parse {}: {error}", workspace_path.display()))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "read {}: {error}",
+                workspace_path.display()
+            ))
         }
+    };
+    if !workspaces
+        .iter()
+        .any(|workspace| workspace.id == DEFAULT_WORKSPACE_ID)
+    {
+        workspaces.push(Workspace::default_host(config.working_dir.clone()));
+    }
+    let mut dirs = std::collections::BTreeSet::new();
+    for workspace in workspaces {
+        // `mission_workspace_roots_for_workspace` validates persisted identity
+        // before returning it. An unavailable/replaced root is therefore not
+        // written through during a global MCP update.
+        for root in mission_workspace_roots_for_workspace(&workspace) {
+            let root = root.canonicalize().map_err(|error| {
+                anyhow::anyhow!(
+                    "canonicalize mission workspace root {}: {error}",
+                    root.display()
+                )
+            })?;
+            let scan_root = workspaces_root_for(&root);
+            if !scan_root.is_dir() {
+                continue;
+            }
+            for entry in std::fs::read_dir(&scan_root)? {
+                let path = entry?.path();
+                if path.is_dir() {
+                    dirs.insert(path);
+                }
+            }
+        }
+    }
+    for path in dirs {
         if write_opencode_config(
             &path,
             mcp_configs.clone(),
@@ -3718,9 +3761,9 @@ pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::
             WorkspaceType::Host,
             &workspace_env,
             None,
-            None, // No command_contents for migration
-            None, // shared_network: not relevant for host workspaces
-            None, // custom_providers: none for migration
+            None,
+            None,
+            None,
         )
         .await
         .is_ok()
@@ -5387,6 +5430,8 @@ WORKING_DIR = "/workspaces/mission-old"
         let workspace = Workspace::default_host(temp.path().to_path_buf());
         let boss = Uuid::new_v4();
         let worker = Uuid::new_v4();
+        persist_mission_workspace_root(&workspace, boss, &old_root).unwrap();
+        persist_mission_workspace_root(&workspace, worker, &new_root).unwrap();
         // This test changes the simulated mount authority itself.  Production
         // writes deliberately refuse to replace a mismatched record, so write
         // the restored fixture directly before verifying the recovered mount.
@@ -5400,7 +5445,6 @@ WORKING_DIR = "/workspaces/mission-old"
         );
         atomic_write_mission_workspace_roots(&mission_workspace_roots_path(&workspace), &restored)
             .unwrap();
-        persist_mission_workspace_root(&workspace, worker, &new_root).unwrap();
         let boss_worktree = mission_workspace_dir_for_root(&old_root, boss).join("wk-1");
         std::fs::create_dir_all(&boss_worktree).unwrap();
 
@@ -5425,15 +5469,16 @@ WORKING_DIR = "/workspaces/mission-old"
 
         // Restoring the selected filesystem identity makes the same worktree
         // usable again; no fallback to the worker's selected root occurred.
-        persist_mission_workspace_root_record(
-            &workspace,
-            boss,
+        let mut restored = read_mission_workspace_roots(&workspace).unwrap();
+        restored.insert(
+            boss.to_string(),
             MissionWorkspaceRootRecord {
                 path: old_root.canonicalize().unwrap().display().to_string(),
                 filesystem_identity: Some(filesystem_identity(&old_root).unwrap()),
             },
-        )
-        .unwrap();
+        );
+        atomic_write_mission_workspace_roots(&mission_workspace_roots_path(&workspace), &restored)
+            .unwrap();
         assert_eq!(
             verify_explicit_mission_working_directory_owner(&workspace, &boss_worktree).unwrap(),
             boss

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -5024,6 +5024,27 @@ WORKING_DIR = "/workspaces/mission-old"
             .contains(&storage.canonicalize().unwrap()));
     }
 
+    #[tokio::test]
+    async fn unavailable_persisted_mission_root_fails_closed_before_configured_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("temporarily-unmounted-storage");
+        std::fs::create_dir_all(&storage).unwrap();
+        let mission = Uuid::new_v4();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+
+        persist_mission_workspace_root(&workspace, mission, &storage).unwrap();
+        // Model an unavailable mount after a restart. Preparation checks this
+        // persisted selection before resolving MISSION_WORKSPACE_ROOT, so it
+        // must surface an error rather than creating a new mission directory
+        // under today's configured root.
+        std::fs::remove_dir(&storage).unwrap();
+        let mcp = McpRegistry::new(temp.path()).await;
+        let result = prepare_mission_workspace_in(&workspace, &mcp, mission).await;
+
+        assert!(result.is_err());
+        assert!(!mission_workspace_dir_for_root(temp.path(), mission).exists());
+    }
+
     #[test]
     fn mission_root_registry_serializes_concurrent_writers_and_readers() {
         use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -915,7 +915,7 @@ fn persisted_mission_workspace_root(workspace: &Workspace, mission_id: Uuid) -> 
 /// Refuse to create a replacement directory when an existing mission's
 /// recorded root cannot be reached.  Falling back here would abandon its
 /// checkout during a transient unmount.
-fn ensure_persisted_mission_root_is_available(
+pub fn ensure_persisted_mission_root_is_available(
     workspace: &Workspace,
     mission_id: Uuid,
 ) -> std::io::Result<()> {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -894,6 +894,88 @@ pub fn mission_workspace_dir_for_root(root: &Path, mission_id: Uuid) -> PathBuf 
     workspaces_root_for(root).join(format!("mission-{}", short_id))
 }
 
+/// Resolve the root used for newly-created default-host mission directories.
+///
+/// `MISSION_WORKSPACE_ROOT` is deliberately only a placement override for the
+/// generated per-mission scratch tree.  Workspace records continue to own
+/// their configured paths, so enabling it never rewrites or moves an existing
+/// workspace.  A bad override fails safely back to the established root.
+pub fn configured_mission_workspace_root(fallback: &Path) -> PathBuf {
+    resolve_mission_workspace_root(
+        std::env::var_os("MISSION_WORKSPACE_ROOT")
+            .map(PathBuf::from)
+            .as_deref(),
+        fallback,
+    )
+}
+
+fn resolve_mission_workspace_root(candidate: Option<&Path>, fallback: &Path) -> PathBuf {
+    resolve_mission_workspace_root_with(candidate, fallback, mission_workspace_root_is_writable)
+}
+
+fn resolve_mission_workspace_root_with(
+    candidate: Option<&Path>,
+    fallback: &Path,
+    is_writable: impl Fn(&Path) -> bool,
+) -> PathBuf {
+    let Some(candidate) = candidate else {
+        return fallback.to_path_buf();
+    };
+    let candidate = candidate.to_path_buf();
+    if !candidate.is_absolute()
+        || candidate
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        tracing::warn!(path = %candidate.display(), "Ignoring unsafe MISSION_WORKSPACE_ROOT; using workspace root");
+        return fallback.to_path_buf();
+    }
+    match std::fs::canonicalize(&candidate) {
+        Ok(path) if path.is_dir() && is_writable(&path) => path,
+        Ok(path) => {
+            tracing::warn!(path = %path.display(), "MISSION_WORKSPACE_ROOT is not a writable directory; using workspace root");
+            fallback.to_path_buf()
+        }
+        Err(error) => {
+            tracing::warn!(path = %candidate.display(), %error, "Cannot resolve MISSION_WORKSPACE_ROOT; using workspace root");
+            fallback.to_path_buf()
+        }
+    }
+}
+
+fn mission_workspace_root_is_writable(root: &Path) -> bool {
+    // Metadata permissions are not enough (ACLs and read-only mounts can
+    // disagree), so make and remove only an unpredictable, empty probe we own.
+    let probe = root.join(format!(".sandboxed-sh-write-probe-{}", Uuid::new_v4()));
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)
+    {
+        Ok(_) => std::fs::remove_file(probe).is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// The root that will hold this mission's generated workspace directory.
+/// Existing generated directories always win, which keeps active missions and
+/// historic workspace records compatible after an operator enables a new root.
+pub fn mission_workspace_root_for_workspace(workspace: &Workspace, mission_id: Uuid) -> PathBuf {
+    let legacy = mission_workspace_dir_for_root(&workspace.path, mission_id);
+    if legacy.exists() || workspace.id != DEFAULT_WORKSPACE_ID {
+        return workspace.path.clone();
+    }
+    configured_mission_workspace_root(&workspace.path)
+}
+
+/// Generated directory for a mission, preserving an existing legacy location.
+pub fn mission_workspace_dir_for_workspace(workspace: &Workspace, mission_id: Uuid) -> PathBuf {
+    mission_workspace_dir_for_root(
+        &mission_workspace_root_for_workspace(workspace, mission_id),
+        mission_id,
+    )
+}
+
 /// Resolve a configured project directory to its host-visible path.
 ///
 /// Mission state (harness config, HOME and XDG data) deliberately lives in a
@@ -2183,7 +2265,7 @@ fn remote_build_wrapper_path(workspace: &Workspace, mission_id: Uuid) -> PathBuf
     if workspace.workspace_type == WorkspaceType::Container && !is_container_fallback(workspace) {
         PathBuf::from("/usr/local/lib/sandboxed-sh/bin/remote-lean-build")
     } else {
-        mission_workspace_dir_for_root(&workspace.path, mission_id)
+        mission_workspace_dir_for_workspace(workspace, mission_id)
             .join(".sandboxed-sh/bin/remote-lean-build")
     }
 }
@@ -2334,7 +2416,7 @@ pub async fn prepare_mission_workspace_in(
 ) -> anyhow::Result<PathBuf> {
     // Use a mission-specific directory under the workspace root so multiple missions
     // can run concurrently without clobbering per-workspace config files.
-    let dir = mission_workspace_dir_for_root(&workspace.path, mission_id);
+    let dir = mission_workspace_dir_for_workspace(workspace, mission_id);
     prepare_workspace_dir(&dir).await?;
     install_remote_build_wrapper(workspace, mission_id).await?;
     let mcp_configs = filter_mcp_configs_for_workspace(
@@ -2532,7 +2614,7 @@ pub async fn prepare_mission_workspace_with_skills_backend(
 ) -> anyhow::Result<PathBuf> {
     // Mission workspace directory lives under the selected workspace root.
     // This keeps filesystem and config effects scoped to the mission.
-    let dir = mission_workspace_dir_for_root(&workspace.path, mission_id);
+    let dir = mission_workspace_dir_for_workspace(workspace, mission_id);
     prepare_workspace_dir(&dir).await?;
     install_remote_build_wrapper(workspace, mission_id).await?;
     // Reviewers still need authenticated read access to private repositories.
@@ -4703,5 +4785,57 @@ WORKING_DIR = "/workspaces/mission-old"
     fn test_codex_reasoning_summary_on_empty_config() {
         let result = ensure_codex_reasoning_summary("");
         assert!(result.starts_with("model_reasoning_summary = \"detailed\"\n"));
+    }
+
+    #[test]
+    fn mission_workspace_root_canonicalizes_symlink_and_rejects_unsafe_fallbacks() {
+        let temp = tempfile::tempdir().unwrap();
+        let fallback = temp.path().join("legacy");
+        let target = temp.path().join("storage");
+        std::fs::create_dir_all(&fallback).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, temp.path().join("storage-link")).unwrap();
+
+        #[cfg(unix)]
+        assert_eq!(
+            resolve_mission_workspace_root(Some(&temp.path().join("storage-link")), &fallback),
+            target.canonicalize().unwrap()
+        );
+        assert_eq!(
+            resolve_mission_workspace_root(Some(&temp.path().join("missing")), &fallback),
+            fallback
+        );
+        assert_eq!(
+            resolve_mission_workspace_root(Some(std::path::Path::new("/tmp/../unsafe")), &fallback),
+            fallback
+        );
+        assert_eq!(
+            resolve_mission_workspace_root_with(Some(&target), &fallback, |_| false),
+            fallback,
+            "an unwritable configured root must fail back even when tests run as root"
+        );
+    }
+
+    #[test]
+    fn existing_mission_directory_keeps_legacy_placement() {
+        let temp = tempfile::tempdir().unwrap();
+        let mission = Uuid::new_v4();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        let legacy = mission_workspace_dir_for_root(&workspace.path, mission);
+        std::fs::create_dir_all(&legacy).unwrap();
+        assert_eq!(
+            mission_workspace_dir_for_workspace(&workspace, mission),
+            legacy
+        );
+    }
+
+    #[test]
+    fn mission_workspace_root_defaults_to_workspace_root() {
+        let temp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_mission_workspace_root(None, temp.path()),
+            temp.path()
+        );
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -601,6 +601,44 @@ impl WorkspaceStore {
             }
         }
 
+        // A custom workspace may be a removable/mounted filesystem.  Persist
+        // its mission-root registry in this store's control directory before
+        // any mission code can consult it.  Copy the old colocated registry
+        // while it is still reachable; if it is not, the stamped control-path
+        // makes later placement resolution fail closed rather than treating a
+        // bare mountpoint as a fresh workspace.
+        for workspace in workspaces.values_mut() {
+            if workspace.id == DEFAULT_WORKSPACE_ID
+                || workspace
+                    .config
+                    .get("mission_workspace_registry_control_root")
+                    .is_some()
+            {
+                continue;
+            }
+            let legacy = legacy_mission_workspace_roots_path(workspace);
+            let control_root = working_dir.to_string_lossy().into_owned();
+            if !workspace.config.is_object() {
+                workspace.config = serde_json::json!({});
+            }
+            workspace.config["mission_workspace_registry_control_root"] =
+                serde_json::Value::String(control_root);
+            let destination = mission_workspace_roots_path(workspace);
+            if !destination.exists() && legacy.exists() {
+                if let Some(parent) = destination.parent() {
+                    if let Err(error) = std::fs::create_dir_all(parent)
+                        .and_then(|_| std::fs::copy(&legacy, &destination).map(|_| ()))
+                    {
+                        tracing::error!(
+                            workspace = %workspace.id,
+                            error = %error,
+                            "failed to migrate custom mission-root registry to control storage"
+                        );
+                    }
+                }
+            }
+        }
+
         // Scan for orphaned containers and restore them
         let orphaned = store.scan_orphaned_containers(&workspaces).await;
         for workspace in orphaned {
@@ -952,8 +990,29 @@ impl From<MissionWorkspaceRootRecordOnDisk> for MissionWorkspaceRootRecord {
     }
 }
 
-fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
+fn legacy_mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
     config_root(&workspace.path).join(MISSION_WORKSPACE_ROOTS_FILE)
+}
+
+/// Custom workspaces can themselves be mounted filesystems.  Their placement
+/// authority must therefore live with the server control store, not on the
+/// volume it is meant to verify.  WorkspaceStore stamps this path into the
+/// persisted workspace definition during migration; the default workspace
+/// keeps its established location for compatibility.
+fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
+    if workspace.id != DEFAULT_WORKSPACE_ID {
+        if let Some(root) = workspace
+            .config
+            .get("mission_workspace_registry_control_root")
+            .and_then(serde_json::Value::as_str)
+        {
+            return PathBuf::from(root)
+                .join(".sandboxed-sh")
+                .join("mission-workspace-roots")
+                .join(format!("{}.json", workspace.id));
+        }
+    }
+    legacy_mission_workspace_roots_path(workspace)
 }
 
 pub(crate) fn filesystem_identity(path: &Path) -> std::io::Result<String> {
@@ -1144,6 +1203,22 @@ pub fn ensure_persisted_mission_root_is_available(
 ) -> std::io::Result<()> {
     let path = mission_workspace_roots_path(workspace);
     let contents = match std::fs::read_to_string(&path) {
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                && workspace.id != DEFAULT_WORKSPACE_ID
+                && workspace
+                    .config
+                    .get("mission_workspace_registry_control_root")
+                    .is_some() =>
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "persisted control registry for custom workspace {} is unavailable",
+                    workspace.id
+                ),
+            ));
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
         Ok(contents) => contents,
@@ -1306,14 +1381,17 @@ fn persist_mission_workspace_root_record(
     record: MissionWorkspaceRootRecord,
 ) -> std::io::Result<()> {
     (|| -> std::io::Result<()> {
-        std::fs::create_dir_all(config_root(&workspace.path))?;
+        let path = mission_workspace_roots_path(workspace);
+        std::fs::create_dir_all(
+            path.parent()
+                .expect("mission workspace root registry has a parent"),
+        )?;
         // The process-local lock avoids blocking an async executor on an
         // advisory file lock when many preparations race. The file lock also
         // serializes independent server processes sharing this workspace.
         let _guard = MISSION_WORKSPACE_ROOTS_LOCK
             .lock()
             .expect("registry lock poisoned");
-        let path = mission_workspace_roots_path(workspace);
         let lock_path = path.with_extension("json.lock");
         let lock_file = std::fs::OpenOptions::new()
             .read(true)
@@ -1482,6 +1560,43 @@ pub fn mission_workspace_roots_for_workspace(workspace: &Workspace) -> Vec<PathB
     roots.sort();
     roots.dedup();
     roots
+}
+
+/// Whether a generated directory is owned by this workspace's persisted
+/// placement authority.  This is deliberately stronger than membership in a
+/// scan root: configured roots may overlap a custom workspace, and scan order
+/// must never select the configuration used to rewrite a mission's MCP file.
+fn owns_persisted_mission_directory(workspace: &Workspace, directory: &Path) -> bool {
+    let Ok(directory) = directory.canonicalize() else {
+        return false;
+    };
+    let Some(short) = directory
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("mission-"))
+    else {
+        return false;
+    };
+    if short.len() != 8 || !short.chars().all(|c| c.is_ascii_hexdigit()) {
+        return false;
+    }
+    let Ok(roots) = read_mission_workspace_roots(workspace) else {
+        return false;
+    };
+    roots.into_iter().any(|(id, record)| {
+        let Ok(mission_id) = Uuid::parse_str(&id) else {
+            return false;
+        };
+        if !id.starts_with(short) {
+            return false;
+        }
+        let Ok((root, _)) = validate_mission_workspace_root(&record) else {
+            return false;
+        };
+        mission_workspace_dir_for_root(&root, mission_id)
+            .canonicalize()
+            .is_ok_and(|expected| expected == directory)
+    })
 }
 
 /// Resolve a configured project directory to its host-visible path.
@@ -3747,7 +3862,13 @@ pub async fn sync_all_workspaces(config: &Config, mcp: &McpRegistry) -> anyhow::
             for entry in std::fs::read_dir(&scan_root)? {
                 let path = entry?.path();
                 if path.is_dir() {
-                    dirs.entry(path).or_insert_with(|| workspace.clone());
+                    if owns_persisted_mission_directory(&workspace, &path) {
+                        // A verified owner always wins over a provisional
+                        // scan-root match from an overlapping workspace.
+                        dirs.insert(path, workspace.clone());
+                    } else {
+                        dirs.entry(path).or_insert_with(|| workspace.clone());
+                    }
                 }
             }
         }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -957,16 +957,27 @@ fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
 }
 
 pub(crate) fn filesystem_identity(path: &Path) -> std::io::Result<String> {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     {
         use std::os::unix::fs::MetadataExt;
         let canonical = path.canonicalize()?;
         let metadata = std::fs::metadata(&canonical)?;
-        // `st_dev` alone does not distinguish a bind mount from the
-        // underlying directory exposed at its mountpoint after unmount. The
-        // inode of the selected root does, and unlike a Linux mount-instance
-        // ID it remains stable across a normal reboot/remount.
-        Ok(format!("dev:{}:ino:{}", metadata.dev(), metadata.ino()))
+        let mount = linux_mount_identity(&canonical)?;
+        // Do not persist `st_dev`: Linux may renumber block devices across a
+        // reboot, and a bind mount shares it with the directory revealed when
+        // that mount disappears.  The mount source/root plus statvfs fsid is
+        // the filesystem authority; the selected root inode additionally
+        // binds the placement to the directory on that filesystem.
+        Ok(format!("linux-v2:{mount}:root-ino:{}", metadata.ino()))
+    }
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
+        // There is no portable mount-source API. Refuse to pretend a path is
+        // a filesystem identity; callers fail closed instead.
+        let _ = path;
+        Err(std::io::Error::other(
+            "stable filesystem identity requires Linux mountinfo",
+        ))
     }
     #[cfg(not(unix))]
     {
@@ -975,6 +986,70 @@ pub(crate) fn filesystem_identity(path: &Path) -> std::io::Result<String> {
         // pretending that an unverified path is a stable filesystem identity.
         Ok(format!("path:{}", path.canonicalize()?.display()))
     }
+}
+
+/// Linux mount identity deliberately excludes mount ID and `st_dev`, both of
+/// which are namespace/boot volatile.  `/proc/self/mountinfo` supplies the
+/// backing source and filesystem root while `statvfs.f_fsid` distinguishes
+/// otherwise identical overlay sources.  Failure to read either is a
+/// verification failure, never a path-only fallback.
+#[cfg(target_os = "linux")]
+fn linux_mount_identity(path: &Path) -> std::io::Result<String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let contents = std::fs::read_to_string("/proc/self/mountinfo")?;
+    let mut selected: Option<(PathBuf, String, String, String)> = None;
+    for line in contents.lines() {
+        let Some((left, right)) = line.split_once(" - ") else {
+            continue;
+        };
+        let fields: Vec<_> = left.split_whitespace().collect();
+        let right: Vec<_> = right.split_whitespace().collect();
+        if fields.len() < 5 || right.len() < 2 {
+            continue;
+        }
+        let mountpoint = PathBuf::from(unescape_mountinfo(fields[4]));
+        if !path.starts_with(&mountpoint) {
+            continue;
+        }
+        let candidate = (
+            mountpoint,
+            unescape_mountinfo(fields[3]),
+            right[0].to_string(),
+            unescape_mountinfo(right[1]),
+        );
+        if selected
+            .as_ref()
+            .is_none_or(|current| candidate.0.as_os_str().len() > current.0.as_os_str().len())
+        {
+            selected = Some(candidate);
+        }
+    }
+    let Some((_mountpoint, root, fstype, source)) = selected else {
+        return Err(std::io::Error::other(
+            "no mountinfo entry for persisted root",
+        ));
+    };
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains NUL"))?;
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(format!(
+        "fsid:{}:type:{}:source:{}:mount-root:{}",
+        stat.f_fsid, fstype, source, root
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn unescape_mountinfo(value: &str) -> String {
+    value
+        .replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
 }
 
 fn read_mission_workspace_roots(
@@ -1010,7 +1085,12 @@ fn validate_mission_workspace_root(
         // unmounted to reveal a same-device directory at the same path.
         let legacy_mount_identity =
             legacy_mount_identity_matches(expected_identity, &actual_identity);
-        if expected_identity != &actual_identity && !legacy_mount_identity {
+        let legacy_device_identity =
+            legacy_device_identity_matches(expected_identity, &actual_identity);
+        if expected_identity != &actual_identity
+            && !legacy_mount_identity
+            && !legacy_device_identity
+        {
             return Err(std::io::Error::other(format!(
                     "persisted mission workspace root {} changed filesystem identity (expected {}, got {})",
                     root.display(), expected_identity, actual_identity
@@ -1023,8 +1103,28 @@ fn validate_mission_workspace_root(
 fn legacy_mount_identity_matches(identity: &str, actual_identity: &str) -> bool {
     identity
         .strip_prefix("mount:")
-        .and_then(|value| value.find(":dev:").map(|offset| &value[offset + 1..]))
+        // Legacy records were `mount:<namespace-local-id>:<stable-id>`.
+        // The stable suffix changed from dev/inode to linux-v2, but the
+        // mount ID itself was never an authority and is discarded here.
+        .and_then(|value| value.split_once(':').map(|(_, stable)| stable))
         .is_some_and(|stable_suffix| stable_suffix == actual_identity)
+}
+
+/// `dev:…:ino:…` was emitted before v2. Device numbers are not stable across
+/// reboot, so migrate it only when the selected-root inode still agrees. This
+/// is a one-time compatibility bridge; the rewritten v2 record thereafter
+/// verifies mount source/fsid and fails closed on a replacement mount.
+fn legacy_device_identity_matches(identity: &str, actual_identity: &str) -> bool {
+    let old_inode = identity
+        .strip_prefix("dev:")
+        .and_then(|v| v.rsplit_once(":ino:"))
+        .map(|(_, inode)| inode);
+    let new_inode = actual_identity
+        .rsplit_once(":root-ino:")
+        .map(|(_, inode)| inode);
+    old_inode
+        .zip(new_inode)
+        .is_some_and(|(old, new)| old == new)
 }
 
 fn is_legacy_mount_identity(identity: &str) -> bool {
@@ -1055,7 +1155,7 @@ pub fn ensure_persisted_mission_root_is_available(
     if record
         .filesystem_identity
         .as_deref()
-        .is_none_or(is_legacy_mount_identity)
+        .is_none_or(|identity| is_legacy_mount_identity(identity) || identity.starts_with("dev:"))
     {
         // Compatibility migration: bind the identity only after the legacy
         // path was successfully reached.  This closes the mountpoint hole for
@@ -1201,9 +1301,6 @@ fn persist_mission_workspace_root_record(
     mission_id: Uuid,
     record: MissionWorkspaceRootRecord,
 ) -> std::io::Result<()> {
-    if workspace.id != DEFAULT_WORKSPACE_ID {
-        return Ok(());
-    }
     (|| -> std::io::Result<()> {
         std::fs::create_dir_all(config_root(&workspace.path))?;
         // The process-local lock avoids blocking an async executor on an
@@ -1354,8 +1451,14 @@ pub fn mission_workspace_dir_for_workspace(workspace: &Workspace, mission_id: Uu
 /// an operator changes `MISSION_WORKSPACE_ROOT`.
 pub fn mission_workspace_roots_for_workspace(workspace: &Workspace) -> Vec<PathBuf> {
     let mut roots = vec![workspace.path.clone()];
-    if workspace.id == DEFAULT_WORKSPACE_ID {
-        roots.push(configured_mission_workspace_root(&workspace.path));
+    {
+        // Every workspace owns a registry.  A custom workspace is just as
+        // capable of hosting a relocated mission as the default host; making
+        // it registry-less forced explicit-directory checks to accidentally
+        // consult the default host's placement authority.
+        if workspace.id == DEFAULT_WORKSPACE_ID {
+            roots.push(configured_mission_workspace_root(&workspace.path));
+        }
         if let Ok(contents) = std::fs::read_to_string(mission_workspace_roots_path(workspace)) {
             if let Ok(saved) =
                 serde_json::from_str::<HashMap<String, MissionWorkspaceRootRecordOnDisk>>(&contents)
@@ -5284,15 +5387,19 @@ WORKING_DIR = "/workspaces/mission-old"
         let workspace = Workspace::default_host(temp.path().to_path_buf());
         let boss = Uuid::new_v4();
         let worker = Uuid::new_v4();
-        persist_mission_workspace_root_record(
-            &workspace,
-            boss,
+        // This test changes the simulated mount authority itself.  Production
+        // writes deliberately refuse to replace a mismatched record, so write
+        // the restored fixture directly before verifying the recovered mount.
+        let mut restored = read_mission_workspace_roots(&workspace).unwrap();
+        restored.insert(
+            boss.to_string(),
             MissionWorkspaceRootRecord {
                 path: old_root.canonicalize().unwrap().display().to_string(),
                 filesystem_identity: Some(filesystem_identity(&old_root).unwrap()),
             },
-        )
-        .unwrap();
+        );
+        atomic_write_mission_workspace_roots(&mission_workspace_roots_path(&workspace), &restored)
+            .unwrap();
         persist_mission_workspace_root(&workspace, worker, &new_root).unwrap();
         let boss_worktree = mission_workspace_dir_for_root(&old_root, boss).join("wk-1");
         std::fs::create_dir_all(&boss_worktree).unwrap();
@@ -5480,12 +5587,9 @@ WORKING_DIR = "/workspaces/mission-old"
         let mission = Uuid::new_v4();
         let workspace = Workspace::default_host(temp.path().to_path_buf());
         std::fs::create_dir_all(config_root(&workspace.path)).unwrap();
-        let device_only = filesystem_identity(&storage)
-            .unwrap()
-            .split(":ino:")
-            .next()
-            .unwrap()
-            .to_owned();
+        // A device-only predecessor record has no directory binding and must
+        // never be promoted on a bind-mount/unmount look-alike.
+        let device_only = "dev:legacy-device-only".to_string();
         std::fs::write(
             mission_workspace_roots_path(&workspace),
             serde_json::json!({mission.to_string(): {
@@ -5497,6 +5601,41 @@ WORKING_DIR = "/workspaces/mission-old"
         .unwrap();
 
         assert!(ensure_persisted_mission_root_is_available(&workspace, mission).is_err());
+    }
+
+    #[test]
+    fn legacy_device_inode_identity_migrates_to_reboot_stable_mount_identity() {
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let temp = tempfile::tempdir().unwrap();
+            let storage = temp.path().join("legacy-device-inode-storage");
+            std::fs::create_dir_all(&storage).unwrap();
+            let mission = Uuid::new_v4();
+            let workspace = Workspace::default_host(temp.path().to_path_buf());
+            std::fs::create_dir_all(config_root(&workspace.path)).unwrap();
+            let inode = std::fs::metadata(&storage).unwrap().ino();
+            std::fs::write(
+                mission_workspace_roots_path(&workspace),
+                serde_json::json!({mission.to_string(): {
+                    "path": storage,
+                    "filesystem_identity": format!("dev:renumbered-after-reboot:ino:{inode}")
+                }})
+                .to_string(),
+            )
+            .unwrap();
+
+            ensure_persisted_mission_root_is_available(&workspace, mission).unwrap();
+            let saved: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(mission_workspace_roots_path(&workspace)).unwrap(),
+            )
+            .unwrap();
+            let identity = saved[mission.to_string()]["filesystem_identity"]
+                .as_str()
+                .unwrap();
+            assert!(identity.starts_with("linux-v2:"));
+            assert!(!identity.contains("dev:renumbered-after-reboot"));
+        }
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -898,18 +898,96 @@ pub fn mission_workspace_dir_for_root(root: &Path, mission_id: Uuid) -> PathBuf 
 const MISSION_WORKSPACE_ROOTS_FILE: &str = "mission-workspace-roots.json";
 static MISSION_WORKSPACE_ROOTS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+/// The filesystem that owned a mission root when it was selected.  A path is
+/// not an identity: after an unmount its mountpoint can remain as an ordinary
+/// directory on the parent filesystem.  On Unix `st_dev` is the kernel's
+/// filesystem/device identity and changes in precisely that situation.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct MissionWorkspaceRootRecord {
+    path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    filesystem_identity: Option<String>,
+}
+
+/// Accept the path-only format written by releases before filesystem identity
+/// was recorded.  The first successful use upgrades it under the registry
+/// lock; an unavailable legacy root is never replaced by the configured root.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum MissionWorkspaceRootRecordOnDisk {
+    Legacy(String),
+    Current(MissionWorkspaceRootRecord),
+}
+
+impl From<MissionWorkspaceRootRecordOnDisk> for MissionWorkspaceRootRecord {
+    fn from(value: MissionWorkspaceRootRecordOnDisk) -> Self {
+        match value {
+            MissionWorkspaceRootRecordOnDisk::Legacy(path) => Self {
+                path,
+                filesystem_identity: None,
+            },
+            MissionWorkspaceRootRecordOnDisk::Current(record) => record,
+        }
+    }
+}
+
 fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
     config_root(&workspace.path).join(MISSION_WORKSPACE_ROOTS_FILE)
 }
 
-fn persisted_mission_workspace_root(workspace: &Workspace, mission_id: Uuid) -> Option<PathBuf> {
-    let contents = std::fs::read_to_string(mission_workspace_roots_path(workspace)).ok()?;
-    let roots: HashMap<String, String> = serde_json::from_str(&contents).ok()?;
-    let root = PathBuf::from(roots.get(&mission_id.to_string())?);
-    // This is persisted local state, but it is still untrusted after a manual
-    // edit.  Do not turn a corrupt registry into an API path escape.
-    let root = root.canonicalize().ok()?;
-    root.is_dir().then_some(root)
+fn filesystem_identity(path: &Path) -> std::io::Result<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Ok(format!("dev:{}", std::fs::metadata(path)?.dev()))
+    }
+    #[cfg(not(unix))]
+    {
+        // The production deployment is Linux.  Keep non-Unix builds safe by
+        // requiring the resolved location to remain unchanged rather than
+        // pretending that an unverified path is a stable filesystem identity.
+        Ok(format!("path:{}", path.canonicalize()?.display()))
+    }
+}
+
+fn read_mission_workspace_roots(
+    workspace: &Workspace,
+) -> std::io::Result<HashMap<String, MissionWorkspaceRootRecord>> {
+    let contents = std::fs::read_to_string(mission_workspace_roots_path(workspace))?;
+    let roots: HashMap<String, MissionWorkspaceRootRecordOnDisk> = serde_json::from_str(&contents)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    Ok(roots
+        .into_iter()
+        .map(|(id, root)| (id, root.into()))
+        .collect())
+}
+
+fn validate_mission_workspace_root(
+    record: &MissionWorkspaceRootRecord,
+) -> std::io::Result<(PathBuf, String)> {
+    let root = PathBuf::from(&record.path).canonicalize()?;
+    if !root.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!(
+                "persisted mission workspace root {} is not a directory",
+                record.path
+            ),
+        ));
+    }
+    let actual_identity = filesystem_identity(&root)?;
+    if let Some(expected_identity) = &record.filesystem_identity {
+        if expected_identity != &actual_identity {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "persisted mission workspace root {} changed filesystem identity (expected {}, got {})",
+                    root.display(), expected_identity, actual_identity
+                ),
+            ));
+        }
+    }
+    Ok((root, actual_identity))
 }
 
 /// Refuse to create a replacement directory when an existing mission's
@@ -920,25 +998,31 @@ pub fn ensure_persisted_mission_root_is_available(
     mission_id: Uuid,
 ) -> std::io::Result<()> {
     let path = mission_workspace_roots_path(workspace);
-    let contents = match std::fs::read_to_string(path) {
-        Ok(contents) => contents,
+    let contents = match std::fs::read_to_string(&path) {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
+        Ok(contents) => contents,
     };
-    let roots: HashMap<String, String> = serde_json::from_str(&contents)
-        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
-    if let Some(root) = roots.get(&mission_id.to_string()) {
-        let root = PathBuf::from(root);
-        let canonical = root.canonicalize()?;
-        if !canonical.is_dir() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!(
-                    "persisted mission workspace root {} is not a directory",
-                    root.display()
-                ),
-            ));
-        }
+    let mut roots: HashMap<String, MissionWorkspaceRootRecordOnDisk> =
+        serde_json::from_str(&contents)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let Some(on_disk) = roots.remove(&mission_id.to_string()) else {
+        return Ok(());
+    };
+    let record: MissionWorkspaceRootRecord = on_disk.into();
+    let (_, identity) = validate_mission_workspace_root(&record)?;
+    if record.filesystem_identity.is_none() {
+        // Compatibility migration: bind the identity only after the legacy
+        // path was successfully reached.  This closes the mountpoint hole for
+        // every later caller and never permits a fallback while unavailable.
+        persist_mission_workspace_root_record(
+            workspace,
+            mission_id,
+            MissionWorkspaceRootRecord {
+                path: record.path,
+                filesystem_identity: Some(identity),
+            },
+        )?;
     }
     Ok(())
 }
@@ -948,7 +1032,7 @@ pub fn ensure_persisted_mission_root_is_available(
 /// complete old JSON document or a complete new one, never a truncation.
 fn atomic_write_mission_workspace_roots(
     path: &Path,
-    roots: &HashMap<String, String>,
+    roots: &HashMap<String, MissionWorkspaceRootRecord>,
 ) -> std::io::Result<()> {
     let parent = path.parent().expect("mission root registry has parent");
     let temp = parent.join(format!(
@@ -981,6 +1065,23 @@ fn persist_mission_workspace_root(
     mission_id: Uuid,
     root: &Path,
 ) -> std::io::Result<()> {
+    let canonical = root.canonicalize()?;
+    let identity = filesystem_identity(&canonical)?;
+    persist_mission_workspace_root_record(
+        workspace,
+        mission_id,
+        MissionWorkspaceRootRecord {
+            path: canonical.to_string_lossy().into_owned(),
+            filesystem_identity: Some(identity),
+        },
+    )
+}
+
+fn persist_mission_workspace_root_record(
+    workspace: &Workspace,
+    mission_id: Uuid,
+    record: MissionWorkspaceRootRecord,
+) -> std::io::Result<()> {
     if workspace.id != DEFAULT_WORKSPACE_ID {
         return Ok(());
     }
@@ -1001,16 +1102,26 @@ fn persist_mission_workspace_root(
             .truncate(false)
             .open(lock_path)?;
         fs2::FileExt::lock_exclusive(&lock_file)?;
-        let mut roots: HashMap<String, String> = match std::fs::read_to_string(&path) {
-            Ok(contents) => serde_json::from_str(&contents)
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
-            Err(error) => return Err(error),
-        };
-        if let std::collections::hash_map::Entry::Vacant(entry) =
-            roots.entry(mission_id.to_string())
-        {
-            entry.insert(root.to_string_lossy().into_owned());
+        let mut roots: HashMap<String, MissionWorkspaceRootRecord> =
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => serde_json::from_str::<
+                    HashMap<String, MissionWorkspaceRootRecordOnDisk>,
+                >(&contents)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?
+                .into_iter()
+                .map(|(id, value)| (id, value.into()))
+                .collect(),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+                Err(error) => return Err(error),
+            };
+        let entry = roots.entry(mission_id.to_string());
+        if matches!(entry, std::collections::hash_map::Entry::Vacant(_)) {
+            entry.or_insert(record);
+            atomic_write_mission_workspace_roots(&path, &roots)?;
+        } else if entry.into_mut().filesystem_identity.is_none() {
+            *roots
+                .get_mut(&mission_id.to_string())
+                .expect("entry exists") = record;
             atomic_write_mission_workspace_roots(&path, &roots)?;
         }
         fs2::FileExt::unlock(&lock_file)?;
@@ -1085,8 +1196,14 @@ fn mission_workspace_root_is_writable(root: &Path) -> bool {
 /// Existing generated directories always win, which keeps active missions and
 /// historic workspace records compatible after an operator enables a new root.
 pub fn mission_workspace_root_for_workspace(workspace: &Workspace, mission_id: Uuid) -> PathBuf {
-    if let Some(root) = persisted_mission_workspace_root(workspace, mission_id) {
-        return root;
+    // All operational callers must use `ensure_persisted_mission_root_is_available`
+    // before resolving.  Do not silently treat an invalid persisted record as
+    // absent here: retain its path so an accidental caller cannot create under
+    // today's configured root.
+    if let Ok(roots) = read_mission_workspace_roots(workspace) {
+        if let Some(record) = roots.get(&mission_id.to_string()) {
+            return PathBuf::from(&record.path);
+        }
     }
     let legacy = mission_workspace_dir_for_root(&workspace.path, mission_id);
     if legacy.exists() || workspace.id != DEFAULT_WORKSPACE_ID {
@@ -1111,10 +1228,14 @@ pub fn mission_workspace_roots_for_workspace(workspace: &Workspace) -> Vec<PathB
     if workspace.id == DEFAULT_WORKSPACE_ID {
         roots.push(configured_mission_workspace_root(&workspace.path));
         if let Ok(contents) = std::fs::read_to_string(mission_workspace_roots_path(workspace)) {
-            if let Ok(saved) = serde_json::from_str::<HashMap<String, String>>(&contents) {
+            if let Ok(saved) =
+                serde_json::from_str::<HashMap<String, MissionWorkspaceRootRecordOnDisk>>(&contents)
+            {
                 roots.extend(saved.into_values().filter_map(|root| {
-                    let root = PathBuf::from(root).canonicalize().ok()?;
-                    root.is_dir().then_some(root)
+                    let record: MissionWorkspaceRootRecord = root.into();
+                    validate_mission_workspace_root(&record)
+                        .ok()
+                        .map(|(root, _)| root)
                 }));
             }
         }
@@ -5045,6 +5166,66 @@ WORKING_DIR = "/workspaces/mission-old"
         assert!(!mission_workspace_dir_for_root(temp.path(), mission).exists());
     }
 
+    #[tokio::test]
+    async fn persisted_root_identity_mismatch_fails_closed_without_recreating_on_mountpoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("mountpoint-left-after-unmount");
+        std::fs::create_dir_all(&storage).unwrap();
+        let mission = Uuid::new_v4();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        let registry_dir = config_root(&workspace.path);
+        std::fs::create_dir_all(&registry_dir).unwrap();
+        // This models the same path after its volume was unmounted: it is
+        // still a directory, but `st_dev` no longer matches the identity that
+        // was recorded when the mission was placed there.
+        std::fs::write(
+            mission_workspace_roots_path(&workspace),
+            serde_json::json!({mission.to_string(): {
+                "path": storage,
+                "filesystem_identity": "dev:identity-before-unmount"
+            }})
+            .to_string(),
+        )
+        .unwrap();
+
+        let mcp = McpRegistry::new(temp.path()).await;
+        let result = prepare_mission_workspace_in(&workspace, &mcp, mission).await;
+        assert!(result.is_err());
+        assert!(!mission_workspace_dir_for_root(temp.path(), mission).exists());
+        assert!(ensure_persisted_mission_root_is_available(&workspace, mission).is_err());
+    }
+
+    #[test]
+    fn legacy_path_only_record_is_migrated_only_after_the_root_is_reachable() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("legacy-storage");
+        std::fs::create_dir_all(&storage).unwrap();
+        let mission = Uuid::new_v4();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        std::fs::create_dir_all(config_root(&workspace.path)).unwrap();
+        std::fs::write(
+            mission_workspace_roots_path(&workspace),
+            serde_json::json!({mission.to_string(): storage}).to_string(),
+        )
+        .unwrap();
+
+        ensure_persisted_mission_root_is_available(&workspace, mission).unwrap();
+        let saved: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(mission_workspace_roots_path(&workspace)).unwrap(),
+        )
+        .unwrap();
+        assert!(saved[mission.to_string()]["filesystem_identity"].is_string());
+        // A fresh workspace models restart: the migrated entry still resolves
+        // to the selected root rather than today's configured placement.
+        assert_eq!(
+            mission_workspace_root_for_workspace(
+                &Workspace::default_host(temp.path().to_path_buf()),
+                mission
+            ),
+            storage.canonicalize().unwrap()
+        );
+    }
+
     #[test]
     fn mission_root_registry_serializes_concurrent_writers_and_readers() {
         use std::sync::atomic::{AtomicBool, Ordering};
@@ -5066,8 +5247,9 @@ WORKING_DIR = "/workspaces/mission-old"
             while !reader_finished.load(Ordering::Acquire) {
                 let path = mission_workspace_roots_path(&reader_workspace);
                 if let Ok(contents) = std::fs::read_to_string(path) {
-                    let _: HashMap<String, String> = serde_json::from_str(&contents)
-                        .expect("readers must never observe partial registry JSON");
+                    let _: HashMap<String, MissionWorkspaceRootRecordOnDisk> =
+                        serde_json::from_str(&contents)
+                            .expect("readers must never observe partial registry JSON");
                 }
             }
         });
@@ -5095,7 +5277,8 @@ WORKING_DIR = "/workspaces/mission-old"
         let after_restart = Workspace::default_host(temp.path().to_path_buf());
         let contents =
             std::fs::read_to_string(mission_workspace_roots_path(&after_restart)).unwrap();
-        let roots: HashMap<String, String> = serde_json::from_str(&contents).unwrap();
+        let roots: HashMap<String, MissionWorkspaceRootRecordOnDisk> =
+            serde_json::from_str(&contents).unwrap();
         assert_eq!(
             roots.len(),
             missions.len(),

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -945,11 +945,15 @@ fn atomic_write_mission_workspace_roots(
 /// Persist the selected root before creating a mission directory.  The
 /// registry lives with the workspace configuration rather than the generated
 /// directory, so it survives restarts and a later environment/config drift.
-fn persist_mission_workspace_root(workspace: &Workspace, mission_id: Uuid, root: &Path) {
+fn persist_mission_workspace_root(
+    workspace: &Workspace,
+    mission_id: Uuid,
+    root: &Path,
+) -> std::io::Result<()> {
     if workspace.id != DEFAULT_WORKSPACE_ID {
-        return;
+        return Ok(());
     }
-    if let Err(error) = (|| -> std::io::Result<()> {
+    (|| -> std::io::Result<()> {
         std::fs::create_dir_all(config_root(&workspace.path))?;
         // The process-local lock avoids blocking an async executor on an
         // advisory file lock when many preparations race. The file lock also
@@ -978,10 +982,7 @@ fn persist_mission_workspace_root(workspace: &Workspace, mission_id: Uuid, root:
         }
         fs2::FileExt::unlock(&lock_file)?;
         Ok(())
-    })() {
-        let path = mission_workspace_roots_path(workspace);
-        tracing::warn!(mission_id = %mission_id, path = %path.display(), %error, "Failed to persist mission workspace root");
-    }
+    })()
 }
 
 /// Resolve the root used for newly-created default-host mission directories.
@@ -1111,8 +1112,9 @@ fn configured_project_dir_with_nspawn(
     // orchestrator-owned git worktree) is authoritative. Only replace the
     // generated per-mission state directory; otherwise every worker would be
     // redirected back to the shared LEAN_PROJECT_PATH checkout.
-    let generated_workspaces = workspaces_root_for(&workspace.path);
-    let is_generated_mission_dir = fallback.parent() == Some(generated_workspaces.as_path())
+    let is_generated_mission_dir = mission_workspace_roots_for_workspace(workspace)
+        .iter()
+        .any(|root| fallback.parent() == Some(workspaces_root_for(root).as_path()))
         && fallback
             .file_name()
             .and_then(|name| name.to_str())
@@ -2531,7 +2533,7 @@ pub async fn prepare_mission_workspace_in(
     // Use a mission-specific directory under the workspace root so multiple missions
     // can run concurrently without clobbering per-workspace config files.
     let root = mission_workspace_root_for_workspace(workspace, mission_id);
-    persist_mission_workspace_root(workspace, mission_id, &root);
+    persist_mission_workspace_root(workspace, mission_id, &root)?;
     let dir = mission_workspace_dir_for_root(&root, mission_id);
     prepare_workspace_dir(&dir).await?;
     install_remote_build_wrapper(workspace, mission_id).await?;
@@ -2731,7 +2733,7 @@ pub async fn prepare_mission_workspace_with_skills_backend(
     // Mission workspace directory lives under the selected workspace root.
     // This keeps filesystem and config effects scoped to the mission.
     let root = mission_workspace_root_for_workspace(workspace, mission_id);
-    persist_mission_workspace_root(workspace, mission_id, &root);
+    persist_mission_workspace_root(workspace, mission_id, &root)?;
     let dir = mission_workspace_dir_for_root(&root, mission_id);
     prepare_workspace_dir(&dir).await?;
     install_remote_build_wrapper(workspace, mission_id).await?;
@@ -4520,6 +4522,24 @@ sandboxed-harness-version:grok=\n";
     }
 
     #[test]
+    fn configured_project_path_recognizes_relocated_mission_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let storage = tempfile::tempdir().unwrap();
+        let project = root.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let mut workspace = Workspace::default_host(root.path().to_path_buf());
+        workspace.env_vars.insert(
+            "LEAN_PROJECT_PATH".to_string(),
+            project.to_string_lossy().into_owned(),
+        );
+        let mission = Uuid::new_v4();
+        persist_mission_workspace_root(&workspace, mission, storage.path()).unwrap();
+        let mission_dir = mission_workspace_dir_for_workspace(&workspace, mission);
+
+        assert_eq!(configured_project_dir(&workspace, &mission_dir), project);
+    }
+
+    #[test]
     fn configured_project_path_rejects_parent_traversal() {
         let root = tempfile::tempdir().unwrap();
         let mut workspace =
@@ -4956,7 +4976,7 @@ WORKING_DIR = "/workspaces/mission-old"
         let mission = Uuid::new_v4();
         let workspace = Workspace::default_host(temp.path().to_path_buf());
 
-        persist_mission_workspace_root(&workspace, mission, &storage);
+        persist_mission_workspace_root(&workspace, mission, &storage).unwrap();
 
         // A fresh workspace value models a process restart; the resolver must
         // use the recorded selection rather than today's configuration.
@@ -5005,7 +5025,7 @@ WORKING_DIR = "/workspaces/mission-old"
                 let start = Arc::clone(&start);
                 std::thread::spawn(move || {
                     start.wait();
-                    persist_mission_workspace_root(&workspace, mission, &storage);
+                    persist_mission_workspace_root(&workspace, mission, &storage).unwrap();
                 })
             })
             .collect();
@@ -5033,6 +5053,15 @@ WORKING_DIR = "/workspaces/mission-old"
                 storage.canonicalize().unwrap()
             );
         }
+    }
+
+    #[test]
+    fn mission_root_registry_persistence_failure_is_returned() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        std::fs::write(config_root(&workspace.path), "not a directory").unwrap();
+
+        assert!(persist_mission_workspace_root(&workspace, Uuid::new_v4(), temp.path()).is_err());
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -829,18 +829,30 @@ impl WorkspaceStore {
             return false; // Cannot delete default workspace
         }
 
-        let existed = {
+        let removed = {
             let mut guard = self.workspaces.write().await;
-            guard.remove(&id).is_some()
+            guard.remove(&id)
         };
 
-        if existed {
+        if let Some(workspace) = removed {
+            let registry = mission_workspace_roots_path(&workspace);
+            if registry.exists() {
+                if let Err(error) = std::fs::remove_file(&registry) {
+                    tracing::warn!(
+                        workspace = %id,
+                        path = %registry.display(),
+                        %error,
+                        "failed to remove mission-root registry after workspace delete"
+                    );
+                }
+            }
             if let Err(e) = self.save_to_disk().await {
                 tracing::error!("Failed to save workspaces to disk: {}", e);
             }
+            true
+        } else {
+            false
         }
-
-        existed
     }
 }
 
@@ -6116,6 +6128,20 @@ WORKING_DIR = "/workspaces/mission-old"
             serde_json::from_str(&contents).unwrap();
         assert!(parsed.is_empty());
         assert!(ensure_persisted_mission_root_is_available(&workspace, Uuid::new_v4()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn deleting_a_custom_workspace_removes_its_control_registry() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = WorkspaceStore::new(temp.path().to_path_buf()).await;
+        let mut workspace = Workspace::new_container("doomed".into(), temp.path().join("mount"));
+        std::fs::create_dir_all(&workspace.path).unwrap();
+        let id = store.add(workspace.clone()).await;
+        workspace = store.get(id).await.unwrap();
+        let registry = mission_workspace_roots_path(&workspace);
+        assert!(registry.exists());
+        assert!(store.delete(id).await);
+        assert!(!registry.exists());
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -801,12 +801,13 @@ impl WorkspaceStore {
     }
 
     /// Update a workspace.
-    pub async fn update(&self, workspace: Workspace) -> bool {
+    pub async fn update(&self, mut workspace: Workspace) -> bool {
         let updated = {
             let mut guard = self.workspaces.write().await;
             if let std::collections::hash_map::Entry::Occupied(mut entry) =
                 guard.entry(workspace.id)
             {
+                preserve_control_registry_authority(entry.get(), &mut workspace, &self.working_dir);
                 entry.insert(workspace);
                 true
             } else {
@@ -919,6 +920,9 @@ pub fn mission_workspace_dir_for_root(root: &Path, mission_id: Uuid) -> PathBuf 
 }
 
 const MISSION_WORKSPACE_ROOTS_FILE: &str = "mission-workspace-roots.json";
+const CONTROL_REGISTRY_CONFIG_KEY: &str = "mission_workspace_registry_control_root";
+/// Reserved registry key for the custom workspace volume itself, not a mission.
+const WORKSPACE_ROOT_REGISTRY_KEY: &str = "__workspace_root__";
 static MISSION_WORKSPACE_ROOTS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 /// The filesystem that owned a mission root when it was selected.  A path is
@@ -956,7 +960,7 @@ pub fn require_verified_mission_workspace(
 /// Accept the path-only format written by releases before filesystem identity
 /// was recorded.  The first successful use upgrades it under the registry
 /// lock; an unavailable legacy root is never replaced by the configured root.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(untagged)]
 enum MissionWorkspaceRootRecordOnDisk {
     Legacy(String),
@@ -988,7 +992,7 @@ fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
     if workspace.id != DEFAULT_WORKSPACE_ID {
         if let Some(root) = workspace
             .config
-            .get("mission_workspace_registry_control_root")
+            .get(CONTROL_REGISTRY_CONFIG_KEY)
             .and_then(serde_json::Value::as_str)
         {
             return PathBuf::from(root)
@@ -1007,19 +1011,21 @@ fn stamp_custom_workspace_control_registry(workspace: &mut Workspace, working_di
     if workspace.id == DEFAULT_WORKSPACE_ID {
         return;
     }
-    if workspace
+    if !workspace
         .config
-        .get("mission_workspace_registry_control_root")
-        .is_none()
+        .get(CONTROL_REGISTRY_CONFIG_KEY)
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|root| !root.is_empty())
     {
         if !workspace.config.is_object() {
             workspace.config = serde_json::json!({});
         }
-        workspace.config["mission_workspace_registry_control_root"] =
+        workspace.config[CONTROL_REGISTRY_CONFIG_KEY] =
             serde_json::Value::String(working_dir.to_string_lossy().into_owned());
     }
     let destination = mission_workspace_roots_path(workspace);
     if destination.exists() {
+        ensure_workspace_root_identity_recorded(workspace);
         return;
     }
     if let Some(parent) = destination.parent() {
@@ -1044,12 +1050,156 @@ fn stamp_custom_workspace_control_registry(workspace: &mut Workspace, working_di
             return;
         }
     }
-    if let Err(error) = atomic_write_mission_workspace_roots(&destination, &HashMap::new()) {
+    let mut roots = HashMap::new();
+    if let Some(record) = workspace_root_registry_record(workspace) {
+        roots.insert(WORKSPACE_ROOT_REGISTRY_KEY.to_string(), record);
+    }
+    if let Err(error) = atomic_write_mission_workspace_roots(&destination, &roots) {
         tracing::error!(
             workspace = %workspace.id,
             error = %error,
             "failed to initialize empty control mission-root registry"
         );
+    }
+}
+
+fn preserve_control_registry_authority(
+    existing: &Workspace,
+    incoming: &mut Workspace,
+    working_dir: &Path,
+) {
+    if incoming.id == DEFAULT_WORKSPACE_ID {
+        return;
+    }
+    let existing_root = existing
+        .config
+        .get(CONTROL_REGISTRY_CONFIG_KEY)
+        .cloned()
+        .filter(|value| value.as_str().is_some_and(|root| !root.is_empty()));
+    if !incoming.config.is_object() {
+        incoming.config = existing.config.clone();
+        if incoming.config.is_object() {
+            if let Some(root) = existing_root {
+                incoming.config[CONTROL_REGISTRY_CONFIG_KEY] = root;
+            }
+            return;
+        }
+        incoming.config = serde_json::json!({});
+    }
+    if let Some(root) = existing_root {
+        incoming.config[CONTROL_REGISTRY_CONFIG_KEY] = root;
+    } else {
+        stamp_custom_workspace_control_registry(incoming, working_dir);
+    }
+}
+
+fn workspace_root_registry_record(workspace: &Workspace) -> Option<MissionWorkspaceRootRecord> {
+    let canonical = workspace.path.canonicalize().ok()?;
+    let identity = filesystem_identity(&canonical).ok()?;
+    Some(MissionWorkspaceRootRecord {
+        path: canonical.to_string_lossy().into_owned(),
+        filesystem_identity: Some(identity),
+    })
+}
+
+fn persist_workspace_root_identity(
+    workspace: &Workspace,
+    record: MissionWorkspaceRootRecord,
+) -> std::io::Result<()> {
+    let path = mission_workspace_roots_path(workspace);
+    std::fs::create_dir_all(
+        path.parent()
+            .expect("mission workspace root registry has a parent"),
+    )?;
+    let _guard = MISSION_WORKSPACE_ROOTS_LOCK
+        .lock()
+        .expect("registry lock poisoned");
+    let lock_path = path.with_extension("json.lock");
+    let lock_file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock_path)?;
+    fs2::FileExt::lock_exclusive(&lock_file)?;
+    let mut roots: HashMap<String, MissionWorkspaceRootRecord> =
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                serde_json::from_str::<HashMap<String, MissionWorkspaceRootRecordOnDisk>>(&contents)
+                    .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?
+                    .into_iter()
+                    .map(|(id, value)| (id, value.into()))
+                    .collect()
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(error) => return Err(error),
+        };
+    roots.insert(WORKSPACE_ROOT_REGISTRY_KEY.to_string(), record);
+    atomic_write_mission_workspace_roots(&path, &roots)?;
+    fs2::FileExt::unlock(&lock_file)?;
+    Ok(())
+}
+
+fn ensure_workspace_root_identity_recorded(workspace: &Workspace) {
+    if workspace.id == DEFAULT_WORKSPACE_ID {
+        return;
+    }
+    let Ok(roots) = read_mission_workspace_roots(workspace) else {
+        return;
+    };
+    if roots.contains_key(WORKSPACE_ROOT_REGISTRY_KEY) {
+        return;
+    }
+    if let Some(record) = workspace_root_registry_record(workspace) {
+        if let Err(error) = persist_workspace_root_identity(workspace, record) {
+            tracing::error!(
+                workspace = %workspace.id,
+                error = %error,
+                "failed to record custom workspace volume identity"
+            );
+        }
+    }
+}
+
+fn ensure_custom_workspace_volume_identity(workspace: &Workspace) -> std::io::Result<()> {
+    if workspace.id == DEFAULT_WORKSPACE_ID {
+        return Ok(());
+    }
+    let path = mission_workspace_roots_path(workspace);
+    let contents = match std::fs::read_to_string(&path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "persisted control registry for custom workspace {} is unavailable",
+                    workspace.id
+                ),
+            ));
+        }
+        Err(error) => return Err(error),
+        Ok(contents) => contents,
+    };
+    let roots: HashMap<String, MissionWorkspaceRootRecordOnDisk> = serde_json::from_str(&contents)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    match roots.get(WORKSPACE_ROOT_REGISTRY_KEY) {
+        Some(on_disk) => {
+            let record: MissionWorkspaceRootRecord = on_disk.clone().into();
+            validate_mission_workspace_root(&record)?;
+            Ok(())
+        }
+        None => {
+            if let Some(record) = workspace_root_registry_record(workspace) {
+                persist_workspace_root_identity(workspace, record)
+            } else {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!(
+                        "custom workspace {} volume identity is missing and the mount is unavailable",
+                        workspace.id
+                    ),
+                ))
+            }
+        }
     }
 }
 
@@ -1239,15 +1389,13 @@ pub fn ensure_persisted_mission_root_is_available(
     workspace: &Workspace,
     mission_id: Uuid,
 ) -> std::io::Result<()> {
+    ensure_custom_workspace_volume_identity(workspace)?;
     let path = mission_workspace_roots_path(workspace);
     let contents = match std::fs::read_to_string(&path) {
         Err(error)
             if error.kind() == std::io::ErrorKind::NotFound
                 && workspace.id != DEFAULT_WORKSPACE_ID
-                && workspace
-                    .config
-                    .get("mission_workspace_registry_control_root")
-                    .is_some() =>
+                && workspace.config.get(CONTROL_REGISTRY_CONFIG_KEY).is_some() =>
         {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
@@ -6117,17 +6265,78 @@ WORKING_DIR = "/workspaces/mission-old"
         let mut workspace = Workspace::new_container("custom".into(), temp.path().join("mount"));
         std::fs::create_dir_all(&workspace.path).unwrap();
         stamp_custom_workspace_control_registry(&mut workspace, temp.path());
-        assert!(workspace.config["mission_workspace_registry_control_root"].is_string());
+        assert!(workspace.config[CONTROL_REGISTRY_CONFIG_KEY].is_string());
         let registry = mission_workspace_roots_path(&workspace);
         assert!(
             registry.exists(),
-            "first-use custom workspace needs an empty control registry"
+            "first-use custom workspace needs a control registry"
         );
         let contents = std::fs::read_to_string(&registry).unwrap();
         let parsed: HashMap<String, MissionWorkspaceRootRecordOnDisk> =
             serde_json::from_str(&contents).unwrap();
-        assert!(parsed.is_empty());
-        assert!(ensure_persisted_mission_root_is_available(&workspace, Uuid::new_v4()).is_ok());
+        if cfg!(target_os = "linux") {
+            assert!(parsed.contains_key(WORKSPACE_ROOT_REGISTRY_KEY));
+        } else {
+            assert!(!parsed.keys().any(|key| key != WORKSPACE_ROOT_REGISTRY_KEY));
+        }
+        if filesystem_identity(&workspace.path).is_ok() {
+            assert!(ensure_persisted_mission_root_is_available(&workspace, Uuid::new_v4()).is_ok());
+        }
+    }
+
+    #[test]
+    fn custom_workspace_volume_identity_mismatch_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut workspace = Workspace::new_container("custom".into(), temp.path().join("mount"));
+        std::fs::create_dir_all(&workspace.path).unwrap();
+        stamp_custom_workspace_control_registry(&mut workspace, temp.path());
+        let registry = mission_workspace_roots_path(&workspace);
+        let mut roots: HashMap<String, MissionWorkspaceRootRecord> = HashMap::new();
+        roots.insert(
+            WORKSPACE_ROOT_REGISTRY_KEY.to_string(),
+            MissionWorkspaceRootRecord {
+                path: workspace.path.to_string_lossy().into_owned(),
+                filesystem_identity: Some("linux-v2:replaced-volume:root-ino:1".into()),
+            },
+        );
+        atomic_write_mission_workspace_roots(&registry, &roots).unwrap();
+        assert!(ensure_persisted_mission_root_is_available(&workspace, Uuid::new_v4()).is_err());
+    }
+
+    #[tokio::test]
+    async fn update_preserves_control_registry_authority() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = WorkspaceStore::new(temp.path().to_path_buf()).await;
+        let workspace = Workspace::new_container("custom".into(), temp.path().join("mount"));
+        std::fs::create_dir_all(&workspace.path).unwrap();
+        let id = store.add(workspace).await;
+        let original = store.get(id).await.unwrap();
+        let original_root = original.config[CONTROL_REGISTRY_CONFIG_KEY]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let mut overwritten = original.clone();
+        overwritten.config = serde_json::json!({
+            "mission_workspace_registry_control_root": "/tmp/attacker-control-root",
+            "unrelated": true
+        });
+        assert!(store.update(overwritten).await);
+        let after = store.get(id).await.unwrap();
+        assert_eq!(
+            after.config[CONTROL_REGISTRY_CONFIG_KEY].as_str(),
+            Some(original_root.as_str())
+        );
+        assert_eq!(after.config["unrelated"], true);
+
+        let mut replaced = after.clone();
+        replaced.config = serde_json::Value::String("not-an-object".into());
+        assert!(store.update(replaced).await);
+        let restored = store.get(id).await.unwrap();
+        assert_eq!(
+            restored.config[CONTROL_REGISTRY_CONFIG_KEY].as_str(),
+            Some(original_root.as_str())
+        );
     }
 
     #[tokio::test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -10,8 +10,9 @@
 //! - **Container**: Execute inside an isolated container environment (systemd-nspawn)
 
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
 
 // Per-backend config generation (Phase 4 of the decomposition).
 pub mod config;
@@ -895,6 +896,7 @@ pub fn mission_workspace_dir_for_root(root: &Path, mission_id: Uuid) -> PathBuf 
 }
 
 const MISSION_WORKSPACE_ROOTS_FILE: &str = "mission-workspace-roots.json";
+static MISSION_WORKSPACE_ROOTS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
     config_root(&workspace.path).join(MISSION_WORKSPACE_ROOTS_FILE)
@@ -910,6 +912,36 @@ fn persisted_mission_workspace_root(workspace: &Workspace, mission_id: Uuid) -> 
     root.is_dir().then_some(root)
 }
 
+/// Atomically replace a registry file and make both the file and the rename
+/// durable before releasing the registry lock. Readers therefore see either a
+/// complete old JSON document or a complete new one, never a truncation.
+fn atomic_write_mission_workspace_roots(
+    path: &Path,
+    roots: &HashMap<String, String>,
+) -> std::io::Result<()> {
+    let parent = path.parent().expect("mission root registry has parent");
+    let temp = parent.join(format!(
+        ".{MISSION_WORKSPACE_ROOTS_FILE}.{}.tmp",
+        Uuid::new_v4()
+    ));
+    let result = (|| -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(roots).expect("root map serializes");
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        std::fs::rename(&temp, path)?;
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
+}
+
 /// Persist the selected root before creating a mission directory.  The
 /// registry lives with the workspace configuration rather than the generated
 /// directory, so it survives restarts and a later environment/config drift.
@@ -917,22 +949,34 @@ fn persist_mission_workspace_root(workspace: &Workspace, mission_id: Uuid, root:
     if workspace.id != DEFAULT_WORKSPACE_ID {
         return;
     }
-    let path = mission_workspace_roots_path(workspace);
-    let mut roots: HashMap<String, String> = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|contents| serde_json::from_str(&contents).ok())
-        .unwrap_or_default();
-    if roots.contains_key(&mission_id.to_string()) {
-        return;
-    }
-    roots.insert(mission_id.to_string(), root.to_string_lossy().into_owned());
     if let Err(error) = (|| -> std::io::Result<()> {
         std::fs::create_dir_all(config_root(&workspace.path))?;
-        std::fs::write(
-            &path,
-            serde_json::to_vec(&roots).expect("root map serializes"),
-        )
+        // The process-local lock avoids blocking an async executor on an
+        // advisory file lock when many preparations race. The file lock also
+        // serializes independent server processes sharing this workspace.
+        let _guard = MISSION_WORKSPACE_ROOTS_LOCK
+            .lock()
+            .expect("registry lock poisoned");
+        let path = mission_workspace_roots_path(workspace);
+        let lock_path = path.with_extension("json.lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(lock_path)?;
+        fs2::FileExt::lock_exclusive(&lock_file)?;
+        let mut roots: HashMap<String, String> = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|contents| serde_json::from_str(&contents).ok())
+            .unwrap_or_default();
+        if !roots.contains_key(&mission_id.to_string()) {
+            roots.insert(mission_id.to_string(), root.to_string_lossy().into_owned());
+            atomic_write_mission_workspace_roots(&path, &roots)?;
+        }
+        fs2::FileExt::unlock(&lock_file)?;
+        Ok(())
     })() {
+        let path = mission_workspace_roots_path(workspace);
         tracing::warn!(mission_id = %mission_id, path = %path.display(), %error, "Failed to persist mission workspace root");
     }
 }
@@ -4920,6 +4964,72 @@ WORKING_DIR = "/workspaces/mission-old"
         );
         assert!(mission_workspace_roots_for_workspace(&after_restart)
             .contains(&storage.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn mission_root_registry_serializes_concurrent_writers_and_readers() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Barrier};
+
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("separate-filesystem");
+        std::fs::create_dir_all(&storage).unwrap();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        let missions: Vec<_> = (0..24).map(|_| Uuid::new_v4()).collect();
+        let start = Arc::new(Barrier::new(missions.len() + 2));
+        let finished = Arc::new(AtomicBool::new(false));
+
+        let reader_workspace = workspace.clone();
+        let reader_start = Arc::clone(&start);
+        let reader_finished = Arc::clone(&finished);
+        let reader = std::thread::spawn(move || {
+            reader_start.wait();
+            while !reader_finished.load(Ordering::Acquire) {
+                let path = mission_workspace_roots_path(&reader_workspace);
+                if let Ok(contents) = std::fs::read_to_string(path) {
+                    let _: HashMap<String, String> = serde_json::from_str(&contents)
+                        .expect("readers must never observe partial registry JSON");
+                }
+            }
+        });
+
+        let writers: Vec<_> = missions
+            .iter()
+            .copied()
+            .map(|mission| {
+                let workspace = workspace.clone();
+                let storage = storage.clone();
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    persist_mission_workspace_root(&workspace, mission, &storage);
+                })
+            })
+            .collect();
+        start.wait();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        finished.store(true, Ordering::Release);
+        reader.join().unwrap();
+
+        let after_restart = Workspace::default_host(temp.path().to_path_buf());
+        let contents =
+            std::fs::read_to_string(mission_workspace_roots_path(&after_restart)).unwrap();
+        let roots: HashMap<String, String> = serde_json::from_str(&contents).unwrap();
+        assert_eq!(
+            roots.len(),
+            missions.len(),
+            "no concurrent update may be lost"
+        );
+        for mission in missions {
+            // A new workspace value models restart/config drift: every entry
+            // remains independently recoverable from the durable registry.
+            assert_eq!(
+                mission_workspace_root_for_workspace(&after_restart, mission),
+                storage.canonicalize().unwrap()
+            );
+        }
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -368,7 +368,7 @@ impl Workspace {
         let port = std::env::var("PORT")
             .ok()
             .filter(|s| !s.trim().is_empty())?;
-        let host_dir = mission_workspace_dir_for_root(&self.path, mission_id);
+        let host_dir = mission_workspace_dir_for_workspace(self, mission_id);
         let short = &mission_id.to_string()[..8];
         let guest_dir = if self.workspace_type == WorkspaceType::Container {
             format!("/workspaces/mission-{}", short)
@@ -894,6 +894,49 @@ pub fn mission_workspace_dir_for_root(root: &Path, mission_id: Uuid) -> PathBuf 
     workspaces_root_for(root).join(format!("mission-{}", short_id))
 }
 
+const MISSION_WORKSPACE_ROOTS_FILE: &str = "mission-workspace-roots.json";
+
+fn mission_workspace_roots_path(workspace: &Workspace) -> PathBuf {
+    config_root(&workspace.path).join(MISSION_WORKSPACE_ROOTS_FILE)
+}
+
+fn persisted_mission_workspace_root(workspace: &Workspace, mission_id: Uuid) -> Option<PathBuf> {
+    let contents = std::fs::read_to_string(mission_workspace_roots_path(workspace)).ok()?;
+    let roots: HashMap<String, String> = serde_json::from_str(&contents).ok()?;
+    let root = PathBuf::from(roots.get(&mission_id.to_string())?);
+    // This is persisted local state, but it is still untrusted after a manual
+    // edit.  Do not turn a corrupt registry into an API path escape.
+    let root = root.canonicalize().ok()?;
+    root.is_dir().then_some(root)
+}
+
+/// Persist the selected root before creating a mission directory.  The
+/// registry lives with the workspace configuration rather than the generated
+/// directory, so it survives restarts and a later environment/config drift.
+fn persist_mission_workspace_root(workspace: &Workspace, mission_id: Uuid, root: &Path) {
+    if workspace.id != DEFAULT_WORKSPACE_ID {
+        return;
+    }
+    let path = mission_workspace_roots_path(workspace);
+    let mut roots: HashMap<String, String> = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|contents| serde_json::from_str(&contents).ok())
+        .unwrap_or_default();
+    if roots.contains_key(&mission_id.to_string()) {
+        return;
+    }
+    roots.insert(mission_id.to_string(), root.to_string_lossy().into_owned());
+    if let Err(error) = (|| -> std::io::Result<()> {
+        std::fs::create_dir_all(config_root(&workspace.path))?;
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&roots).expect("root map serializes"),
+        )
+    })() {
+        tracing::warn!(mission_id = %mission_id, path = %path.display(), %error, "Failed to persist mission workspace root");
+    }
+}
+
 /// Resolve the root used for newly-created default-host mission directories.
 ///
 /// `MISSION_WORKSPACE_ROOT` is deliberately only a placement override for the
@@ -961,6 +1004,9 @@ fn mission_workspace_root_is_writable(root: &Path) -> bool {
 /// Existing generated directories always win, which keeps active missions and
 /// historic workspace records compatible after an operator enables a new root.
 pub fn mission_workspace_root_for_workspace(workspace: &Workspace, mission_id: Uuid) -> PathBuf {
+    if let Some(root) = persisted_mission_workspace_root(workspace, mission_id) {
+        return root;
+    }
     let legacy = mission_workspace_dir_for_root(&workspace.path, mission_id);
     if legacy.exists() || workspace.id != DEFAULT_WORKSPACE_ID {
         return workspace.path.clone();
@@ -974,6 +1020,27 @@ pub fn mission_workspace_dir_for_workspace(workspace: &Workspace, mission_id: Uu
         &mission_workspace_root_for_workspace(workspace, mission_id),
         mission_id,
     )
+}
+
+/// Roots that can contain generated mission directories for this workspace.
+/// Used by maintenance scans; registered roots preserve discoverability after
+/// an operator changes `MISSION_WORKSPACE_ROOT`.
+pub fn mission_workspace_roots_for_workspace(workspace: &Workspace) -> Vec<PathBuf> {
+    let mut roots = vec![workspace.path.clone()];
+    if workspace.id == DEFAULT_WORKSPACE_ID {
+        roots.push(configured_mission_workspace_root(&workspace.path));
+        if let Ok(contents) = std::fs::read_to_string(mission_workspace_roots_path(workspace)) {
+            if let Ok(saved) = serde_json::from_str::<HashMap<String, String>>(&contents) {
+                roots.extend(saved.into_values().filter_map(|root| {
+                    let root = PathBuf::from(root).canonicalize().ok()?;
+                    root.is_dir().then_some(root)
+                }));
+            }
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    roots
 }
 
 /// Resolve a configured project directory to its host-visible path.
@@ -2416,7 +2483,9 @@ pub async fn prepare_mission_workspace_in(
 ) -> anyhow::Result<PathBuf> {
     // Use a mission-specific directory under the workspace root so multiple missions
     // can run concurrently without clobbering per-workspace config files.
-    let dir = mission_workspace_dir_for_workspace(workspace, mission_id);
+    let root = mission_workspace_root_for_workspace(workspace, mission_id);
+    persist_mission_workspace_root(workspace, mission_id, &root);
+    let dir = mission_workspace_dir_for_root(&root, mission_id);
     prepare_workspace_dir(&dir).await?;
     install_remote_build_wrapper(workspace, mission_id).await?;
     let mcp_configs = filter_mcp_configs_for_workspace(
@@ -2614,7 +2683,9 @@ pub async fn prepare_mission_workspace_with_skills_backend(
 ) -> anyhow::Result<PathBuf> {
     // Mission workspace directory lives under the selected workspace root.
     // This keeps filesystem and config effects scoped to the mission.
-    let dir = mission_workspace_dir_for_workspace(workspace, mission_id);
+    let root = mission_workspace_root_for_workspace(workspace, mission_id);
+    persist_mission_workspace_root(workspace, mission_id, &root);
+    let dir = mission_workspace_dir_for_root(&root, mission_id);
     prepare_workspace_dir(&dir).await?;
     install_remote_build_wrapper(workspace, mission_id).await?;
     // Reviewers still need authenticated read access to private repositories.
@@ -4828,6 +4899,27 @@ WORKING_DIR = "/workspaces/mission-old"
             mission_workspace_dir_for_workspace(&workspace, mission),
             legacy
         );
+    }
+
+    #[test]
+    fn persisted_mission_root_survives_restart_and_config_drift() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("separate-filesystem");
+        std::fs::create_dir_all(&storage).unwrap();
+        let mission = Uuid::new_v4();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+
+        persist_mission_workspace_root(&workspace, mission, &storage);
+
+        // A fresh workspace value models a process restart; the resolver must
+        // use the recorded selection rather than today's configuration.
+        let after_restart = Workspace::default_host(temp.path().to_path_buf());
+        assert_eq!(
+            mission_workspace_dir_for_workspace(&after_restart, mission),
+            mission_workspace_dir_for_root(&storage.canonicalize().unwrap(), mission)
+        );
+        assert!(mission_workspace_roots_for_workspace(&after_restart)
+            .contains(&storage.canonicalize().unwrap()));
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1072,6 +1072,80 @@ pub fn ensure_persisted_mission_root_is_available(
     Ok(())
 }
 
+/// Verify the persisted owner of an explicit directory below a mission
+/// workspace.  A worker can legitimately run in a boss's worktree, but the
+/// worker's own selected root says nothing about the filesystem that owns that
+/// worktree.  Resolve the physical `workspaces/mission-<short>` ancestor,
+/// require exactly one registry owner, and validate that owner's persisted
+/// root before accepting any descendant.
+///
+/// Callers intentionally receive an error for a directory outside a mission
+/// workspace: an explicit override is a capability, not a generic escape hatch
+/// from the selected mission placement.
+pub fn verify_explicit_mission_working_directory_owner(
+    workspace: &Workspace,
+    requested: &Path,
+) -> std::io::Result<Uuid> {
+    let requested = requested.canonicalize()?;
+    let mission_dir = requested
+        .ancestors()
+        .find(|ancestor| {
+            ancestor
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_prefix("mission-"))
+                .is_some_and(|short| {
+                    short.len() == 8 && short.chars().all(|c| c.is_ascii_hexdigit())
+                })
+                && ancestor
+                    .parent()
+                    .and_then(|parent| parent.file_name())
+                    .and_then(|name| name.to_str())
+                    == Some("workspaces")
+        })
+        .ok_or_else(|| {
+            std::io::Error::other(format!(
+                "explicit working directory {} has no mission workspace owner",
+                requested.display()
+            ))
+        })?;
+    let short = mission_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("mission-"))
+        .expect("checked mission directory name");
+
+    let roots = read_mission_workspace_roots(workspace)?;
+    let mut matches = Vec::new();
+    for (id, record) in roots {
+        if !id.starts_with(short) {
+            continue;
+        }
+        let mission_id = Uuid::parse_str(&id).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid mission root registry id",
+            )
+        })?;
+        let (root, _) = validate_mission_workspace_root(&record)?;
+        let expected = mission_workspace_dir_for_root(&root, mission_id).canonicalize()?;
+        if expected == mission_dir {
+            matches.push(mission_id);
+        }
+    }
+    match matches.as_slice() {
+        [mission_id] => Ok(*mission_id),
+        [] => Err(std::io::Error::other(format!(
+            "explicit working directory {} is not a verified persisted mission placement",
+            requested.display()
+        ))),
+        _ => Err(std::io::Error::other(format!(
+            "explicit working directory {} has ambiguous mission ownership",
+            requested.display()
+        ))),
+    }
+}
+
 /// Atomically replace a registry file and make both the file and the rename
 /// durable before releasing the registry lock. Readers therefore see either a
 /// complete old JSON document or a complete new one, never a truncation.
@@ -1105,7 +1179,7 @@ fn atomic_write_mission_workspace_roots(
 /// Persist the selected root before creating a mission directory.  The
 /// registry lives with the workspace configuration rather than the generated
 /// directory, so it survives restarts and a later environment/config drift.
-fn persist_mission_workspace_root(
+pub(crate) fn persist_mission_workspace_root(
     workspace: &Workspace,
     mission_id: Uuid,
     root: &Path,
@@ -5198,6 +5272,49 @@ WORKING_DIR = "/workspaces/mission-old"
         );
         assert!(mission_workspace_roots_for_workspace(&after_restart)
             .contains(&storage.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn explicit_ancestor_worktree_requires_the_ancestors_verified_filesystem() {
+        let temp = tempfile::tempdir().unwrap();
+        let old_root = temp.path().join("boss-old-filesystem");
+        let new_root = temp.path().join("worker-new-filesystem");
+        std::fs::create_dir_all(&old_root).unwrap();
+        std::fs::create_dir_all(&new_root).unwrap();
+        let workspace = Workspace::default_host(temp.path().to_path_buf());
+        let boss = Uuid::new_v4();
+        let worker = Uuid::new_v4();
+        persist_mission_workspace_root(&workspace, boss, &old_root).unwrap();
+        persist_mission_workspace_root(&workspace, worker, &new_root).unwrap();
+        let boss_worktree = mission_workspace_dir_for_root(&old_root, boss).join("wk-1");
+        std::fs::create_dir_all(&boss_worktree).unwrap();
+
+        assert_eq!(
+            verify_explicit_mission_working_directory_owner(&workspace, &boss_worktree).unwrap(),
+            boss
+        );
+
+        // Model an unmount that leaves a different filesystem at the same
+        // path. The worker's new root remains valid, but it must not authorize
+        // a turn or offload in the boss's stale worktree.
+        let mut roots = read_mission_workspace_roots(&workspace).unwrap();
+        roots
+            .get_mut(&boss.to_string())
+            .unwrap()
+            .filesystem_identity = Some("dev:replaced:ino:root".to_string());
+        atomic_write_mission_workspace_roots(&mission_workspace_roots_path(&workspace), &roots)
+            .unwrap();
+        assert!(
+            verify_explicit_mission_working_directory_owner(&workspace, &boss_worktree).is_err()
+        );
+
+        // Restoring the selected filesystem identity makes the same worktree
+        // usable again; no fallback to the worker's selected root occurred.
+        persist_mission_workspace_root(&workspace, boss, &old_root).unwrap();
+        assert_eq!(
+            verify_explicit_mission_working_directory_owner(&workspace, &boss_worktree).unwrap(),
+            boss
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add a canonical, writable MISSION_WORKSPACE_ROOT for new default-host mission scratch directories, preserving existing mission and workspace locations.
- Use statvfs for workspace filesystem admission and fleet health; include measured path, filesystem ID, free GiB, and required GiB without secrets.
- Default local estimates to 64 GiB with a 150 GiB reserve, including Ask and Telegram actor paths; document future runner-load soft scoring.

## Verification
- cargo fmt --check
- cargo check
- focused admission/path/filesystem tests (pass)
- cargo test --lib: 1906/1907 pass; existing remote-build persistence/timing test remains failing when rerun alone.
- cargo clippy --all-targets -- -D warnings

No existing workspaces or mission directories are moved or deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core mission creation admission, multi-process disk leases, and filesystem identity checks that gate writes, deletes, and GC—incorrect behavior could refuse missions or touch the wrong tree after mount changes.
> 
> **Overview**
> **Mission scratch placement** can target a configurable `MISSION_WORKSPACE_ROOT` (with persisted per-mission roots and filesystem identity); existing workspaces and directories are not moved.
> 
> **Disk pressure and admission** shift from root `/` to the filesystem backing mission workspaces: `statvfs`-based usage drives admission refusals, fleet health (path, filesystem id, free/required GiB), and the disk watcher (per-filesystem alerts and GC sweeps). Defaults tighten to a **64 GiB** default local estimate and **150 GiB** emergency reserve.
> 
> **Durable local-disk accounting** adds a file-locked reservation ledger reconciled against live mission stores on create/restart, with `requires_local_disk` persisted on mission rows (including board workers and the control actor). Reservations release on terminal status when no runner is active; internal reservation tags are blocked from user edits.
> 
> **Fail-closed safety** across Ask, mission runners, FS API, and delete/GC: unverified or replaced persisted roots reject fallback to workspace root; explicit working directories must verify ownership; mission delete refuses when placement cannot be confirmed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197c3d4412d224d73d2b7739be34227be6c5ebd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->