### PR TITLE
fix(projects): delete wipes missions instead of keeping them

### DIFF
--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -402,6 +402,31 @@ describe("ProjectsBoard", () => {
     );
   });
 
+  test("delete confirmation does not carry over to another project", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([project({ slug: "verity" }), project({ slug: "beal" })]),
+    );
+    mockedAction.mockResolvedValue(undefined);
+
+    renderBoard();
+
+    fireEvent.click(await screen.findByRole("button", { name: /verity/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Delete$/ }));
+    expect(screen.getByRole("button", { name: /Delete all/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /beal/ }));
+    expect(
+      screen.queryByRole("button", { name: /Delete all/ }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: /^Delete$/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Delete all/ }));
+    await waitFor(() =>
+      expect(mockedAction).toHaveBeenCalledWith("beal", "delete", {
+        deleteMode: "delete_missions",
+      }),
+    );
+  });
+
   test("confirmed delete revalidates the overview and the row disappears", async () => {
     // First load shows the project; the post-delete revalidation returns an
     // overview without it, so the row must leave the triage list.

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -382,7 +382,7 @@ describe("ProjectsBoard", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /^Pause$/ }));
     await waitFor(() =>
-      expect(mockedAction).toHaveBeenCalledWith("verity", "pause"),
+      expect(mockedAction).toHaveBeenCalledWith("verity", "pause", undefined),
     );
   });
 
@@ -392,11 +392,13 @@ describe("ProjectsBoard", () => {
 
     renderBoard();
 
-    fireEvent.click(await screen.findByRole("button", { name: /Delete/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Delete$/ }));
     expect(mockedAction).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: /Confirm/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Delete all/ }));
     await waitFor(() =>
-      expect(mockedAction).toHaveBeenCalledWith("verity", "delete"),
+      expect(mockedAction).toHaveBeenCalledWith("verity", "delete", {
+        deleteMode: "delete_missions",
+      }),
     );
   });
 
