### PR TITLE
fix(projects): surface controller chapters as recent activity

### DIFF
--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -57,8 +57,17 @@ disagree, the grant wins. If the grant is empty, the setup questions have not be
 answered: ask them once (see `references/controller-setup-questions.md`) and operate
 under this skill's defaults meanwhile. **`merge_authority=full` is permission to
 merge.** Do not open a `[DECISION:]` asking Thomas to bless a green in-scope merge;
-record the merge as a granted act and do it. `review-first` is the only merge
-posture that must escalate.
+record the merge as a granted act and do it. **`review-first` means get or do a
+review, then merge** — it is not "ask Thomas". After a review exists (yours or a
+bot's), merge and start the next item. Do not open a decision to bless the merge.
+
+**Missing or red GitHub CI is not a blocker when a local or previous exact-head
+proof already exists.** Merge (or land on the campaign branch) and start the next
+item. Do not open a decision. Do not wait for the next tick to "re-check CI."
+
+**One live writer per branch, not per project.** Two writers may run at once when
+they do not share a branch (repair on `#76` plus merge of `#85` is allowed). A
+second writer on the *same* branch is the lease violation.
 
 **Owner chat updates the grant only when the order is durable.** An explicit
 standing grant — "you may merge in this repo", "review-first from now on" —
@@ -148,6 +157,9 @@ and any live surface read *this*, not a parsed trailer. Once per tick:
   track)` so it appears in the project's inventory. An unlinked worker is invisible.
 - At your first tick (or after the prompt changed), read `get_project_grant(slug)` — the
   merge authority, budget, and any PAUSED live there and outrank the prompt.
+- Each tick, `set_project_track` for every open in-scope PR and issue so the roadmap
+  stays populated even when no mission is live. Open tracks must not be dropped just
+  because the writer finished.
 
 Keep emitting the two text trailers below during this transition (dual-write); the
 structured call is authoritative, the trailers are the compatibility path.

--- a/src/api/controller_honesty.rs
+++ b/src/api/controller_honesty.rs
@@ -94,6 +94,22 @@ pub fn should_silence_headline(headline: &str, has_live_writer: bool) -> bool {
     has_live_writer && is_stale_lease_claim(headline)
 }
 
+/// Mission-complete inspect callbacks are real events for the timeline but
+/// they are not autonomous acts — they used to steal the card's latest
+/// headline ("Needs You") and they must not flood Recent activity.
+pub fn is_inspect_callback_headline(headline: &str) -> bool {
+    headline.trim().starts_with("[Mission callback:")
+}
+
+/// Headline that should appear on the Recent activity panel: a controller
+/// chapter, not silence, not a relaunch, not an inspect callback.
+pub fn is_material_activity_headline(headline: &str) -> bool {
+    let trimmed = headline.trim();
+    !trimmed.is_empty()
+        && !should_silence_headline(trimmed, false)
+        && !is_inspect_callback_headline(trimmed)
+}
+
 /// Collapse a question so "relancer X ?" and "Relancer  X?" are one row.
 pub fn normalize_decision_question(question: &str) -> String {
     question
@@ -142,6 +158,23 @@ mod tests {
         assert!(is_lease_blocker(Some("source #2332 dirty lease writer")));
         assert!(mode_claims_lease_block(Some("blocked:lease-writer")));
         assert!(!is_stale_lease_claim("blocked by dirty source"));
+    }
+
+    #[test]
+    fn inspect_callbacks_are_not_recent_activity() {
+        assert!(is_inspect_callback_headline(
+            "[Mission callback: Lido closure v2 — re-pin Verity from minimal-11]"
+        ));
+        assert!(!is_material_activity_headline(
+            "[Mission callback: Repair Lido #76 false receipt provenance]"
+        ));
+        assert!(!is_material_activity_headline("[SILENT]"));
+        assert!(!is_material_activity_headline(
+            "Lido audit — RE-PIN RELANCÉ"
+        ));
+        assert!(is_material_activity_headline(
+            "Lido #81 — RÉPARATION/REVIEW EN COURS"
+        ));
     }
 
     #[test]

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -330,6 +330,46 @@ fn ingest_deliveries_with_live(
                 }
             }
         }
+        // A material chapter without a `[DECISION:]` trailer still belongs
+        // on Recent activity. Controllers were told not to open owner
+        // questions for in-grant work, so they stopped emitting trailers
+        // entirely — and the panel froze on the last answered escalation
+        // (Lido SRv3, 2026-08-16). Inspect callbacks stay out.
+        if !recorded_decided {
+            if let Some(text) = headline {
+                if super::controller_honesty::is_material_activity_headline(text) {
+                    let grant = projects.get_grant(slug).ok().flatten();
+                    let autonomy = grant.as_ref().and_then(|g| g.autonomy_level.clone());
+                    let merge_authority = grant.as_ref().and_then(|g| g.merge_authority.clone());
+                    if let Ok(disposition) = resolve_decision_disposition_for_grant(
+                        autonomy.as_deref(),
+                        merge_authority.as_deref(),
+                        Some("granted"),
+                        Some("decided"),
+                        Some("report"),
+                    ) {
+                        if disposition.status == "decided" {
+                            recorded_decided = true;
+                            let decision = super::projects_store::NewDecision {
+                                question: text.to_string(),
+                                rationale: None,
+                                kind: Some("report".to_string()),
+                                authority: disposition.authority,
+                                status: disposition.status,
+                                evidence: None,
+                            };
+                            if let Err(error) = projects.record_decision_from_delivery(
+                                slug,
+                                &delivery.at,
+                                &decision,
+                            ) {
+                                tracing::warn!("state ingest activity: {slug}: {error}");
+                            }
+                        }
+                    }
+                }
+            }
+        }
         // A merge announcement (headline or a grant-allowed decided act)
         // retires older "merge #N?" questions so the card stops asking
         // about a PR that already landed. The current delivery's own
@@ -495,7 +535,7 @@ pub async fn get_project(
     let decisions = state.projects.open_decisions(&slug).map_err(store_err)?;
     let recent = state
         .projects
-        .recent_decisions(&slug, 20)
+        .recent_activity(&slug, 20)
         .map_err(store_err)?;
     let conversation = state
         .projects
@@ -3702,6 +3742,57 @@ mod tests {
         assert!(recent
             .iter()
             .any(|d| d.question == "Merged #2" && d.status.as_deref() == Some("decided")));
+    }
+
+    #[test]
+    fn material_headlines_without_a_decision_trailer_still_land_on_recent_activity() {
+        let store = super::super::projects_store::ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("verity-lido", None, None, None, None)
+            .expect("seed");
+        store
+            .set_grant(
+                "verity-lido",
+                Some("review-first"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some("act_reversible"),
+            )
+            .expect("grant");
+        let aliases = HashMap::new();
+        let overrides = HashMap::new();
+        let chapter = parse_delivery(
+            "cron_1",
+            1_755_360_000.0,
+            "[Cron delivery: Lido]\nLido #81 — RÉPARATION/REVIEW EN COURS\n\
+             [CTRL: verity-lido | mode=active | wait=0 | next=review-81]\n\
+             [STATE_SIGNATURE: verity-lido|pr-81|review]\n",
+        );
+        let inspect = parse_delivery(
+            "s",
+            1_755_360_100.0,
+            "[Cron delivery: Lido]\n[Mission callback: Repair Lido #76]\n\
+             [STATE_SIGNATURE: verity-lido|mission-callback|inspect]\n",
+        );
+        ingest_deliveries(&store, &aliases, &overrides, vec![chapter, inspect]);
+        let recent = store.recent_activity("verity-lido", 10).expect("activity");
+        assert!(
+            recent.iter().any(|d| d.question.contains("#81")),
+            "controller chapter must become a decided act"
+        );
+        assert!(
+            recent
+                .iter()
+                .all(|d| !d.question.starts_with("[Mission callback:")),
+            "inspect callbacks stay off the panel"
+        );
+        assert!(store
+            .open_decisions("verity-lido")
+            .expect("open")
+            .is_empty());
     }
 
     #[test]

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -13,7 +13,7 @@
 //! file on any shape change, and it is read-modify-write — fine for a human
 //! toggling a bucket, not for something written per tick.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -1439,6 +1439,49 @@ impl ProjectsStore {
         )
     }
 
+    /// What the Hermes project rail shows as Recent activity: the ledger
+    /// (`decided` / `answered`) plus material controller state headlines that
+    /// never carried a `[DECISION:]` trailer. Without the union the panel
+    /// freezes on the last owner question even while the controller is
+    /// merging and ticking (Lido SRv3, 2026-08-16).
+    pub fn recent_activity(&self, slug: &str, limit: u32) -> Result<Vec<ProjectDecision>, String> {
+        let mut items = self.recent_decisions(slug, limit)?;
+        let seen_at: HashSet<String> = items.iter().map(|item| item.at.clone()).collect();
+        let seen_question: HashSet<String> = items
+            .iter()
+            .map(|item| super::controller_honesty::normalize_decision_question(&item.question))
+            .collect();
+        for state in self.state_timeline(slug, limit as usize)? {
+            let Some(headline) = state.headline.as_deref() else {
+                continue;
+            };
+            if !super::controller_honesty::is_material_activity_headline(headline) {
+                continue;
+            }
+            if seen_at.contains(&state.last_seen_at) {
+                continue;
+            }
+            let normalized = super::controller_honesty::normalize_decision_question(headline);
+            if seen_question.contains(&normalized) {
+                continue;
+            }
+            items.push(ProjectDecision {
+                at: state.last_seen_at,
+                question: headline.to_string(),
+                rationale: None,
+                kind: Some("report".to_string()),
+                authority: "granted".to_string(),
+                status: Some("decided".to_string()),
+                answer: None,
+                answered_at: None,
+                evidence: None,
+            });
+        }
+        items.sort_by(|a, b| b.at.cmp(&a.at));
+        items.truncate(limit as usize);
+        Ok(items)
+    }
+
     fn decisions_where(
         &self,
         slug: &str,
@@ -2559,6 +2602,38 @@ mod tests {
         assert_eq!(
             recent[1].evidence.as_ref().unwrap()["pr_url"],
             "https://github.com/x/y/pull/2213"
+        );
+
+        store
+            .record_state(
+                "verity",
+                "pr-81|review",
+                Some("Lido #81 — RÉPARATION/REVIEW EN COURS"),
+                "2026-08-16T15:30:54Z",
+                Some("cron_1"),
+            )
+            .expect("state");
+        store
+            .record_state(
+                "verity",
+                "mission-callback|x",
+                Some("[Mission callback: Repair Lido #76]"),
+                "2026-08-16T15:31:00Z",
+                Some("s"),
+            )
+            .expect("inspect");
+        let activity = store.recent_activity("verity", 10).expect("activity");
+        assert!(
+            activity
+                .iter()
+                .any(|d| d.question.contains("#81") && d.status.as_deref() == Some("decided")),
+            "controller chapter must surface on Recent activity"
+        );
+        assert!(
+            activity
+                .iter()
+                .all(|d| !d.question.starts_with("[Mission callback:")),
+            "inspect callbacks must not flood Recent activity"
         );
 
         assert_eq!(store.pending_decision_counts().expect("counts").len(), 0);


### PR DESCRIPTION
## Summary

Recent activity on the project rail was only the decision ledger. After controllers stopped opening owner questions for in-grant work, the panel froze on the last answered escalation.

- `get_project` now uses `recent_activity()`, which unions decided/answered ledger rows with material controller state headlines.
- Ingest records material headlines as granted decided acts (`kind=report`). `[SILENT]` and inspect callbacks (`[Mission callback:`) stay off the panel.
- `controllers-policy`: `review-first` means get or do a review, then merge (not ask Thomas); missing/red GitHub CI is not a blocker when local or exact-head proof exists; one live writer per branch, not per project; each tick `set_project_track` for open in-scope PRs and issues.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --lib inspect_callbacks_are_not_recent_activity`
- [x] `cargo test --lib material_headlines_without`
- [x] `cargo test --lib autonomous_acts_never`
- [x] `cargo test --lib live_writer_silences`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes project ingest and activity display semantics (synthetic decided rows from headlines); policy shifts affect autonomous merge/CI behavior across controllers.
> 
> **Overview**
> Fixes **Recent activity** freezing when controllers stopped emitting `[DECISION:]` trailers for in-grant work. The project rail now calls **`recent_activity()`**, which merges decided/answered ledger entries with **material state headlines** from the timeline, while **`[Mission callback:`** inspect lines and silenced/relaunch noise stay off the panel.
> 
> **Ingest** records material headlines as granted **`kind=report`** decided acts when no decision trailer was present. **`controller_honesty`** adds **`is_material_activity_headline`** / **`is_inspect_callback_headline`** to drive that filtering.
> 
> **`controllers-policy`** updates autonomy text: **`review-first`** means review then merge (not escalate to the owner); missing/red GitHub CI is not a blocker when local/exact-head proof exists; **one live writer per branch** (parallel writers on different branches OK); each tick **`set_project_track`** for open in-scope PRs/issues so the roadmap does not empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebfc895bd40519dae173cba823b651350b37be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->