### PR TITLE
fix(grok): refuse cross-arch host CLI copies into containers

### DIFF
--- a/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
+++ b/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
@@ -78,7 +78,12 @@ export function MissionWorkbenchPanel({
     mission?.title?.trim() ||
     (mission ? getMissionShortName(mission.id) : "No mission selected");
   const status = mission
-    ? missionStatusLabel(mission.status, isRunning, mission.awaiting_kind)
+    ? missionStatusLabel(
+        mission.status,
+        isRunning,
+        mission.awaiting_kind,
+        mission.needs_operator === true,
+      )
     : null;
   const canResume =
     mission &&

--- a/dashboard/src/app/control/components/common.tsx
+++ b/dashboard/src/app/control/components/common.tsx
@@ -55,6 +55,7 @@ export function missionStatusLabel(
   status: MissionStatus,
   isRunning = false,
   awaitingKind?: AwaitingKind | null,
+  needsOperator = false,
 ): {
   label: string;
   className: string;
@@ -75,15 +76,15 @@ export function missionStatusLabel(
       };
     case "awaiting_user":
       // Distinguish "agent asked a question" (decision) from "agent finished,
-      // waiting to be acked/merged" (ack). The old single "Needs You" label
-      // was ambiguous.
+      // waiting to be acked/merged" (ack). Missing kind is Awaiting Review
+      // unless the API marked this a qualified operator page.
       if (awaitingKind === "decision") {
         return {
           label: "Needs Decision",
           className: "bg-amber-500/20 text-amber-400",
         };
       }
-      if (awaitingKind === "ack") {
+      if (awaitingKind === "ack" || !needsOperator) {
         return {
           label: "Awaiting Review",
           className: "bg-sky-500/20 text-sky-400",

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -9045,6 +9045,7 @@ export default function ControlClient() {
         activeMission.status,
         viewingMissionIsRunning,
         activeMission.awaiting_kind,
+        activeMission.needs_operator === true,
       )
     : null;
   const faviconStatus = useMemo<MissionStatus | null>(() => {

--- a/dashboard/src/app/overview/page.tsx
+++ b/dashboard/src/app/overview/page.tsx
@@ -108,7 +108,11 @@ const CompactMissionCard = memo(function CompactMissionCard({
   onDelete: (id: string) => void;
   onToggleWorkers?: (id: string) => void;
 }) {
-  const color = getMissionTextColor(mission.status, isRunningForDisplay);
+  const color = getMissionTextColor(
+    mission.status,
+    isRunningForDisplay,
+    mission.awaiting_kind,
+  );
   const title = getMissionTitle(mission);
   const groupedWorkers = workers ?? [];
   const hasWorkers = groupedWorkers.length > 0;
@@ -366,10 +370,9 @@ function OverviewPageContent() {
     }
   );
 
-  // Missions parked on a frontend tool (e.g. AskUserQuestion). The backend
-  // reports them in the running list with run state `waiting_for_tool`, but
-  // they are blocked on the user, so they belong in "Needs You" — not
-  // "Running". Track them separately and keep them out of the running set.
+  // Missions parked on a frontend tool (e.g. AskUserQuestion). They stay in
+  // Running unless the API marked them `needs_operator` — controller-owned
+  // questions inside triage grace are not a human page.
   const waitingForToolMissionIds = useMemo(() => {
     return new Set(
       runningMissions
@@ -378,14 +381,11 @@ function OverviewPageContent() {
     );
   }, [runningMissions]);
 
-  // Build a set of actually-executing mission IDs from the runtime state
-  // (excluding those merely waiting on a frontend tool).
+  // Build a set of actually-executing mission IDs from the runtime state.
+  // waiting_for_tool stays here so unqualified AskUserQuestion rows remain
+  // Running; categorizeMissions promotes only `needs_operator` to Needs You.
   const runningMissionIds = useMemo(() => {
-    return new Set(
-      runningMissions
-        .filter((rm) => rm.state !== 'waiting_for_tool')
-        .map((rm) => rm.mission_id)
-    );
+    return new Set(runningMissions.map((rm) => rm.mission_id));
   }, [runningMissions]);
 
   // Build a set of missions with active automations
@@ -634,9 +634,8 @@ function OverviewPageContent() {
                         isActuallyRunning={
                           // Offer Cancel (not Delete) whenever the harness is
                           // still alive — including a mission parked on a
-                          // frontend tool (waiting_for_tool). It shows as
-                          // "Needs You", but its process is live and should be
-                          // cancellable, not deleted outright.
+                          // frontend tool (waiting_for_tool). The process is
+                          // live even when the card sits in Needs You.
                           runningMissionIds.has(mission.id) ||
                           waitingForToolMissionIds.has(mission.id)
                         }

--- a/dashboard/src/components/hermes/alerts-feed.tsx
+++ b/dashboard/src/components/hermes/alerts-feed.tsx
@@ -15,10 +15,15 @@ import { cn } from "@/lib/utils";
 
 type FeedFilter = "all" | "needs-you" | "finished";
 
-const FILTER_STATUSES: Record<FeedFilter, string[] | undefined> = {
-  all: undefined,
-  "needs-you": ["awaiting_user"],
-  finished: ["completed", "failed", "interrupted", "blocked", "not_feasible"],
+const FILTER_QUERY: Record<
+  FeedFilter,
+  { statuses?: string[]; needs_operator?: boolean }
+> = {
+  all: {},
+  "needs-you": { needs_operator: true },
+  finished: {
+    statuses: ["completed", "failed", "interrupted", "blocked", "not_feasible"],
+  },
 };
 
 const FILTER_LABELS: Record<FeedFilter, string> = {
@@ -50,7 +55,7 @@ export function AlertsFeed() {
 
   const { data, isLoading } = useSWR(
     ["hermes-alerts", filter],
-    () => listAlerts({ statuses: FILTER_STATUSES[filter], limit: 30 }),
+    () => listAlerts({ ...FILTER_QUERY[filter], limit: 30 }),
     {
       refreshInterval: 15000,
       revalidateOnFocus: false,
@@ -95,7 +100,7 @@ export function AlertsFeed() {
     setLoadingMore(true);
     try {
       const page = await listAlerts({
-        statuses: FILTER_STATUSES[filter],
+        ...FILTER_QUERY[filter],
         before: cursor,
         limit: 30,
       });
@@ -170,6 +175,7 @@ function AlertRow({ alert }: { alert: AlertFeedEntry }) {
   const awaitingKind = (alert.mission?.awaiting_kind ?? null) as
     | AwaitingKind
     | null;
+  const needsOperator = alert.mission?.needs_operator === true;
   const title =
     alert.mission?.title?.trim() || getMissionShortName(alert.mission_id);
   const ts = new Date(alert.timestamp);
@@ -195,7 +201,7 @@ function AlertRow({ alert }: { alert: AlertFeedEntry }) {
       </div>
       <div className="mt-0.5 flex items-center gap-2 pl-3.5">
         <span className="shrink-0 text-[10px] font-medium text-white/50">
-          {statusLabel(status, awaitingKind)}
+          {statusLabel(status, awaitingKind, needsOperator)}
         </span>
         {alert.summary && (
           <span className="min-w-0 truncate text-[11px] text-white/40">

--- a/dashboard/src/components/hermes/mission-chip.tsx
+++ b/dashboard/src/components/hermes/mission-chip.tsx
@@ -71,7 +71,11 @@ export function MissionChip({ missionId }: { missionId: string }) {
             </span>
             <span className="mt-1 flex items-center gap-1.5 text-xs text-white/55">
               <span className={cn("h-1.5 w-1.5 rounded-full", dot)} />
-              {statusLabel(mission.status, mission.awaiting_kind ?? null)}
+              {statusLabel(
+                mission.status,
+                mission.awaiting_kind ?? null,
+                mission.needs_operator === true,
+              )}
               {mission.workspace_name && (
                 <span className="truncate text-white/35">
                   · {mission.workspace_name}

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -220,7 +220,11 @@ function getMissionStatusDisplay(
       Icon: getStatusIcon(statusKey),
       tone: getMissionStatusToneClass(runningState, true),
       label: waiting
-        ? (mission?.needs_operator ? 'Needs You' : 'Awaiting Review')
+        ? mission?.needs_operator
+          ? 'Needs You'
+          : mission?.awaiting_kind === 'ack'
+            ? 'Awaiting Review'
+            : 'Needs Decision'
         : (runningState || 'running').replace(/_/g, ' '),
       spin: !waiting,
     };

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -168,7 +168,11 @@ function getMissionBackendLabel(mission: Mission): string {
 function getMissionStatusLabel(mission: Mission): string {
   // Distinguish "Needs Decision" vs "Awaiting Review" for awaiting_user using
   // awaiting_kind, matching the control workbench/header.
-  return statusLabel(mission.status, mission.awaiting_kind) ?? mission.status ?? 'Unknown';
+  return statusLabel(
+    mission.status,
+    mission.awaiting_kind,
+    mission.needs_operator === true,
+  ) ?? mission.status ?? 'Unknown';
 }
 
 function getMissionStatusToneClass(
@@ -215,7 +219,9 @@ function getMissionStatusDisplay(
     return {
       Icon: getStatusIcon(statusKey),
       tone: getMissionStatusToneClass(runningState, true),
-      label: waiting ? 'Needs You' : (runningState || 'running').replace(/_/g, ' '),
+      label: waiting
+        ? (mission?.needs_operator ? 'Needs You' : 'Awaiting Review')
+        : (runningState || 'running').replace(/_/g, ' '),
       spin: !waiting,
     };
   }

--- a/dashboard/src/lib/api/hermes.ts
+++ b/dashboard/src/lib/api/hermes.ts
@@ -270,6 +270,7 @@ export interface AlertMissionSummary {
   status: string;
   workspace_name?: string | null;
   awaiting_kind?: string | null;
+  needs_operator?: boolean;
 }
 
 export interface AlertFeedEntry {
@@ -288,11 +289,13 @@ export interface AlertsFeedResponse {
 
 export async function listAlerts(opts?: {
   statuses?: string[];
+  needs_operator?: boolean;
   before?: string;
   limit?: number;
 }): Promise<AlertsFeedResponse> {
   const params = new URLSearchParams();
   if (opts?.statuses?.length) params.set("statuses", opts.statuses.join(","));
+  if (opts?.needs_operator) params.set("needs_operator", "true");
   if (opts?.before) params.set("before", opts.before);
   if (opts?.limit) params.set("limit", String(opts.limit));
   const qs = params.toString();

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -101,6 +101,12 @@ export interface Mission {
    * decision (a real question) or is just waiting to be acked/merged.
    */
   awaiting_kind?: AwaitingKind | null;
+  /**
+   * Qualified operator page. True only for an unanswered decision /
+   * AskUserQuestion with no owning controller, or after triage grace.
+   * The dashboard must not reimplement grace from origin + timestamps.
+   */
+  needs_operator?: boolean;
   /** Activity (P#5): when the status last changed (persisted). */
   last_status_change_at?: string | null;
   /** Activity: timestamp of the most recent mission event (computed). */

--- a/dashboard/src/lib/mission-status.test.ts
+++ b/dashboard/src/lib/mission-status.test.ts
@@ -91,8 +91,8 @@ describe('mission-status', () => {
         expect(categorizeMission('awaiting_user', false, false, false, 'ack')).toBe('finished');
       });
 
-      it('in-grace controller decisions stay out of Needs You', () => {
-        expect(categorizeMission('awaiting_user', false, false, false, 'decision')).toBe('other');
+      it('in-grace controller decisions stay on the board in Running', () => {
+        expect(categorizeMission('awaiting_user', false, false, false, 'decision')).toBe('running');
       });
 
       it('failure statuses no longer land in needs-you (they go to finished/red)', () => {
@@ -161,6 +161,15 @@ describe('mission-status', () => {
       expect(result['needs-you'].map(m => m.id)).toEqual(['2']);
       expect(result.finished.map(m => m.id)).toEqual(['3', '4', '5', '6']);
       expect(result.other).toEqual([]);
+    });
+
+    it('keeps in-grace parked decisions in Running', () => {
+      const missions: TestMission[] = [
+        { id: 'triage', status: 'awaiting_user', awaiting_kind: 'decision', needs_operator: false },
+      ];
+      const result = categorizeMissions(missions, new Set());
+      expect(result['needs-you']).toEqual([]);
+      expect(result.running.map(m => m.id)).toEqual(['triage']);
     });
 
     it('ack is Finished, not Needs You', () => {

--- a/dashboard/src/lib/mission-status.test.ts
+++ b/dashboard/src/lib/mission-status.test.ts
@@ -7,6 +7,7 @@ import {
   finishedTone,
   getMissionDotColor,
   getMissionTextColor,
+  statusLabel,
   FINISHED_STATUSES,
   NEEDS_ATTENTION_STATUSES,
 } from './mission-status';
@@ -33,8 +34,10 @@ describe('mission-status', () => {
   });
 
   describe('needsAttentionStatus', () => {
-    it('returns true only for awaiting_user', () => {
-      expect(needsAttentionStatus('awaiting_user')).toBe(true);
+    it('returns true only when the API marked needs_operator', () => {
+      expect(needsAttentionStatus('awaiting_user', true)).toBe(true);
+      expect(needsAttentionStatus('awaiting_user')).toBe(false);
+      expect(needsAttentionStatus('awaiting_user', false)).toBe(false);
     });
 
     it('returns false for failure statuses (now in Finished/red)', () => {
@@ -79,8 +82,17 @@ describe('mission-status', () => {
     });
 
     describe('needs-you when not running', () => {
-      it('categorizes awaiting_user missions as needs-you when not running', () => {
-        expect(categorizeMission('awaiting_user', false)).toBe('needs-you');
+      it('categorizes only needs_operator missions as needs-you', () => {
+        expect(categorizeMission('awaiting_user', false, false, true, 'decision')).toBe('needs-you');
+        expect(categorizeMission('awaiting_user', false)).toBe('finished');
+      });
+
+      it('ack leaves the inbox for Finished / Awaiting Review', () => {
+        expect(categorizeMission('awaiting_user', false, false, false, 'ack')).toBe('finished');
+      });
+
+      it('in-grace controller decisions stay out of Needs You', () => {
+        expect(categorizeMission('awaiting_user', false, false, false, 'decision')).toBe('other');
       });
 
       it('failure statuses no longer land in needs-you (they go to finished/red)', () => {
@@ -112,23 +124,30 @@ describe('mission-status', () => {
       });
     });
 
-    describe('waiting for tool takes priority over running', () => {
-      it('categorizes a mission parked on a frontend tool as needs-you', () => {
-        // Backend still reports the mission as running (run state
-        // waiting_for_tool), but it is blocked on the user.
-        expect(categorizeMission('active', true, true)).toBe('needs-you');
-        expect(categorizeMission('active', false, true)).toBe('needs-you');
+    describe('waiting for tool is Needs You only when needs_operator', () => {
+      it('keeps controller-owned waiting_for_tool inside grace in Running', () => {
+        expect(categorizeMission('active', true, true, false)).toBe('running');
+        expect(categorizeMission('active', false, true, false)).toBe('running');
+      });
+
+      it('promotes waiting_for_tool to Needs You when the API says so', () => {
+        expect(categorizeMission('active', true, true, true)).toBe('needs-you');
       });
     });
   });
 
   describe('categorizeMissions', () => {
-    type TestMission = { id: string; status: MissionStatus };
+    type TestMission = {
+      id: string;
+      status: MissionStatus;
+      needs_operator?: boolean;
+      awaiting_kind?: 'decision' | 'ack' | null;
+    };
 
     it('groups missions into correct categories', () => {
       const missions: TestMission[] = [
         { id: '1', status: 'active' },
-        { id: '2', status: 'awaiting_user' },
+        { id: '2', status: 'awaiting_user', needs_operator: true, awaiting_kind: 'decision' },
         { id: '3', status: 'completed' },
         { id: '4', status: 'failed' },
         { id: '5', status: 'acknowledged' },
@@ -144,13 +163,35 @@ describe('mission-status', () => {
       expect(result.other).toEqual([]);
     });
 
-    it('puts missions waiting on a frontend tool in needs-you, not running', () => {
+    it('ack is Finished, not Needs You', () => {
       const missions: TestMission[] = [
-        { id: 'asking', status: 'active' }, // parked on AskUserQuestion
-        { id: 'executing', status: 'active' }, // genuinely running a turn
+        { id: 'ack', status: 'awaiting_user', awaiting_kind: 'ack', needs_operator: false },
       ];
-      // Backend reports both in the running list, but `asking` is waiting_for_tool.
-      const runningIds = new Set(['executing']);
+      const result = categorizeMissions(missions, new Set());
+      expect(result['needs-you']).toEqual([]);
+      expect(result.finished.map(m => m.id)).toEqual(['ack']);
+    });
+
+    it('puts controller-owned waiting_for_tool inside grace in running', () => {
+      const missions: TestMission[] = [
+        { id: 'asking', status: 'active', needs_operator: false },
+        { id: 'executing', status: 'active' },
+      ];
+      const runningIds = new Set(['asking', 'executing']);
+      const waitingForToolIds = new Set(['asking']);
+
+      const result = categorizeMissions(missions, runningIds, waitingForToolIds);
+
+      expect(result.running.map(m => m.id)).toEqual(['asking', 'executing']);
+      expect(result['needs-you']).toEqual([]);
+    });
+
+    it('promotes waiting_for_tool to Needs You only when needs_operator', () => {
+      const missions: TestMission[] = [
+        { id: 'asking', status: 'active', needs_operator: true },
+        { id: 'executing', status: 'active' },
+      ];
+      const runningIds = new Set(['asking', 'executing']);
       const waitingForToolIds = new Set(['asking']);
 
       const result = categorizeMissions(missions, runningIds, waitingForToolIds);
@@ -161,9 +202,9 @@ describe('mission-status', () => {
 
     it('handles resumed mission correctly (awaiting_user but running)', () => {
       const missions: TestMission[] = [
-        { id: 'resumed', status: 'awaiting_user' }, // DB still says awaiting_user
+        { id: 'resumed', status: 'awaiting_user', needs_operator: true, awaiting_kind: 'decision' },
         { id: 'new', status: 'active' },
-        { id: 'waiting', status: 'awaiting_user' },
+        { id: 'waiting', status: 'awaiting_user', needs_operator: true, awaiting_kind: 'decision' },
       ];
       const runningIds = new Set(['resumed', 'new']);
 
@@ -269,8 +310,21 @@ describe('mission-status', () => {
       expect(FINISHED_STATUSES).toHaveLength(6);
     });
 
-    it('NEEDS_ATTENTION_STATUSES contains only awaiting_user', () => {
-      expect(NEEDS_ATTENTION_STATUSES).toEqual(['awaiting_user']);
+    it('NEEDS_ATTENTION_STATUSES is empty — Needs You is needs_operator, not a status list', () => {
+      expect(NEEDS_ATTENTION_STATUSES).toEqual([]);
+    });
+  });
+
+  describe('statusLabel', () => {
+    it('prefers Awaiting Review when kind is missing unless needs_operator', () => {
+      expect(statusLabel('awaiting_user')).toBe('Awaiting Review');
+      expect(statusLabel('awaiting_user', null, false)).toBe('Awaiting Review');
+      expect(statusLabel('awaiting_user', null, true)).toBe('Needs You');
+    });
+
+    it('uses awaiting_kind labels when present', () => {
+      expect(statusLabel('awaiting_user', 'ack')).toBe('Awaiting Review');
+      expect(statusLabel('awaiting_user', 'decision')).toBe('Needs Decision');
     });
   });
 });

--- a/dashboard/src/lib/mission-status.ts
+++ b/dashboard/src/lib/mission-status.ts
@@ -8,11 +8,10 @@ import type { AwaitingKind, MissionStatus } from './api/missions';
 export type MissionCategory = 'running' | 'needs-you' | 'finished' | 'other';
 export type FinishedTone = 'green' | 'red';
 
-// "Needs You" is reserved for missions where the agent finished its turn
-// cleanly (`awaiting_user`) and is waiting on the user. Failure paths
-// (interrupted, blocked, not_feasible, failed) live in Finished with a red
-// tone instead.
-export const NEEDS_ATTENTION_STATUSES: MissionStatus[] = ['awaiting_user'];
+// "Needs You" is a qualified operator page (`needs_operator` from the API).
+// A bare `awaiting_user` list is not enough — ack and in-grace controller
+// waits stay out of that column. Failure paths live in Finished (red).
+export const NEEDS_ATTENTION_STATUSES: MissionStatus[] = [];
 export const FINISHED_STATUSES: MissionStatus[] = [
   'completed',
   'acknowledged',
@@ -32,10 +31,14 @@ export function isFinishedStatus(status: MissionStatus): boolean {
 }
 
 /**
- * Check if a mission needs user attention based on its stored status.
+ * Check if a mission needs the operator. Trust the API `needs_operator`
+ * flag so the dashboard does not reimplement controller-triage grace.
  */
-export function needsAttentionStatus(status: MissionStatus): boolean {
-  return NEEDS_ATTENTION_STATUSES.includes(status);
+export function needsAttentionStatus(
+  _status: MissionStatus,
+  needsOperator = false
+): boolean {
+  return needsOperator;
 }
 
 /**
@@ -50,25 +53,29 @@ export function finishedTone(status: MissionStatus): FinishedTone {
  * Categorize a mission based on runtime state and stored status.
  *
  * Priority order:
- * 1. Needs You (waiting for tool) - the agent is parked on a frontend tool
- *    (e.g. AskUserQuestion). The backend still reports this mission as
- *    "running" (run state `waiting_for_tool`) because its harness is alive,
- *    but it is blocked on the user, so it belongs in Needs You — not Running.
- * 2. Running - mission is actually executing a turn
- * 3. Needs You - awaiting_user AND not running
- * 4. Finished - completed/acknowledged/failed/interrupted/blocked/not_feasible AND not running
- * 5. Other - anything else (active-but-not-running, pending)
+ * 1. Needs You — only when the API says `needs_operator` (decision /
+ *    AskUserQuestion after grace / no origin).
+ * 2. Running — actually executing, or waiting_for_tool that is not an
+ *    operator page (controller still has first triage).
+ * 3. Finished — completed/acked/failed/blocked, plus awaiting_user ack
+ *    (sky Awaiting Review).
+ * 4. Other — anything else (active-but-not-running, in-grace decisions).
  */
 export function categorizeMission(
   status: MissionStatus,
   isActuallyRunning: boolean,
-  isWaitingForTool = false
+  isWaitingForTool = false,
+  needsOperator = false,
+  awaitingKind?: AwaitingKind | null
 ): MissionCategory {
-  if (isWaitingForTool) {
+  // A live turn beats a stale awaiting_user/needs_operator flag (resume).
+  // waiting_for_tool is the exception: the harness is alive but parked on
+  // the user, so a qualified page still belongs in Needs You.
+  if (needsAttentionStatus(status, needsOperator) && (!isActuallyRunning || isWaitingForTool)) {
     return 'needs-you';
   }
 
-  if (isActuallyRunning) {
+  if (isActuallyRunning || isWaitingForTool) {
     return 'running';
   }
 
@@ -79,11 +86,7 @@ export function categorizeMission(
     return 'running';
   }
 
-  if (needsAttentionStatus(status)) {
-    return 'needs-you';
-  }
-
-  if (isFinishedStatus(status)) {
+  if (isFinishedStatus(status) || (status === 'awaiting_user' && awaitingKind !== 'decision')) {
     return 'finished';
   }
 
@@ -95,10 +98,17 @@ export function categorizeMission(
  * Returns missions grouped by category with each mission only in one category.
  *
  * `waitingForToolMissionIds` is the subset of running missions parked on a
- * frontend tool (run state `waiting_for_tool`); they are surfaced as Needs You
- * rather than Running even though the backend still reports them as running.
+ * frontend tool (run state `waiting_for_tool`). They stay in Running unless
+ * the API marked them `needs_operator`.
  */
-export function categorizeMissions<T extends { id: string; status: MissionStatus }>(
+export function categorizeMissions<
+  T extends {
+    id: string;
+    status: MissionStatus;
+    needs_operator?: boolean;
+    awaiting_kind?: AwaitingKind | null;
+  },
+>(
   missions: T[],
   runningMissionIds: Set<string>,
   waitingForToolMissionIds: Set<string> = new Set()
@@ -113,7 +123,13 @@ export function categorizeMissions<T extends { id: string; status: MissionStatus
   for (const mission of missions) {
     const isWaitingForTool = waitingForToolMissionIds.has(mission.id);
     const isActuallyRunning = runningMissionIds.has(mission.id);
-    const category = categorizeMission(mission.status, isActuallyRunning, isWaitingForTool);
+    const category = categorizeMission(
+      mission.status,
+      isActuallyRunning,
+      isWaitingForTool,
+      mission.needs_operator === true,
+      mission.awaiting_kind
+    );
     result[category].push(mission);
   }
 
@@ -152,7 +168,7 @@ export const STATUS_TEXT_COLORS: Record<MissionStatus, string> = {
 export const STATUS_LABELS: Record<MissionStatus, string> = {
   pending: 'Pending',
   active: 'Active',
-  awaiting_user: 'Needs You',
+  awaiting_user: 'Awaiting Review',
   acknowledged: 'Acknowledged',
   completed: 'Completed',
   failed: 'Failed',
@@ -175,14 +191,19 @@ export const AWAITING_KIND_LABELS: Record<AwaitingKind, string> = {
 
 /**
  * Display label for a mission status, refined by `awaiting_kind` when the
- * mission is parked in `awaiting_user`. Falls back to the generic status label.
+ * mission is parked in `awaiting_user`. Missing kind is Awaiting Review
+ * unless the API marked the mission `needs_operator`.
  */
 export function statusLabel(
   status: MissionStatus,
   awaitingKind?: AwaitingKind | null,
+  needsOperator = false,
 ): string {
-  if (status === 'awaiting_user' && awaitingKind) {
-    return AWAITING_KIND_LABELS[awaitingKind];
+  if (status === 'awaiting_user') {
+    if (awaitingKind) {
+      return AWAITING_KIND_LABELS[awaitingKind];
+    }
+    return needsOperator ? 'Needs You' : AWAITING_KIND_LABELS.ack;
   }
   return STATUS_LABELS[status] ?? status;
 }
@@ -191,9 +212,16 @@ export function statusLabel(
  * Get the display dot color for a mission, considering runtime state.
  * Running missions always show indigo regardless of stored status.
  */
-export function getMissionDotColor(status: MissionStatus, isActuallyRunning: boolean): string {
+export function getMissionDotColor(
+  status: MissionStatus,
+  isActuallyRunning: boolean,
+  awaitingKind?: AwaitingKind | null,
+): string {
   if (isActuallyRunning) {
     return 'bg-indigo-400';
+  }
+  if (status === 'awaiting_user' && awaitingKind === 'ack') {
+    return 'bg-sky-400';
   }
   return STATUS_DOT_COLORS[status] || 'bg-gray-400';
 }
@@ -201,9 +229,16 @@ export function getMissionDotColor(status: MissionStatus, isActuallyRunning: boo
 /**
  * Get the display text color for a mission, considering runtime state.
  */
-export function getMissionTextColor(status: MissionStatus, isActuallyRunning: boolean): string {
+export function getMissionTextColor(
+  status: MissionStatus,
+  isActuallyRunning: boolean,
+  awaitingKind?: AwaitingKind | null,
+): string {
   if (isActuallyRunning) {
     return 'text-indigo-400';
+  }
+  if (status === 'awaiting_user' && awaitingKind === 'ack') {
+    return 'text-sky-400';
   }
   return STATUS_TEXT_COLORS[status] || 'text-white/40';
 }

--- a/dashboard/src/lib/mission-status.ts
+++ b/dashboard/src/lib/mission-status.ts
@@ -59,7 +59,8 @@ export function finishedTone(status: MissionStatus): FinishedTone {
  *    operator page (controller still has first triage).
  * 3. Finished — completed/acked/failed/blocked, plus awaiting_user ack
  *    (sky Awaiting Review).
- * 4. Other — anything else (active-but-not-running, in-grace decisions).
+ * 4. Running — in-grace parked decisions (controller still owns triage).
+ * 5. Other — anything else (active-but-not-running).
  */
 export function categorizeMission(
   status: MissionStatus,
@@ -88,6 +89,12 @@ export function categorizeMission(
 
   if (isFinishedStatus(status) || (status === 'awaiting_user' && awaitingKind !== 'decision')) {
     return 'finished';
+  }
+
+  // Controller still owns triage — keep the card on the board in Running
+  // rather than dropping it into the unrendered `other` bucket.
+  if (status === 'awaiting_user' && awaitingKind === 'decision') {
+    return 'running';
   }
 
   return 'other';

--- a/dashboard/tests/overview.spec.ts
+++ b/dashboard/tests/overview.spec.ts
@@ -406,6 +406,7 @@ test.describe('Overview Page', () => {
 
     await expect(page.getByText('PR ready for review')).toBeVisible();
     await expect(page.getByText('Ask parked inside grace')).toBeVisible();
+    await expect(page.getByText('Controller is triaging')).toBeVisible();
   });
 
   test('Needs You is empty when nothing qualifies', async ({ page }) => {

--- a/dashboard/tests/overview.spec.ts
+++ b/dashboard/tests/overview.spec.ts
@@ -276,46 +276,51 @@ test.describe('Overview Page', () => {
     expect(hasLive || !hasLive).toBeTruthy();
   });
 
-  test('shows a needs you inbox for blocked and interrupted missions', async ({ page }) => {
+  test('Needs You only lists qualified operator pages', async ({ page }) => {
     const now = new Date().toISOString();
-    const blockedMission = {
+    const decisionMission = {
       id: '11111111-1111-4111-8111-111111111111',
-      title: 'Review deployment plan',
-      status: 'blocked',
+      title: 'Pick a merge strategy',
+      status: 'awaiting_user',
+      awaiting_kind: 'decision',
+      needs_operator: true,
       workspace_name: 'dev-workspace',
       history: [],
-      resumable: true,
       created_at: now,
       updated_at: now,
     };
-    const interruptedMission = {
+    const ackMission = {
       id: '22222222-2222-4222-8222-222222222222',
-      title: 'Answer product question',
-      status: 'interrupted',
+      title: 'PR ready for review',
+      status: 'awaiting_user',
+      awaiting_kind: 'ack',
+      needs_operator: false,
       workspace_name: 'app-workspace',
       history: [],
-      resumable: false,
       created_at: now,
       updated_at: now,
     };
-    const runningInterruptedMission = {
+    const inGraceMission = {
       id: '33333333-3333-4333-8333-333333333333',
-      title: 'Running resumed mission',
-      status: 'interrupted',
+      title: 'Controller is triaging',
+      status: 'awaiting_user',
+      awaiting_kind: 'decision',
+      needs_operator: false,
+      origin_session_id: 'sess-1',
       history: [],
-      resumable: true,
       created_at: now,
       updated_at: now,
     };
-    const extraBlockedMissions = Array.from({ length: 8 }, (_, index) => ({
-      id: `44444444-4444-4444-8444-44444444444${index}`,
-      title: `Waiting mission ${index + 1}`,
-      status: 'blocked',
+    const waitingToolMission = {
+      id: '44444444-4444-4444-8444-444444444444',
+      title: 'Ask parked inside grace',
+      status: 'active',
+      needs_operator: false,
+      origin_session_id: 'sess-1',
       history: [],
-      resumable: false,
       created_at: now,
       updated_at: now,
-    }));
+    };
 
     await page.route('**/api/**', async (route) => {
       const path = new URL(route.request().url()).pathname;
@@ -340,7 +345,7 @@ test.describe('Overview Page', () => {
 
       if (path === '/api/stats') {
         await json({
-          total_tasks: 3,
+          total_tasks: 4,
           active_tasks: 1,
           completed_tasks: 0,
           failed_tasks: 0,
@@ -357,16 +362,11 @@ test.describe('Overview Page', () => {
         return;
       }
       if (path === '/api/control/missions') {
-        await json([
-          blockedMission,
-          interruptedMission,
-          ...extraBlockedMissions,
-          runningInterruptedMission,
-        ]);
+        await json([decisionMission, ackMission, inGraceMission, waitingToolMission]);
         return;
       }
       if (path === '/api/control/running') {
-        await json([{ mission_id: runningInterruptedMission.id, state: 'running', queue_len: 0 }]);
+        await json([{ mission_id: waitingToolMission.id, state: 'waiting_for_tool', queue_len: 0 }]);
         return;
       }
       if (path === '/api/control/automations') {
@@ -398,11 +398,81 @@ test.describe('Overview Page', () => {
 
     await page.goto('/');
 
-    const inbox = page.getByRole('heading', { name: 'Needs You' }).locator('xpath=ancestor::section');
-    await expect(inbox).toBeVisible();
-    await expect(inbox.locator('.tabular-nums')).toHaveText('10');
-    await expect(inbox.getByText('Review deployment plan')).toBeVisible();
-    await expect(inbox.getByText('Answer product question')).toBeVisible();
-    await expect(inbox.getByText('Running resumed mission')).not.toBeVisible();
+    const needsYou = page.locator('div').filter({ hasText: /^Needs You/ }).first();
+    await expect(needsYou.getByText('Pick a merge strategy')).toBeVisible();
+    await expect(needsYou.getByText('PR ready for review')).toHaveCount(0);
+    await expect(needsYou.getByText('Controller is triaging')).toHaveCount(0);
+    await expect(needsYou.getByText('Ask parked inside grace')).toHaveCount(0);
+
+    await expect(page.getByText('PR ready for review')).toBeVisible();
+    await expect(page.getByText('Ask parked inside grace')).toBeVisible();
+  });
+
+  test('Needs You is empty when nothing qualifies', async ({ page }) => {
+    const now = new Date().toISOString();
+    const ackMission = {
+      id: '22222222-2222-4222-8222-222222222222',
+      title: 'PR ready for review',
+      status: 'awaiting_user',
+      awaiting_kind: 'ack',
+      needs_operator: false,
+      history: [],
+      created_at: now,
+      updated_at: now,
+    };
+
+    await page.route('**/api/**', async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      if (route.request().method() === 'OPTIONS') {
+        await route.fulfill({
+          status: 204,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': '*',
+            'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+          },
+        });
+        return;
+      }
+      const json = (body: unknown) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          headers: { 'Access-Control-Allow-Origin': '*' },
+          body: JSON.stringify(body),
+        });
+
+      if (path === '/api/stats') {
+        await json({
+          total_tasks: 1,
+          active_tasks: 0,
+          completed_tasks: 0,
+          failed_tasks: 0,
+          total_cost_cents: 0,
+          actual_cost_cents: 0,
+          estimated_cost_cents: 0,
+          unknown_cost_cents: 0,
+          success_rate: 1,
+        });
+        return;
+      }
+      if (path === '/api/workspaces' || path === '/api/control/automations') {
+        await json([]);
+        return;
+      }
+      if (path === '/api/control/missions') {
+        await json([ackMission]);
+        return;
+      }
+      if (path === '/api/control/running') {
+        await json([]);
+        return;
+      }
+      await json({});
+    });
+
+    await page.goto('/');
+    await expect(page.getByText('All good!')).toBeVisible();
+    await expect(page.getByText('PR ready for review')).toBeVisible();
   });
 });

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -93,11 +93,13 @@ Chaque livraison, **y compris les `[SILENT]`**, se termine par :
   dit depuis combien de ticks. `blocked:<cause>` est le seul suffixe autorisé
   et nomme la cause (`blocked:disk` est un vrai no-lane ; `blocked:harness`
   n'en est pas un).
-- `blocked:harness` — suffixe temporaire (≤ 3 ticks) pour un CLI manquant, un
-  binaire mauvaise arch, ou un `nsenter` cassé, puis contournement (autre
-  backend, workspace host). Ce n'est **pas** un projet bloqué. Préférer
-  `mode=active` + `next=` changer de backend / réparer le harness. Ne jamais
-  poser un `blocked` nu pour un échec de harness.
+- `blocked:harness` — suffixe de **trailer** temporaire (≤ 3 ticks) pour un
+  CLI manquant, un binaire mauvaise arch, ou un `nsenter` cassé, puis
+  contournement (autre backend, workspace host). Ce n'est **pas** un projet
+  bloqué. L'appel structuré `update_project_status` n'accepte que
+  `active`/`blocked`/`paused` : écrire `mode=blocked` + `blocker=harness`.
+  Préférer `mode=active` + `next=` changer de backend / réparer le harness.
+  Ne jamais poser un `blocked` nu pour un échec de harness.
 - `mode=paused` — dormant volontairement.
 
 Avant, ces trois régimes te parvenaient tous sous la forme d'un `[SILENT]`

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -89,13 +89,15 @@ Chaque livraison, **y compris les `[SILENT]`**, se termine par :
 ```
 
 - `mode=active` — il travaille. Un tick sain et muet, c'est `[SILENT]` + ce trailer.
-- `mode=blocked` — **aucune lane ne peut avancer**. `wait=` dit depuis combien
-  de ticks. Un suffixe `blocked:<cause>` nomme la cause ; c'est le seul suffixe
-  autorisé. `blocked` nu n'est pas un fourre-tout.
-- `blocked:harness` — CLI manquant, binaire mauvaise arch, `nsenter` cassé.
-  Au plus 3 ticks, puis contournement (autre backend, workspace host). Un
-  échec de harness n'est **pas** un projet bloqué : rester `mode=active` avec
-  `next=` changer de backend / réparer le harness, plutôt que `blocked` nu.
+- `mode=blocked` **sans suffixe** — **aucune lane ne peut avancer**. `wait=`
+  dit depuis combien de ticks. `blocked:<cause>` est le seul suffixe autorisé
+  et nomme la cause (`blocked:disk` est un vrai no-lane ; `blocked:harness`
+  n'en est pas un).
+- `blocked:harness` — suffixe temporaire (≤ 3 ticks) pour un CLI manquant, un
+  binaire mauvaise arch, ou un `nsenter` cassé, puis contournement (autre
+  backend, workspace host). Ce n'est **pas** un projet bloqué. Préférer
+  `mode=active` + `next=` changer de backend / réparer le harness. Ne jamais
+  poser un `blocked` nu pour un échec de harness.
 - `mode=paused` — dormant volontairement.
 
 Avant, ces trois régimes te parvenaient tous sous la forme d'un `[SILENT]`
@@ -116,8 +118,8 @@ objectif** avec un blocker infra nommé (`blocked:disk`, …). Le travail
 plateforme s'ouvre sous `sandboxed-sh`. On ne retitre pas, on ne réutilise
 pas la session de campagne (Lido « Corriger et merger les PRs » devenue un
 P0 disque). Un ordre explicite dans le chat (« merge these PRs ») met à jour
-le grant (`merge_authority` / `material_bar`) ; un « never merge to main »
-périmé ne le surclasse pas.
+`merge_authority` — `material_bar` seulement si l'ordre change aussi ce qui
+mérite une livraison. Un « never merge to main » périmé ne le surclasse pas.
 
 ## Le board
 

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -89,8 +89,13 @@ Chaque livraison, **y compris les `[SILENT]`**, se termine par :
 ```
 
 - `mode=active` — il travaille. Un tick sain et muet, c'est `[SILENT]` + ce trailer.
-- `mode=blocked` — il bute sur quelque chose d'externe. `wait=` dit depuis combien
-  de ticks.
+- `mode=blocked` — **aucune lane ne peut avancer**. `wait=` dit depuis combien
+  de ticks. Un suffixe `blocked:<cause>` nomme la cause ; c'est le seul suffixe
+  autorisé. `blocked` nu n'est pas un fourre-tout.
+- `blocked:harness` — CLI manquant, binaire mauvaise arch, `nsenter` cassé.
+  Au plus 3 ticks, puis contournement (autre backend, workspace host). Un
+  échec de harness n'est **pas** un projet bloqué : rester `mode=active` avec
+  `next=` changer de backend / réparer le harness, plutôt que `blocked` nu.
 - `mode=paused` — dormant volontairement.
 
 Avant, ces trois régimes te parvenaient tous sous la forme d'un `[SILENT]`
@@ -101,6 +106,18 @@ ticks ». Maintenant `grep 'mode=blocked'` suffit, et le board les affiche.
 il doit vérifier que la dépendance est encore vivante, tenter un contournement
 borné, et livrer un rapport non silencieux. À 6 ticks, il escalade avec une
 question précise.
+
+Un callback d'inspect (`awaiting_user`, mission parkée) ne pose pas
+`mode=blocked` : ces statuts omettent le `[CTRL:]`. Recopier l'ancien
+trailer est une dérive de prompt.
+
+Si le dispatch est refusé (disque, auth, capacité), le projet **garde son
+objectif** avec un blocker infra nommé (`blocked:disk`, …). Le travail
+plateforme s'ouvre sous `sandboxed-sh`. On ne retitre pas, on ne réutilise
+pas la session de campagne (Lido « Corriger et merger les PRs » devenue un
+P0 disque). Un ordre explicite dans le chat (« merge these PRs ») met à jour
+le grant (`merge_authority` / `material_bar`) ; un « never merge to main »
+périmé ne le surclasse pas.
 
 ## Le board
 

--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -60,6 +60,12 @@ merge.** Do not open a `[DECISION:]` asking Thomas to bless a green in-scope mer
 record the merge as a granted act and do it. `review-first` is the only merge
 posture that must escalate.
 
+**Owner chat updates the grant.** An explicit order in the project session —
+"Merge these PRs" — is not a comment: `set_project_grant` and update
+`merge_authority` / `material_bar`. If the order is ambiguous, record
+`pending_user` and act once answered. A stale "never merge to main" in the
+prompt or an old GRANT block does not outrank a later owner order.
+
 Precedence, highest wins:
 
 1. **Structured pause** — a `resume_condition` in the project grant (preferred), or a
@@ -92,7 +98,17 @@ End EVERY delivery, including `[SILENT]`, with exactly one line:
 
 `[CTRL: <project> | mode=active|blocked|paused | wait=<consecutive ticks in this mode> | next=<next action, or resume/unblock condition>]`
 
-Machine-parsed — keep the format. **`mode` is EXACTLY one of `active`, `blocked`, or `paused`** — never a version, host, suite, or free text. A value like `v0.2-local-host` is rejected and your mode silently stops reaching the board. Put version/host/suite detail in `next=` or the report body, not in `mode`. `blocked` may carry a cause as `blocked:<cause>`; that is the only suffix allowed. `[SILENT]` means "nothing material for Thomas", never
+Machine-parsed — keep the format. **`mode` is EXACTLY one of `active`, `blocked`, or `paused`** — never a version, host, suite, or free text. A value like `v0.2-local-host` is rejected and your mode silently stops reaching the board. Put version/host/suite detail in `next=` or the report body, not in `mode`. `blocked` may carry a cause as `blocked:<cause>`; that is the only suffix allowed.
+
+**`mode=blocked` with no suffix means no lane can progress.** A missing CLI, a
+wrong-arch binary, or a container `nsenter` failure is not that. Stay
+`mode=active` with `next=` switch-backend / repair-harness, or use
+`blocked:harness` for at most 3 ticks, then work around (other backend, host
+workspace). Bare `blocked` for a harness failure is a lie about the project.
+Coldcard `acfb03d2` (2026-08-13) finished `Codex CLI not found` and the
+callback painted the campaign blocked.
+
+`[SILENT]` means "nothing material for Thomas", never
 "I did nothing": a healthy quiet tick is `[SILENT]` followed by
 `[CTRL: ... mode=active | wait=0 | ...]`.
 
@@ -232,6 +248,9 @@ repeated failure `repeat-loop-guard` · tool-call limits `context-budget`.
 - **A mission asking a question gets an answer or an escalation, never silence.** Use `answer_mission_question` to respond to a mission blocked on AskUserQuestion — plain messages queue behind the blocked turn and will not unblock it.
 - **The store refuses two classes of lie.** A headline that only restates an auto-resume (`RELANCÉE`, `relaunch`) is ingested as `[SILENT]`. A writer-lease claim while a writer is live is coerced to `mode=active` and also silenced. Do not fight this: if the campaign actually changed heads or gates, change the `STATE_SIGNATURE` fields.
 - **Owner questions are unique and expire.** The same `pending_user` question is recorded once. After 24h unanswered it becomes `expired`; act on the conservative in-grant default, do not re-ask.
+- **Do not stamp `mode=blocked` from an inspect callback.** Inspect callbacks omit `[CTRL:]` on `awaiting_user`. A controller that copies the old trailer onto a callback is prompt drift: ingest already refuses inspect for mode, and re-emitting `mode=blocked` from a parked turn is how the board stays red after the writer moved on. Inspect, then write your own trailer from live state.
+- **Do not abandon the objective.** If dispatch is refused (disk, auth, capacity): keep the original project on its objective with a named infra blocker (`blocked:disk`, `blocked:auth`, `blocked:capacity`); open or fix the platform work under its own project (`sandboxed-sh`). Do not retitle or reuse the campaign session. Lido “Corriger et merger les PRs” becoming a P0 disk ticket is the incident — a platform outage is not a new campaign.
+- **Harness ≠ project blocked.** Missing CLI, wrong-arch binary, container `nsenter` failure: `mode=active` + `next=` switch backend / repair harness, or `blocked:harness` ≤ 3 ticks then workaround. See the trailer rule above.
 
 ## Optimisations d exécution (2026-08-10, leçons terrain)
 

--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -62,9 +62,12 @@ posture that must escalate.
 
 **Owner chat updates the grant.** An explicit order in the project session —
 "Merge these PRs" — is not a comment: `set_project_grant` and update
-`merge_authority` / `material_bar`. If the order is ambiguous, record
-`pending_user` and act once answered. A stale "never merge to main" in the
-prompt or an old GRANT block does not outrank a later owner order.
+`merge_authority`. Touch `material_bar` only when the owner actually changes
+what is worth a delivery. If the order is ambiguous, record `pending_user`,
+proceed with the conservative in-grant default, and apply `set_project_grant`
+when answered (or on 24h expiry). Do not stall the tick. A stale "never merge
+to main" in the prompt or an old GRANT block does not outrank a later owner
+order.
 
 Precedence, highest wins:
 

--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -60,14 +60,19 @@ merge.** Do not open a `[DECISION:]` asking Thomas to bless a green in-scope mer
 record the merge as a granted act and do it. `review-first` is the only merge
 posture that must escalate.
 
-**Owner chat updates the grant.** An explicit order in the project session —
-"Merge these PRs" — is not a comment: `set_project_grant` and update
-`merge_authority`. Touch `material_bar` only when the owner actually changes
-what is worth a delivery. If the order is ambiguous, record `pending_user`,
-proceed with the conservative in-grant default, and apply `set_project_grant`
-when answered (or on 24h expiry). Do not stall the tick. A stale "never merge
-to main" in the prompt or an old GRANT block does not outrank a later owner
-order.
+**Owner chat updates the grant only when the order is durable.** An explicit
+standing grant — "you may merge in this repo", "review-first from now on" —
+is not a comment: `set_project_grant` and update `merge_authority`. A one-off
+"Merge these PRs" is a scoped decision for the named PRs only; record it as
+`pending_user`/`decided` with the PR list, do **not** widen `merge_authority`
+to `full`. The grant schema cannot represent a PR-limited authorization.
+Touch `material_bar` only when the owner actually changes what is worth a
+delivery. If the order is ambiguous, record `pending_user`, proceed with the
+conservative **existing** in-grant default, and apply `set_project_grant`
+only when the owner answers with a durable grant. On 24h expiry, keep the
+current grant — never guess a `merge_authority` value. Do not stall the tick.
+A stale "never merge to main" in the prompt or an old GRANT block does not
+outrank a later owner standing order.
 
 Precedence, highest wins:
 
@@ -106,8 +111,12 @@ Machine-parsed — keep the format. **`mode` is EXACTLY one of `active`, `blocke
 **`mode=blocked` with no suffix means no lane can progress.** A missing CLI, a
 wrong-arch binary, or a container `nsenter` failure is not that. Stay
 `mode=active` with `next=` switch-backend / repair-harness, or use
-`blocked:harness` for at most 3 ticks, then work around (other backend, host
-workspace). Bare `blocked` for a harness failure is a lie about the project.
+trailer `blocked:harness` for at most 3 ticks, then work around (other
+backend, host workspace). The structured `update_project_status` call
+accepts only `active` / `blocked` / `paused`: write `mode=blocked` with
+`blocker=harness`. Reserve `blocked:harness` for the CTRL trailer.
+Bare `blocked` with no harness blocker for a CLI/`nsenter` failure is a
+lie about the project.
 Coldcard `acfb03d2` (2026-08-13) finished `Codex CLI not found` and the
 callback painted the campaign blocked.
 
@@ -250,10 +259,10 @@ repeated failure `repeat-loop-guard` · tool-call limits `context-budget`.
 - **Acknowledge what you have absorbed.** When a failed/interrupted mission has been superseded (retry dispatched, work re-planned, or intentionally dropped), immediately mark it `acknowledged` — an unacknowledged terminal mission is an open operator alert. The attention surface only counts UNacknowledged failures; leaving absorbed failures unacknowledged cries wolf on every board.
 - **A mission asking a question gets an answer or an escalation, never silence.** Use `answer_mission_question` to respond to a mission blocked on AskUserQuestion — plain messages queue behind the blocked turn and will not unblock it.
 - **The store refuses two classes of lie.** A headline that only restates an auto-resume (`RELANCÉE`, `relaunch`) is ingested as `[SILENT]`. A writer-lease claim while a writer is live is coerced to `mode=active` and also silenced. Do not fight this: if the campaign actually changed heads or gates, change the `STATE_SIGNATURE` fields.
-- **Owner questions are unique and expire.** The same `pending_user` question is recorded once. After 24h unanswered it becomes `expired`; act on the conservative in-grant default, do not re-ask.
+- **Owner questions are unique and expire.** The same `pending_user` question is recorded once. After 24h unanswered it becomes `expired`; act on the conservative existing grant, do not re-ask, and do not call `set_project_grant` to invent a value.
 - **Do not stamp `mode=blocked` from an inspect callback.** Inspect callbacks omit `[CTRL:]` on `awaiting_user`. A controller that copies the old trailer onto a callback is prompt drift: ingest already refuses inspect for mode, and re-emitting `mode=blocked` from a parked turn is how the board stays red after the writer moved on. Inspect, then write your own trailer from live state.
 - **Do not abandon the objective.** If dispatch is refused (disk, auth, capacity): keep the original project on its objective with a named infra blocker (`blocked:disk`, `blocked:auth`, `blocked:capacity`); open or fix the platform work under its own project (`sandboxed-sh`). Do not retitle or reuse the campaign session. Lido “Corriger et merger les PRs” becoming a P0 disk ticket is the incident — a platform outage is not a new campaign.
-- **Harness ≠ project blocked.** Missing CLI, wrong-arch binary, container `nsenter` failure: `mode=active` + `next=` switch backend / repair harness, or `blocked:harness` ≤ 3 ticks then workaround. See the trailer rule above.
+- **Harness ≠ project blocked.** Missing CLI, wrong-arch binary, container `nsenter` failure: `mode=active` + `next=` switch backend / repair harness, or trailer `blocked:harness` ≤ 3 ticks then workaround. Structured write: `update_project_status(..., mode=blocked, blocker=harness)`. See the trailer rule above.
 
 ## Optimisations d exécution (2026-08-10, leçons terrain)
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4024,6 +4024,26 @@ impl ControlHub {
         Ok(collected)
     }
 
+    /// Mission IDs whose live run is parked on AskUserQuestion (`WaitingUser`).
+    /// Used so project chips share the same `needs_operator` clock as list/detail.
+    pub(crate) async fn collect_waiting_user_mission_ids(&self) -> HashSet<Uuid> {
+        let mut ids = HashSet::new();
+        let Ok(inventory) = self.mission_store_inventory().await else {
+            return ids;
+        };
+        for store in inventory.live {
+            let Ok(runs) = store.list_active_mission_runs().await else {
+                continue;
+            };
+            for run in runs {
+                if run.execution_state == MissionExecutionState::WaitingUser {
+                    ids.insert(run.mission_id);
+                }
+            }
+        }
+        ids
+    }
+
     /// Board tasks across every store whose boss mission belongs to this
     /// project family. Live stores answer through the trait; persisted SQLite
     /// databases with no live control session (fresh restart, other users) are
@@ -11725,8 +11745,10 @@ pub async fn get_mission_events(
 pub struct AlertsFeedQuery {
     /// Comma-separated mission statuses to keep (e.g. `awaiting_user,failed`).
     pub statuses: Option<String>,
-    /// When true, keep only alerts whose current mission is a qualified
-    /// operator page (`needs_operator`). Used by the Needs You feed filter.
+    /// When true, keep only alerts that are themselves a current operator
+    /// page (`awaiting_user` or live AskUserQuestion). Current-state: the
+    /// mission must still `needs_operator` now. The handler walks the raw
+    /// status-event feed until `limit` matches so a sparse page is not empty.
     pub needs_operator: Option<bool>,
     /// Timestamp cursor: return alerts strictly older than this.
     pub before: Option<String>,
@@ -11760,6 +11782,31 @@ pub struct AlertsFeedResponse {
     pub next_cursor: Option<String>,
 }
 
+fn refresh_summary_for_waiting_user(
+    summary: &mut mission_store::MissionSummary,
+    waiting_for_user_tool: bool,
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    if !waiting_for_user_tool {
+        return;
+    }
+    let parsed_status = serde_json::from_value(serde_json::Value::String(summary.status.clone()))
+        .unwrap_or(MissionStatus::Active);
+    summary.needs_operator = super::operator_attention::needs_operator(
+        &super::operator_attention::OperatorAttentionInput {
+            status: parsed_status,
+            awaiting_kind: summary.awaiting_kind.as_deref(),
+            has_origin_session: summary
+                .origin_session_id
+                .as_deref()
+                .is_some_and(|id| !id.is_empty()),
+            updated_at: &summary.updated_at,
+            waiting_for_user_tool: true,
+        },
+        now,
+    );
+}
+
 /// Cross-mission feed of status-change alerts, newest first. Source of truth
 /// is `mission_events` (`mission_status_changed`), decorated best-effort with
 /// mission summaries and Telegram delivery state.
@@ -11770,95 +11817,139 @@ pub async fn get_alerts_feed(
 ) -> Result<Json<AlertsFeedResponse>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
-
-    let events = control
-        .mission_store
-        .get_status_events_global(query.before.as_deref(), limit)
-        .await
-        .map_err(internal_error)?;
-
-    // Cursor comes from the raw (unfiltered) page so pagination never stalls
-    // even when a status filter empties a page.
-    let next_cursor = if events.len() == limit {
-        events.last().map(|e| e.timestamp.clone())
-    } else {
-        None
-    };
-
+    let needs_operator_only = query.needs_operator == Some(true);
     let wanted: Option<Vec<String>> = query.statuses.as_deref().map(|s| {
         s.split(',')
             .map(|p| p.trim().to_string())
             .filter(|p| !p.is_empty())
             .collect()
     });
-
-    let mut entries: Vec<AlertFeedEntry> = events
+    let waiting_user_ids: HashSet<Uuid> = control
+        .mission_store
+        .list_active_mission_runs()
+        .await
+        .unwrap_or_default()
         .into_iter()
-        .filter_map(|e| {
-            let status = e.metadata.get("status")?.as_str()?.to_string();
-            if let Some(wanted) = &wanted {
-                if !wanted.contains(&status) {
-                    return None;
-                }
-            }
-            Some(AlertFeedEntry {
-                mission_id: e.mission_id,
-                status,
-                summary: e.content,
-                timestamp: e.timestamp,
-                mission: None,
-                delivery: None,
-            })
-        })
+        .filter(|run| run.execution_state == MissionExecutionState::WaitingUser)
+        .map(|run| run.mission_id)
         .collect();
+    let now = chrono::Utc::now();
 
-    let mission_ids: Vec<Uuid> = {
-        let mut ids: Vec<Uuid> = entries.iter().map(|e| e.mission_id).collect();
-        ids.sort();
-        ids.dedup();
-        ids
+    // `needs_operator` is sparse, so walk raw pages until we fill `limit`
+    // (or exhaust) instead of returning an empty 30-row window.
+    const MAX_OPERATOR_PAGES: usize = 10;
+    let max_pages = if needs_operator_only {
+        MAX_OPERATOR_PAGES
+    } else {
+        1
     };
+    let mut before = query.before.clone();
+    let mut entries: Vec<AlertFeedEntry> = Vec::new();
+    let mut next_cursor = None;
+    let mut seen_ids: HashSet<Uuid> = HashSet::new();
+    let mut summaries: HashMap<Uuid, mission_store::MissionSummary> = HashMap::new();
+    let mut telegram_alerts = Vec::new();
 
-    let summaries = control
-        .mission_store
-        .get_mission_summaries(&mission_ids)
-        .await
-        .map_err(internal_error)?;
-    let telegram_alerts = control
-        .mission_store
-        .list_telegram_alerts_for_missions(&mission_ids)
-        .await
-        .unwrap_or_default();
+    for _ in 0..max_pages {
+        let events = control
+            .mission_store
+            .get_status_events_global(before.as_deref(), limit)
+            .await
+            .map_err(internal_error)?;
+        let page_len = events.len();
+        next_cursor = if page_len == limit {
+            events.last().map(|e| e.timestamp.clone())
+        } else {
+            None
+        };
 
-    for entry in &mut entries {
-        entry.mission = summaries.get(&entry.mission_id).cloned();
-        // Loose join: telegram_alerts has no FK to the event row; match the
-        // alert class (`mission_<status>` before any `:` suffix). The list is
-        // ordered created_at DESC, so the first match is the most recent.
-        let class = format!("mission_{}", entry.status);
-        entry.delivery = telegram_alerts
-            .iter()
-            .find(|a| {
-                a.mission_id == Some(entry.mission_id)
-                    && a.event_kind.split(':').next().unwrap_or(&a.event_kind) == class
+        let mut page: Vec<AlertFeedEntry> = events
+            .into_iter()
+            .filter_map(|e| {
+                let status = e.metadata.get("status")?.as_str()?.to_string();
+                if let Some(wanted) = &wanted {
+                    if !wanted.contains(&status) {
+                        return None;
+                    }
+                }
+                Some(AlertFeedEntry {
+                    mission_id: e.mission_id,
+                    status,
+                    summary: e.content,
+                    timestamp: e.timestamp,
+                    mission: None,
+                    delivery: None,
+                })
             })
-            .map(|a| AlertFeedDelivery {
-                channel: "telegram",
-                status: a.status.clone(),
-                sent_at: a.sent_at.clone(),
-                acknowledged_at: a.acknowledged_at.clone(),
-                last_error: a.last_error.clone(),
-            });
-    }
+            .collect();
 
-    if query.needs_operator == Some(true) {
-        entries.retain(|entry| {
-            entry
-                .mission
-                .as_ref()
-                .is_some_and(|summary| summary.needs_operator)
-        });
+        let new_ids: Vec<Uuid> = {
+            let mut ids: Vec<Uuid> = page
+                .iter()
+                .map(|e| e.mission_id)
+                .filter(|id| seen_ids.insert(*id))
+                .collect();
+            ids.sort();
+            ids.dedup();
+            ids
+        };
+        if !new_ids.is_empty() {
+            let fetched = control
+                .mission_store
+                .get_mission_summaries(&new_ids)
+                .await
+                .map_err(internal_error)?;
+            summaries.extend(fetched);
+            telegram_alerts.extend(
+                control
+                    .mission_store
+                    .list_telegram_alerts_for_missions(&new_ids)
+                    .await
+                    .unwrap_or_default(),
+            );
+        }
+
+        for entry in &mut page {
+            if let Some(summary) = summaries.get_mut(&entry.mission_id) {
+                let waiting = waiting_user_ids.contains(&entry.mission_id);
+                refresh_summary_for_waiting_user(summary, waiting, now);
+                entry.mission = Some(summary.clone());
+            }
+            let class = format!("mission_{}", entry.status);
+            entry.delivery = telegram_alerts
+                .iter()
+                .find(|a| {
+                    a.mission_id == Some(entry.mission_id)
+                        && a.event_kind.split(':').next().unwrap_or(&a.event_kind) == class
+                })
+                .map(|a| AlertFeedDelivery {
+                    channel: "telegram",
+                    status: a.status.clone(),
+                    sent_at: a.sent_at.clone(),
+                    acknowledged_at: a.acknowledged_at.clone(),
+                    last_error: a.last_error.clone(),
+                });
+        }
+
+        if needs_operator_only {
+            page.retain(|entry| {
+                super::operator_attention::alert_event_is_operator_page(
+                    &entry.status,
+                    entry
+                        .mission
+                        .as_ref()
+                        .is_some_and(|summary| summary.needs_operator),
+                    waiting_user_ids.contains(&entry.mission_id),
+                )
+            });
+        }
+        entries.extend(page);
+        if entries.len() >= limit || next_cursor.is_none() {
+            break;
+        }
+        before = next_cursor.clone();
     }
+    entries.truncate(limit);
 
     Ok(Json(AlertsFeedResponse {
         alerts: entries,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -11829,6 +11829,52 @@ pub struct AlertsFeedResponse {
     pub next_cursor: Option<String>,
 }
 
+fn telegram_delivery_for_status(
+    telegram_alerts: &[crate::api::mission_store::TelegramAlert],
+    mission_id: Uuid,
+    status: &str,
+) -> Option<AlertFeedDelivery> {
+    let class = format!("mission_{status}");
+    telegram_alerts
+        .iter()
+        .find(|alert| {
+            alert.mission_id == Some(mission_id)
+                && alert
+                    .event_kind
+                    .split(':')
+                    .next()
+                    .unwrap_or(&alert.event_kind)
+                    == class
+        })
+        .map(|alert| AlertFeedDelivery {
+            channel: "telegram",
+            status: alert.status.clone(),
+            sent_at: alert.sent_at.clone(),
+            acknowledged_at: alert.acknowledged_at.clone(),
+            last_error: alert.last_error.clone(),
+        })
+}
+
+/// Synthesize a current-state alert for a live AskUserQuestion so Needs You
+/// does not depend on the mission's (possibly ancient) `active` status event
+/// still sitting inside the historical scan window.
+fn live_wait_alert_entry(
+    mission_id: Uuid,
+    summary: mission_store::MissionSummary,
+    wait_started_at: Option<&str>,
+    now: &str,
+    delivery: Option<AlertFeedDelivery>,
+) -> AlertFeedEntry {
+    AlertFeedEntry {
+        mission_id,
+        status: "active".to_string(),
+        summary: "Waiting for user input".to_string(),
+        timestamp: wait_started_at.unwrap_or(now).to_string(),
+        mission: Some(summary),
+        delivery,
+    }
+}
+
 fn refresh_summary_for_waiting_user(
     summary: &mut mission_store::MissionSummary,
     waiting_for_user_tool: bool,
@@ -11894,8 +11940,56 @@ pub async fn get_alerts_feed(
     let mut entries: Vec<AlertFeedEntry> = Vec::new();
     let mut next_cursor = None;
     let mut seen_ids: HashSet<Uuid> = HashSet::new();
+    let mut seeded_live: HashSet<Uuid> = HashSet::new();
     let mut summaries: HashMap<Uuid, mission_store::MissionSummary> = HashMap::new();
     let mut telegram_alerts = Vec::new();
+
+    // Current live waits belong on the first Needs You page even when the
+    // mission's last status event is older than the historical window.
+    if needs_operator_only && query.before.is_none() && !waiting_user_waits.is_empty() {
+        let live_ids: Vec<Uuid> = waiting_user_waits.keys().copied().collect();
+        let fetched = control
+            .mission_store
+            .get_mission_summaries(&live_ids)
+            .await
+            .map_err(internal_error)?;
+        summaries.extend(fetched);
+        telegram_alerts.extend(
+            control
+                .mission_store
+                .list_telegram_alerts_for_missions(&live_ids)
+                .await
+                .unwrap_or_default(),
+        );
+        let now_rfc = now.to_rfc3339();
+        for (mission_id, started_at) in &waiting_user_waits {
+            if let Some(wanted) = &wanted {
+                if !wanted.iter().any(|status| status == "active") {
+                    continue;
+                }
+            }
+            let Some(summary) = summaries.get_mut(mission_id) else {
+                continue;
+            };
+            refresh_summary_for_waiting_user(summary, true, started_at.as_deref(), now);
+            if !summary.needs_operator {
+                continue;
+            }
+            entries.push(live_wait_alert_entry(
+                *mission_id,
+                summary.clone(),
+                started_at.as_deref(),
+                &now_rfc,
+                telegram_delivery_for_status(&telegram_alerts, *mission_id, "awaiting_user")
+                    .or_else(|| {
+                        telegram_delivery_for_status(&telegram_alerts, *mission_id, "active")
+                    }),
+            ));
+            seeded_live.insert(*mission_id);
+            seen_ids.insert(*mission_id);
+        }
+        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    }
 
     for _ in 0..max_pages {
         let events = control
@@ -11969,24 +12063,15 @@ pub async fn get_alerts_feed(
                 );
                 entry.mission = Some(summary.clone());
             }
-            let class = format!("mission_{}", entry.status);
-            entry.delivery = telegram_alerts
-                .iter()
-                .find(|a| {
-                    a.mission_id == Some(entry.mission_id)
-                        && a.event_kind.split(':').next().unwrap_or(&a.event_kind) == class
-                })
-                .map(|a| AlertFeedDelivery {
-                    channel: "telegram",
-                    status: a.status.clone(),
-                    sent_at: a.sent_at.clone(),
-                    acknowledged_at: a.acknowledged_at.clone(),
-                    last_error: a.last_error.clone(),
-                });
+            entry.delivery =
+                telegram_delivery_for_status(&telegram_alerts, entry.mission_id, &entry.status);
         }
 
         if needs_operator_only {
             page.retain(|entry| {
+                if seeded_live.contains(&entry.mission_id) {
+                    return false;
+                }
                 super::operator_attention::alert_event_is_operator_page(
                     &entry.status,
                     entry
@@ -31823,5 +31908,46 @@ Investigate <service/> failures.
             (slow_count as u64) + slow_lagged >= PRODUCER_EVENTS as u64,
             "slow subscriber's got+lost should still account for the producer (got={slow_count} lagged={slow_lagged})"
         );
+    }
+
+    fn test_summary(needs_operator: bool) -> super::mission_store::MissionSummary {
+        super::mission_store::MissionSummary {
+            title: Some("ask".into()),
+            status: "active".into(),
+            workspace_name: None,
+            awaiting_kind: None,
+            needs_operator,
+            origin_session_id: None,
+            updated_at: "2026-01-01T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn live_wait_alert_uses_the_tool_start_not_the_ancient_active_event() {
+        let mission_id = uuid::Uuid::new_v4();
+        let entry = super::live_wait_alert_entry(
+            mission_id,
+            test_summary(true),
+            Some("2026-08-16T12:00:00Z"),
+            "2026-08-16T12:05:00Z",
+            None,
+        );
+        assert_eq!(entry.mission_id, mission_id);
+        assert_eq!(entry.status, "active");
+        assert_eq!(entry.timestamp, "2026-08-16T12:00:00Z");
+        assert_eq!(entry.summary, "Waiting for user input");
+        assert!(entry.mission.is_some_and(|m| m.needs_operator));
+    }
+
+    #[test]
+    fn live_wait_alert_falls_back_to_now_when_tool_start_is_missing() {
+        let entry = super::live_wait_alert_entry(
+            uuid::Uuid::new_v4(),
+            test_summary(true),
+            None,
+            "2026-08-16T12:05:00Z",
+            None,
+        );
+        assert_eq!(entry.timestamp, "2026-08-16T12:05:00Z");
     }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4024,24 +4024,22 @@ impl ControlHub {
         Ok(collected)
     }
 
-    /// Mission IDs whose live run is parked on AskUserQuestion (`WaitingUser`).
-    /// Used so project chips share the same `needs_operator` clock as list/detail.
-    pub(crate) async fn collect_waiting_user_mission_ids(&self) -> HashSet<Uuid> {
-        let mut ids = HashSet::new();
+    /// Live AskUserQuestion waits: mission id → user-wait tool `started_at`.
+    /// Presence means `WaitingUser`; the value is the grace clock (None if the
+    /// tool row is not registered yet — treated as just started).
+    pub(crate) async fn collect_waiting_user_waits(&self) -> HashMap<Uuid, Option<String>> {
+        let mut waits = HashMap::new();
         let Ok(inventory) = self.mission_store_inventory().await else {
-            return ids;
+            return waits;
         };
         for store in inventory.live {
             let Ok(runs) = store.list_active_mission_runs().await else {
                 continue;
             };
-            for run in runs {
-                if run.execution_state == MissionExecutionState::WaitingUser {
-                    ids.insert(run.mission_id);
-                }
-            }
+            let store_waits = user_wait_starts_for_runs(store.as_ref(), &runs).await;
+            waits.extend(store_waits);
         }
-        ids
+        waits
     }
 
     /// Board tasks across every store whose boss mission belongs to this
@@ -5185,6 +5183,7 @@ fn attach_execution_to_mission_value(
     mut value: serde_json::Value,
     mission: &Mission,
     run: Option<&MissionRun>,
+    wait_started_at: Option<&str>,
 ) -> serde_json::Value {
     if let Some(object) = value.as_object_mut() {
         object.insert(
@@ -5207,6 +5206,7 @@ fn attach_execution_to_mission_value(
             serde_json::Value::Bool(super::operator_attention::mission_needs_operator(
                 mission,
                 waiting_for_user_tool,
+                wait_started_at,
                 chrono::Utc::now(),
             )),
         );
@@ -5216,6 +5216,35 @@ fn attach_execution_to_mission_value(
 
 fn is_user_wait_tool(tool_kind: &str) -> bool {
     matches!(tool_kind, "request_user_input" | "frontend_tool") || is_interactive_ui_tool(tool_kind)
+}
+
+pub(crate) async fn user_wait_tool_started_at(
+    store: &dyn MissionStore,
+    run: &MissionRun,
+) -> Option<String> {
+    if run.execution_state != MissionExecutionState::WaitingUser {
+        return None;
+    }
+    let tools = store.list_active_tool_executions(run.run_id).await.ok()?;
+    tools
+        .into_iter()
+        .filter(|tool| is_user_wait_tool(&tool.tool_kind))
+        .map(|tool| tool.started_at)
+        .min()
+}
+
+pub(crate) async fn user_wait_starts_for_runs(
+    store: &dyn MissionStore,
+    runs: impl IntoIterator<Item = &MissionRun>,
+) -> HashMap<Uuid, Option<String>> {
+    let mut waits = HashMap::new();
+    for run in runs {
+        if run.execution_state != MissionExecutionState::WaitingUser {
+            continue;
+        }
+        waits.insert(run.mission_id, user_wait_tool_started_at(store, run).await);
+    }
+    waits
 }
 
 const PROVISIONAL_TOOL_DEADLINE_SECS: i64 = 120;
@@ -5602,11 +5631,20 @@ pub async fn list_missions(
         .into_iter()
         .map(|run| (run.mission_id, run))
         .collect();
+    let wait_starts =
+        user_wait_starts_for_runs(control.mission_store.as_ref(), active_runs.values()).await;
     let values = missions
         .into_iter()
         .map(|mission| {
             let value = serde_json::to_value(&mission).unwrap_or(serde_json::Value::Null);
-            attach_execution_to_mission_value(value, &mission, active_runs.get(&mission.id))
+            attach_execution_to_mission_value(
+                value,
+                &mission,
+                active_runs.get(&mission.id),
+                wait_starts
+                    .get(&mission.id)
+                    .and_then(|started| started.as_deref()),
+            )
         })
         .collect();
     Ok(Json(values))
@@ -6499,10 +6537,15 @@ pub async fn get_mission(
                 .get_active_mission_run(mission.id)
                 .await
                 .map_err(internal_error)?;
+            let wait_started_at = match active_run.as_ref() {
+                Some(run) => user_wait_tool_started_at(control.mission_store.as_ref(), run).await,
+                None => None,
+            };
             let mut value = attach_execution_to_mission_value(
                 serde_json::to_value(&mission).map_err(internal_error)?,
                 &mission,
                 active_run.as_ref(),
+                wait_started_at.as_deref(),
             );
             let host_configured =
                 state.config.spark_arbiter_url.is_some() || state.config.spark_ssh_target.is_some();
@@ -6919,11 +6962,19 @@ pub async fn get_mission_digest(
             }
         }
     }
-    let execution = control
+    let active_run = control
         .mission_store
         .get_active_mission_run(mission.id)
         .await
-        .map_err(internal_error)?
+        .map_err(internal_error)?;
+    let waiting_for_user_tool = active_run
+        .as_ref()
+        .is_some_and(|run| run.execution_state == MissionExecutionState::WaitingUser);
+    let wait_started_at = match active_run.as_ref() {
+        Some(run) => user_wait_tool_started_at(control.mission_store.as_ref(), run).await,
+        None => None,
+    };
+    let execution = active_run
         .as_ref()
         .map(|run| mission_execution_projection(run, mission.status));
 
@@ -6934,12 +6985,8 @@ pub async fn get_mission_digest(
         "awaiting_kind": mission.awaiting_kind.map(|k| k.as_str()),
         "needs_operator": super::operator_attention::mission_needs_operator(
             &mission,
-            execution.as_ref().is_some_and(|value| {
-                value
-                    .get("state")
-                    .and_then(serde_json::Value::as_str)
-                    == Some("waiting_user")
-            }),
+            waiting_for_user_tool,
+            wait_started_at.as_deref(),
             chrono::Utc::now(),
         ),
         "terminal_reason": mission.terminal_reason,
@@ -11785,6 +11832,7 @@ pub struct AlertsFeedResponse {
 fn refresh_summary_for_waiting_user(
     summary: &mut mission_store::MissionSummary,
     waiting_for_user_tool: bool,
+    wait_started_at: Option<&str>,
     now: chrono::DateTime<chrono::Utc>,
 ) {
     if !waiting_for_user_tool {
@@ -11802,6 +11850,7 @@ fn refresh_summary_for_waiting_user(
                 .is_some_and(|id| !id.is_empty()),
             updated_at: &summary.updated_at,
             waiting_for_user_tool: true,
+            wait_started_at,
         },
         now,
     );
@@ -11824,15 +11873,13 @@ pub async fn get_alerts_feed(
             .filter(|p| !p.is_empty())
             .collect()
     });
-    let waiting_user_ids: HashSet<Uuid> = control
+    let active_runs = control
         .mission_store
         .list_active_mission_runs()
         .await
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|run| run.execution_state == MissionExecutionState::WaitingUser)
-        .map(|run| run.mission_id)
-        .collect();
+        .unwrap_or_default();
+    let waiting_user_waits =
+        user_wait_starts_for_runs(control.mission_store.as_ref(), &active_runs).await;
     let now = chrono::Utc::now();
 
     // `needs_operator` is sparse, so walk raw pages until we fill `limit`
@@ -11911,8 +11958,15 @@ pub async fn get_alerts_feed(
 
         for entry in &mut page {
             if let Some(summary) = summaries.get_mut(&entry.mission_id) {
-                let waiting = waiting_user_ids.contains(&entry.mission_id);
-                refresh_summary_for_waiting_user(summary, waiting, now);
+                let waiting = waiting_user_waits.contains_key(&entry.mission_id);
+                refresh_summary_for_waiting_user(
+                    summary,
+                    waiting,
+                    waiting_user_waits
+                        .get(&entry.mission_id)
+                        .and_then(|started| started.as_deref()),
+                    now,
+                );
                 entry.mission = Some(summary.clone());
             }
             let class = format!("mission_{}", entry.status);
@@ -11939,7 +11993,7 @@ pub async fn get_alerts_feed(
                         .mission
                         .as_ref()
                         .is_some_and(|summary| summary.needs_operator),
-                    waiting_user_ids.contains(&entry.mission_id),
+                    waiting_user_waits.contains_key(&entry.mission_id),
                 )
             });
         }
@@ -11949,7 +12003,17 @@ pub async fn get_alerts_feed(
         }
         before = next_cursor.clone();
     }
+    let truncated = entries.len() > limit;
+    let had_more_raw = next_cursor.is_some();
     entries.truncate(limit);
+    // After a filter walk, leftover matches sit on the truncated tail of
+    // this page. Point the cursor at the last *kept* event so Load older
+    // does not skip them (the raw-page cursor would).
+    if needs_operator_only && (truncated || (entries.len() == limit && had_more_raw)) {
+        if let Some(last) = entries.last() {
+            next_cursor = Some(last.timestamp.clone());
+        }
+    }
 
     Ok(Json(AlertsFeedResponse {
         alerts: entries,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5180,6 +5180,16 @@ fn attach_execution_to_mission_value(
                 serde_json::Value::Null
             },
         );
+        let waiting_for_user_tool =
+            run.is_some_and(|run| run.execution_state == MissionExecutionState::WaitingUser);
+        object.insert(
+            "needs_operator".to_string(),
+            serde_json::Value::Bool(super::operator_attention::mission_needs_operator(
+                mission,
+                waiting_for_user_tool,
+                chrono::Utc::now(),
+            )),
+        );
     }
     value
 }
@@ -6902,6 +6912,16 @@ pub async fn get_mission_digest(
         "title": mission.title,
         "status": mission.status,
         "awaiting_kind": mission.awaiting_kind.map(|k| k.as_str()),
+        "needs_operator": super::operator_attention::mission_needs_operator(
+            &mission,
+            execution.as_ref().is_some_and(|value| {
+                value
+                    .get("state")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("waiting_user")
+            }),
+            chrono::Utc::now(),
+        ),
         "terminal_reason": mission.terminal_reason,
         "terminal_evidence": mission.terminal_evidence,
         "short_description": mission.short_description,
@@ -11705,6 +11725,9 @@ pub async fn get_mission_events(
 pub struct AlertsFeedQuery {
     /// Comma-separated mission statuses to keep (e.g. `awaiting_user,failed`).
     pub statuses: Option<String>,
+    /// When true, keep only alerts whose current mission is a qualified
+    /// operator page (`needs_operator`). Used by the Needs You feed filter.
+    pub needs_operator: Option<bool>,
     /// Timestamp cursor: return alerts strictly older than this.
     pub before: Option<String>,
     pub limit: Option<usize>,
@@ -11826,6 +11849,15 @@ pub async fn get_alerts_feed(
                 acknowledged_at: a.acknowledged_at.clone(),
                 last_error: a.last_error.clone(),
             });
+    }
+
+    if query.needs_operator == Some(true) {
+        entries.retain(|entry| {
+            entry
+                .mission
+                .as_ref()
+                .is_some_and(|summary| summary.needs_operator)
+        });
     }
 
     Ok(Json(AlertsFeedResponse {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7694,24 +7694,11 @@ fn elf_machine_name(machine: u16) -> &'static str {
     }
 }
 
-/// Resolve an overlay probe without following a symlink out of the rootfs.
-/// `File::open` would chase an absolute `/usr/bin/dash` link onto the host.
-fn overlay_trusted_path(
-    workspace: &crate::workspace::Workspace,
-    path: &std::path::Path,
+/// Keep every hop under the overlay root. `..` that walks out is refused.
+fn normalize_overlay_path(
+    root: &std::path::Path,
+    joined: std::path::PathBuf,
 ) -> Option<std::path::PathBuf> {
-    let meta = path.symlink_metadata().ok()?;
-    if !meta.file_type().is_symlink() {
-        return Some(path.to_path_buf());
-    }
-    let target = std::fs::read_link(path).ok()?;
-    let joined = if target.is_absolute() {
-        workspace
-            .path
-            .join(target.strip_prefix("/").unwrap_or(target.as_path()))
-    } else {
-        path.parent()?.join(target)
-    };
     let mut normalized = std::path::PathBuf::new();
     for component in joined.components() {
         match component {
@@ -7726,9 +7713,36 @@ fn overlay_trusted_path(
             std::path::Component::Normal(_) => normalized.push(component),
         }
     }
-    normalized
-        .starts_with(&workspace.path)
-        .then_some(normalized)
+    normalized.starts_with(root).then_some(normalized)
+}
+
+/// Resolve an overlay probe without following a symlink out of the rootfs.
+/// `File::open` would chase an absolute `/usr/bin/dash` link onto the host.
+/// A chain such as `sh -> /etc/alternatives/sh -> /usr/bin/dash` must be
+/// rewritten hop-by-hop; stopping after the first link still leaves a
+/// host-absolute target.
+fn overlay_trusted_path(
+    workspace: &crate::workspace::Workspace,
+    path: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    const MAX_SYMLINK_HOPS: usize = 32;
+    let mut current = path.to_path_buf();
+    for _ in 0..MAX_SYMLINK_HOPS {
+        let meta = current.symlink_metadata().ok()?;
+        if !meta.file_type().is_symlink() {
+            return Some(current);
+        }
+        let target = std::fs::read_link(&current).ok()?;
+        let joined = if target.is_absolute() {
+            workspace
+                .path
+                .join(target.strip_prefix("/").unwrap_or(target.as_path()))
+        } else {
+            current.parent()?.join(target)
+        };
+        current = normalize_overlay_path(&workspace.path, joined)?;
+    }
+    None
 }
 
 fn overlay_elf_e_machine(
@@ -9333,6 +9347,47 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn overlay_elf_follows_a_two_level_symlink_chain_inside_the_rootfs() {
+        let container = tempfile::tempdir().unwrap();
+        write_fake_elf(
+            &container.path().join("usr/bin/dash"),
+            super::ELF_EM_AARCH64,
+        );
+        fs::create_dir_all(container.path().join("etc/alternatives")).unwrap();
+        fs::create_dir_all(container.path().join("bin")).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            symlink(
+                "/usr/bin/dash",
+                container.path().join("etc/alternatives/sh"),
+            )
+            .unwrap();
+            symlink("/etc/alternatives/sh", container.path().join("bin/sh")).unwrap();
+        }
+        let workspace = container_workspace_at(container.path());
+        assert_eq!(
+            super::overlay_elf_e_machine(&workspace, &container.path().join("bin/sh")),
+            Some(super::ELF_EM_AARCH64),
+            "must read the overlay dash ELF, not follow the second link onto the host"
+        );
+
+        let host = tempfile::tempdir().unwrap();
+        write_fake_elf(&host.path().join("grok"), super::ELF_EM_X86_64);
+        let err = super::copy_host_executable_into_container(&workspace, &host.path().join("grok"))
+            .expect_err("cross-arch copy must be refused after resolving the symlink chain");
+        assert!(
+            err.contains("does not match container arch"),
+            "expected arch-mismatch error, got: {err}"
+        );
+        assert!(
+            !container.path().join("usr/local/bin/grok").exists(),
+            "refused copy must not leave a guest binary"
+        );
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7694,16 +7694,52 @@ fn elf_machine_name(machine: u16) -> &'static str {
     }
 }
 
-fn host_elf_machine() -> Option<u16> {
-    match std::env::consts::ARCH {
-        "x86_64" => Some(ELF_EM_X86_64),
-        "aarch64" => Some(ELF_EM_AARCH64),
-        _ => None,
+/// Resolve an overlay probe without following a symlink out of the rootfs.
+/// `File::open` would chase an absolute `/usr/bin/dash` link onto the host.
+fn overlay_trusted_path(
+    workspace: &crate::workspace::Workspace,
+    path: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    let meta = path.symlink_metadata().ok()?;
+    if !meta.file_type().is_symlink() {
+        return Some(path.to_path_buf());
     }
+    let target = std::fs::read_link(path).ok()?;
+    let joined = if target.is_absolute() {
+        workspace
+            .path
+            .join(target.strip_prefix("/").unwrap_or(target.as_path()))
+    } else {
+        path.parent()?.join(target)
+    };
+    let mut normalized = std::path::PathBuf::new();
+    for component in joined.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            std::path::Component::Normal(_) => normalized.push(component),
+        }
+    }
+    normalized
+        .starts_with(&workspace.path)
+        .then_some(normalized)
 }
 
-/// Container ISA from the nspawn overlay (`/bin/sh` etc.), else the host
-/// arch — nspawn images are debootstrapped for the machine that created them.
+fn overlay_elf_e_machine(
+    workspace: &crate::workspace::Workspace,
+    path: &std::path::Path,
+) -> Option<u16> {
+    elf_e_machine(&overlay_trusted_path(workspace, path)?)
+}
+
+/// Container ISA from the nspawn overlay only. Unknown ISA is `None` —
+/// callers must fail closed rather than assume the host arch.
 pub(crate) fn container_overlay_elf_machine(
     workspace: &crate::workspace::Workspace,
 ) -> Option<u16> {
@@ -7722,18 +7758,18 @@ pub(crate) fn container_overlay_elf_machine(
     ];
     for probe in PROBES {
         if let Some(path) = container_overlay_command_path(workspace, probe) {
-            if let Some(machine) = elf_e_machine(&path) {
+            if let Some(machine) = overlay_elf_e_machine(workspace, &path) {
                 return Some(machine);
             }
         }
         if probe.contains('/') {
             let path = workspace.path.join(probe.trim_start_matches('/'));
-            if let Some(machine) = elf_e_machine(&path) {
+            if let Some(machine) = overlay_elf_e_machine(workspace, &path) {
                 return Some(machine);
             }
         }
     }
-    host_elf_machine()
+    None
 }
 
 fn refuse_cross_arch_host_copy(
@@ -7744,7 +7780,10 @@ fn refuse_cross_arch_host_copy(
         return Ok(());
     };
     let Some(container_machine) = container_overlay_elf_machine(workspace) else {
-        return Ok(());
+        return Err(format!(
+            "Refusing to copy {} into the container: could not determine container arch from the nspawn overlay (x86_64=62, aarch64=183)",
+            host_executable.display(),
+        ));
     };
     if host_machine == container_machine {
         return Ok(());
@@ -9322,6 +9361,31 @@ mod tests {
     }
 
     #[test]
+    fn copy_host_executable_refuses_elf_arch_mismatch_aarch64_on_x86_64() {
+        let host = tempfile::tempdir().unwrap();
+        let container = tempfile::tempdir().unwrap();
+        let host_bin = host.path().join("grok");
+        write_fake_elf(&host_bin, super::ELF_EM_AARCH64);
+        write_fake_elf(&container.path().join("bin/sh"), super::ELF_EM_X86_64);
+
+        let workspace = container_workspace_at(container.path());
+        let err = super::copy_host_executable_into_container(&workspace, &host_bin)
+            .expect_err("cross-arch copy must be refused");
+        assert!(
+            err.contains("does not match container arch"),
+            "expected arch-mismatch error, got: {err}"
+        );
+        assert!(
+            err.contains("62") && err.contains("183"),
+            "error should name ELF e_machine values, got: {err}"
+        );
+        assert!(
+            !container.path().join("usr/local/bin/grok").exists(),
+            "refused copy must not leave a guest binary"
+        );
+    }
+
+    #[test]
     fn copy_host_executable_allows_matching_elf_arch() {
         let host = tempfile::tempdir().unwrap();
         let container = tempfile::tempdir().unwrap();
@@ -9334,6 +9398,23 @@ mod tests {
             .expect("matching arch must copy");
         assert_eq!(dest, "/usr/local/bin/grok");
         assert!(container.path().join("usr/local/bin/grok").is_file());
+    }
+
+    #[test]
+    fn copy_host_executable_refuses_when_container_isa_unknown() {
+        let host = tempfile::tempdir().unwrap();
+        let container = tempfile::tempdir().unwrap();
+        let host_bin = host.path().join("grok");
+        write_fake_elf(&host_bin, super::ELF_EM_X86_64);
+
+        let workspace = container_workspace_at(container.path());
+        let err = super::copy_host_executable_into_container(&workspace, &host_bin)
+            .expect_err("unknown container ISA must refuse an ELF copy");
+        assert!(
+            err.contains("could not determine container arch"),
+            "expected fail-closed unknown-ISA error, got: {err}"
+        );
+        assert!(!container.path().join("usr/local/bin/grok").exists());
     }
 
     fn container_workspace_at(path: &std::path::Path) -> crate::workspace::Workspace {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -6243,20 +6243,27 @@ pub(crate) fn container_overlay_command_path(
 }
 
 /// Guest-absolute path for an overlay hit, e.g. `/usr/local/bin/grok`.
+///
+/// The overlay file wins over `program`. A configured host path such as
+/// `/opt/grok-cli` must not be returned once we have found the in-guest
+/// binary — `nsenter --root` can only exec a container path.
 pub(crate) fn container_overlay_guest_path(
     workspace: &Workspace,
     overlay_path: &Path,
     program: &str,
 ) -> String {
-    if program.contains('/') {
-        return program.to_string();
-    }
     overlay_path
         .strip_prefix(&workspace.path)
         .ok()
         .map(|rel| format!("/{}", rel.to_string_lossy()))
         .filter(|guest| guest != "/")
-        .unwrap_or_else(|| format!("/usr/local/bin/{program}"))
+        .unwrap_or_else(|| {
+            if program.contains('/') {
+                program.to_string()
+            } else {
+                format!("/usr/local/bin/{program}")
+            }
+        })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7659,6 +7666,99 @@ fn host_executable_available(program: &str) -> bool {
     }
 }
 
+const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
+pub(crate) const ELF_EM_X86_64: u16 = 62;
+pub(crate) const ELF_EM_AARCH64: u16 = 183;
+
+/// ELF `e_machine` from the first 20 bytes, or `None` for scripts / non-ELF.
+pub(crate) fn elf_e_machine(path: &std::path::Path) -> Option<u16> {
+    use std::io::Read;
+    let mut header = [0u8; 20];
+    let mut file = std::fs::File::open(path).ok()?;
+    file.read_exact(&mut header).ok()?;
+    if header[0..4] != ELF_MAGIC {
+        return None;
+    }
+    match header[5] {
+        1 => Some(u16::from_le_bytes([header[18], header[19]])),
+        2 => Some(u16::from_be_bytes([header[18], header[19]])),
+        _ => None,
+    }
+}
+
+fn elf_machine_name(machine: u16) -> &'static str {
+    match machine {
+        ELF_EM_X86_64 => "x86_64",
+        ELF_EM_AARCH64 => "aarch64",
+        _ => "unknown",
+    }
+}
+
+fn host_elf_machine() -> Option<u16> {
+    match std::env::consts::ARCH {
+        "x86_64" => Some(ELF_EM_X86_64),
+        "aarch64" => Some(ELF_EM_AARCH64),
+        _ => None,
+    }
+}
+
+/// Container ISA from the nspawn overlay (`/bin/sh` etc.), else the host
+/// arch — nspawn images are debootstrapped for the machine that created them.
+pub(crate) fn container_overlay_elf_machine(
+    workspace: &crate::workspace::Workspace,
+) -> Option<u16> {
+    const PROBES: &[&str] = &[
+        "sh",
+        "bash",
+        "/bin/sh",
+        "/usr/bin/sh",
+        "/bin/bash",
+        "/usr/bin/bash",
+        "/lib64/ld-linux-x86-64.so.2",
+        "/lib/ld-linux-x86-64.so.2",
+        "/lib/ld-linux-aarch64.so.1",
+        "/usr/lib/ld-linux-aarch64.so.1",
+        "/lib64/ld-linux-aarch64.so.1",
+    ];
+    for probe in PROBES {
+        if let Some(path) = container_overlay_command_path(workspace, probe) {
+            if let Some(machine) = elf_e_machine(&path) {
+                return Some(machine);
+            }
+        }
+        if probe.contains('/') {
+            let path = workspace.path.join(probe.trim_start_matches('/'));
+            if let Some(machine) = elf_e_machine(&path) {
+                return Some(machine);
+            }
+        }
+    }
+    host_elf_machine()
+}
+
+fn refuse_cross_arch_host_copy(
+    workspace: &crate::workspace::Workspace,
+    host_executable: &std::path::Path,
+) -> Result<(), String> {
+    let Some(host_machine) = elf_e_machine(host_executable) else {
+        return Ok(());
+    };
+    let Some(container_machine) = container_overlay_elf_machine(workspace) else {
+        return Ok(());
+    };
+    if host_machine == container_machine {
+        return Ok(());
+    }
+    Err(format!(
+        "Refusing to copy {} into the container: host ELF machine {} ({}) does not match container arch {} ({}) (x86_64=62, aarch64=183)",
+        host_executable.display(),
+        host_machine,
+        elf_machine_name(host_machine),
+        container_machine,
+        elf_machine_name(container_machine),
+    ))
+}
+
 pub(crate) fn copy_host_executable_into_container(
     workspace: &crate::workspace::Workspace,
     host_executable: &std::path::Path,
@@ -7667,6 +7767,11 @@ pub(crate) fn copy_host_executable_into_container(
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| "Host executable has invalid filename".to_string())?;
+
+    // A host-native CLI exec-format-fails inside a foreign-arch nspawn
+    // rootfs. Refuse so the mission reports a missing CLI instead of
+    // dying later with Exec format error.
+    refuse_cross_arch_host_copy(workspace, host_executable)?;
 
     let dest_dir = workspace.path.join("usr").join("local").join("bin");
     std::fs::create_dir_all(&dest_dir)
@@ -9173,6 +9278,64 @@ mod tests {
         assert_eq!(fs::read(&copied).unwrap(), fs::read(&real).unwrap());
     }
 
+    fn write_fake_elf(path: &std::path::Path, e_machine: u16) {
+        let mut header = vec![0u8; 64];
+        header[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        header[4] = 2; // ELFCLASS64
+        header[5] = 1; // ELFDATA2LSB
+        header[6] = 1; // EV_CURRENT
+        header[18..20].copy_from_slice(&e_machine.to_le_bytes());
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, header).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    #[test]
+    fn copy_host_executable_refuses_elf_arch_mismatch() {
+        let host = tempfile::tempdir().unwrap();
+        let container = tempfile::tempdir().unwrap();
+        let host_bin = host.path().join("grok");
+        write_fake_elf(&host_bin, super::ELF_EM_X86_64);
+        write_fake_elf(&container.path().join("bin/sh"), super::ELF_EM_AARCH64);
+
+        let workspace = container_workspace_at(container.path());
+        let err = super::copy_host_executable_into_container(&workspace, &host_bin)
+            .expect_err("cross-arch copy must be refused");
+        assert!(
+            err.contains("does not match container arch"),
+            "expected arch-mismatch error, got: {err}"
+        );
+        assert!(
+            err.contains("62") && err.contains("183"),
+            "error should name ELF e_machine values, got: {err}"
+        );
+        assert!(
+            !container.path().join("usr/local/bin/grok").exists(),
+            "refused copy must not leave a guest binary"
+        );
+    }
+
+    #[test]
+    fn copy_host_executable_allows_matching_elf_arch() {
+        let host = tempfile::tempdir().unwrap();
+        let container = tempfile::tempdir().unwrap();
+        let host_bin = host.path().join("grok");
+        write_fake_elf(&host_bin, super::ELF_EM_AARCH64);
+        write_fake_elf(&container.path().join("bin/sh"), super::ELF_EM_AARCH64);
+
+        let workspace = container_workspace_at(container.path());
+        let dest = super::copy_host_executable_into_container(&workspace, &host_bin)
+            .expect("matching arch must copy");
+        assert_eq!(dest, "/usr/local/bin/grok");
+        assert!(container.path().join("usr/local/bin/grok").is_file());
+    }
+
     fn container_workspace_at(path: &std::path::Path) -> crate::workspace::Workspace {
         crate::workspace::Workspace {
             id: Uuid::new_v4(),
@@ -9223,6 +9386,11 @@ mod tests {
         assert_eq!(
             super::container_overlay_guest_path(&workspace, &grok_hit, "grok"),
             "/usr/local/bin/grok"
+        );
+        assert_eq!(
+            super::container_overlay_guest_path(&workspace, &grok_hit, "/opt/grok-cli"),
+            "/usr/local/bin/grok",
+            "configured host path must not replace the overlay guest path"
         );
         assert_eq!(
             super::container_overlay_command_path(&workspace, "/usr/bin/curl").as_deref(),

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -619,6 +619,12 @@ pub struct MissionSummary {
     pub awaiting_kind: Option<String>,
     /// Qualified operator page — computed at read time from kind/origin/grace.
     pub needs_operator: bool,
+    /// Clock + origin for recomputing `needs_operator` once live WaitingUser
+    /// is known. Not on the wire.
+    #[serde(skip)]
+    pub origin_session_id: Option<String>,
+    #[serde(skip)]
+    pub updated_at: String,
 }
 
 /// Persisted summary for one tool call across all of its stored events.

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -617,6 +617,8 @@ pub struct MissionSummary {
     pub status: String,
     pub workspace_name: Option<String>,
     pub awaiting_kind: Option<String>,
+    /// Qualified operator page — computed at read time from kind/origin/grace.
+    pub needs_operator: bool,
 }
 
 /// Persisted summary for one tool call across all of its stored events.

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -4414,20 +4414,44 @@ impl MissionStore for SqliteMissionStore {
             let conn = conn.blocking_lock();
             let placeholders = vec!["?"; id_strings.len()].join(",");
             let sql = format!(
-                "SELECT id, title, status, workspace_name, awaiting_kind \
+                "SELECT id, title, status, workspace_name, awaiting_kind, \
+                 origin_session_id, COALESCE(last_status_change_at, updated_at) \
                  FROM missions WHERE id IN ({placeholders})"
             );
+            let now = chrono::Utc::now();
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
             let rows = stmt
                 .query_map(rusqlite::params_from_iter(id_strings.iter()), |row| {
                     let mid: String = row.get(0)?;
+                    let status: String = row.get(2)?;
+                    let awaiting_kind: Option<String> = row.get(4)?;
+                    let origin_session_id: Option<String> = row.get(5)?;
+                    let updated_at: String = row.get(6)?;
+                    let parsed_status =
+                        serde_json::from_value::<crate::api::control::events::MissionStatus>(
+                            serde_json::Value::String(status.clone()),
+                        )
+                        .unwrap_or(crate::api::control::events::MissionStatus::Active);
+                    let needs_operator = crate::api::operator_attention::needs_operator(
+                        &crate::api::operator_attention::OperatorAttentionInput {
+                            status: parsed_status,
+                            awaiting_kind: awaiting_kind.as_deref(),
+                            has_origin_session: origin_session_id
+                                .as_deref()
+                                .is_some_and(|id| !id.is_empty()),
+                            updated_at: &updated_at,
+                            waiting_for_user_tool: false,
+                        },
+                        now,
+                    );
                     Ok((
                         mid,
                         MissionSummary {
                             title: row.get(1)?,
-                            status: row.get(2)?,
+                            status,
                             workspace_name: row.get(3)?,
-                            awaiting_kind: row.get(4)?,
+                            awaiting_kind,
+                            needs_operator,
                         },
                     ))
                 })

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -4415,7 +4415,7 @@ impl MissionStore for SqliteMissionStore {
             let placeholders = vec!["?"; id_strings.len()].join(",");
             let sql = format!(
                 "SELECT id, title, status, workspace_name, awaiting_kind, \
-                 origin_session_id, COALESCE(last_status_change_at, updated_at) \
+                 origin_session_id, updated_at, last_status_change_at \
                  FROM missions WHERE id IN ({placeholders})"
             );
             let now = chrono::Utc::now();
@@ -4427,6 +4427,10 @@ impl MissionStore for SqliteMissionStore {
                     let awaiting_kind: Option<String> = row.get(4)?;
                     let origin_session_id: Option<String> = row.get(5)?;
                     let updated_at: String = row.get(6)?;
+                    let last_status_change_at: Option<String> = row.get(7)?;
+                    let persisted_clock = last_status_change_at
+                        .as_deref()
+                        .unwrap_or(updated_at.as_str());
                     let parsed_status =
                         serde_json::from_value::<crate::api::control::events::MissionStatus>(
                             serde_json::Value::String(status.clone()),
@@ -4439,7 +4443,7 @@ impl MissionStore for SqliteMissionStore {
                             has_origin_session: origin_session_id
                                 .as_deref()
                                 .is_some_and(|id| !id.is_empty()),
-                            updated_at: &updated_at,
+                            updated_at: persisted_clock,
                             waiting_for_user_tool: false,
                         },
                         now,
@@ -4452,6 +4456,8 @@ impl MissionStore for SqliteMissionStore {
                             workspace_name: row.get(3)?,
                             awaiting_kind,
                             needs_operator,
+                            origin_session_id,
+                            updated_at,
                         },
                     ))
                 })

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -4445,6 +4445,7 @@ impl MissionStore for SqliteMissionStore {
                                 .is_some_and(|id| !id.is_empty()),
                             updated_at: persisted_clock,
                             waiting_for_user_tool: false,
+                            wait_started_at: None,
                         },
                         now,
                     );

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -50,6 +50,7 @@ mod monitoring;
 mod native_loop_observer;
 pub mod oauth_reconcile;
 pub mod opencode;
+pub(crate) mod operator_attention;
 pub mod paloma;
 pub mod project_health;
 pub mod projects_overview;

--- a/src/api/operator_attention.rs
+++ b/src/api/operator_attention.rs
@@ -20,8 +20,12 @@ pub struct OperatorAttentionInput<'a> {
     pub status: MissionStatus,
     pub awaiting_kind: Option<&'a str>,
     pub has_origin_session: bool,
+    /// Clock for persisted `awaiting_user`+`decision` (`last_status_change_at`).
     pub updated_at: &'a str,
     pub waiting_for_user_tool: bool,
+    /// Live AskUserQuestion clock: the user-wait tool's `started_at`.
+    /// Never `missions.updated_at` — that is the Active flip.
+    pub wait_started_at: Option<&'a str>,
 }
 
 /// Whether this mission is a qualified operator page right now.
@@ -34,34 +38,27 @@ pub fn needs_operator(input: &OperatorAttentionInput<'_>, now: DateTime<Utc>) ->
     if !is_qualified_operator_page(input) {
         return false;
     }
-    !held_for_controller_triage(input.has_origin_session, age_secs(input.updated_at, now))
+    !held_for_controller_triage(input.has_origin_session, page_age_secs(input, now))
 }
 
 /// [`needs_operator`] from a stored mission plus optional live AskUserQuestion.
 pub fn mission_needs_operator(
     mission: &Mission,
     waiting_for_user_tool: bool,
+    wait_started_at: Option<&str>,
     now: DateTime<Utc>,
 ) -> bool {
-    needs_operator(&attention_input(mission, waiting_for_user_tool), now)
+    needs_operator(
+        &attention_input(mission, waiting_for_user_tool, wait_started_at),
+        now,
+    )
 }
 
-pub fn attention_input(
-    mission: &Mission,
+pub fn attention_input<'a>(
+    mission: &'a Mission,
     waiting_for_user_tool: bool,
-) -> OperatorAttentionInput<'_> {
-    // Live AskUserQuestion leaves status Active, so last_status_change_at is
-    // the Active flip — often hours old. Clock that wait from updated_at
-    // (last row touch / tool activity), not the status transition.
-    let updated_at = if waiting_for_user_tool {
-        mission.updated_at.as_str()
-    } else {
-        mission
-            .activity
-            .last_status_change_at
-            .as_deref()
-            .unwrap_or(mission.updated_at.as_str())
-    };
+    wait_started_at: Option<&'a str>,
+) -> OperatorAttentionInput<'a> {
     OperatorAttentionInput {
         status: mission.status,
         awaiting_kind: mission.awaiting_kind.map(|kind| kind.as_str()),
@@ -69,8 +66,13 @@ pub fn attention_input(
             .origin_session_id
             .as_deref()
             .is_some_and(|id| !id.is_empty()),
-        updated_at,
+        updated_at: mission
+            .activity
+            .last_status_change_at
+            .as_deref()
+            .unwrap_or(mission.updated_at.as_str()),
         waiting_for_user_tool,
+        wait_started_at: wait_started_at.filter(|ts| !ts.is_empty()),
     }
 }
 
@@ -100,6 +102,18 @@ fn is_qualified_operator_page(input: &OperatorAttentionInput<'_>) -> bool {
 
 fn held_for_controller_triage(has_origin_session: bool, awaiting_secs: i64) -> bool {
     has_origin_session && awaiting_secs < CONTROLLER_TRIAGE_GRACE_SECS
+}
+
+fn page_age_secs(input: &OperatorAttentionInput<'_>, now: DateTime<Utc>) -> i64 {
+    if input.waiting_for_user_tool {
+        // Missing tool start: treat as now so a long-lived Active row does
+        // not page the instant AskUserQuestion fires. Never use updated_at.
+        return input
+            .wait_started_at
+            .map(|ts| age_secs(ts, now))
+            .unwrap_or(0);
+    }
+    age_secs(input.updated_at, now)
 }
 
 fn age_secs(timestamp: &str, now: DateTime<Utc>) -> i64 {
@@ -136,6 +150,7 @@ mod tests {
             has_origin_session: has_origin,
             updated_at,
             waiting_for_user_tool,
+            wait_started_at: waiting_for_user_tool.then_some(updated_at),
         }
     }
 
@@ -303,21 +318,25 @@ mod tests {
         assert!(mission_needs_operator(
             &sample_mission(Some(AwaitingKind::Decision), None, &fresh),
             false,
+            None,
             now()
         ));
         assert!(!mission_needs_operator(
             &sample_mission(Some(AwaitingKind::Decision), Some("sess-1"), &fresh),
             false,
+            None,
             now()
         ));
         assert!(mission_needs_operator(
             &sample_mission(Some(AwaitingKind::Decision), Some("sess-1"), &expired),
             false,
+            None,
             now()
         ));
         assert!(!mission_needs_operator(
             &sample_mission(Some(AwaitingKind::Ack), Some("sess-1"), &expired),
             false,
+            None,
             now()
         ));
     }
@@ -334,9 +353,37 @@ mod tests {
             &status_flip,
         );
         assert!(
-            !mission_needs_operator(&mission, true, now()),
+            !mission_needs_operator(&mission, true, Some(&tool_start), now()),
             "controller-owned AskUserQuestion inside grace must not page just because Active is old"
         );
+    }
+
+    #[test]
+    fn live_ask_user_question_clocks_grace_from_tool_started_at_not_updated_at() {
+        let too_old = ts_ago(CONTROLLER_TRIAGE_GRACE_SECS + 600);
+        let tool_start = ts_ago(30);
+        let mission = sample_mission_with_status(
+            MissionStatus::Active,
+            None,
+            Some("sess-1"),
+            &too_old,
+            &too_old,
+        );
+        assert!(
+            !mission_needs_operator(&mission, true, Some(&tool_start), now()),
+            "grace must start at the user-wait tool started_at, not missions.updated_at"
+        );
+        assert!(
+            !mission_needs_operator(&mission, true, None, now()),
+            "missing tool start must not fall back to updated_at and page immediately"
+        );
+        let expired_tool = ts_ago(CONTROLLER_TRIAGE_GRACE_SECS + 1);
+        assert!(mission_needs_operator(
+            &mission,
+            true,
+            Some(&expired_tool),
+            now()
+        ));
     }
 
     #[test]

--- a/src/api/operator_attention.rs
+++ b/src/api/operator_attention.rs
@@ -50,6 +50,18 @@ pub fn attention_input(
     mission: &Mission,
     waiting_for_user_tool: bool,
 ) -> OperatorAttentionInput<'_> {
+    // Live AskUserQuestion leaves status Active, so last_status_change_at is
+    // the Active flip — often hours old. Clock that wait from updated_at
+    // (last row touch / tool activity), not the status transition.
+    let updated_at = if waiting_for_user_tool {
+        mission.updated_at.as_str()
+    } else {
+        mission
+            .activity
+            .last_status_change_at
+            .as_deref()
+            .unwrap_or(mission.updated_at.as_str())
+    };
     OperatorAttentionInput {
         status: mission.status,
         awaiting_kind: mission.awaiting_kind.map(|kind| kind.as_str()),
@@ -57,13 +69,26 @@ pub fn attention_input(
             .origin_session_id
             .as_deref()
             .is_some_and(|id| !id.is_empty()),
-        updated_at: mission
-            .activity
-            .last_status_change_at
-            .as_deref()
-            .unwrap_or(mission.updated_at.as_str()),
+        updated_at,
         waiting_for_user_tool,
     }
+}
+
+/// Whether a status-change alert row is itself an operator page.
+///
+/// `needs_operator=true` on the alerts feed is **current-state**: the mission
+/// must qualify now. The event is kept only when it is the page itself
+/// (`awaiting_user`) or a live AskUserQuestion (`active` + WaitingUser), so
+/// older failed/completed rows on the same mission do not fill Needs You.
+pub fn alert_event_is_operator_page(
+    event_status: &str,
+    current_needs_operator: bool,
+    waiting_for_user_tool: bool,
+) -> bool {
+    if !current_needs_operator {
+        return false;
+    }
+    event_status == "awaiting_user" || (waiting_for_user_tool && event_status == "active")
 }
 
 fn is_qualified_operator_page(input: &OperatorAttentionInput<'_>) -> bool {
@@ -210,9 +235,25 @@ mod tests {
         origin: Option<&str>,
         updated_at: &str,
     ) -> Mission {
+        sample_mission_with_status(
+            MissionStatus::AwaitingUser,
+            kind,
+            origin,
+            updated_at,
+            updated_at,
+        )
+    }
+
+    fn sample_mission_with_status(
+        status: MissionStatus,
+        kind: Option<AwaitingKind>,
+        origin: Option<&str>,
+        updated_at: &str,
+        last_status_change_at: &str,
+    ) -> Mission {
         Mission {
             id: Uuid::new_v4(),
-            status: MissionStatus::AwaitingUser,
+            status,
             title: Some("q".into()),
             short_description: None,
             metadata_updated_at: None,
@@ -246,7 +287,7 @@ mod tests {
             scheduling: Default::default(),
             project: Default::default(),
             activity: MissionActivity {
-                last_status_change_at: Some(updated_at.to_string()),
+                last_status_change_at: Some(last_status_change_at.to_string()),
                 ..Default::default()
             },
             awaiting_kind: kind,
@@ -279,5 +320,35 @@ mod tests {
             false,
             now()
         ));
+    }
+
+    #[test]
+    fn live_ask_user_question_clocks_grace_from_updated_at_not_active_flip() {
+        let status_flip = ts_ago(CONTROLLER_TRIAGE_GRACE_SECS + 600);
+        let tool_start = ts_ago(30);
+        let mission = sample_mission_with_status(
+            MissionStatus::Active,
+            None,
+            Some("sess-1"),
+            &tool_start,
+            &status_flip,
+        );
+        assert!(
+            !mission_needs_operator(&mission, true, now()),
+            "controller-owned AskUserQuestion inside grace must not page just because Active is old"
+        );
+    }
+
+    #[test]
+    fn alert_event_filter_keeps_pages_not_historical_noise() {
+        // ack / in-grace decision: current needs_operator is false.
+        assert!(!alert_event_is_operator_page("awaiting_user", false, false));
+        // no-origin decision that still qualifies.
+        assert!(alert_event_is_operator_page("awaiting_user", true, false));
+        // live AskUserQuestion qualifies only with WaitingUser + current page.
+        assert!(alert_event_is_operator_page("active", true, true));
+        assert!(!alert_event_is_operator_page("active", true, false));
+        assert!(!alert_event_is_operator_page("failed", true, true));
+        assert!(!alert_event_is_operator_page("completed", true, false));
     }
 }

--- a/src/api/operator_attention.rs
+++ b/src/api/operator_attention.rs
@@ -1,0 +1,283 @@
+//! Qualified "Needs You" attention: a real operator page, not worker idle.
+//!
+//! Shared by mission JSON, the projects board, Telegram, and Paloma so the
+//! 20-minute controller-triage grace cannot drift across surfaces.
+
+use chrono::{DateTime, Utc};
+
+use super::control::events::MissionStatus;
+use super::mission_store::Mission;
+
+/// How long a controller-owned unanswered question stays off the operator
+/// inbox. After this the owning controller failed to resolve it and the
+/// human is paged. Matches the historical Telegram constant.
+pub const CONTROLLER_TRIAGE_GRACE_SECS: i64 = 20 * 60;
+
+/// Inputs the operator-page predicate needs. Callers that already have a
+/// [`Mission`] should prefer [`mission_needs_operator`].
+#[derive(Debug, Clone, Copy)]
+pub struct OperatorAttentionInput<'a> {
+    pub status: MissionStatus,
+    pub awaiting_kind: Option<&'a str>,
+    pub has_origin_session: bool,
+    pub updated_at: &'a str,
+    pub waiting_for_user_tool: bool,
+}
+
+/// Whether this mission is a qualified operator page right now.
+///
+/// True only for an unanswered decision / AskUserQuestion that has no
+/// owning controller session, or whose controller-triage grace has expired.
+/// `awaiting_kind=ack`, blocked/inspect states, and in-grace controller-owned
+/// waits are not operator pages.
+pub fn needs_operator(input: &OperatorAttentionInput<'_>, now: DateTime<Utc>) -> bool {
+    if !is_qualified_operator_page(input) {
+        return false;
+    }
+    !held_for_controller_triage(input.has_origin_session, age_secs(input.updated_at, now))
+}
+
+/// [`needs_operator`] from a stored mission plus optional live AskUserQuestion.
+pub fn mission_needs_operator(
+    mission: &Mission,
+    waiting_for_user_tool: bool,
+    now: DateTime<Utc>,
+) -> bool {
+    needs_operator(&attention_input(mission, waiting_for_user_tool), now)
+}
+
+pub fn attention_input(
+    mission: &Mission,
+    waiting_for_user_tool: bool,
+) -> OperatorAttentionInput<'_> {
+    OperatorAttentionInput {
+        status: mission.status,
+        awaiting_kind: mission.awaiting_kind.map(|kind| kind.as_str()),
+        has_origin_session: mission
+            .origin_session_id
+            .as_deref()
+            .is_some_and(|id| !id.is_empty()),
+        updated_at: mission
+            .activity
+            .last_status_change_at
+            .as_deref()
+            .unwrap_or(mission.updated_at.as_str()),
+        waiting_for_user_tool,
+    }
+}
+
+fn is_qualified_operator_page(input: &OperatorAttentionInput<'_>) -> bool {
+    if input.waiting_for_user_tool {
+        return true;
+    }
+    input.status == MissionStatus::AwaitingUser && input.awaiting_kind == Some("decision")
+}
+
+fn held_for_controller_triage(has_origin_session: bool, awaiting_secs: i64) -> bool {
+    has_origin_session && awaiting_secs < CONTROLLER_TRIAGE_GRACE_SECS
+}
+
+fn age_secs(timestamp: &str, now: DateTime<Utc>) -> i64 {
+    DateTime::parse_from_rfc3339(timestamp)
+        .map(|parsed| (now - parsed.with_timezone(&Utc)).num_seconds())
+        .unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::mission_store::{AwaitingKind, MissionActivity, MissionMode};
+    use chrono::TimeZone;
+    use uuid::Uuid;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 16, 12, 0, 0).unwrap()
+    }
+
+    fn ts_ago(secs: i64) -> String {
+        (now() - chrono::Duration::seconds(secs)).to_rfc3339()
+    }
+
+    fn input<'a>(
+        status: MissionStatus,
+        kind: Option<&'a str>,
+        has_origin: bool,
+        updated_at: &'a str,
+        waiting_for_user_tool: bool,
+    ) -> OperatorAttentionInput<'a> {
+        OperatorAttentionInput {
+            status,
+            awaiting_kind: kind,
+            has_origin_session: has_origin,
+            updated_at,
+            waiting_for_user_tool,
+        }
+    }
+
+    #[test]
+    fn ack_with_controller_origin_is_not_needs_operator() {
+        let updated = ts_ago(CONTROLLER_TRIAGE_GRACE_SECS + 60);
+        assert!(!needs_operator(
+            &input(
+                MissionStatus::AwaitingUser,
+                Some("ack"),
+                true,
+                &updated,
+                false
+            ),
+            now()
+        ));
+    }
+
+    #[test]
+    fn decision_without_origin_needs_operator_immediately() {
+        let updated = ts_ago(5);
+        assert!(needs_operator(
+            &input(
+                MissionStatus::AwaitingUser,
+                Some("decision"),
+                false,
+                &updated,
+                false
+            ),
+            now()
+        ));
+    }
+
+    #[test]
+    fn decision_with_origin_inside_grace_is_not_needs_operator() {
+        let updated = ts_ago(60);
+        assert!(!needs_operator(
+            &input(
+                MissionStatus::AwaitingUser,
+                Some("decision"),
+                true,
+                &updated,
+                false
+            ),
+            now()
+        ));
+    }
+
+    #[test]
+    fn decision_with_origin_past_grace_needs_operator() {
+        let updated = ts_ago(CONTROLLER_TRIAGE_GRACE_SECS + 1);
+        assert!(needs_operator(
+            &input(
+                MissionStatus::AwaitingUser,
+                Some("decision"),
+                true,
+                &updated,
+                false
+            ),
+            now()
+        ));
+    }
+
+    #[test]
+    fn waiting_for_tool_on_controller_owned_mission_inside_grace_is_not_needs_operator() {
+        let updated = ts_ago(30);
+        assert!(!needs_operator(
+            &input(MissionStatus::Active, None, true, &updated, true),
+            now()
+        ));
+    }
+
+    #[test]
+    fn waiting_for_tool_without_origin_needs_operator() {
+        let updated = ts_ago(5);
+        assert!(needs_operator(
+            &input(MissionStatus::Active, None, false, &updated, true),
+            now()
+        ));
+    }
+
+    #[test]
+    fn blocked_and_missing_kind_are_not_operator_pages() {
+        let updated = ts_ago(CONTROLLER_TRIAGE_GRACE_SECS + 1);
+        assert!(!needs_operator(
+            &input(MissionStatus::Blocked, None, false, &updated, false),
+            now()
+        ));
+        assert!(!needs_operator(
+            &input(MissionStatus::AwaitingUser, None, false, &updated, false),
+            now()
+        ));
+    }
+
+    fn sample_mission(
+        kind: Option<AwaitingKind>,
+        origin: Option<&str>,
+        updated_at: &str,
+    ) -> Mission {
+        Mission {
+            id: Uuid::new_v4(),
+            status: MissionStatus::AwaitingUser,
+            title: Some("q".into()),
+            short_description: None,
+            metadata_updated_at: None,
+            metadata_source: None,
+            metadata_model: None,
+            metadata_version: None,
+            workspace_id: Uuid::nil(),
+            workspace_name: None,
+            agent: None,
+            model_override: None,
+            model_effort: None,
+            fast_mode: false,
+            backend: "opencode".into(),
+            config_profile: None,
+            history: vec![],
+            created_at: updated_at.to_string(),
+            updated_at: updated_at.to_string(),
+            interrupted_at: None,
+            paused_at: None,
+            resumable: false,
+            desktop_sessions: vec![],
+            session_id: None,
+            terminal_reason: None,
+            terminal_evidence: None,
+            parent_mission_id: None,
+            working_directory: None,
+            mission_mode: MissionMode::Task,
+            goal_mode: false,
+            goal_objective: None,
+            first_viewed_at: None,
+            scheduling: Default::default(),
+            project: Default::default(),
+            activity: MissionActivity {
+                last_status_change_at: Some(updated_at.to_string()),
+                ..Default::default()
+            },
+            awaiting_kind: kind,
+            origin: origin.map(|_| "hermes".into()),
+            origin_session_id: origin.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn mission_helper_uses_stored_kind_and_origin() {
+        let fresh = ts_ago(10);
+        let expired = ts_ago(CONTROLLER_TRIAGE_GRACE_SECS + 5);
+        assert!(mission_needs_operator(
+            &sample_mission(Some(AwaitingKind::Decision), None, &fresh),
+            false,
+            now()
+        ));
+        assert!(!mission_needs_operator(
+            &sample_mission(Some(AwaitingKind::Decision), Some("sess-1"), &fresh),
+            false,
+            now()
+        ));
+        assert!(mission_needs_operator(
+            &sample_mission(Some(AwaitingKind::Decision), Some("sess-1"), &expired),
+            false,
+            now()
+        ));
+        assert!(!mission_needs_operator(
+            &sample_mission(Some(AwaitingKind::Ack), Some("sess-1"), &expired),
+            false,
+            now()
+        ));
+    }
+}

--- a/src/api/paloma/planner.rs
+++ b/src/api/paloma/planner.rs
@@ -24,21 +24,20 @@ pub fn alert_kind_for_status(status: MissionStatus) -> Option<&'static str> {
 pub fn alert_importance_for_mission(
     mission: &Mission,
     interest: TelegramMissionInterestLevel,
+    waiting_for_user_tool: bool,
 ) -> &'static str {
     if interest == TelegramMissionInterestLevel::High {
         return "high";
     }
+    if crate::api::operator_attention::mission_needs_operator(
+        mission,
+        waiting_for_user_tool,
+        Utc::now(),
+    ) {
+        return "high";
+    }
     match mission.status {
         MissionStatus::Failed | MissionStatus::Blocked => "high",
-        MissionStatus::AwaitingUser
-            if crate::api::operator_attention::mission_needs_operator(
-                mission,
-                false,
-                Utc::now(),
-            ) =>
-        {
-            "high"
-        }
         MissionStatus::Active => "normal",
         _ => "low",
     }

--- a/src/api/paloma/planner.rs
+++ b/src/api/paloma/planner.rs
@@ -25,6 +25,7 @@ pub fn alert_importance_for_mission(
     mission: &Mission,
     interest: TelegramMissionInterestLevel,
     waiting_for_user_tool: bool,
+    wait_started_at: Option<&str>,
 ) -> &'static str {
     if interest == TelegramMissionInterestLevel::High {
         return "high";
@@ -32,6 +33,7 @@ pub fn alert_importance_for_mission(
     if crate::api::operator_attention::mission_needs_operator(
         mission,
         waiting_for_user_tool,
+        wait_started_at,
         Utc::now(),
     ) {
         return "high";

--- a/src/api/paloma/planner.rs
+++ b/src/api/paloma/planner.rs
@@ -29,7 +29,16 @@ pub fn alert_importance_for_mission(
         return "high";
     }
     match mission.status {
-        MissionStatus::AwaitingUser | MissionStatus::Failed | MissionStatus::Blocked => "high",
+        MissionStatus::Failed | MissionStatus::Blocked => "high",
+        MissionStatus::AwaitingUser
+            if crate::api::operator_attention::mission_needs_operator(
+                mission,
+                false,
+                Utc::now(),
+            ) =>
+        {
+            "high"
+        }
         MissionStatus::Active => "normal",
         _ => "low",
     }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1804,6 +1804,7 @@ pub async fn projects_overview(
         .collect_project_missions(chrono::Duration::hours(TERMINAL_MISSION_HORIZON_HOURS))
         .await
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
+    let waiting_user_ids = state.control.collect_waiting_user_mission_ids().await;
 
     // Delivery-derived facts come from the projects store, which the
     // background ingestor keeps current — the overview never scans the Hermes
@@ -1875,7 +1876,10 @@ pub async fn projects_overview(
         let builder = rows
             .entry(key.clone())
             .or_insert_with(|| ProjectRowBuilder::new(key));
-        builder.missions.push(mission_chip(mission));
+        builder.missions.push(mission_chip(
+            mission,
+            waiting_user_ids.contains(&mission.id),
+        ));
         builder.health_inputs.push(OwnedHealthInput {
             track: mission.project.track.clone(),
             status: mission.status,
@@ -2125,8 +2129,9 @@ pub(crate) fn humanize_slug(slug: &str) -> String {
 
 /// Roster/CTRL mode is the default; live work and parked decisions win.
 /// `paused` is never overridden — the operator (or controller) parked it.
-/// Raw `awaiting_user` is not a decision block; only a qualified
-/// `needs_operator` page or a pending_user ledger row is.
+/// Raw `awaiting_user` is not a decision block. A `pending_user` ledger row
+/// becomes `blocked:decision` only when there is no live work (and no
+/// qualified `needs_operator` page). Live work still wins.
 pub(crate) fn honest_controller_mode(
     store_mode: Option<&str>,
     has_live_mission: bool,
@@ -2550,7 +2555,7 @@ fn bucket_rank(bucket: &str) -> u8 {
     }
 }
 
-fn mission_chip(mission: &Mission) -> MissionChip {
+fn mission_chip(mission: &Mission, waiting_for_user_tool: bool) -> MissionChip {
     MissionChip {
         id: mission.id.to_string(),
         status: mission.status,
@@ -2559,7 +2564,7 @@ fn mission_chip(mission: &Mission) -> MissionChip {
         github_pr: mission.project.github_pr.clone(),
         needs_operator: super::operator_attention::mission_needs_operator(
             mission,
-            false,
+            waiting_for_user_tool,
             chrono::Utc::now(),
         ),
     }
@@ -4363,9 +4368,6 @@ mod tests {
     fn pending_user_is_attention_regardless_of_missions() {
         let mut builder = ProjectRowBuilder::new("verity".to_string());
         builder.pending_decisions = 1;
-        builder
-            .missions
-            .push(awaiting_chip("00000002-aaaa-bbbb-cccc-dddddddddddd", false));
         let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
         assert!(row
             .attention_reasons
@@ -4375,6 +4377,8 @@ mod tests {
             .attention_reasons
             .iter()
             .any(|r| r.contains("awaiting user input")));
+        assert_eq!(row.mode.as_deref(), Some("blocked:decision"));
+        assert_eq!(row.bucket, "attention");
     }
 
     /// Freshness alone is not enough: without an active mode the controller

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1564,6 +1564,9 @@ struct MissionChip {
     title: Option<String>,
     updated_at: String,
     github_pr: Option<String>,
+    /// Qualified operator page — ack / in-grace controller waits stay false.
+    #[serde(default)]
+    needs_operator: bool,
 }
 
 /// Owned copy of what the health rollup reads.
@@ -2122,10 +2125,12 @@ pub(crate) fn humanize_slug(slug: &str) -> String {
 
 /// Roster/CTRL mode is the default; live work and parked decisions win.
 /// `paused` is never overridden — the operator (or controller) parked it.
+/// Raw `awaiting_user` is not a decision block; only a qualified
+/// `needs_operator` page or a pending_user ledger row is.
 pub(crate) fn honest_controller_mode(
     store_mode: Option<&str>,
     has_live_mission: bool,
-    awaiting_user: bool,
+    needs_operator: bool,
     pending_decisions: u32,
 ) -> Option<String> {
     let base = store_mode
@@ -2134,10 +2139,10 @@ pub(crate) fn honest_controller_mode(
     if base.eq_ignore_ascii_case("paused") {
         return store_mode.map(str::to_string);
     }
-    if has_live_mission && !awaiting_user {
+    if has_live_mission && !needs_operator {
         return Some("active".to_string());
     }
-    if pending_decisions > 0 {
+    if pending_decisions > 0 || needs_operator {
         return Some("blocked:decision".to_string());
     }
     store_mode.map(str::to_string)
@@ -2246,12 +2251,12 @@ impl ProjectRowBuilder {
                 attention.push("same state on 3 consecutive updates".to_string());
             }
         }
-        // A parked question always needs the operator: no freshness or mode
-        // signal from the controller can answer on the human's behalf.
+        // Only qualified operator pages count as "awaiting user". Ack and
+        // in-grace controller-owned questions stay off the attention shelf.
         let awaiting_user = self
             .missions
             .iter()
-            .filter(|chip| chip.status == MissionStatus::AwaitingUser)
+            .filter(|chip| chip.needs_operator)
             .count();
         let has_live_mission = self
             .missions
@@ -2552,6 +2557,11 @@ fn mission_chip(mission: &Mission) -> MissionChip {
         title: mission.title.clone(),
         updated_at: mission.updated_at.clone(),
         github_pr: mission.project.github_pr.clone(),
+        needs_operator: super::operator_attention::mission_needs_operator(
+            mission,
+            false,
+            chrono::Utc::now(),
+        ),
     }
 }
 
@@ -3843,6 +3853,14 @@ mod tests {
             honest_controller_mode(Some("blocked:transport-cap"), false, false, 0).as_deref(),
             Some("blocked:transport-cap")
         );
+        assert_eq!(
+            honest_controller_mode(Some("active"), true, true, 0).as_deref(),
+            Some("blocked:decision")
+        );
+        assert_eq!(
+            honest_controller_mode(Some("active"), true, false, 0).as_deref(),
+            Some("active")
+        );
     }
 
     #[test]
@@ -3856,6 +3874,7 @@ mod tests {
             title: Some("rebase #2332".into()),
             updated_at: "2026-08-14T06:00:00Z".into(),
             github_pr: None,
+            needs_operator: false,
         });
         let row = builder.finish(&[], None, None, "2026-08-14T06:05:00Z");
         assert_eq!(row.mode.as_deref(), Some("active"));
@@ -4041,6 +4060,7 @@ mod tests {
                 title: None,
                 updated_at: "2026-08-01T00:00:00Z".to_string(),
                 github_pr: None,
+                needs_operator: false,
             });
         }
         let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
@@ -4062,6 +4082,7 @@ mod tests {
             title: None,
             updated_at: "2026-08-02T00:00:00Z".to_string(),
             github_pr: None,
+            needs_operator: false,
         }
     }
 
@@ -4284,6 +4305,7 @@ mod tests {
             title: None,
             updated_at: "2026-08-04T11:00:00Z".to_string(),
             github_pr: None,
+            needs_operator: true,
         });
         builder
             .missions
@@ -4296,6 +4318,63 @@ mod tests {
             .iter()
             .any(|r| r.contains("awaiting user input")));
         assert!(row.attention_reasons.iter().any(|r| r.contains("Failed")));
+    }
+
+    fn awaiting_chip(id: &str, needs_operator: bool) -> MissionChip {
+        MissionChip {
+            id: id.to_string(),
+            status: MissionStatus::AwaitingUser,
+            title: None,
+            updated_at: "2026-08-04T11:00:00Z".to_string(),
+            github_pr: None,
+            needs_operator,
+        }
+    }
+
+    #[test]
+    fn ack_with_controller_origin_is_not_project_attention() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder
+            .missions
+            .push(awaiting_chip("00000002-aaaa-bbbb-cccc-dddddddddddd", false));
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(!row
+            .attention_reasons
+            .iter()
+            .any(|r| r.contains("awaiting user input")));
+        assert_ne!(row.mode.as_deref(), Some("blocked:decision"));
+    }
+
+    #[test]
+    fn decision_without_origin_is_project_attention() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder
+            .missions
+            .push(awaiting_chip("00000002-aaaa-bbbb-cccc-dddddddddddd", true));
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(row
+            .attention_reasons
+            .iter()
+            .any(|r| r.contains("awaiting user input")));
+        assert_eq!(row.mode.as_deref(), Some("blocked:decision"));
+    }
+
+    #[test]
+    fn pending_user_is_attention_regardless_of_missions() {
+        let mut builder = ProjectRowBuilder::new("verity".to_string());
+        builder.pending_decisions = 1;
+        builder
+            .missions
+            .push(awaiting_chip("00000002-aaaa-bbbb-cccc-dddddddddddd", false));
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert!(row
+            .attention_reasons
+            .iter()
+            .any(|r| r.contains("decision awaiting you")));
+        assert!(!row
+            .attention_reasons
+            .iter()
+            .any(|r| r.contains("awaiting user input")));
     }
 
     /// Freshness alone is not enough: without an active mode the controller

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1804,7 +1804,7 @@ pub async fn projects_overview(
         .collect_project_missions(chrono::Duration::hours(TERMINAL_MISSION_HORIZON_HOURS))
         .await
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
-    let waiting_user_ids = state.control.collect_waiting_user_mission_ids().await;
+    let waiting_user_waits = state.control.collect_waiting_user_waits().await;
 
     // Delivery-derived facts come from the projects store, which the
     // background ingestor keeps current — the overview never scans the Hermes
@@ -1878,7 +1878,10 @@ pub async fn projects_overview(
             .or_insert_with(|| ProjectRowBuilder::new(key));
         builder.missions.push(mission_chip(
             mission,
-            waiting_user_ids.contains(&mission.id),
+            waiting_user_waits.contains_key(&mission.id),
+            waiting_user_waits
+                .get(&mission.id)
+                .and_then(|started| started.as_deref()),
         ));
         builder.health_inputs.push(OwnedHealthInput {
             track: mission.project.track.clone(),
@@ -2555,7 +2558,11 @@ fn bucket_rank(bucket: &str) -> u8 {
     }
 }
 
-fn mission_chip(mission: &Mission, waiting_for_user_tool: bool) -> MissionChip {
+fn mission_chip(
+    mission: &Mission,
+    waiting_for_user_tool: bool,
+    wait_started_at: Option<&str>,
+) -> MissionChip {
     MissionChip {
         id: mission.id.to_string(),
         status: mission.status,
@@ -2565,6 +2572,7 @@ fn mission_chip(mission: &Mission, waiting_for_user_tool: bool) -> MissionChip {
         needs_operator: super::operator_attention::mission_needs_operator(
             mission,
             waiting_for_user_tool,
+            wait_started_at,
             chrono::Utc::now(),
         ),
     }

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -19,11 +19,32 @@ use crate::workspace::Workspace;
 use crate::workspace_exec::WorkspaceExec;
 
 /// Overlay / guest path for a Grok CLI, never a host path like `/opt/grok-cli`.
+///
+/// Absolute configured programs are not overlay-looked-up: an overlay file at
+/// `opt/grok-cli` would otherwise become the exec path, and nsenter without
+/// `--root` would resolve it on the host.
 fn grok_overlay_guest_path(workspace: &Workspace, program: &str) -> Option<String> {
-    let overlay = container_overlay_command_path(workspace, program)
-        .or_else(|| container_overlay_command_path(workspace, "/usr/local/bin/grok"))
-        .or_else(|| container_overlay_command_path(workspace, "grok"))?;
+    let relative = (!program.starts_with('/')).then_some(program);
+    let overlay = container_overlay_command_path(workspace, "/usr/local/bin/grok")
+        .or_else(|| container_overlay_command_path(workspace, "grok"))
+        .or_else(|| relative.and_then(|name| container_overlay_command_path(workspace, name)))?;
     Some(container_overlay_guest_path(workspace, &overlay, "grok"))
+}
+
+/// Whether nsenter `Present` may be used as the exec path. Absolute container
+/// paths that missed the guest overlay are host paths (`/opt/grok-cli`).
+fn grok_cli_path_from_presence(
+    is_container: bool,
+    program: &str,
+    cli_path: &str,
+    presence: CommandPresence,
+) -> Option<String> {
+    match presence {
+        CommandPresence::Present if !(is_container && program.starts_with('/')) => {
+            Some(cli_path.to_string())
+        }
+        _ => None,
+    }
 }
 
 async fn install_grok_cli_in_workspace(
@@ -138,12 +159,11 @@ async fn ensure_grok_cli_available(
     if let Some(guest) = grok_overlay_guest_path(&workspace_exec.workspace, program) {
         return Ok(guest);
     }
-    match command_presence(workspace_exec, cwd, program).await {
-        // An absolute configured path that missed the overlay is a host
-        // path (`/opt/grok-cli`). nsenter --root cannot exec it.
-        CommandPresence::Present if !(is_container && program.starts_with('/')) => {
-            return Ok(cli_path.to_string());
-        }
+    let presence = command_presence(workspace_exec, cwd, program).await;
+    if let Some(path) = grok_cli_path_from_presence(is_container, program, cli_path, presence) {
+        return Ok(path);
+    }
+    match presence {
         CommandPresence::Present => {
             tracing::warn!(
                 program,
@@ -1727,17 +1747,25 @@ mod tests {
         }
     }
 
-    #[test]
-    fn grok_overlay_prefers_guest_path_over_host_opt_cli() {
-        let root = tempfile::tempdir().unwrap();
-        let grok = root.path().join("usr/local/bin/grok");
-        fs::create_dir_all(grok.parent().unwrap()).unwrap();
-        fs::write(&grok, b"#!/bin/sh\necho grok\n").unwrap();
+    fn write_executable(path: &std::path::Path, contents: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&grok, fs::Permissions::from_mode(0o755)).unwrap();
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
         }
+    }
+
+    #[test]
+    fn grok_overlay_prefers_guest_path_over_host_opt_cli() {
+        let root = tempfile::tempdir().unwrap();
+        write_executable(
+            &root.path().join("usr/local/bin/grok"),
+            b"#!/bin/sh\necho grok\n",
+        );
         let workspace = container_workspace_at(root.path());
         assert_eq!(
             grok_overlay_guest_path(&workspace, "/opt/grok-cli").as_deref(),
@@ -1745,22 +1773,84 @@ mod tests {
         );
     }
 
+    #[test]
+    fn grok_overlay_ignores_absolute_opt_cli_even_when_present() {
+        let root = tempfile::tempdir().unwrap();
+        write_executable(
+            &root.path().join("opt/grok-cli"),
+            b"#!/bin/sh\necho host-grok\n",
+        );
+        let workspace = container_workspace_at(root.path());
+        assert_eq!(
+            grok_overlay_guest_path(&workspace, "/opt/grok-cli"),
+            None,
+            "overlay /opt/grok-cli must not become the guest exec path"
+        );
+    }
+
+    #[test]
+    fn grok_presence_never_returns_absolute_container_host_path() {
+        assert_eq!(
+            grok_cli_path_from_presence(
+                true,
+                "/opt/grok-cli",
+                "/opt/grok-cli",
+                CommandPresence::Present,
+            ),
+            None
+        );
+        assert_eq!(
+            grok_cli_path_from_presence(true, "grok", "grok", CommandPresence::Present).as_deref(),
+            Some("grok")
+        );
+        assert_eq!(
+            grok_cli_path_from_presence(
+                false,
+                "/opt/grok-cli",
+                "/opt/grok-cli",
+                CommandPresence::Present,
+            )
+            .as_deref(),
+            Some("/opt/grok-cli")
+        );
+    }
+
     #[tokio::test]
     async fn ensure_grok_cli_prefers_guest_overlay_over_host_opt_path() {
         let root = tempfile::tempdir().unwrap();
-        let grok = root.path().join("usr/local/bin/grok");
-        fs::create_dir_all(grok.parent().unwrap()).unwrap();
-        fs::write(&grok, b"#!/bin/sh\necho grok\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&grok, fs::Permissions::from_mode(0o755)).unwrap();
-        }
+        write_executable(
+            &root.path().join("usr/local/bin/grok"),
+            b"#!/bin/sh\necho grok\n",
+        );
         let exec = WorkspaceExec::new(container_workspace_at(root.path()));
         let path = ensure_grok_cli_available(&exec, root.path(), "/opt/grok-cli")
             .await
             .expect("overlay grok must be used");
         assert_eq!(path, "/usr/local/bin/grok");
+    }
+
+    #[tokio::test]
+    async fn ensure_grok_cli_never_returns_opt_path_when_overlay_has_no_grok() {
+        let root = tempfile::tempdir().unwrap();
+        write_executable(
+            &root.path().join("opt/grok-cli"),
+            b"#!/bin/sh\necho host-grok\n",
+        );
+        let prev = std::env::var("SANDBOXED_SH_AUTO_INSTALL_GROK").ok();
+        std::env::set_var("SANDBOXED_SH_AUTO_INSTALL_GROK", "0");
+        let exec = WorkspaceExec::new(container_workspace_at(root.path()));
+        let result = ensure_grok_cli_available(&exec, root.path(), "/opt/grok-cli").await;
+        match prev {
+            Some(value) => std::env::set_var("SANDBOXED_SH_AUTO_INSTALL_GROK", value),
+            None => std::env::remove_var("SANDBOXED_SH_AUTO_INSTALL_GROK"),
+        }
+        match result {
+            Ok(path) => assert_ne!(
+                path, "/opt/grok-cli",
+                "overlay-miss must not exec the host path"
+            ),
+            Err(_) => {}
+        }
     }
 
     #[test]

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -18,66 +18,19 @@ use crate::util::env_var_bool;
 use crate::workspace::Workspace;
 use crate::workspace_exec::WorkspaceExec;
 
-async fn ensure_grok_cli_available(
+/// Overlay / guest path for a Grok CLI, never a host path like `/opt/grok-cli`.
+fn grok_overlay_guest_path(workspace: &Workspace, program: &str) -> Option<String> {
+    let overlay = container_overlay_command_path(workspace, program)
+        .or_else(|| container_overlay_command_path(workspace, "/usr/local/bin/grok"))
+        .or_else(|| container_overlay_command_path(workspace, "grok"))?;
+    Some(container_overlay_guest_path(workspace, &overlay, "grok"))
+}
+
+async fn install_grok_cli_in_workspace(
     workspace_exec: &WorkspaceExec,
     cwd: &std::path::Path,
     cli_path: &str,
 ) -> Result<String, String> {
-    let program = cli_path.split(' ').next().unwrap_or(cli_path);
-    if let Some(overlay) = container_overlay_command_path(&workspace_exec.workspace, program)
-        .or_else(|| {
-            container_overlay_command_path(&workspace_exec.workspace, "/usr/local/bin/grok")
-        })
-    {
-        return Ok(container_overlay_guest_path(
-            &workspace_exec.workspace,
-            &overlay,
-            program,
-        ));
-    }
-    match command_presence(workspace_exec, cwd, program).await {
-        CommandPresence::Present => return Ok(cli_path.to_string()),
-        CommandPresence::Inconclusive => {
-            tracing::warn!(
-                program,
-                "Grok CLI nsenter probe timed out; not treating as absent"
-            );
-        }
-        CommandPresence::Absent => {}
-    }
-
-    // Host-copy first, same as Codex/OpenCode. The assistant container had a
-    // dangling symlink at /usr/local/bin/grok → /root/.grok/downloads/... so
-    // `ls` on the overlay looked fine and `command -v grok` inside nspawn
-    // failed (Verity #2332 writer 08306fdb, 2026-08-13).
-    if workspace_exec.workspace.workspace_type == crate::workspace::WorkspaceType::Container {
-        if let Some(host) = resolve_host_executable(program)
-            .or_else(|| resolve_host_executable("/usr/local/bin/grok"))
-        {
-            if let Ok(dest) = copy_host_executable_into_container(&workspace_exec.workspace, &host)
-            {
-                if container_overlay_command_path(&workspace_exec.workspace, &dest).is_some()
-                    || command_available(workspace_exec, cwd, &dest).await
-                {
-                    tracing::info!(
-                        host = %host.display(),
-                        dest,
-                        "Copied host Grok CLI into container workspace"
-                    );
-                    return Ok(dest);
-                }
-            }
-        }
-    }
-
-    let auto_install = env_var_bool("SANDBOXED_SH_AUTO_INSTALL_GROK", true);
-    if !auto_install {
-        return Err(format!(
-            "Grok Build CLI '{}' not found in workspace. Install it with: curl -fsSL https://x.ai/cli/install.sh | bash",
-            cli_path
-        ));
-    }
-
     match command_presence(workspace_exec, cwd, "curl").await {
         CommandPresence::Present => {}
         CommandPresence::Inconclusive => {
@@ -133,16 +86,110 @@ async fn ensure_grok_cli_available(
         return Err(format!("Grok Build install failed: {}", message));
     }
 
-    if command_available(workspace_exec, cwd, cli_path).await {
-        Ok(cli_path.to_string())
-    } else if command_available(workspace_exec, cwd, "/usr/local/bin/grok").await {
+    if let Some(guest) = grok_overlay_guest_path(&workspace_exec.workspace, "grok") {
+        return Ok(guest);
+    }
+    if command_available(workspace_exec, cwd, "/usr/local/bin/grok").await {
         Ok("/usr/local/bin/grok".to_string())
+    } else if !cli_path.starts_with('/') && command_available(workspace_exec, cwd, cli_path).await {
+        Ok(cli_path.to_string())
     } else {
         Err(
             "Grok Build install completed but 'grok' is still not available in workspace PATH."
                 .to_string(),
         )
     }
+}
+
+async fn copy_host_grok_cli_into_container(
+    workspace_exec: &WorkspaceExec,
+    cwd: &std::path::Path,
+    program: &str,
+) -> Result<Option<String>, String> {
+    let Some(host) = resolve_host_executable(program)
+        .or_else(|| resolve_host_executable("/usr/local/bin/grok"))
+        .or_else(|| resolve_host_executable("grok"))
+    else {
+        return Ok(None);
+    };
+    let dest = copy_host_executable_into_container(&workspace_exec.workspace, &host)?;
+    if container_overlay_command_path(&workspace_exec.workspace, &dest).is_some()
+        || command_available(workspace_exec, cwd, &dest).await
+    {
+        tracing::info!(
+            host = %host.display(),
+            dest,
+            "Copied host Grok CLI into container workspace"
+        );
+        return Ok(Some(dest));
+    }
+    Ok(None)
+}
+
+async fn ensure_grok_cli_available(
+    workspace_exec: &WorkspaceExec,
+    cwd: &std::path::Path,
+    cli_path: &str,
+) -> Result<String, String> {
+    let program = cli_path.split(' ').next().unwrap_or(cli_path);
+    let is_container =
+        workspace_exec.workspace.workspace_type == crate::workspace::WorkspaceType::Container;
+
+    if let Some(guest) = grok_overlay_guest_path(&workspace_exec.workspace, program) {
+        return Ok(guest);
+    }
+    match command_presence(workspace_exec, cwd, program).await {
+        // An absolute configured path that missed the overlay is a host
+        // path (`/opt/grok-cli`). nsenter --root cannot exec it.
+        CommandPresence::Present if !(is_container && program.starts_with('/')) => {
+            return Ok(cli_path.to_string());
+        }
+        CommandPresence::Present => {
+            tracing::warn!(
+                program,
+                "Ignoring host-absolute Grok CLI path for container workspace"
+            );
+        }
+        CommandPresence::Inconclusive => {
+            tracing::warn!(
+                program,
+                "Grok CLI nsenter probe timed out; not treating as absent"
+            );
+        }
+        CommandPresence::Absent => {}
+    }
+
+    let auto_install = env_var_bool("SANDBOXED_SH_AUTO_INSTALL_GROK", true);
+    let mut install_error = None;
+    if auto_install {
+        match install_grok_cli_in_workspace(workspace_exec, cwd, cli_path).await {
+            Ok(path) => return Ok(path),
+            Err(err) => install_error = Some(err),
+        }
+    }
+
+    // Host copy is last resort and only after the ELF arch check inside
+    // copy_host_executable_into_container.
+    if is_container {
+        match copy_host_grok_cli_into_container(workspace_exec, cwd, program).await {
+            Ok(Some(dest)) => return Ok(dest),
+            Ok(None) => {}
+            Err(err) => {
+                return Err(format!(
+                    "Grok Build CLI not found in workspace and the host CLI cannot be copied: {err}"
+                ));
+            }
+        }
+    }
+
+    if let Some(err) = install_error {
+        return Err(err);
+    }
+
+    Err(format!(
+        "Grok Build CLI '{}' not found in workspace. Install it with: curl -fsSL https://x.ai/cli/install.sh | bash",
+        cli_path
+    ))
 }
 
 fn grok_event_is_reasoning_type(value: &serde_json::Value) -> bool {
@@ -1649,6 +1696,72 @@ async fn run_grok_acp_turn(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workspace::WorkspaceType;
+    use std::fs;
+
+    fn container_workspace_at(path: &std::path::Path) -> Workspace {
+        Workspace {
+            id: Uuid::new_v4(),
+            name: "verity".into(),
+            workspace_type: WorkspaceType::Container,
+            path: path.to_path_buf(),
+            status: crate::workspace::WorkspaceStatus::Ready,
+            error_message: None,
+            config: serde_json::json!({}),
+            template: None,
+            distro: None,
+            env_vars: Default::default(),
+            init_scripts: Vec::new(),
+            init_script: None,
+            created_at: chrono::Utc::now(),
+            skills: Vec::new(),
+            plugins: Vec::new(),
+            shared_network: None,
+            tailscale_mode: None,
+            mcps: Vec::new(),
+            mcps_replace_defaults: true,
+            config_profile: None,
+            resolved_git_credentials: None,
+            read_only_command_guard_dir: None,
+            harness_versions: None,
+        }
+    }
+
+    #[test]
+    fn grok_overlay_prefers_guest_path_over_host_opt_cli() {
+        let root = tempfile::tempdir().unwrap();
+        let grok = root.path().join("usr/local/bin/grok");
+        fs::create_dir_all(grok.parent().unwrap()).unwrap();
+        fs::write(&grok, b"#!/bin/sh\necho grok\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&grok, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let workspace = container_workspace_at(root.path());
+        assert_eq!(
+            grok_overlay_guest_path(&workspace, "/opt/grok-cli").as_deref(),
+            Some("/usr/local/bin/grok")
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_grok_cli_prefers_guest_overlay_over_host_opt_path() {
+        let root = tempfile::tempdir().unwrap();
+        let grok = root.path().join("usr/local/bin/grok");
+        fs::create_dir_all(grok.parent().unwrap()).unwrap();
+        fs::write(&grok, b"#!/bin/sh\necho grok\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&grok, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let exec = WorkspaceExec::new(container_workspace_at(root.path()));
+        let path = ensure_grok_cli_available(&exec, root.path(), "/opt/grok-cli")
+            .await
+            .expect("overlay grok must be used");
+        assert_eq!(path, "/usr/local/bin/grok");
+    }
 
     #[test]
     fn grok_event_reasoning_handles_streaming_json_thought_events() {

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -24,11 +24,18 @@ use crate::workspace_exec::WorkspaceExec;
 /// `opt/grok-cli` would otherwise become the exec path, and nsenter without
 /// `--root` would resolve it on the host.
 fn grok_overlay_guest_path(workspace: &Workspace, program: &str) -> Option<String> {
-    let relative = (!program.starts_with('/')).then_some(program);
-    let overlay = container_overlay_command_path(workspace, "/usr/local/bin/grok")
-        .or_else(|| container_overlay_command_path(workspace, "grok"))
-        .or_else(|| relative.and_then(|name| container_overlay_command_path(workspace, name)))?;
-    Some(container_overlay_guest_path(workspace, &overlay, "grok"))
+    // Relative cli_path overrides (e.g. `custom-grok`) must win over the
+    // ordinary overlay binary. Absolute configured programs are host paths
+    // and are never overlay-looked-up.
+    let overlay = if program.starts_with('/') {
+        container_overlay_command_path(workspace, "/usr/local/bin/grok")
+            .or_else(|| container_overlay_command_path(workspace, "grok"))?
+    } else {
+        container_overlay_command_path(workspace, program)
+            .or_else(|| container_overlay_command_path(workspace, "/usr/local/bin/grok"))
+            .or_else(|| container_overlay_command_path(workspace, "grok"))?
+    };
+    Some(container_overlay_guest_path(workspace, &overlay, program))
 }
 
 /// Whether nsenter `Present` may be used as the exec path. Absolute container
@@ -1757,6 +1764,25 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
         }
+    }
+
+    #[test]
+    fn grok_overlay_prefers_configured_relative_program() {
+        let root = tempfile::tempdir().unwrap();
+        write_executable(
+            &root.path().join("usr/local/bin/grok"),
+            b"#!/bin/sh\necho ordinary\n",
+        );
+        write_executable(
+            &root.path().join("usr/local/bin/custom-grok"),
+            b"#!/bin/sh\necho custom\n",
+        );
+        let workspace = container_workspace_at(root.path());
+        assert_eq!(
+            grok_overlay_guest_path(&workspace, "custom-grok").as_deref(),
+            Some("/usr/local/bin/custom-grok"),
+            "relative cli_path must win over ordinary /usr/local/bin/grok"
+        );
     }
 
     #[test]

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -120,28 +120,6 @@ struct TelegramReplyRecord {
     created_at: Instant,
 }
 
-/// How long an operator/controller-launched mission may sit in `awaiting_user`
-/// before its question escalates to the human. Within this window the owning
-/// controller is expected to triage it (answer via `answer_mission_question`)
-/// on its own tick, so the human only ever sees questions the controller
-/// couldn't resolve. Overridable via `CONTROLLER_TRIAGE_GRACE_SECS`.
-const CONTROLLER_TRIAGE_GRACE_SECS: i64 = 20 * 60;
-
-/// Whether to HOLD an `awaiting_user` human alert so the owning controller can
-/// triage first. True only for a mission an operator/controller launched
-/// (`has_origin_session`) that has been awaiting for less than the triage
-/// grace. After the grace (controller didn't resolve it) or for a mission with
-/// no owning controller, the human is alerted as before.
-fn holds_for_controller_triage(
-    status: MissionStatus,
-    has_origin_session: bool,
-    awaiting_secs: i64,
-) -> bool {
-    status == MissionStatus::AwaitingUser
-        && has_origin_session
-        && awaiting_secs < CONTROLLER_TRIAGE_GRACE_SECS
-}
-
 const TELEGRAM_UPDATE_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_REPLY_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_SCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -1368,30 +1346,16 @@ async fn plan_paloma_alert_for_mission(
         .await
         .unwrap_or_default();
     let alert_now = Utc::now();
-    // Controller-first triage: a mission an operator/controller launched
-    // (origin_session_id present) that is only awaiting_user should be triaged
-    // by its OWNING controller — which reads the question and answers it via
-    // `answer_mission_question` on its tick — not bubbled straight to the human.
-    // Hold the human alert for a grace window; escalate to the human only if the
-    // question is still unanswered after `CONTROLLER_TRIAGE_GRACE_SECS` (the
-    // controller couldn't resolve it), so "needs you" stays rare and qualified.
+    // Needs You is a qualified page. Ack, inspect, and in-grace
+    // controller-owned questions stay out of the human inbox.
+    if mission.status == MissionStatus::AwaitingUser
+        && !crate::api::operator_attention::mission_needs_operator(&mission, false, alert_now)
     {
-        let awaiting_secs = chrono::DateTime::parse_from_rfc3339(&mission.updated_at)
-            .ok()
-            .map(|t| (alert_now - t.with_timezone(&Utc)).num_seconds())
-            .unwrap_or(i64::MAX);
-        if holds_for_controller_triage(
-            mission.status,
-            mission.origin_session_id.is_some(),
-            awaiting_secs,
-        ) {
-            tracing::debug!(
-                mission_id = %mission.id,
-                awaiting_secs,
-                "Paloma alert: holding awaiting_user alert — owning controller gets first triage"
-            );
-            return;
-        }
+        tracing::debug!(
+            mission_id = %mission.id,
+            "Paloma alert: holding awaiting_user — not a qualified operator page"
+        );
+        return;
     }
     let policy_snapshot = paloma_policy_snapshot_json(&mission, interest, alert_now);
     if interest == TelegramMissionInterestLevel::Muted {
@@ -7630,32 +7594,41 @@ mod tests {
     }
 
     #[test]
-    fn controller_first_triage_holds_fresh_awaiting_for_controller_owned_missions() {
-        use super::{holds_for_controller_triage, CONTROLLER_TRIAGE_GRACE_SECS};
-        // Owned by a controller + freshly awaiting → hold (controller triages).
-        assert!(holds_for_controller_triage(
-            MissionStatus::AwaitingUser,
-            true,
-            60
-        ));
-        // Past the grace → escalate to the human (controller didn't resolve it).
-        assert!(!holds_for_controller_triage(
-            MissionStatus::AwaitingUser,
-            true,
-            CONTROLLER_TRIAGE_GRACE_SECS + 1
-        ));
-        // No owning controller → alert the human as before.
-        assert!(!holds_for_controller_triage(
-            MissionStatus::AwaitingUser,
-            false,
-            60
-        ));
-        // Not an awaiting-user question → unaffected.
-        assert!(!holds_for_controller_triage(
-            MissionStatus::Failed,
-            true,
-            60
-        ));
+    fn controller_first_triage_holds_unqualified_awaiting_user() {
+        use crate::api::mission_store::AwaitingKind;
+        use crate::api::operator_attention::{
+            mission_needs_operator, CONTROLLER_TRIAGE_GRACE_SECS,
+        };
+        use chrono::TimeZone;
+        let now = Utc.with_ymd_and_hms(2026, 8, 16, 12, 0, 0).unwrap();
+        let mut owned = test_mission("triage me", MissionStatus::AwaitingUser);
+        owned.awaiting_kind = Some(AwaitingKind::Decision);
+        owned.origin_session_id = Some("sess-1".into());
+        owned.updated_at = (now - chrono::Duration::seconds(60)).to_rfc3339();
+        assert!(
+            !mission_needs_operator(&owned, false, now),
+            "fresh controller-owned decision stays with the controller"
+        );
+
+        owned.updated_at =
+            (now - chrono::Duration::seconds(CONTROLLER_TRIAGE_GRACE_SECS + 1)).to_rfc3339();
+        assert!(
+            mission_needs_operator(&owned, false, now),
+            "expired grace pages the human"
+        );
+
+        let mut unowned = test_mission("ask the human", MissionStatus::AwaitingUser);
+        unowned.awaiting_kind = Some(AwaitingKind::Decision);
+        unowned.origin_session_id = None;
+        unowned.updated_at = (now - chrono::Duration::seconds(5)).to_rfc3339();
+        assert!(mission_needs_operator(&unowned, false, now));
+
+        let mut ack = test_mission("review me", MissionStatus::AwaitingUser);
+        ack.awaiting_kind = Some(AwaitingKind::Ack);
+        ack.origin_session_id = Some("sess-1".into());
+        ack.updated_at =
+            (now - chrono::Duration::seconds(CONTROLLER_TRIAGE_GRACE_SECS + 1)).to_rfc3339();
+        assert!(!mission_needs_operator(&ack, false, now));
     }
 
     #[test]
@@ -7777,6 +7750,19 @@ mod tests {
         );
         assert_eq!(
             paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::High),
+            "high"
+        );
+
+        let mut ack = test_mission("review me", MissionStatus::AwaitingUser);
+        ack.awaiting_kind = Some(crate::api::mission_store::AwaitingKind::Ack);
+        assert_eq!(
+            paloma_alert_importance_for_mission(&ack, TelegramMissionInterestLevel::Normal),
+            "low"
+        );
+        let mut decision = test_mission("pick one", MissionStatus::AwaitingUser);
+        decision.awaiting_kind = Some(crate::api::mission_store::AwaitingKind::Decision);
+        assert_eq!(
+            paloma_alert_importance_for_mission(&decision, TelegramMissionInterestLevel::Normal),
             "high"
         );
     }

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -1005,6 +1005,19 @@ fn paloma_alert_event_kind_at(
     )
 }
 
+/// Unique alert key for a live AskUserQuestion. Status stays `active`, so
+/// the usual status-event suffix would collapse every wait on the same
+/// mission onto one telegram_alerts row.
+fn paloma_alert_event_kind_for_live_wait(wait_started_at: Option<&str>) -> String {
+    match wait_started_at {
+        Some(started) => format!(
+            "mission_awaiting_user:{}",
+            started.replace([':', '.', '+'], "-")
+        ),
+        None => "mission_awaiting_user:live".to_string(),
+    }
+}
+
 #[cfg(test)]
 fn paloma_should_alert_long_running_mission_at(
     mission: &Mission,
@@ -1480,7 +1493,11 @@ async fn plan_paloma_alert_for_mission(
     )
     .await;
     let now = now_string();
-    let event_kind = paloma_alert_event_kind_at(&mission, base_kind, &events, alert_now);
+    let event_kind = if waiting_for_user_tool && needs_operator {
+        paloma_alert_event_kind_for_live_wait(wait_started_at.as_deref())
+    } else {
+        paloma_alert_event_kind_at(&mission, base_kind, &events, alert_now)
+    };
     let importance = paloma_alert_importance_for_mission(
         &mission,
         interest,
@@ -6837,14 +6854,14 @@ mod tests {
         is_paloma_shared_summary_allowed, markdown_to_telegram_html, merge_telegram_chat_metadata,
         mission_card_should_reanchor, mission_label, normalize_paloma_natural_command,
         paloma_alert_body, paloma_alert_class_from_event_kind, paloma_alert_digest_text,
-        paloma_alert_event_kind_at, paloma_alert_importance_for_mission,
-        paloma_alert_kind_for_status, paloma_channel_job_name, paloma_chat_is_allowed,
-        paloma_command_error_response, paloma_mission_has_failure_only_preference,
-        paloma_role_for_user, paloma_shared_summary_body,
-        paloma_should_alert_long_running_mission_at, paloma_should_alert_mission_at,
-        paloma_status_event_is_new, paloma_status_seen_sequences, paloma_timestamp_is_recent,
-        parse_paloma_selector_and_payload, redact_for_telegram, render_telegram_chunk,
-        sanitize_telegram_visible_text, scope_for_extracted_memory,
+        paloma_alert_event_kind_at, paloma_alert_event_kind_for_live_wait,
+        paloma_alert_importance_for_mission, paloma_alert_kind_for_status, paloma_channel_job_name,
+        paloma_chat_is_allowed, paloma_command_error_response,
+        paloma_mission_has_failure_only_preference, paloma_role_for_user,
+        paloma_shared_summary_body, paloma_should_alert_long_running_mission_at,
+        paloma_should_alert_mission_at, paloma_status_event_is_new, paloma_status_seen_sequences,
+        paloma_timestamp_is_recent, parse_paloma_selector_and_payload, redact_for_telegram,
+        render_telegram_chunk, sanitize_telegram_visible_text, scope_for_extracted_memory,
         select_latest_awaiting_user_mission, should_silence_paloma_shared_command,
         telegram_action_target_matches, telegram_chat_display_title, telegram_shared_file_caption,
         truncate_for_telegram, verify_internal_telegram_action_token, workflow_reply_text,
@@ -7866,6 +7883,23 @@ mod tests {
                 Utc.with_ymd_and_hms(2026, 5, 20, 1, 0, 0).unwrap()
             ),
             "mission_awaiting_user:2026-05-20T00-05-00Z"
+        );
+    }
+
+    #[test]
+    fn live_wait_alert_kind_uses_the_tool_start_not_the_active_status() {
+        assert_eq!(
+            paloma_alert_event_kind_for_live_wait(Some("2026-05-20T01:10:00Z")),
+            "mission_awaiting_user:2026-05-20T01-10-00Z"
+        );
+        assert_ne!(
+            paloma_alert_event_kind_for_live_wait(Some("2026-05-20T01:10:00Z")),
+            paloma_alert_event_kind_for_live_wait(Some("2026-05-20T01:40:00Z")),
+            "a second AskUserQuestion on the same active mission must not collide"
+        );
+        assert_eq!(
+            paloma_alert_event_kind_for_live_wait(None),
+            "mission_awaiting_user:live"
         );
     }
 

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -984,8 +984,9 @@ fn paloma_alert_kind_for_status(status: MissionStatus) -> Option<&'static str> {
 fn paloma_alert_importance_for_mission(
     mission: &Mission,
     interest: TelegramMissionInterestLevel,
+    waiting_for_user_tool: bool,
 ) -> &'static str {
-    planner::alert_importance_for_mission(mission, interest)
+    planner::alert_importance_for_mission(mission, interest, waiting_for_user_tool)
 }
 
 fn paloma_alert_event_kind_at(
@@ -1332,9 +1333,6 @@ async fn plan_paloma_alert_for_mission(
     alert_preferences: &[TelegramAlertPreference],
     mission: Mission,
 ) {
-    let Some(base_kind) = paloma_alert_kind_for_status(mission.status) else {
-        return;
-    };
     let interest = subscriptions
         .get(&mission.id)
         .copied()
@@ -1346,17 +1344,36 @@ async fn plan_paloma_alert_for_mission(
         .await
         .unwrap_or_default();
     let alert_now = Utc::now();
+    let waiting_for_user_tool = ctx
+        .mission_store
+        .get_active_mission_run(mission.id)
+        .await
+        .ok()
+        .flatten()
+        .is_some_and(|run| {
+            run.execution_state == crate::api::mission_store::MissionExecutionState::WaitingUser
+        });
+    let needs_operator = crate::api::operator_attention::mission_needs_operator(
+        &mission,
+        waiting_for_user_tool,
+        alert_now,
+    );
     // Needs You is a qualified page. Ack, inspect, and in-grace
     // controller-owned questions stay out of the human inbox.
-    if mission.status == MissionStatus::AwaitingUser
-        && !crate::api::operator_attention::mission_needs_operator(&mission, false, alert_now)
-    {
+    if (mission.status == MissionStatus::AwaitingUser || waiting_for_user_tool) && !needs_operator {
         tracing::debug!(
             mission_id = %mission.id,
-            "Paloma alert: holding awaiting_user — not a qualified operator page"
+            "Paloma alert: holding — not a qualified operator page"
         );
         return;
     }
+    let Some(base_kind) = (if waiting_for_user_tool && needs_operator {
+        Some("mission_awaiting_user")
+    } else {
+        paloma_alert_kind_for_status(mission.status)
+    }) else {
+        return;
+    };
     let policy_snapshot = paloma_policy_snapshot_json(&mission, interest, alert_now);
     if interest == TelegramMissionInterestLevel::Muted {
         log_paloma_alert_decision(
@@ -1447,7 +1464,8 @@ async fn plan_paloma_alert_for_mission(
     .await;
     let now = now_string();
     let event_kind = paloma_alert_event_kind_at(&mission, base_kind, &events, alert_now);
-    let importance = paloma_alert_importance_for_mission(&mission, interest).to_string();
+    let importance =
+        paloma_alert_importance_for_mission(&mission, interest, waiting_for_user_tool).to_string();
     let _ = ctx
         .mission_store
         .create_telegram_alert_if_absent(TelegramAlert {
@@ -7745,24 +7763,36 @@ mod tests {
         assert_eq!(kind_early, "mission_long_running");
         assert_eq!(kind_early, kind_later);
         assert_eq!(
-            paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::Normal),
+            paloma_alert_importance_for_mission(
+                &mission,
+                TelegramMissionInterestLevel::Normal,
+                false
+            ),
             "normal"
         );
         assert_eq!(
-            paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::High),
+            paloma_alert_importance_for_mission(
+                &mission,
+                TelegramMissionInterestLevel::High,
+                false
+            ),
             "high"
         );
 
         let mut ack = test_mission("review me", MissionStatus::AwaitingUser);
         ack.awaiting_kind = Some(crate::api::mission_store::AwaitingKind::Ack);
         assert_eq!(
-            paloma_alert_importance_for_mission(&ack, TelegramMissionInterestLevel::Normal),
+            paloma_alert_importance_for_mission(&ack, TelegramMissionInterestLevel::Normal, false),
             "low"
         );
         let mut decision = test_mission("pick one", MissionStatus::AwaitingUser);
         decision.awaiting_kind = Some(crate::api::mission_store::AwaitingKind::Decision);
         assert_eq!(
-            paloma_alert_importance_for_mission(&decision, TelegramMissionInterestLevel::Normal),
+            paloma_alert_importance_for_mission(
+                &decision,
+                TelegramMissionInterestLevel::Normal,
+                false
+            ),
             "high"
         );
     }

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -1293,6 +1293,36 @@ async fn paloma_pending_alert_still_eligible(
     let Ok(Some(mission)) = ctx.mission_store.get_mission(mission_id).await else {
         return false;
     };
+    let active_run = ctx
+        .mission_store
+        .get_active_mission_run(mission.id)
+        .await
+        .ok()
+        .flatten();
+    let waiting_for_user_tool = active_run.as_ref().is_some_and(|run| {
+        run.execution_state == crate::api::mission_store::MissionExecutionState::WaitingUser
+    });
+    // Live AskUserQuestion alerts are keyed `mission_awaiting_user:<start>`
+    // while the stored mission stays Active. Kind-from-status would derive
+    // `mission_long_running` and drop the pending page before delivery.
+    if alert.event_kind.starts_with("mission_awaiting_user") {
+        if !waiting_for_user_tool {
+            return false;
+        }
+        let wait_started_at = match active_run.as_ref() {
+            Some(run) => {
+                crate::api::control::user_wait_tool_started_at(ctx.mission_store.as_ref(), run)
+                    .await
+            }
+            None => None,
+        };
+        return crate::api::operator_attention::mission_needs_operator(
+            &mission,
+            true,
+            wait_started_at.as_deref(),
+            now,
+        );
+    }
     let Some(current_kind) = paloma_alert_kind_for_status(mission.status) else {
         return false;
     };

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -985,8 +985,9 @@ fn paloma_alert_importance_for_mission(
     mission: &Mission,
     interest: TelegramMissionInterestLevel,
     waiting_for_user_tool: bool,
+    wait_started_at: Option<&str>,
 ) -> &'static str {
-    planner::alert_importance_for_mission(mission, interest, waiting_for_user_tool)
+    planner::alert_importance_for_mission(mission, interest, waiting_for_user_tool, wait_started_at)
 }
 
 fn paloma_alert_event_kind_at(
@@ -1344,18 +1345,25 @@ async fn plan_paloma_alert_for_mission(
         .await
         .unwrap_or_default();
     let alert_now = Utc::now();
-    let waiting_for_user_tool = ctx
+    let active_run = ctx
         .mission_store
         .get_active_mission_run(mission.id)
         .await
         .ok()
-        .flatten()
-        .is_some_and(|run| {
-            run.execution_state == crate::api::mission_store::MissionExecutionState::WaitingUser
-        });
+        .flatten();
+    let waiting_for_user_tool = active_run.as_ref().is_some_and(|run| {
+        run.execution_state == crate::api::mission_store::MissionExecutionState::WaitingUser
+    });
+    let wait_started_at = match active_run.as_ref() {
+        Some(run) => {
+            crate::api::control::user_wait_tool_started_at(ctx.mission_store.as_ref(), run).await
+        }
+        None => None,
+    };
     let needs_operator = crate::api::operator_attention::mission_needs_operator(
         &mission,
         waiting_for_user_tool,
+        wait_started_at.as_deref(),
         alert_now,
     );
     // Needs You is a qualified page. Ack, inspect, and in-grace
@@ -1374,7 +1382,13 @@ async fn plan_paloma_alert_for_mission(
     }) else {
         return;
     };
-    let policy_snapshot = paloma_policy_snapshot_json(&mission, interest, alert_now);
+    // Qualified live AskUserQuestion is a user page, not a long-running
+    // Active turn — skip the 30-minute gate and "is still running" copy.
+    let mut policy_mission = mission.clone();
+    if waiting_for_user_tool && needs_operator {
+        policy_mission.status = MissionStatus::AwaitingUser;
+    }
+    let policy_snapshot = paloma_policy_snapshot_json(&policy_mission, interest, alert_now);
     if interest == TelegramMissionInterestLevel::Muted {
         log_paloma_alert_decision(
             ctx,
@@ -1390,8 +1404,8 @@ async fn plan_paloma_alert_for_mission(
         .await;
         return;
     }
-    if paloma_mission_has_failure_only_preference(alert_preferences, mission.id)
-        && mission.status != MissionStatus::Failed
+    if paloma_mission_has_failure_only_preference(alert_preferences, policy_mission.id)
+        && policy_mission.status != MissionStatus::Failed
     {
         log_paloma_alert_decision(
             ctx,
@@ -1407,7 +1421,7 @@ async fn plan_paloma_alert_for_mission(
         .await;
         return;
     }
-    if !paloma_should_alert_mission_at(&mission, &events, interest, alert_now) {
+    if !paloma_should_alert_mission_at(&policy_mission, &events, interest, alert_now) {
         log_paloma_alert_decision(
             ctx,
             owner_id,
@@ -1416,7 +1430,10 @@ async fn plan_paloma_alert_for_mission(
             "create_alert",
             false,
             Some(paloma_alert_suppression_reason(
-                &mission, &events, interest, alert_now,
+                &policy_mission,
+                &events,
+                interest,
+                alert_now,
             )),
             policy_snapshot,
             None,
@@ -1449,7 +1466,7 @@ async fn plan_paloma_alert_for_mission(
         .await;
         return;
     }
-    let body = paloma_alert_body(&mission, &events);
+    let body = paloma_alert_body(&policy_mission, &events);
     log_paloma_alert_decision(
         ctx,
         owner_id,
@@ -1464,8 +1481,13 @@ async fn plan_paloma_alert_for_mission(
     .await;
     let now = now_string();
     let event_kind = paloma_alert_event_kind_at(&mission, base_kind, &events, alert_now);
-    let importance =
-        paloma_alert_importance_for_mission(&mission, interest, waiting_for_user_tool).to_string();
+    let importance = paloma_alert_importance_for_mission(
+        &mission,
+        interest,
+        waiting_for_user_tool,
+        wait_started_at.as_deref(),
+    )
+    .to_string();
     let _ = ctx
         .mission_store
         .create_telegram_alert_if_absent(TelegramAlert {
@@ -7624,14 +7646,14 @@ mod tests {
         owned.origin_session_id = Some("sess-1".into());
         owned.updated_at = (now - chrono::Duration::seconds(60)).to_rfc3339();
         assert!(
-            !mission_needs_operator(&owned, false, now),
+            !mission_needs_operator(&owned, false, None, now),
             "fresh controller-owned decision stays with the controller"
         );
 
         owned.updated_at =
             (now - chrono::Duration::seconds(CONTROLLER_TRIAGE_GRACE_SECS + 1)).to_rfc3339();
         assert!(
-            mission_needs_operator(&owned, false, now),
+            mission_needs_operator(&owned, false, None, now),
             "expired grace pages the human"
         );
 
@@ -7639,14 +7661,14 @@ mod tests {
         unowned.awaiting_kind = Some(AwaitingKind::Decision);
         unowned.origin_session_id = None;
         unowned.updated_at = (now - chrono::Duration::seconds(5)).to_rfc3339();
-        assert!(mission_needs_operator(&unowned, false, now));
+        assert!(mission_needs_operator(&unowned, false, None, now));
 
         let mut ack = test_mission("review me", MissionStatus::AwaitingUser);
         ack.awaiting_kind = Some(AwaitingKind::Ack);
         ack.origin_session_id = Some("sess-1".into());
         ack.updated_at =
             (now - chrono::Duration::seconds(CONTROLLER_TRIAGE_GRACE_SECS + 1)).to_rfc3339();
-        assert!(!mission_needs_operator(&ack, false, now));
+        assert!(!mission_needs_operator(&ack, false, None, now));
     }
 
     #[test]
@@ -7766,7 +7788,8 @@ mod tests {
             paloma_alert_importance_for_mission(
                 &mission,
                 TelegramMissionInterestLevel::Normal,
-                false
+                false,
+                None
             ),
             "normal"
         );
@@ -7774,7 +7797,8 @@ mod tests {
             paloma_alert_importance_for_mission(
                 &mission,
                 TelegramMissionInterestLevel::High,
-                false
+                false,
+                None
             ),
             "high"
         );
@@ -7782,7 +7806,12 @@ mod tests {
         let mut ack = test_mission("review me", MissionStatus::AwaitingUser);
         ack.awaiting_kind = Some(crate::api::mission_store::AwaitingKind::Ack);
         assert_eq!(
-            paloma_alert_importance_for_mission(&ack, TelegramMissionInterestLevel::Normal, false),
+            paloma_alert_importance_for_mission(
+                &ack,
+                TelegramMissionInterestLevel::Normal,
+                false,
+                None
+            ),
             "low"
         );
         let mut decision = test_mission("pick one", MissionStatus::AwaitingUser);
@@ -7791,7 +7820,8 @@ mod tests {
             paloma_alert_importance_for_mission(
                 &decision,
                 TelegramMissionInterestLevel::Normal,
-                false
+                false,
+                None
             ),
             "high"
         );


### PR DESCRIPTION
## Summary
- Host→container Grok copies require matching ELF `e_machine`.
- Fail closed if container ISA cannot be read.
- Never exec host `/opt/grok-cli` inside the guest.
- `SANDBOXED_SH_NSENTER_USE_TARGET_ROOT` stays opt-in.

## Test plan
- [ ] `cargo test --lib -- copy_host_executable grok`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Operator-inbox and alerting semantics change fleet-wide; incorrect `needs_operator` would hide or flood human pages. Container CLI copy/refusal paths affect mission harness startup on mixed-arch nspawn hosts.
> 
> **Overview**
> **Needs You is now a qualified operator page**, not every `awaiting_user` or `waiting_for_tool` mission. A new `operator_attention` module computes `needs_operator` on the server (decision / live AskUserQuestion, minus **20-minute controller triage** when `origin_session_id` is set; ack and in-grace controller waits stay off the human inbox). Mission list/detail JSON, project chips, Paloma/Telegram, and the alerts feed all consume this flag instead of re-deriving grace from timestamps.
> 
> The **dashboard** maps columns and labels from `needs_operator` + `awaiting_kind` (ack → Finished / “Awaiting Review”; in-grace decisions stay **Running**). Hermes “Needs you” filters use `needs_operator=true` with paginated feed fixes and synthetic rows for live AskUserQuestion waits.
> 
> **Grok in container workspaces** prefers guest overlay paths over host `/opt/grok-cli`, and **host→container CLI copies** check ELF arch (fail closed if container ISA is unknown). Overlay guest path resolution and symlink handling are tightened.
> 
> Controller **docs/skills** clarify `blocked` vs `blocked:harness`, grant updates from owner chat, and not copying `mode=blocked` from inspect callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c064140e82708618c5426417c0c2681d5a86207d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->