@@ -413,12 +415,14 @@ describe("ProjectsBoard", () => {
     renderBoard();
 
     fireEvent.click(await screen.findByRole("button", { name: /verity/ }));
-    fireEvent.click(await screen.findByRole("button", { name: /Delete/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Delete$/ }));
     expect(mockedAction).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: /Confirm/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Delete all/ }));
 
     await waitFor(() =>
-      expect(mockedAction).toHaveBeenCalledWith("verity", "delete"),
+      expect(mockedAction).toHaveBeenCalledWith("verity", "delete", {
+        deleteMode: "delete_missions",
+      }),
     );
     await waitFor(() =>
       expect(

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -705,7 +705,11 @@ function ProjectActions({ project }: { project: ProjectRow }) {
       setBusy(action);
       setActionError(null);
       try {
-        await postProjectAction(project.slug, action);
+        await postProjectAction(
+          project.slug,
+          action,
+          action === "delete" ? { deleteMode: "delete_missions" } : undefined,
+        );
         await mutate("projects-overview");
       } catch (err) {
         setActionError(String(err instanceof Error ? err.message : err));
@@ -842,13 +846,19 @@ function ProjectActions({ project }: { project: ProjectRow }) {
         <ActionButton
           icon={Archive}
           label="Archive"
+          title="Hide this project from the board. Missions and history stay."
           busy={busy === "archive"}
           onClick={() => run("archive")}
         />
       )}
       <ActionButton
         icon={Trash2}
-        label={confirmDelete ? "Confirm?" : "Delete"}
+        label={confirmDelete ? "Delete all?" : "Delete"}
+        title={
+          confirmDelete
+            ? "Permanently delete this project, its missions, and its history. Cancel live missions first. Archive if you only want it off the board."
+            : "Permanently delete this project, its missions, and its history. Archive to keep them."
+        }
         danger={confirmDelete}
         busy={busy === "delete"}
         onClick={() => {

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -700,6 +700,10 @@ function ProjectActions({ project }: { project: ProjectRow }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
+  useEffect(() => {
+    setConfirmDelete(false);
+  }, [project.slug]);
+
   const run = useCallback(
     async (action: ProjectAction) => {
       setBusy(action);

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -190,13 +190,22 @@ export type ProjectAction =
   | "delete"
   | "restore";
 
+export type ProjectDeleteMode = "keep_missions" | "delete_missions";
+
 export async function postProjectAction(
   slug: string,
   action: ProjectAction,
+  options?: { deleteMode?: ProjectDeleteMode },
 ): Promise<void> {
+  const body: { action: ProjectAction; delete_mode?: ProjectDeleteMode } = {
+    action,
+  };
+  if (action === "delete") {
+    body.delete_mode = options?.deleteMode ?? "delete_missions";
+  }
   await apiPost(
     `/api/projects/${encodeURIComponent(slug)}/action`,
-    { action },
+    body,
     "Failed to apply project action",
   );
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4175,11 +4175,18 @@ impl ControlHub {
         Ok(collected)
     }
 
-    /// Delete every mission tagged with this exact project across live and
-    /// offline stores. This is intentionally fail-closed: a project-wide data
-    /// delete cannot race a running, queued, paused, or otherwise resumable
-    /// mission. The operator must finish or cancel those missions first.
-    pub(crate) async fn delete_project_missions(&self, project: &str) -> Result<Vec<Uuid>, String> {
+    /// Delete every mission tagged with any of these project keys across live
+    /// and offline stores. Callers must pass every alias the board folds onto
+    /// the project (`project_tag_keys`), not only the canonical slug. This is
+    /// intentionally fail-closed: a project-wide data delete cannot race a
+    /// running, queued, paused, or otherwise resumable mission. The operator
+    /// must finish or cancel those missions first. All tags are scanned before
+    /// any delete so a live mission on an alias cannot be discovered after a
+    /// partial wipe.
+    pub(crate) async fn delete_project_missions(
+        &self,
+        projects: &[String],
+    ) -> Result<Vec<Uuid>, String> {
         const PAGE_SIZE: usize = 200;
         let inventory = self.mission_store_inventory().await?;
         let mut stores: Vec<Arc<dyn MissionStore>> = inventory.live;
@@ -4202,24 +4209,40 @@ impl ControlHub {
             ));
         }
 
-        let filter = mission_store::MissionFilter {
-            project: Some(project.to_string()),
-            ..Default::default()
+        let tags: Vec<String> = {
+            let mut seen = std::collections::HashSet::new();
+            projects
+                .iter()
+                .map(|tag| tag.trim())
+                .filter(|tag| !tag.is_empty() && seen.insert((*tag).to_string()))
+                .map(str::to_string)
+                .collect()
         };
         let mut plans: Vec<(Arc<dyn MissionStore>, Vec<Mission>)> = Vec::new();
         for store in stores {
             let mut matched = Vec::new();
-            let mut offset = 0;
-            loop {
-                let page = store
-                    .list_missions_filtered(&filter, PAGE_SIZE, offset)
-                    .await?;
-                let page_len = page.len();
-                matched.extend(page);
-                if page_len < PAGE_SIZE {
-                    break;
+            let mut seen_ids = std::collections::HashSet::new();
+            for tag in &tags {
+                let filter = mission_store::MissionFilter {
+                    project: Some(tag.clone()),
+                    ..Default::default()
+                };
+                let mut offset = 0;
+                loop {
+                    let page = store
+                        .list_missions_filtered(&filter, PAGE_SIZE, offset)
+                        .await?;
+                    let page_len = page.len();
+                    for mission in page {
+                        if seen_ids.insert(mission.id) {
+                            matched.push(mission);
+                        }
+                    }
+                    if page_len < PAGE_SIZE {
+                        break;
+                    }
+                    offset += page_len;
                 }
-                offset += page_len;
             }
             for mission in &matched {
                 if !mission.status.is_terminal() && mission.status != MissionStatus::Acknowledged {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4257,6 +4257,17 @@ impl ControlHub {
                         mission.id
                     ));
                 }
+                let children = collect_child_mission_ids(&store, mission.id)
+                    .await
+                    .map_err(|(_, error)| error)?;
+                for child_id in children {
+                    if !seen_ids.contains(&child_id) {
+                        return Err(format!(
+                            "Cannot delete project data while mission {} has descendant {} tagged outside this project. Re-tag or delete that child first.",
+                            mission.id, child_id
+                        ));
+                    }
+                }
             }
             plans.push((store, matched));
         }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -2727,16 +2727,16 @@ fn read_overrides(dir: &Path) -> HashMap<String, String> {
 #[derive(Debug, Deserialize)]
 pub struct ProjectActionRequest {
     action: String,
-    /// Only used by `delete`: `keep_missions` removes project-owned state but
-    /// preserves mission history; `delete_missions` also deletes every mission
-    /// tagged with the exact project slug.
+    /// Only used by `delete`. Default is `delete_missions` (wipe tagged
+    /// missions). Pass `keep_missions` to drop the roster row and keep
+    /// mission history — archive is the usual way to keep a project.
     #[serde(default)]
     delete_mode: Option<String>,
 }
 
-/// Apply a board action to a project. Delete is a real project deletion, with
-/// an explicit mission-retention policy; its board override remains as a
-/// tombstone so surviving missions or tracker markdown cannot recreate it.
+/// Apply a board action to a project. Delete wipes the roster row and, by
+/// default, every mission tagged with the slug. The board override stays as a
+/// tombstone so tracker markdown cannot recreate the row.
 #[derive(Debug, serde::Deserialize)]
 pub struct BindConversationRequest {
     pub session_id: String,
@@ -2820,7 +2820,7 @@ pub async fn project_action(
             overrides.insert(slug.clone(), "archived".to_string());
         }
         "delete" => {
-            match request.delete_mode.as_deref().unwrap_or("keep_missions") {
+            match request.delete_mode.as_deref().unwrap_or("delete_missions") {
                 "keep_missions" => {}
                 "delete_missions" => {
                     deleted_mission_ids = state

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -2823,9 +2823,10 @@ pub async fn project_action(
             match request.delete_mode.as_deref().unwrap_or("delete_missions") {
                 "keep_missions" => {}
                 "delete_missions" => {
+                    let tags = project_tag_keys(&slug);
                     deleted_mission_ids = state
                         .control
-                        .delete_project_missions(&slug)
+                        .delete_project_missions(&tags)
                         .await
                         .map_err(|error| (StatusCode::CONFLICT, error))?;
                 }


### PR DESCRIPTION
## Summary
- Board Delete now sends `delete_mode=delete_missions`.
- API default for delete is wipe, not keep. Archive remains the keep-history action.
- Confirm copy is **Delete all?** with a tooltip that says to archive if you want to keep missions.

## Test plan
- [ ] dashboard `projects-board` unit tests
- [ ] Delete a parked project: missions gone. Live mission: conflict until cancelled.
- [ ] Archive still hides the row and keeps missions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the default for irreversible project/mission deletion and expands backend wipe logic across tag aliases; live-mission guards remain but operator mistakes are more destructive.
> 
> **Overview**
> **Project delete now wipes tagged missions by default** instead of keeping history unless callers opt into `keep_missions`. The projects board always posts `delete_mode: delete_missions`, and the API default matches when the field is omitted.
> 
> **Board UX** clarifies the destructive path: confirm reads **Delete all?**, archive/delete tooltips explain hide-vs-wipe, and delete confirmation resets when you select another project so you cannot confirm delete on the wrong row.
> 
> **Backend mission deletion** takes every folded `project_tag_keys` alias (not only the slug), scans all tags before any delete, dedupes missions across stores, and **fails closed** if a descendant mission is tagged outside those keys or if non-terminal/active runs still exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1eaf586801400cd4a3e53b4fcfd3799536f4975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->