### PR TITLE
fix(workspace): resolve MCP launchers across workspace-root symlinks

### DIFF
--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -2175,13 +2175,12 @@ pub async fn project_updates(
         .as_deref()
         .map(read_alias_map)
         .unwrap_or_default();
-    // Accept either the routing key or a tracker slug that aliases route TO.
-    let mut keys: Vec<String> = vec![slug.clone()];
-    for (from, to) in &aliases {
-        if to == &slug {
-            keys.push(from.clone());
-        }
-    }
+    // Accept the requested slug, its canonical, and every alias that folds
+    // onto the same card. `verity` must see `verity-core` deliveries — the
+    // board folds that way, but this endpoint used to only expand aliases
+    // that *point at* the raw slug, so `GET /verity/updates` stayed frozen
+    // on August-7 `project:verity` rows.
+    let keys = project_tag_keys_with(&aliases, &slug);
     let limit = query.limit.unwrap_or(50).min(200);
     let updates =
         tokio::task::spawn_blocking(move || read_deliveries(&db, DELIVERY_SCAN_LIMIT, Some(&keys)))

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1993,6 +1993,25 @@ fn mcp_launcher_shell_escape(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
+/// Relative path of `child` inside `workspace_root`.
+///
+/// Prod workspaces are often stored as `/root/.sandboxed-sh/containers/<name>`
+/// while `MISSION_WORKSPACE_ROOT` resolves the same directory through the
+/// `/srv/sandboxed-storage/...` target of that symlink. `Path::strip_prefix`
+/// is lexical and treats those as unrelated, which made every container
+/// resume fail with "MCP launcher is outside the container workspace".
+fn strip_workspace_prefix(child: &Path, workspace_root: &Path) -> Option<PathBuf> {
+    if let Ok(relative) = child.strip_prefix(workspace_root) {
+        return Some(relative.to_path_buf());
+    }
+    let canonical_child = std::fs::canonicalize(child).ok()?;
+    let canonical_root = std::fs::canonicalize(workspace_root).ok()?;
+    canonical_child
+        .strip_prefix(canonical_root)
+        .ok()
+        .map(Path::to_path_buf)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn write_mcp_env_launcher(
     config: &McpServerConfig,
@@ -2075,9 +2094,8 @@ fn write_mcp_env_launcher(
     write_result?;
 
     if workspace_type == WorkspaceType::Container && !container_fallback {
-        let relative = launcher_host_path
-            .strip_prefix(workspace_root)
-            .map_err(|_| anyhow::anyhow!("MCP launcher is outside the container workspace"))?;
+        let relative = strip_workspace_prefix(&launcher_host_path, workspace_root)
+            .ok_or_else(|| anyhow::anyhow!("MCP launcher is outside the container workspace"))?;
         Ok(format!("/{}", relative.to_string_lossy()))
     } else {
         Ok(launcher_host_path.to_string_lossy().to_string())
@@ -2282,9 +2300,8 @@ fn opencode_entry_from_mcp(
                 && nspawn::nspawn_available();
 
             if workspace_type == WorkspaceType::Container && !container_fallback {
-                let relative = workspace_dir
-                    .strip_prefix(workspace_root)
-                    .unwrap_or_else(|_| Path::new(""));
+                let relative =
+                    strip_workspace_prefix(workspace_dir, workspace_root).unwrap_or_default();
                 let guest_dir = if relative.as_os_str().is_empty() {
                     "/".to_string()
                 } else {
@@ -2317,9 +2334,7 @@ fn opencode_entry_from_mcp(
             )?;
 
             if use_nspawn {
-                let rel = workspace_dir
-                    .strip_prefix(workspace_root)
-                    .unwrap_or_else(|_| Path::new(""));
+                let rel = strip_workspace_prefix(workspace_dir, workspace_root).unwrap_or_default();
                 let rel_str = if rel.as_os_str().is_empty() {
                     "/".to_string()
                 } else {
@@ -6380,5 +6395,31 @@ WORKING_DIR = "/workspaces/mission-old"
                 );
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strip_workspace_prefix_follows_a_symlink_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("srv/containers/dumbcontracts");
+        std::fs::create_dir_all(
+            real.join("workspaces/mission-bf2b79ee/.sandboxed-sh/mcp-launchers"),
+        )
+        .unwrap();
+        let link_parent = temp.path().join("root/.sandboxed-sh/containers");
+        std::fs::create_dir_all(&link_parent).unwrap();
+        let link = link_parent.join("dumbcontracts");
+        symlink(&real, &link).unwrap();
+
+        let child = real.join("workspaces/mission-bf2b79ee/.sandboxed-sh/mcp-launchers/x.sh");
+        std::fs::write(&child, "#!/bin/bash\n").unwrap();
+
+        let relative = strip_workspace_prefix(&child, &link).expect("same directory via symlink");
+        assert_eq!(
+            relative,
+            PathBuf::from("workspaces/mission-bf2b79ee/.sandboxed-sh/mcp-launchers/x.sh")
+        );
     }
 }


### PR DESCRIPTION
## Why
After #851, container mission dirs are prepared on the canonical persist path (`/srv/sandboxed-storage/.../containers/dumbcontracts/...`) while `workspace.path` stays the `/root/.sandboxed-sh/containers/...` symlink. `Path::strip_prefix` is lexical, so every post-deploy resume of a container writer failed with `MCP launcher is outside the container workspace`.

That is why Verity #2335 (`bf2b79ee`) never came back after the last sandboxed restart: auto-resume queued, prep failed, watchdog marked `orphan_no_runner`.

Separately, `GET /api/projects/verity/updates` only expanded aliases that *point at* `verity`. Real deliveries are tagged `verity-core`, so the card/session the operator watches looked frozen since 15:11 (and the `verity` state timeline last moved on August 7).

## What
- Canonicalize both sides before stripping the workspace prefix when writing the MCP env launcher (and the guest/nspawn relative paths).
- Reuse `project_tag_keys_with` for `/updates` so `verity` includes `verity-core` and every other nickname that folds onto the same card.

## Test
- `strip_workspace_prefix_follows_a_symlink_root`
- existing `sibling_verity_projects_do_not_share_a_hyphen_family` already asserts `verity` → `verity-core`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches container workspace path resolution for MCP/nspawn (mission resume) and broadens delivery query keys for project updates; localized helpers with a symlink unit test, but wrong paths could still break container agents or show wrong update feeds.
> 
> **Overview**
> **Container MCP resume** no longer fails when `workspace.path` is a symlink (e.g. `/root/.sandboxed-sh/containers/...`) while mission files live on the canonical path (`/srv/sandboxed-storage/...`). A new `strip_workspace_prefix` tries lexical `strip_prefix` first, then canonicalizes both sides before computing guest paths for MCP launchers, nspawn, and related env.
> 
> **Project updates API** (`GET .../updates`) now uses `project_tag_keys_with` instead of only collecting aliases that point *at* the requested slug. Requests like `verity` include deliveries tagged `verity-core` and other nicknames on the same card, matching how the board folds aliases.
> 
> Adds `strip_workspace_prefix_follows_a_symlink_root` on Unix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a1f9a573b0e5462912895b2a3919798fb234f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->