### PR TITLE
fix(projects): do not flag controller-behind on a long-running writer

### DIFF
--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -118,7 +118,7 @@ describe("cardSummary", () => {
       "landed-old",
     );
     expect(summary.lastSignalAt).toBe("2026-08-14T05:50:00Z");
-    expect(summary.lastWorkAt).toBe("2026-08-14T05:52:00Z");
+    expect(summary.lastWorkAt).toBeNull();
     expect(summary.idleNextAction).toBe(false);
     expect(summary.controllerBehind).toBe(false);
   });
@@ -172,6 +172,56 @@ describe("cardSummary", () => {
     expect(summary.lastWorkAt).toBe("2026-08-14T15:35:08Z");
     expect(summary.controllerBehind).toBe(true);
     expect(summary.idleNextAction).toBe(false);
+  });
+
+  test("does not flag a long-running writer the controller already acknowledged", () => {
+    const summary = cardSummary(
+      row({
+        pending_decisions: 0,
+        latest_update: {
+          headline: "Verity PR #2335 — RÉPARATION ACTIVE",
+          body: null,
+          session_id: "s",
+          at: "2026-08-16T22:25:00Z",
+          signature: "verity",
+          mode: "active",
+          blocker: null,
+        },
+        missions: [
+          {
+            id: "bf2b79ee",
+            status: "active",
+            title: "Repair Verity PR #2335",
+            updated_at: "2026-08-16T22:50:00Z",
+            last_status_change_at: "2026-08-16T20:30:00Z",
+            github_pr: null,
+          },
+        ],
+        health: {
+          missions: 2,
+          active: 1,
+          failed: 0,
+          overdue: 0,
+          tracks_needing_attention: 0,
+          tracks: [
+            {
+              track: "pr-2335",
+              verdict: "active",
+              missions: 1,
+              active: 1,
+              failed: 0,
+              completed: 0,
+              overdue: 0,
+              desired_states: {},
+              last_activity_at: "2026-08-16T22:50:00Z",
+            },
+          ],
+        },
+      }),
+    );
+    expect(summary.liveAttempts).toBe(1);
+    expect(summary.lastWorkAt).toBe("2026-08-16T20:30:00Z");
+    expect(summary.controllerBehind).toBe(false);
   });
 
   test("flags next_action with zero live attempts when the owner is not asked", () => {

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -99,13 +99,17 @@ export function cardSummary(project: ProjectRow): CardSummary {
 const CONTROLLER_BEHIND_MS = 15 * 60 * 1000;
 
 function latestLiveWorkAt(project: ProjectRow): string | null {
-  const fromMissions = (project.missions ?? [])
-    .filter((mission) => LIVE_ATTEMPT.has(mission.status))
-    .map((mission) => mission.updated_at);
-  const fromTracks = (project.health?.tracks ?? [])
-    .filter((track) => track.active > 0)
-    .map((track) => track.last_activity_at);
-  return latestTimestamp([...fromMissions, ...fromTracks]);
+  // Use when the live attempt *started*, not the last tool heartbeat.
+  // A writer that has been running for 20 minutes is not new work the
+  // controller missed.
+  return latestTimestamp(
+    (project.missions ?? [])
+      .filter((mission) => LIVE_ATTEMPT.has(mission.status))
+      .map(
+        (mission) =>
+          nonblank(mission.last_status_change_at) ?? mission.updated_at,
+      ),
+  );
 }
 
 function isControllerBehind(

--- a/dashboard/src/lib/api/projects.ts
+++ b/dashboard/src/lib/api/projects.ts
@@ -17,6 +17,8 @@ export interface ProjectMissionChip {
   title: string | null;
   updated_at: string;
   github_pr: string | null;
+  /** When the mission entered its current status. Heartbeats only bump updated_at. */
+  last_status_change_at?: string | null;
 }
 
 export interface ProjectDeliveryUpdate {

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -1666,6 +1666,11 @@ struct MissionChip {
     title: Option<String>,
     updated_at: String,
     github_pr: Option<String>,
+    /// When this mission last entered its current status. Heartbeats bump
+    /// `updated_at` on every tool event; this stays put so "controller behind"
+    /// compares work *start*, not the last tick.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_status_change_at: Option<String>,
     /// Qualified operator page — ack / in-grace controller waits stay false.
     #[serde(default)]
     needs_operator: bool,
@@ -2714,6 +2719,11 @@ fn mission_chip(
         title: mission.title.clone(),
         updated_at: mission.updated_at.clone(),
         github_pr: mission.project.github_pr.clone(),
+        last_status_change_at: mission
+            .activity
+            .last_status_change_at
+            .clone()
+            .or_else(|| Some(mission.created_at.clone())),
         needs_operator: super::operator_attention::mission_needs_operator(
             mission,
             waiting_for_user_tool,
@@ -4436,6 +4446,7 @@ mod tests {
             title: Some("rebase #2332".into()),
             updated_at: "2026-08-14T06:00:00Z".into(),
             github_pr: None,
+            last_status_change_at: None,
             needs_operator: false,
         });
         let row = builder.finish(&[], None, None, "2026-08-14T06:05:00Z");
@@ -4622,6 +4633,7 @@ mod tests {
                 title: None,
                 updated_at: "2026-08-01T00:00:00Z".to_string(),
                 github_pr: None,
+                last_status_change_at: None,
                 needs_operator: false,
             });
         }
@@ -4644,6 +4656,7 @@ mod tests {
             title: None,
             updated_at: "2026-08-02T00:00:00Z".to_string(),
             github_pr: None,
+            last_status_change_at: None,
             needs_operator: false,
         }
     }
@@ -4868,6 +4881,7 @@ mod tests {
             title: None,
             updated_at: "2026-08-04T11:00:00Z".to_string(),
             github_pr: None,
+            last_status_change_at: None,
             needs_operator: true,
         });
         builder
@@ -4890,6 +4904,7 @@ mod tests {
             title: None,
             updated_at: "2026-08-04T11:00:00Z".to_string(),
             github_pr: None,
+            last_status_change_at: None,
             needs_operator,
         }
     }
@@ -5121,6 +5136,7 @@ mod tests {
             title: Some("Certify Lido PR #88 exact head".to_string()),
             updated_at: "2026-08-16T19:00:00Z".to_string(),
             github_pr: None,
+            last_status_change_at: None,
             needs_operator: false,
         });
         builder.missions.push(MissionChip {
@@ -5129,6 +5145,7 @@ mod tests {
             title: Some("Design P-RESERVE-RELATIONAL implementation packet".to_string()),
             updated_at: "2026-08-16T19:00:01Z".to_string(),
             github_pr: None,
+            last_status_change_at: None,
             needs_operator: false,
         });
         let row = builder.finish(&[], None, None, "2026-08-16T19:05:00Z");


### PR DESCRIPTION
The right-rail **controller behind** badge compared live `updated_at` (every tool heartbeat) to the last controller delivery. Any writer running longer than 15 minutes lit the badge even when the controller had already reported that writer.

Now the board uses `last_status_change_at` (when the attempt became live) and ignores track `last_activity_at` (which includes finished siblings).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only staleness heuristic change with new API field; wrong timestamps could hide real controller lag but does not touch auth or mission execution.
> 
> **Overview**
> Fixes false **controller behind** badges on the projects board when a writer keeps heartbeating but the controller already reported that attempt.
> 
> **`lastWorkAt`** for the 15-minute comparison now uses when live missions **entered their current status** (`last_status_change_at`, falling back to `updated_at`), not mission `updated_at` heartbeats or health-track `last_activity_at`. The overview API exposes **`last_status_change_at`** on mission chips (from stored mission activity, else `created_at`).
> 
> Tests cover the long-running-writer case and adjust expectations when only track activity would have implied work without a live mission timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c698a9df04a46308dc7e502ca3f13bab6696eceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->