### PR TITLE
fix(projects): stop callback/ingest from painting stale blocked

### DIFF
--- a/patches/hermes/mission_status_route.py
+++ b/patches/hermes/mission_status_route.py
@@ -194,8 +194,7 @@ def format_mission_callback(payload: dict) -> str:
     ]
     if body:
         lines.append(body)
-    # Parked / interrupted turns still wake the controller, but must not
-    # project mode=blocked onto the board (wait_ticks=0 stale chip).
+    # No [CTRL:] — ingest would project mode=blocked from a parked turn.
     emit_ctrl = status not in {
         "awaiting_user",
         "awaitinguser",

--- a/patches/hermes/mission_status_route.py
+++ b/patches/hermes/mission_status_route.py
@@ -185,7 +185,6 @@ def format_mission_callback(payload: dict) -> str:
         payload.get("terminal_evidence") if status != "completed" else None,
     ]
     body = "\n".join(str(b).strip() for b in bits if b and str(b).strip())
-    mode = "active" if status == "completed" else "blocked"
     event_id = extract_event_id(payload)
     lines = [
         f"[Mission callback: {title}]",
@@ -195,14 +194,24 @@ def format_mission_callback(payload: dict) -> str:
     ]
     if body:
         lines.append(body)
+    # Parked / interrupted turns still wake the controller, but must not
+    # project mode=blocked onto the board (wait_ticks=0 stale chip).
+    emit_ctrl = status not in {
+        "awaiting_user",
+        "awaitinguser",
+        "acknowledged",
+        "interrupted",
+    }
     if status != "completed":
         lines.append(
             "If this is infra (missing CLI, auth, workspace), fix or "
             "[DECISION:] — do not stay silent in another session."
         )
-    lines.append(
-        f"[CTRL: {project} | mode={mode} | wait=0 | next=inspect {mission_id}]"
-    )
+    if emit_ctrl:
+        mode = "active" if status == "completed" else "blocked"
+        lines.append(
+            f"[CTRL: {project} | mode={mode} | wait=0 | next=inspect {mission_id}]"
+        )
     lines.append(
         f"[STATE_SIGNATURE: {project}|mission-callback|{mission_id}|{status}|inspect]"
     )

--- a/patches/hermes/test_mission_status_route.py
+++ b/patches/hermes/test_mission_status_route.py
@@ -155,6 +155,23 @@ def test_awaiting_user_callback_omits_ctrl():
     )
 
 
+def test_interrupted_callback_omits_ctrl():
+    text = format_mission_callback(
+        {
+            "mission_id": "acfb03d2",
+            "status": "interrupted",
+            "title": "killed mid-run",
+            "project": "verity-core",
+        }
+    )
+    assert "[CTRL:" not in text
+    assert "mode=blocked" not in text
+    assert (
+        "[STATE_SIGNATURE: verity-core|mission-callback|acfb03d2|interrupted|inspect]"
+        in text
+    )
+
+
 def test_origin_must_reference_the_mission_when_inspectable():
     from gateway.platforms.mission_status_route import append_mission_callback
 

--- a/patches/hermes/test_mission_status_route.py
+++ b/patches/hermes/test_mission_status_route.py
@@ -134,6 +134,27 @@ def test_callback_text_carries_ctrl_and_signature():
     assert "[DECISION:]" in text
 
 
+def test_awaiting_user_callback_omits_ctrl():
+    text = format_mission_callback(
+        {
+            "mission_id": "acfb03d2",
+            "status": "awaiting_user",
+            "title": "need a secret",
+            "project": "verity-core",
+            "short_description": "Waiting on an API key",
+        }
+    )
+    assert "[Mission callback: need a secret]" in text
+    assert "status=awaiting_user mission=acfb03d2" in text
+    assert "Waiting on an API key" in text
+    assert "[CTRL:" not in text
+    assert "mode=blocked" not in text
+    assert (
+        "[STATE_SIGNATURE: verity-core|mission-callback|acfb03d2|awaiting_user|inspect]"
+        in text
+    )
+
+
 def test_origin_must_reference_the_mission_when_inspectable():
     from gateway.platforms.mission_status_route import append_mission_callback
 

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -142,8 +142,8 @@ async fn live_writer_project_slugs(state: &super::routes::AppState) -> HashSet<S
 /// prefix lets readers keep rendering `state` as absent for those.
 const CTRL_DESCRIPTOR_PREFIX: &str = "ctrl:";
 
-/// Mission-complete callbacks always carry `next=inspect`. They wake the
-/// controller but must not project a mode or a "blocker reported" chip.
+/// Headline `[Mission callback:` or descriptor `mission-callback|…|inspect`
+/// (routing key already stripped).
 fn is_mission_inspect_callback(headline: &str, state: Option<&str>) -> bool {
     if headline.starts_with("[Mission callback:") {
         return true;
@@ -256,10 +256,8 @@ fn ingest_deliveries_with_live(
                 1
             }
         };
-        // Replay of an older state returns 0 and must not touch mode/wait.
-        // Inspect callbacks wake the controller but never project a mode.
-        // A batch applies at most the newest delivery per slug so an older
-        // blocked trailer cannot overwrite a newer active one.
+        // record_state / record_silent_observation return 0 for an already-
+        // counted or older delivery; do not project mode from that `at`.
         if observations > 0
             && !is_mission_inspect_callback(&delivery.headline, delivery.state.as_deref())
         {
@@ -272,11 +270,10 @@ fn ingest_deliveries_with_live(
                     wait: observations.saturating_sub(1) as i64,
                     blocker: blocker.map(str::to_string),
                 };
-                match pending_modes.get(slug) {
-                    Some(existing) if existing.at > write.at => {}
-                    _ => {
-                        pending_modes.insert(slug.to_string(), write);
-                    }
+                if pending_modes.get(slug).is_none_or(|existing| {
+                    !super::projects_store::rfc3339_after(&existing.at, &write.at)
+                }) {
+                    pending_modes.insert(slug.to_string(), write);
                 }
             }
         }
@@ -2202,15 +2199,13 @@ impl ProjectRowBuilder {
 
         if let Some(latest) = &self.latest_update {
             if let Some(blocker) = latest.blocker.as_deref() {
-                let inspect =
-                    is_mission_inspect_callback(&latest.headline, latest.state.as_deref());
                 let stale_mode = chrono::DateTime::parse_from_rfc3339(&latest.at)
                     .ok()
                     .zip(chrono::DateTime::parse_from_rfc3339(now).ok())
                     .is_some_and(|(at, now)| {
                         now.signed_duration_since(at) > chrono::Duration::hours(STALE_ACTIVE_HOURS)
                     });
-                if !inspect && !stale_mode {
+                if !stale_mode {
                     attention.push(format!("blocker reported: {blocker}"));
                 }
             }
@@ -4849,6 +4844,8 @@ mod tests {
 
     #[test]
     fn inspect_callback_does_not_add_blocker_reported() {
+        // Ingest never copies inspect onto the roster, so latest_update has
+        // no blocker to chip — even when the newest headline is a callback.
         let mut builder = ProjectRowBuilder::new("verity".into());
         builder.attach_store_update(
             DeliveryUpdate {
@@ -4858,8 +4855,8 @@ mod tests {
                 at: "2026-08-04T11:50:00Z".into(),
                 signature: Some("verity".into()),
                 state: Some("mission-callback|acfb03d2|failed|inspect".into()),
-                mode: Some("blocked".into()),
-                blocker: Some("Codex CLI not found".into()),
+                mode: None,
+                blocker: None,
                 decision: None,
             },
             1,
@@ -4871,6 +4868,34 @@ mod tests {
                 .iter()
                 .any(|r| r.contains("blocker reported")),
             "inspect callbacks must not raise blocker attention: {:?}",
+            row.attention_reasons
+        );
+    }
+
+    #[test]
+    fn inspect_headline_does_not_hide_a_fresh_roster_blocker() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.attach_store_update(
+            DeliveryUpdate {
+                headline: "[Mission callback: coldcard skip kernel]".into(),
+                body: None,
+                session_id: "s".into(),
+                at: "2026-08-04T11:50:00Z".into(),
+                signature: Some("verity".into()),
+                state: Some("mission-callback|acfb03d2|failed|inspect".into()),
+                mode: Some("blocked".into()),
+                blocker: Some("transport-cap".into()),
+                decision: None,
+            },
+            1,
+            1,
+        );
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(
+            row.attention_reasons
+                .iter()
+                .any(|r| r.contains("blocker reported")),
+            "a genuine roster blocker must still chip: {:?}",
             row.attention_reasons
         );
     }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -256,18 +256,30 @@ fn ingest_deliveries_with_live(
                 1
             }
         };
-        // record_state / record_silent_observation return 0 for an already-
-        // counted or older delivery; do not project mode from that `at`.
-        if observations > 0
-            && !is_mission_inspect_callback(&delivery.headline, delivery.state.as_deref())
-        {
+        // Queue the newest gated_mode even when this delivery was already
+        // counted: a crash between record_state and project_mode_from_signal
+        // must retry. The mode watermark rejects older-than-watermark signals,
+        // so a replay stays idempotent. Inspect callbacks still never write.
+        if !is_mission_inspect_callback(&delivery.headline, delivery.state.as_deref()) {
             if let Some(mode) = gated_mode {
                 let base = mode.split_once(':').map_or(mode, |(base, _)| base);
                 let blocker = mode.split_once(':').map(|(_, cause)| cause);
+                let wait = if observations > 0 {
+                    observations.saturating_sub(1) as i64
+                } else {
+                    // Already counted: reuse the stored observation count so
+                    // a retry does not reset wait_ticks to 0.
+                    projects
+                        .state_timeline(slug, 1)
+                        .ok()
+                        .and_then(|events| events.into_iter().next())
+                        .map(|event| event.observations.saturating_sub(1) as i64)
+                        .unwrap_or(0)
+                };
                 let write = PendingModeWrite {
                     at: delivery.at.clone(),
                     mode: base.to_string(),
-                    wait: observations.saturating_sub(1) as i64,
+                    wait,
                     blocker: blocker.map(str::to_string),
                 };
                 if pending_modes.get(slug).is_none_or(|existing| {
@@ -1899,11 +1911,13 @@ pub async fn projects_overview(
         let builder = rows
             .entry(key.clone())
             .or_insert_with(|| ProjectRowBuilder::new(key.clone()));
+        let mode_signal_at = record.mode_signal_at.or(Some(record.updated_at));
         if is_canonical {
             builder.title = record.title;
             builder.next_action = record.next_action;
             builder.mode = record.mode;
             builder.controller_cron_id = record.controller_cron_id;
+            builder.mode_signal_at = mode_signal_at;
         } else {
             builder.title = builder.title.take().or(record.title);
             builder.next_action = builder.next_action.take().or(record.next_action);
@@ -1912,6 +1926,7 @@ pub async fn projects_overview(
                 .controller_cron_id
                 .take()
                 .or(record.controller_cron_id);
+            builder.mode_signal_at = builder.mode_signal_at.take().or(mode_signal_at);
         }
     }
     // The latest ingested state per project becomes the row's latest_update —
@@ -2142,6 +2157,9 @@ struct ProjectRowBuilder {
     /// Health inputs, accumulated alongside the display chips.
     health_inputs: Vec<OwnedHealthInput>,
     latest_update: Option<DeliveryUpdate>,
+    /// When the roster mode/blocker was last written. Ages "blocker reported"
+    /// independently of the newest state-event timestamp.
+    mode_signal_at: Option<String>,
     /// How many consecutive deliveries reported the latest state — the stall
     /// signal's input, read from the store's observation count.
     latest_observations: u32,
@@ -2163,6 +2181,7 @@ impl ProjectRowBuilder {
             missions: Vec::new(),
             health_inputs: Vec::new(),
             latest_update: None,
+            mode_signal_at: None,
             latest_observations: 0,
             updates_count: 0,
             autonomy_level: None,
@@ -2199,7 +2218,13 @@ impl ProjectRowBuilder {
 
         if let Some(latest) = &self.latest_update {
             if let Some(blocker) = latest.blocker.as_deref() {
-                let stale_mode = chrono::DateTime::parse_from_rfc3339(&latest.at)
+                // Age from the mode write, not the newest state event. A
+                // fresh mission callback refreshes `latest.at` without
+                // touching a stale roster blocker; a fresh HTTP set_mode
+                // stamps `mode_signal_at` even when the last state event is
+                // old.
+                let signal_at = self.mode_signal_at.as_deref().unwrap_or(&latest.at);
+                let stale_mode = chrono::DateTime::parse_from_rfc3339(signal_at)
                     .ok()
                     .zip(chrono::DateTime::parse_from_rfc3339(now).ok())
                     .is_some_and(|(at, now)| {
@@ -4904,6 +4929,7 @@ mod tests {
     fn stale_blocker_signal_does_not_raise_blocker_reported() {
         let mut builder = ProjectRowBuilder::new("verity".into());
         builder.controller_cron_id = Some("cron-1".into());
+        builder.mode_signal_at = Some("2026-08-02T11:00:00Z".into());
         builder.attach_store_update(
             active_update("2026-08-02T11:00:00Z", Some("waiting on CI")),
             1,
@@ -4918,5 +4944,115 @@ mod tests {
             row.attention_reasons
         );
         assert_eq!(row.controller_health, Some("stale"));
+    }
+
+    #[test]
+    fn stale_roster_blocker_does_not_chip_when_state_event_is_fresh() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.mode_signal_at = Some("2026-08-02T11:00:00Z".into());
+        builder.attach_store_update(
+            active_update("2026-08-04T11:50:00Z", Some("waiting on CI")),
+            1,
+            5,
+        );
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(
+            !row.attention_reasons
+                .iter()
+                .any(|r| r.contains("blocker reported")),
+            "a stale roster blocker must not look new just because a callback refreshed latest.at: {:?}",
+            row.attention_reasons
+        );
+    }
+
+    #[test]
+    fn fresh_mode_signal_chips_even_when_state_event_is_old() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.mode_signal_at = Some("2026-08-04T11:50:00Z".into());
+        builder.attach_store_update(
+            active_update("2026-08-02T11:00:00Z", Some("waiting on CI")),
+            1,
+            5,
+        );
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(
+            row.attention_reasons
+                .iter()
+                .any(|r| r.contains("blocker reported")),
+            "a fresh HTTP/mode signal must chip even when the last state event is old: {:?}",
+            row.attention_reasons
+        );
+    }
+
+    #[test]
+    fn already_counted_delivery_retries_deferred_mode_write() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity", None, None, None, None)
+            .expect("seed");
+        let content = "[Cron delivery: Verity]\nBlocked\n\
+                       [CTRL: verity | mode=blocked:lease | wait=0 | next=wait]\n\
+                       [STATE_SIGNATURE: verity|phase|head|blocked]\n";
+        let delivery = parse_delivery("sess", 1_754_003_600.0, content);
+        // State committed, mode write lost — the crash window the next scan
+        // must retry instead of treating observations==0 as completion.
+        let descriptor = delivery.state.clone().expect("descriptor");
+        assert_eq!(
+            store
+                .record_state(
+                    "verity",
+                    &descriptor,
+                    Some(delivery.headline.as_str()),
+                    &delivery.at,
+                    Some("sess"),
+                )
+                .expect("pre-record"),
+            1
+        );
+        assert_eq!(
+            store
+                .get_project("verity")
+                .expect("read")
+                .expect("present")
+                .mode,
+            None
+        );
+        ingest_deliveries(&store, &HashMap::new(), &HashMap::new(), vec![delivery]);
+        let record = store.get_project("verity").expect("read").expect("present");
+        assert_eq!(record.mode.as_deref(), Some("blocked"));
+        assert_eq!(record.blocker.as_deref(), Some("lease"));
+        assert_eq!(record.wait_ticks, 0);
+        assert!(record.mode_signal_at.is_some());
+    }
+
+    #[test]
+    fn replaying_an_already_applied_mode_does_not_reset_wait() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        for i in 0..3 {
+            let tick = "[Cron delivery: Lido]\n[SILENT]\n[CTRL: lido | mode=blocked:transport-cap | wait=0 | next=x]";
+            ingest_deliveries(
+                &store,
+                &HashMap::new(),
+                &HashMap::new(),
+                vec![parse_delivery(
+                    &format!("sess-{i}"),
+                    1_754_000_000.0 + (i as f64) * 60.0,
+                    tick,
+                )],
+            );
+        }
+        let before = store.get_project("lido").expect("read").expect("present");
+        assert_eq!(before.wait_ticks, 2);
+        let last = "[Cron delivery: Lido]\n[SILENT]\n[CTRL: lido | mode=blocked:transport-cap | wait=0 | next=x]";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            vec![parse_delivery("sess-2", 1_754_000_000.0 + 120.0, last)],
+        );
+        let after = store.get_project("lido").expect("read").expect("present");
+        assert_eq!(after.mode.as_deref(), Some("blocked"));
+        assert_eq!(after.blocker.as_deref(), Some("transport-cap"));
+        assert_eq!(after.wait_ticks, 2);
     }
 }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -142,6 +142,27 @@ async fn live_writer_project_slugs(state: &super::routes::AppState) -> HashSet<S
 /// prefix lets readers keep rendering `state` as absent for those.
 const CTRL_DESCRIPTOR_PREFIX: &str = "ctrl:";
 
+/// Mission-complete callbacks always carry `next=inspect`. They wake the
+/// controller but must not project a mode or a "blocker reported" chip.
+fn is_mission_inspect_callback(headline: &str, state: Option<&str>) -> bool {
+    if headline.starts_with("[Mission callback:") {
+        return true;
+    }
+    state.is_some_and(|descriptor| {
+        let mut parts = descriptor.split('|');
+        parts.next() == Some("mission-callback") && parts.next_back() == Some("inspect")
+    })
+}
+
+/// Newest pending `[CTRL:]` mode per slug, applied after the oldest-first
+/// timeline replay so a mixed batch cannot let an older blocked trailer win.
+struct PendingModeWrite {
+    at: String,
+    mode: String,
+    wait: i64,
+    blocker: Option<String>,
+}
+
 /// Fold one batch of deliveries into the projects store.
 ///
 /// This is THE delivery router: alias resolution, roster auto-upsert, state
@@ -163,6 +184,7 @@ fn ingest_deliveries_with_live(
     deliveries: Vec<DeliveryUpdate>,
     live_projects: &HashSet<String>,
 ) {
+    let mut pending_modes: HashMap<String, PendingModeWrite> = HashMap::new();
     // read_deliveries returns newest-first; replay oldest-first so a
     // run of the same state lands as one extended row rather than
     // being rejected as out-of-order.
@@ -234,22 +256,28 @@ fn ingest_deliveries_with_live(
                 1
             }
         };
-        // Project the controller's `[CTRL: … mode=… ]` mode onto the
-        // project record — independent of the descriptor, so a
-        // CTRL-only delivery still updates the mode column. Idempotent
-        // on replay: `wait` comes from the observation count, not a
-        // per-call increment.
-        if let Some(mode) = gated_mode {
-            let base = mode.split_once(':').map_or(mode, |(base, _)| base);
-            let blocker = mode.split_once(':').map(|(_, cause)| cause);
-            if let Err(error) = projects.project_mode_from_signal(
-                slug,
-                base,
-                observations.saturating_sub(1) as i64,
-                None,
-                blocker,
-            ) {
-                tracing::warn!("state ingest mode: {slug}: {error}");
+        // Replay of an older state returns 0 and must not touch mode/wait.
+        // Inspect callbacks wake the controller but never project a mode.
+        // A batch applies at most the newest delivery per slug so an older
+        // blocked trailer cannot overwrite a newer active one.
+        if observations > 0
+            && !is_mission_inspect_callback(&delivery.headline, delivery.state.as_deref())
+        {
+            if let Some(mode) = gated_mode {
+                let base = mode.split_once(':').map_or(mode, |(base, _)| base);
+                let blocker = mode.split_once(':').map(|(_, cause)| cause);
+                let write = PendingModeWrite {
+                    at: delivery.at.clone(),
+                    mode: base.to_string(),
+                    wait: observations.saturating_sub(1) as i64,
+                    blocker: blocker.map(str::to_string),
+                };
+                match pending_modes.get(slug) {
+                    Some(existing) if existing.at > write.at => {}
+                    _ => {
+                        pending_modes.insert(slug.to_string(), write);
+                    }
+                }
             }
         }
         // A `[DECISION: …]` trailer reaches the ledger through the same
@@ -305,6 +333,18 @@ fn ingest_deliveries_with_live(
             ) {
                 tracing::warn!("state ingest close merged decisions: {slug}: {error}");
             }
+        }
+    }
+    for (slug, write) in pending_modes {
+        if let Err(error) = projects.project_mode_from_signal(
+            &slug,
+            &write.mode,
+            write.wait,
+            None,
+            write.blocker.as_deref(),
+            Some(write.at.as_str()),
+        ) {
+            tracing::warn!("state ingest mode: {slug}: {error}");
         }
     }
 }
@@ -2162,7 +2202,17 @@ impl ProjectRowBuilder {
 
         if let Some(latest) = &self.latest_update {
             if let Some(blocker) = latest.blocker.as_deref() {
-                attention.push(format!("blocker reported: {blocker}"));
+                let inspect =
+                    is_mission_inspect_callback(&latest.headline, latest.state.as_deref());
+                let stale_mode = chrono::DateTime::parse_from_rfc3339(&latest.at)
+                    .ok()
+                    .zip(chrono::DateTime::parse_from_rfc3339(now).ok())
+                    .is_some_and(|(at, now)| {
+                        now.signed_duration_since(at) > chrono::Duration::hours(STALE_ACTIVE_HOURS)
+                    });
+                if !inspect && !stale_mode {
+                    attention.push(format!("blocker reported: {blocker}"));
+                }
             }
             // Same non-silent state three ticks in a row: the controller
             // keeps reporting an unchanged world — the phantom-lease shape.
@@ -3926,7 +3976,9 @@ mod tests {
         let mut builder = ProjectRowBuilder::new("verity".to_string());
         // Three deliveries of SAMPLE collapse in the store into one state
         // event with observations=3; the builder sees that count.
-        builder.attach_store_update(parse_delivery("s", 3.0, SAMPLE), 3, 3);
+        let mut update = parse_delivery("s", 1_754_000_000.0, SAMPLE);
+        update.at = "2026-08-04T11:00:00Z".into();
+        builder.attach_store_update(update, 3, 3);
         let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
         assert_eq!(row.bucket, "attention");
         assert!(row.attention_reasons.iter().any(|r| r.contains("blocker")));
@@ -4685,5 +4737,161 @@ mod tests {
         assert_eq!(record.blocker.as_deref(), Some("transport-cap"));
         assert_eq!(record.wait_ticks, 2);
         assert_eq!(store.state_event_totals().expect("totals")["lido"], 3);
+    }
+
+    #[test]
+    fn older_blocked_replay_does_not_paint_mode_or_reset_wait() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity", None, None, None, None)
+            .expect("seed");
+        let newer = "[Cron delivery: Verity]\nCertify merged\n\
+                     [CTRL: verity | mode=active | wait=2 | next=x]\n\
+                     [STATE_SIGNATURE: verity|phase|head|clean]\n";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            vec![parse_delivery("sess-new", 1_754_003_600.0, newer)],
+        );
+        store
+            .project_mode_from_signal("verity", "active", 2, None, None, None)
+            .expect("seed wait");
+        let before = store.get_project("verity").expect("read").expect("present");
+        assert_eq!(before.mode.as_deref(), Some("active"));
+        assert_eq!(before.wait_ticks, 2);
+
+        let older = "[Cron delivery: Verity]\nBLOQUÉE\n**Blocked by:** stale lease\n\
+                     [CTRL: verity | mode=blocked:lease | wait=0 | next=inspect x]\n\
+                     [STATE_SIGNATURE: verity|phase-old|head|blocked]\n";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            vec![parse_delivery("sess-old", 1_754_000_000.0, older)],
+        );
+        let after = store.get_project("verity").expect("read").expect("present");
+        assert_eq!(after.mode.as_deref(), Some("active"));
+        assert_eq!(after.wait_ticks, 2);
+    }
+
+    #[test]
+    fn http_set_mode_survives_older_ingest_callback() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity", None, None, None, None)
+            .expect("seed");
+        store
+            .set_mode("verity", "active", Some("continue"), None)
+            .expect("http");
+        // A regular (non-inspect) older blocked CTRL must still lose to the
+        // HTTP watermark — inspect callbacks are skipped earlier.
+        let older = "[Cron delivery: Verity]\nOld block\n\
+                     [CTRL: verity | mode=blocked:lease | wait=0 | next=wait]\n\
+                     [STATE_SIGNATURE: verity|old|head|blocked]\n";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            vec![parse_delivery("sess-old", 1_754_000_000.0, older)],
+        );
+        let record = store.get_project("verity").expect("read").expect("present");
+        assert_eq!(record.mode.as_deref(), Some("active"));
+    }
+
+    #[test]
+    fn inspect_callback_does_not_write_mode() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity", None, None, None, None)
+            .expect("seed");
+        store
+            .set_mode("verity", "active", Some("continue"), None)
+            .expect("http");
+        let callback = "[Mission callback: coldcard skip kernel]\n\
+                        status=failed mission=acfb03d2\n\
+                        Codex CLI not found\n\
+                        [CTRL: verity | mode=blocked | wait=0 | next=inspect acfb03d2]\n\
+                        [STATE_SIGNATURE: verity|mission-callback|acfb03d2|failed|inspect]\n";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            vec![parse_delivery("sess-cb", 1_754_003_600.0, callback)],
+        );
+        let record = store.get_project("verity").expect("read").expect("present");
+        assert_eq!(record.mode.as_deref(), Some("active"));
+    }
+
+    #[test]
+    fn newest_delivery_in_a_mixed_batch_wins_mode() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        let older = "[Cron delivery: Verity]\nOld block\n\
+                     [CTRL: verity | mode=blocked:lease | wait=0 | next=wait]\n\
+                     [STATE_SIGNATURE: verity|old|head|blocked]\n";
+        let newer = "[Cron delivery: Verity]\nMoved on\n\
+                     [CTRL: verity | mode=active | wait=0 | next=x]\n\
+                     [STATE_SIGNATURE: verity|new|head|clean]\n";
+        ingest_deliveries(
+            &store,
+            &HashMap::new(),
+            &HashMap::new(),
+            // Newest-first, as read_deliveries returns them.
+            vec![
+                parse_delivery("sess-new", 1_754_003_600.0, newer),
+                parse_delivery("sess-old", 1_754_000_000.0, older),
+            ],
+        );
+        let record = store.get_project("verity").expect("read").expect("present");
+        assert_eq!(record.mode.as_deref(), Some("active"));
+        assert_eq!(record.blocker, None);
+    }
+
+    #[test]
+    fn inspect_callback_does_not_add_blocker_reported() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.attach_store_update(
+            DeliveryUpdate {
+                headline: "[Mission callback: coldcard skip kernel]".into(),
+                body: None,
+                session_id: "s".into(),
+                at: "2026-08-04T11:50:00Z".into(),
+                signature: Some("verity".into()),
+                state: Some("mission-callback|acfb03d2|failed|inspect".into()),
+                mode: Some("blocked".into()),
+                blocker: Some("Codex CLI not found".into()),
+                decision: None,
+            },
+            1,
+            1,
+        );
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(
+            !row.attention_reasons
+                .iter()
+                .any(|r| r.contains("blocker reported")),
+            "inspect callbacks must not raise blocker attention: {:?}",
+            row.attention_reasons
+        );
+    }
+
+    #[test]
+    fn stale_blocker_signal_does_not_raise_blocker_reported() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.controller_cron_id = Some("cron-1".into());
+        builder.attach_store_update(
+            active_update("2026-08-02T11:00:00Z", Some("waiting on CI")),
+            1,
+            5,
+        );
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(
+            !row.attention_reasons
+                .iter()
+                .any(|r| r.contains("blocker reported")),
+            "a 24h-stale mode signal must not paint a fresh BLOCKED: {:?}",
+            row.attention_reasons
+        );
+        assert_eq!(row.controller_health, Some("stale"));
     }
 }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -267,13 +267,15 @@ fn ingest_deliveries_with_live(
                 let wait = if observations > 0 {
                     observations.saturating_sub(1) as i64
                 } else {
-                    // Already counted: reuse the stored observation count so
-                    // a retry does not reset wait_ticks to 0.
+                    // Already counted: keep the roster wait, not the newest
+                    // state event's observations. A later callback can open a
+                    // new 1-observation row; reading that would reset
+                    // wait_ticks to 0 on every overlapping scan.
                     projects
-                        .state_timeline(slug, 1)
+                        .get_project(slug)
                         .ok()
-                        .and_then(|events| events.into_iter().next())
-                        .map(|event| event.observations.saturating_sub(1) as i64)
+                        .flatten()
+                        .map(|record| record.wait_ticks)
                         .unwrap_or(0)
                 };
                 let write = PendingModeWrite {

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -243,6 +243,13 @@ impl ProjectsStore {
             "mode_signal_at",
             "mode_signal_at TEXT",
         )?;
+        // Rows that already had a mode before this column existed must not
+        // look unstamped: the first ingest would otherwise overwrite them.
+        connection.execute(
+            "UPDATE projects SET mode_signal_at = updated_at \
+             WHERE mode_signal_at IS NULL AND mode IS NOT NULL",
+            [],
+        )?;
         connection.execute_batch(
             "CREATE INDEX IF NOT EXISTS idx_project_decisions_status \
              ON project_decisions(slug, status);",
@@ -405,7 +412,9 @@ impl ProjectsStore {
     ///
     /// Idempotent on `at`: the ingestor re-reads an overlapping window every
     /// cycle, so replaying a delivery it has already seen must not inflate the
-    /// count. Returns the resulting observation count for this state.
+    /// count. Returns the resulting observation count, or `0` when this `at`
+    /// was already counted (or is older than the open event) so ingest can
+    /// skip mode.
     pub fn record_state(
         &self,
         slug: &str,
@@ -430,7 +439,7 @@ impl ProjectsStore {
             if open_signature == signature {
                 // Already counted, or older than what we have: nothing to do.
                 if at <= last_seen_at.as_str() {
-                    return Ok(observations);
+                    return Ok(0);
                 }
                 connection
                     .execute(
@@ -476,7 +485,7 @@ impl ProjectsStore {
     /// exists at all is one created, with `descriptor` and no headline.
     ///
     /// Idempotent on `at`, same as [`Self::record_state`]. Returns the
-    /// resulting observation count.
+    /// resulting observation count, or `0` when this `at` was already counted.
     pub fn record_silent_observation(
         &self,
         slug: &str,
@@ -499,7 +508,7 @@ impl ProjectsStore {
         if let Some((first_seen_at, last_seen_at, observations)) = current {
             // Already counted, or older than what we have: nothing to do.
             if at <= last_seen_at.as_str() {
-                return Ok(observations);
+                return Ok(0);
             }
             connection
                 .execute(
@@ -975,13 +984,26 @@ impl ProjectsStore {
         let connection = self.lock()?;
         match at {
             Some(at) => {
-                // HTTP set_mode stamps mode_signal_at; refuse an older delivery
-                // so a finished-turn callback cannot undo a newer controller write.
+                let watermark: Option<String> = connection
+                    .query_row(
+                        "SELECT mode_signal_at FROM projects WHERE slug = ?1",
+                        params![slug],
+                        |row| row.get(0),
+                    )
+                    .optional()
+                    .map_err(|e| e.to_string())?
+                    .flatten();
+                if watermark
+                    .as_deref()
+                    .is_some_and(|watermark| !rfc3339_at_least(at, watermark))
+                {
+                    return Ok(());
+                }
                 connection
                     .execute(
                         "UPDATE projects SET mode = ?2, wait_ticks = ?3, next_action = ?4, \
                          blocker = ?5, updated_at = ?6, mode_signal_at = ?7 \
-                         WHERE slug = ?1 AND (mode_signal_at IS NULL OR ?7 >= mode_signal_at)",
+                         WHERE slug = ?1",
                         params![slug, mode, wait, next_action, blocker, now, at],
                     )
                     .map_err(|e| e.to_string())?;
@@ -1528,6 +1550,32 @@ pub struct UnroutedDelivery {
     pub blocker: Option<String>,
 }
 
+/// Parsed RFC3339 compare so `Z` and `+00:00` (and other offsets) order by
+/// instant, not by the serialized suffix.
+pub(crate) fn rfc3339_at_least(candidate: &str, watermark: &str) -> bool {
+    match (
+        chrono::DateTime::parse_from_rfc3339(candidate),
+        chrono::DateTime::parse_from_rfc3339(watermark),
+    ) {
+        (Ok(candidate), Ok(watermark)) => candidate >= watermark,
+        // Unparseable candidate must not clobber a known watermark.
+        (Err(_), Ok(_)) => false,
+        _ => true,
+    }
+}
+
+/// Strict instant compare for newest-in-batch selection. Unparseable
+/// values fall back to string order.
+pub(crate) fn rfc3339_after(candidate: &str, existing: &str) -> bool {
+    match (
+        chrono::DateTime::parse_from_rfc3339(candidate),
+        chrono::DateTime::parse_from_rfc3339(existing),
+    ) {
+        (Ok(candidate), Ok(existing)) => candidate > existing,
+        _ => candidate > existing,
+    }
+}
+
 /// A project as an object in its own right, not a union reconstructed per read.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ProjectRecord {
@@ -1935,12 +1983,34 @@ mod tests {
             .record_state("verity", "blocked", None, "2026-08-04T10:15:00Z", None)
             .expect("record");
         for _ in 0..5 {
-            store
-                .record_state("verity", "blocked", None, "2026-08-04T10:15:00Z", None)
-                .expect("replay");
+            assert_eq!(
+                store
+                    .record_state("verity", "blocked", None, "2026-08-04T10:15:00Z", None)
+                    .expect("replay"),
+                0
+            );
         }
         let timeline = store.state_timeline("verity", 10).expect("timeline");
         assert_eq!(timeline[0].observations, 2);
+    }
+
+    #[test]
+    fn silent_replay_returns_zero_and_does_not_extend() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        assert_eq!(
+            store
+                .record_silent_observation("verity", "ctrl:active", "2026-08-04T10:00:00Z", None)
+                .expect("first"),
+            1
+        );
+        assert_eq!(
+            store
+                .record_silent_observation("verity", "ctrl:blocked", "2026-08-04T10:00:00Z", None)
+                .expect("replay"),
+            0
+        );
+        let timeline = store.state_timeline("verity", 10).expect("timeline");
+        assert_eq!(timeline[0].observations, 1);
     }
 
     /// An out-of-order delivery from the overlap window must not be recorded
@@ -2134,6 +2204,73 @@ mod tests {
         assert_eq!(after.mode.as_deref(), Some("active"));
         assert_eq!(after.wait_ticks, 1);
         assert_eq!(after.blocker, None);
+    }
+
+    #[test]
+    fn rfc3339_watermark_compares_instants_not_suffixes() {
+        assert!(rfc3339_at_least(
+            "2026-08-16T12:00:00Z",
+            "2026-08-16T12:00:00+00:00"
+        ));
+        assert!(rfc3339_at_least(
+            "2026-08-16T12:00:00+00:00",
+            "2026-08-16T12:00:00Z"
+        ));
+        assert!(!rfc3339_at_least(
+            "2026-08-16T11:00:00Z",
+            "2026-08-16T12:00:00+00:00"
+        ));
+        assert!(rfc3339_after(
+            "2026-08-16T13:00:00Z",
+            "2026-08-16T12:00:00+00:00"
+        ));
+        assert!(!rfc3339_after(
+            "2026-08-16T12:00:00Z",
+            "2026-08-16T12:00:00+00:00"
+        ));
+    }
+
+    #[test]
+    fn mode_signal_at_backfills_from_updated_at_on_existing_modes() {
+        let connection = Connection::open_in_memory().expect("conn");
+        connection
+            .execute_batch(
+                "CREATE TABLE projects (
+                    slug TEXT PRIMARY KEY NOT NULL,
+                    title TEXT, objective TEXT,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    mode TEXT,
+                    wait_ticks INTEGER NOT NULL DEFAULT 0,
+                    next_action TEXT, blocker TEXT,
+                    controller_cron_id TEXT, repository TEXT,
+                    created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+                );
+                INSERT INTO projects
+                    (slug, status, mode, wait_ticks, created_at, updated_at)
+                VALUES
+                    ('bench', 'active', 'active', 0,
+                     '2026-08-01T00:00:00Z', '2026-08-10T12:00:00Z'),
+                    ('idle', 'active', NULL, 0,
+                     '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');",
+            )
+            .expect("old schema");
+        ProjectsStore::initialize(&connection).expect("migrate");
+        let stamped: String = connection
+            .query_row(
+                "SELECT mode_signal_at FROM projects WHERE slug = 'bench'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("stamped");
+        assert_eq!(stamped, "2026-08-10T12:00:00Z");
+        let idle: Option<String> = connection
+            .query_row(
+                "SELECT mode_signal_at FROM projects WHERE slug = 'idle'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("idle");
+        assert_eq!(idle, None);
     }
 
     #[test]

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -80,7 +80,10 @@ CREATE TABLE IF NOT EXISTS projects (
     controller_cron_id TEXT,                             -- the controller<->project link
     repository         TEXT,
     created_at         TEXT NOT NULL,
-    updated_at         TEXT NOT NULL
+    updated_at         TEXT NOT NULL,
+    -- Watermark for the last mode write. HTTP set_mode stamps now; ingest
+    -- only overwrites when the delivery is at least this new.
+    mode_signal_at     TEXT
 );
 
 -- The autonomy grant, structured so it survives a controller rewriting its own
@@ -233,6 +236,12 @@ impl ProjectsStore {
             "project_grant",
             "autonomy_level",
             "autonomy_level TEXT",
+        )?;
+        Self::ensure_column(
+            connection,
+            "projects",
+            "mode_signal_at",
+            "mode_signal_at TEXT",
         )?;
         connection.execute_batch(
             "CREATE INDEX IF NOT EXISTS idx_project_decisions_status \
@@ -937,7 +946,7 @@ impl ProjectsStore {
             .execute(
                 "UPDATE projects SET mode = ?2, next_action = ?3, blocker = ?4, \
                  wait_ticks = CASE WHEN ?5 THEN wait_ticks + 1 ELSE 0 END, \
-                 updated_at = ?6 WHERE slug = ?1",
+                 updated_at = ?6, mode_signal_at = ?6 WHERE slug = ?1",
                 params![slug, mode, next_action, blocker, unchanged, now],
             )
             .map_err(|e| e.to_string())?;
@@ -960,16 +969,33 @@ impl ProjectsStore {
         wait: i64,
         next_action: Option<&str>,
         blocker: Option<&str>,
+        at: Option<&str>,
     ) -> Result<(), String> {
         let now = Utc::now().to_rfc3339();
         let connection = self.lock()?;
-        connection
-            .execute(
-                "UPDATE projects SET mode = ?2, wait_ticks = ?3, next_action = ?4, \
-                 blocker = ?5, updated_at = ?6 WHERE slug = ?1",
-                params![slug, mode, wait, next_action, blocker, now],
-            )
-            .map_err(|e| e.to_string())?;
+        match at {
+            Some(at) => {
+                // HTTP set_mode stamps mode_signal_at; refuse an older delivery
+                // so a finished-turn callback cannot undo a newer controller write.
+                connection
+                    .execute(
+                        "UPDATE projects SET mode = ?2, wait_ticks = ?3, next_action = ?4, \
+                         blocker = ?5, updated_at = ?6, mode_signal_at = ?7 \
+                         WHERE slug = ?1 AND (mode_signal_at IS NULL OR ?7 >= mode_signal_at)",
+                        params![slug, mode, wait, next_action, blocker, now, at],
+                    )
+                    .map_err(|e| e.to_string())?;
+            }
+            None => {
+                connection
+                    .execute(
+                        "UPDATE projects SET mode = ?2, wait_ticks = ?3, next_action = ?4, \
+                         blocker = ?5, updated_at = ?6 WHERE slug = ?1",
+                        params![slug, mode, wait, next_action, blocker, now],
+                    )
+                    .map_err(|e| e.to_string())?;
+            }
+        }
         Ok(())
     }
 
@@ -2059,7 +2085,7 @@ mod tests {
         let store = ProjectsStore::open_in_memory().expect("store");
         // No project row: the ingestor must not create one from a trailer.
         store
-            .project_mode_from_signal("ghost", "active", 0, None, None)
+            .project_mode_from_signal("ghost", "active", 0, None, None, None)
             .expect("no-op, not an error");
         assert!(store.get_project("ghost").expect("read").is_none());
 
@@ -2069,15 +2095,45 @@ mod tests {
         // Replaying the same signal twice does not inflate wait — it is passed
         // in, not incremented, so overlapping ingest cycles are harmless.
         store
-            .project_mode_from_signal("bench", "blocked", 2, None, Some("transport-cap"))
+            .project_mode_from_signal("bench", "blocked", 2, None, Some("transport-cap"), None)
             .expect("m1");
         store
-            .project_mode_from_signal("bench", "blocked", 2, None, Some("transport-cap"))
+            .project_mode_from_signal("bench", "blocked", 2, None, Some("transport-cap"), None)
             .expect("m2 replay");
         let p = store.get_project("bench").expect("read").expect("present");
         assert_eq!(p.mode.as_deref(), Some("blocked"));
         assert_eq!(p.wait_ticks, 2);
         assert_eq!(p.blocker.as_deref(), Some("transport-cap"));
+    }
+
+    #[test]
+    fn mode_signal_watermark_refuses_older_deliveries() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("bench", None, None, None, None)
+            .expect("seed");
+        store
+            .set_mode("bench", "active", None, None)
+            .expect("http set_mode");
+        store.set_mode("bench", "active", None, None).expect("tick");
+        let before = store.get_project("bench").expect("read").expect("present");
+        assert_eq!(before.mode.as_deref(), Some("active"));
+        assert_eq!(before.wait_ticks, 1);
+
+        store
+            .project_mode_from_signal(
+                "bench",
+                "blocked",
+                0,
+                None,
+                Some("stale-callback"),
+                Some("2020-01-01T00:00:00Z"),
+            )
+            .expect("older signal");
+        let after = store.get_project("bench").expect("read").expect("present");
+        assert_eq!(after.mode.as_deref(), Some("active"));
+        assert_eq!(after.wait_ticks, 1);
+        assert_eq!(after.blocker, None);
     }
 
     #[test]

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -728,7 +728,8 @@ impl ProjectsStore {
             .prepare(
                 "SELECT slug, title, objective, status, mode, wait_ticks, \
                  next_action, blocker, controller_cron_id, repository, \
-                 created_at, updated_at FROM projects ORDER BY updated_at DESC, slug",
+                 created_at, updated_at, mode_signal_at FROM projects \
+                 ORDER BY updated_at DESC, slug",
             )
             .map_err(|e| e.to_string())?;
         let rows = statement
@@ -745,7 +746,7 @@ impl ProjectsStore {
             .query_row(
                 "SELECT slug, title, objective, status, mode, wait_ticks, \
                  next_action, blocker, controller_cron_id, repository, \
-                 created_at, updated_at FROM projects WHERE slug = ?1",
+                 created_at, updated_at, mode_signal_at FROM projects WHERE slug = ?1",
                 params![slug],
                 Self::project_from_row,
             )
@@ -891,6 +892,7 @@ impl ProjectsStore {
             repository: row.get(9)?,
             created_at: row.get(10)?,
             updated_at: row.get(11)?,
+            mode_signal_at: row.get(12)?,
         })
     }
 
@@ -1598,6 +1600,8 @@ pub struct ProjectRecord {
     pub repository: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode_signal_at: Option<String>,
 }
 
 /// A chat-planned roadmap item: the project-scoped precursor of a board task.
@@ -2126,7 +2130,12 @@ mod tests {
         store
             .set_mode("bench", "active", Some("run"), None)
             .expect("m1");
-        assert_eq!(store.get_project("bench").unwrap().unwrap().wait_ticks, 0);
+        let after_http = store.get_project("bench").unwrap().unwrap();
+        assert_eq!(after_http.wait_ticks, 0);
+        assert!(
+            after_http.mode_signal_at.is_some(),
+            "HTTP set_mode must stamp mode_signal_at so explicit blockers stay fresh"
+        );
 
         // Same mode+blocker two more ticks: the counter is how long it's been here.
         store


### PR DESCRIPTION
## Summary
- Mission-complete callbacks no longer emit `[CTRL: mode=blocked]` on `awaiting_user`.
- Ingest ignores `record_state=0` for mode, applies at most the newest delivery per slug, and will not overwrite a newer HTTP `set_mode`.
- Inspect callbacks do not become a fresh BLOCKED chip.

Fixes the Verity/Lido/Lean Silicon ghost `blocked` + `wait_ticks=0` lie.

## Test plan
- [ ] `cargo test --lib api::projects`
- [ ] Hermes pytest for `mission_status_route`
- [ ] After Hermes patch deploy: next `awaiting_user` callback must not flip a project to blocked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core delivery ingest and roster mode projection; behavior changes are well-tested but wrong watermark logic could leave modes stale or ignore legitimate CTRL updates.
> 
> **Overview**
> Stops **ghost `blocked`** on the projects board when missions park or ingest replays overlap.
> 
> **Hermes** — `format_mission_callback` skips the `[CTRL: … mode=blocked]` trailer for `awaiting_user`, `acknowledged`, and `interrupted` (still emits `STATE_SIGNATURE` with `inspect`). Failed/completed paths unchanged.
> 
> **Ingest / store** — Adds `mode_signal_at` and applies mode only from the **newest** delivery per slug after the batch replay; `project_mode_from_signal` ignores signals older than the watermark (HTTP `set_mode` stamps it). **Mission inspect** callbacks never write roster mode. `record_state` / silent replay return **0** when `at` was already counted so mode is not derived from stale observation counts; deferred mode writes still retry after a crash.
> 
> **Overview** — "blocker reported" attention uses `mode_signal_at` (not just the latest state event time) so a fresh callback headline does not make an old blocker look new.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91c2cb82eb19f51daa946045c6fbc528481fe82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->