### PR TITLE
fix(control): hold disk leases only for live missions

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -907,6 +907,110 @@ mod campaign_guard_tests {
         );
     }
 
+    #[tokio::test]
+    async fn silent_recycle_of_pr88_writer_as_reserve_is_rejected() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(
+                Some("Repair Lido PR #88"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create");
+        store
+            .update_mission_project(
+                mission.id,
+                mission_store::MissionProjectPatch {
+                    github_pr: Some(Some("lfglabs-dev/lido-srv3-proof-closure#88".to_string())),
+                    track: Some(Some("pr-88-repair".to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+        let loaded = store.get_mission(mission.id).await.unwrap().unwrap();
+        let err = apply_writer_reuse_or_conflict(
+            &store,
+            &loaded,
+            None,
+            None,
+            None,
+            Some("Implement P-RESERVE-RELATIONAL first slice".into()),
+        )
+        .await
+        .expect_err("silent recycle");
+        assert_eq!(err.0, StatusCode::CONFLICT);
+        assert!(err.1.contains("writer_identity_stale"));
+
+        apply_writer_reuse_or_conflict(
+            &store,
+            &loaded,
+            Some(String::new()),
+            Some("p-reserve-relational".into()),
+            Some("P-RESERVE-RELATIONAL first slice".into()),
+            Some("Implement P-RESERVE-RELATIONAL first slice".into()),
+        )
+        .await
+        .expect("explicit retag");
+        let updated = store.get_mission(mission.id).await.unwrap().unwrap();
+        assert_eq!(updated.project.github_pr.as_deref(), None);
+        assert_eq!(
+            updated.project.track.as_deref(),
+            Some("p-reserve-relational")
+        );
+    }
+
+    #[tokio::test]
+    async fn same_work_followup_without_pr_mention_is_accepted() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(
+                Some("Repair Lido PR #88"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create");
+        store
+            .update_mission_project(
+                mission.id,
+                mission_store::MissionProjectPatch {
+                    github_pr: Some(Some("lfglabs-dev/lido-srv3-proof-closure#88".to_string())),
+                    track: Some(Some("pr-88-repair".to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("tag");
+        let loaded = store.get_mission(mission.id).await.unwrap().unwrap();
+        apply_writer_reuse_or_conflict(
+            &store,
+            &loaded,
+            None,
+            None,
+            None,
+            Some("fix the failing test".into()),
+        )
+        .await
+        .expect("same-work chat must not 409");
+        let updated = store.get_mission(mission.id).await.unwrap().unwrap();
+        assert_eq!(
+            updated.project.github_pr.as_deref(),
+            Some("lfglabs-dev/lido-srv3-proof-closure#88")
+        );
+        assert_eq!(updated.project.track.as_deref(), Some("pr-88-repair"));
+        assert_eq!(updated.title.as_deref(), Some("Repair Lido PR #88"));
+    }
+
     #[test]
     fn dispatch_gate_blocks_paused_and_archived_only() {
         // paused → 423 Locked; archived → 409 Conflict.
@@ -3242,6 +3346,15 @@ pub struct ControlMessageRequest {
     /// message to the session's current mission.
     #[serde(default, alias = "target_mission_id")]
     pub mission_id: Option<Uuid>,
+    /// Explicit identity update when retasking a writer. Omit to leave
+    /// stored `github_pr` / `track` / `title` unchanged; empty string
+    /// clears. A different objective without these fields is refused.
+    #[serde(default)]
+    pub github_pr: Option<String>,
+    #[serde(default)]
+    pub track: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
     /// Catch-all for unrecognized request fields — surfaced as `warnings` in
     /// the response instead of being silently dropped (a mistyped targeting
     /// field once silently rerouted a message to the wrong mission).
@@ -4541,6 +4654,15 @@ pub async fn post_message(
             .await
             .map_err(internal_error)?
         {
+            apply_writer_reuse_or_conflict(
+                &control.mission_store,
+                &mission,
+                req.github_pr.clone(),
+                req.track.clone(),
+                req.title.clone(),
+                Some(content.clone()),
+            )
+            .await?;
             if mission_is_pr_writer_in_store(&control.mission_store, &mission)
                 .await
                 .map_err(internal_error)?
@@ -6740,8 +6862,6 @@ fn cross_tenant_mission_projection(
     })
 }
 
-/// Read-only scan of an offline sqlite store for project-tagged missions.
-/// Returns lightweight Mission values (no history) — enough for board rows.
 fn collect_project_missions_from_sqlite(
     path: &std::path::Path,
     terminal_cutoff_rfc3339: &str,
@@ -7610,8 +7730,14 @@ fn contains_internal_disk_reservation_tag(tags: &[String]) -> bool {
         .any(|tag| tag.trim().starts_with(DISK_RESERVATION_TAG_PREFIX))
 }
 
+/// Only missions that are actually running hold a scratch lease.
+/// Parked (`awaiting_user`, `paused`) and every terminal status release —
+/// those were the 2026-08-17 zombie majority (~18 TiB paper vs ~2 TiB free).
 fn mission_holds_disk_reservation(status: MissionStatus) -> bool {
-    !status.is_terminal() && status != MissionStatus::Acknowledged
+    matches!(
+        status,
+        MissionStatus::Active | MissionStatus::Pending | MissionStatus::WaitingBackground
+    )
 }
 
 fn disk_admission_required_bytes(emergency: u64, reserved: u64, candidate: u64) -> u64 {
@@ -7890,6 +8016,17 @@ async fn reconcile_disk_reservation_ledger_under_lock(
     Ok(())
 }
 
+/// Periodic / on-demand purge of dead leases. The workspace GC loop calls
+/// this even when directory GC is dry-run so an operator never has to edit
+/// `disk-reservations-v2.json` by hand.
+pub(crate) async fn sweep_stale_disk_reservations(
+    control_hub: &ControlHub,
+    config: &Config,
+) -> Result<(), String> {
+    let _guard = acquire_durable_disk_admission_lock(config).await?;
+    reconcile_disk_reservation_ledger_under_lock(control_hub, config).await
+}
+
 /// The caller must retain the returned lock through mission persistence and
 /// its reservation-tag write.  That makes admission, creation and durable
 /// reconstruction one atomic protocol across local control processes.
@@ -8034,7 +8171,7 @@ async fn acquire_durable_pr_writer_lock(
     })
 }
 
-fn canonical_github_pr(raw: &str) -> String {
+pub(crate) fn canonical_github_pr(raw: &str) -> String {
     let mut value = raw
         .trim()
         .split(['?', '#'])
@@ -8320,6 +8457,84 @@ fn message_requests_pr_writer(mission: &Mission, content: &str) -> bool {
 struct PrWriterLease {
     id: Uuid,
     status: MissionStatus,
+}
+
+async fn apply_writer_reuse_or_conflict(
+    store: &Arc<dyn crate::api::mission_store::MissionStore>,
+    mission: &Mission,
+    github_pr: Option<String>,
+    track: Option<String>,
+    title: Option<String>,
+    work_hint: Option<String>,
+) -> Result<(), (StatusCode, String)> {
+    use crate::api::writer_recycle::{apply_writer_reuse, WriterIdentity, WriterIdentityPatch};
+
+    let to_patch = |value: Option<String>| -> Option<Option<String>> {
+        value.map(|raw| {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+    };
+    let stored = WriterIdentity {
+        title: mission.title.clone(),
+        github_pr: mission.project.github_pr.clone(),
+        track: mission.project.track.clone(),
+    };
+    let next = apply_writer_reuse(
+        &stored,
+        &WriterIdentityPatch {
+            title: to_patch(title),
+            github_pr: to_patch(github_pr),
+            track: to_patch(track),
+            work_hint,
+        },
+    )
+    .map_err(|err| {
+        (
+            StatusCode::CONFLICT,
+            serde_json::json!({
+                "error": err.error,
+                "message": err.message,
+            })
+            .to_string(),
+        )
+    })?;
+    if next.github_pr == stored.github_pr
+        && next.track == stored.track
+        && next.title == stored.title
+    {
+        return Ok(());
+    }
+    store
+        .update_mission_project(
+            mission.id,
+            crate::api::mission_store::MissionProjectPatch {
+                github_pr: Some(next.github_pr.clone()),
+                track: Some(next.track.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(internal_error)?;
+    if next.title != stored.title {
+        if let Some(title) = next.title {
+            let _ = store
+                .update_mission_metadata(
+                    mission.id,
+                    Some(Some(title.as_str())),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+        }
+    }
+    Ok(())
 }
 
 fn pr_writer_lease(mission: &Mission) -> PrWriterLease {
@@ -13438,6 +13653,16 @@ pub struct ResumeMissionRequest {
     /// Optional attribution override (e.g. `"system:fleet-watcher"`).
     #[serde(default)]
     pub actor: Option<String>,
+    /// Required when the resume retasks the writer onto different work.
+    #[serde(default)]
+    pub github_pr: Option<String>,
+    #[serde(default)]
+    pub track: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Optional objective for the resumed turn; used to detect silent recycle.
+    #[serde(default)]
+    pub content: Option<String>,
 }
 
 /// Resume an interrupted mission.
@@ -13448,15 +13673,23 @@ pub async fn resume_mission(
     Path(mission_id): Path<Uuid>,
     body: Option<Json<ResumeMissionRequest>>,
 ) -> Result<Json<Mission>, (StatusCode, String)> {
-    let (clean_workspace, skip_message, actor_override) = body
-        .map(|b| {
-            let r = b.0;
-            (r.clean_workspace, r.skip_message, r.actor)
-        })
-        .unwrap_or((false, false, None));
-    let actor = resolve_actor(actor_override, &user);
+    let request = body.map(|b| b.0).unwrap_or_default();
+    let clean_workspace = request.clean_workspace;
+    let skip_message = request.skip_message;
+    let actor = resolve_actor(request.actor.clone(), &user);
 
     let control = control_for_user(&state, &user).await;
+    if let Ok(Some(mission)) = control.mission_store.get_mission(mission_id).await {
+        apply_writer_reuse_or_conflict(
+            &control.mission_store,
+            &mission,
+            request.github_pr.clone(),
+            request.track.clone(),
+            request.title.clone(),
+            request.content.clone(),
+        )
+        .await?;
+    }
     tracing::info!(mission_id = %mission_id, actor = %actor, "FLEET-004 mission resume requested");
 
     let outcome: Result<Mission, (StatusCode, String)> = async {
@@ -32923,7 +33156,11 @@ Investigate <service/> failures.
     fn terminal_missions_release_disk_admission_reservations() {
         assert!(mission_holds_disk_reservation(MissionStatus::Pending));
         assert!(mission_holds_disk_reservation(MissionStatus::Active));
-        assert!(mission_holds_disk_reservation(MissionStatus::AwaitingUser));
+        assert!(mission_holds_disk_reservation(
+            MissionStatus::WaitingBackground
+        ));
+        assert!(!mission_holds_disk_reservation(MissionStatus::AwaitingUser));
+        assert!(!mission_holds_disk_reservation(MissionStatus::Paused));
         assert!(!mission_holds_disk_reservation(MissionStatus::Completed));
         assert!(!mission_holds_disk_reservation(MissionStatus::Failed));
         assert!(!mission_holds_disk_reservation(MissionStatus::Acknowledged));

--- a/src/api/controller_honesty.rs
+++ b/src/api/controller_honesty.rs
@@ -120,6 +120,84 @@ pub fn normalize_decision_question(question: &str) -> String {
         .join(" ")
 }
 
+/// A next-action that means "idle until a PR appears" rather than do the
+/// stored roadmap item. Controllers rephrase this every tick, which used
+/// to look like progress.
+pub fn is_watch_idle_next_action(next: Option<&str>) -> bool {
+    let Some(raw) = next.map(fold_headline) else {
+        return false;
+    };
+    if raw.is_empty() {
+        return false;
+    }
+    let watch = raw.contains("watch")
+        || raw.contains("surveill")
+        || raw.contains("monitor")
+        || raw.contains("veille");
+    let pr = raw.contains("pr") || raw.contains("pull request");
+    watch && pr
+}
+
+/// Track `desired_state` that still wants implementation (not merge/done).
+pub fn is_implement_ready_desired(desired: Option<&str>) -> bool {
+    let Some(raw) = desired.map(fold_headline) else {
+        return false;
+    };
+    raw == "implement"
+        || raw == "implementable"
+        || raw == "implement-ready"
+        || raw == "ready"
+        || raw.starts_with("implement")
+}
+
+fn track_is_open(status: Option<&str>) -> bool {
+    match status.map(fold_headline) {
+        None => true,
+        Some(s) if s.is_empty() => true,
+        Some(s) => !matches!(
+            s.as_str(),
+            "done" | "merged" | "closed" | "superseded" | "dropped"
+        ),
+    }
+}
+
+fn track_is_open_pr(track: &str, status: Option<&str>) -> bool {
+    let name = fold_headline(track);
+    track_is_open(status) && (name.starts_with("pr-") || name.starts_with("pr "))
+}
+
+/// When the drain is empty and a stored track is still implementable, that
+/// item wins over a "watch for a new PR" idle line.
+pub fn honest_next_action(
+    reported: Option<&str>,
+    tracks: &[(String, Option<String>, Option<String>)],
+) -> Option<String> {
+    let implement = tracks.iter().find_map(|(track, desired, status)| {
+        if !track_is_open(status.as_deref()) {
+            return None;
+        }
+        if is_implement_ready_desired(desired.as_deref()) {
+            return Some(format!("implement {track}"));
+        }
+        None
+    });
+    let has_open_pr = tracks
+        .iter()
+        .any(|(track, _, status)| track_is_open_pr(track, status.as_deref()));
+    if let Some(item) = implement {
+        if !has_open_pr && is_watch_idle_next_action(reported) {
+            return Some(item);
+        }
+        if reported.is_none() || reported.is_some_and(|s| s.trim().is_empty()) {
+            return Some(item);
+        }
+    }
+    reported
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 fn fold_headline(headline: &str) -> String {
     headline
         .chars()
@@ -216,5 +294,53 @@ mod tests {
             normalize_decision_question("Relancer  coldcard_skip depuis le checkpoint ?"),
             normalize_decision_question("relancer coldcard_skip depuis le checkpoint ?")
         );
+    }
+
+    #[test]
+    fn watch_idle_does_not_win_over_implement_ready_track() {
+        let tracks = vec![(
+            "p-reserve-relational".to_string(),
+            Some("implement".to_string()),
+            Some("open".to_string()),
+        )];
+        assert_eq!(
+            honest_next_action(
+                Some("watch for a new Lido PR or exact-head finding"),
+                &tracks
+            )
+            .as_deref(),
+            Some("implement p-reserve-relational")
+        );
+        assert_eq!(
+            honest_next_action(Some("surveiller toute nouvelle PR Lido vers main"), &tracks)
+                .as_deref(),
+            Some("implement p-reserve-relational")
+        );
+        // An open PR drain still reports the controller's line.
+        let with_pr = vec![
+            tracks[0].clone(),
+            (
+                "pr-84".to_string(),
+                Some("mergeable".to_string()),
+                Some("open".to_string()),
+            ),
+        ];
+        assert_eq!(
+            honest_next_action(Some("watch for a new Lido PR"), &with_pr).as_deref(),
+            Some("watch for a new Lido PR")
+        );
+    }
+
+    #[test]
+    fn watch_phrasing_is_detected() {
+        assert!(is_watch_idle_next_action(Some(
+            "watch for a new Lido PR or exact-head finding"
+        )));
+        assert!(is_watch_idle_next_action(Some(
+            "monitor-open-prs then merge"
+        )));
+        assert!(!is_watch_idle_next_action(Some(
+            "implement p-reserve-relational"
+        )));
     }
 }

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -460,7 +460,8 @@ impl MissionStore for FileMissionStore {
             mission.awaiting_kind = None;
         }
         drop(missions);
-        self.persist().await
+        self.persist().await?;
+        Ok(())
     }
 
     async fn set_mission_first_viewed_at_if_unset(

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -4002,10 +4002,11 @@ impl MissionStore for SqliteMissionStore {
                     params![id.to_string()],
                 );
             }
-            Ok(())
+            Ok::<(), String>(())
         })
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())??;
+        Ok(())
     }
 
     async fn update_mission_history(
@@ -4675,7 +4676,7 @@ impl MissionStore for SqliteMissionStore {
     async fn delete_mission(&self, id: Uuid) -> Result<bool, String> {
         let conn = self.conn.clone();
 
-        tokio::task::spawn_blocking(move || {
+        let removed = tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
             let rows = conn
                 .execute(
@@ -4683,10 +4684,11 @@ impl MissionStore for SqliteMissionStore {
                     params![id.to_string()],
                 )
                 .map_err(|e| e.to_string())?;
-            Ok(rows > 0)
+            Ok::<bool, String>(rows > 0)
         })
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())??;
+        Ok(removed)
     }
 
     async fn delete_empty_untitled_missions_excluding(

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -69,6 +69,7 @@ async fn run_loop(state: Arc<AppState>) {
     interval.tick().await;
     loop {
         interval.tick().await;
+        sweep_disk_reservations(&state).await;
         run_configured_sweep(&state, "scheduled").await;
         // Container `/tmp` scratch shares this cadence but not this GC's
         // settings: it is disk hygiene for a path no mission record points at,
@@ -122,6 +123,16 @@ async fn run_configured_sweep(state: &Arc<AppState>, trigger: &'static str) {
         dry_run = params.dry_run,
         "mission workspace GC sweep finished",
     );
+}
+
+/// Drop scratch leases whose mission is not live. Runs even when workspace
+/// GC is dry-run/disabled — the reservation file is what blocks admission,
+/// not the mission directory.
+async fn sweep_disk_reservations(state: &Arc<AppState>) {
+    match crate::api::control::sweep_stale_disk_reservations(&state.control, &state.config).await {
+        Ok(()) => {}
+        Err(error) => tracing::warn!(%error, "disk reservation sweep failed"),
+    }
 }
 
 fn gc_execution_enabled() -> bool {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -77,6 +77,7 @@ pub mod usage_optimize;
 pub mod validation;
 pub mod webhook_markers;
 pub mod workspaces;
+pub(crate) mod writer_recycle;
 
 pub use routes::serve;
 pub use types::*;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -2051,6 +2051,18 @@ pub async fn projects_overview(
             .or_insert_with(|| ProjectRowBuilder::new(key.clone()));
         builder.apply_roster(record, canonical_has_roster);
     }
+    for (slug, builder) in &mut rows {
+        if let Ok(tracks) = state.projects.tracks(slug) {
+            let tuples: Vec<(String, Option<String>, Option<String>)> = tracks
+                .into_iter()
+                .map(|track| (track.track, track.desired_state, track.status))
+                .collect();
+            builder.next_action = super::controller_honesty::honest_next_action(
+                builder.next_action.as_deref(),
+                &tuples,
+            );
+        }
+    }
     // The latest ingested state per project becomes the row's latest_update —
     // same serialized shape the delivery scan used to produce, now read back
     // from the store the ingestor maintains.

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -949,7 +949,8 @@ impl ProjectsStore {
     /// Set the controller-reported mode and next-action. Increments
     /// `wait_ticks` while the mode/blocker are unchanged, and resets it to 0 on
     /// any change — so "how long has it been blocked on this" is a column read,
-    /// not a scan of the delivery log.
+    /// not a scan of the delivery log. Rephrasing `next=` does not reset wait.
+    /// A watch-idle next-action yields to an implement-ready stored track.
     pub fn set_mode(
         &self,
         slug: &str,
@@ -957,6 +958,7 @@ impl ProjectsStore {
         next_action: Option<&str>,
         blocker: Option<&str>,
     ) -> Result<(), String> {
+        let next_action = self.honest_next_action_for(slug, next_action)?;
         let now = Utc::now().to_rfc3339();
         let connection = self.lock()?;
         let previous: Option<(Option<String>, Option<String>)> = connection
@@ -985,6 +987,21 @@ impl ProjectsStore {
         Ok(())
     }
 
+    fn honest_next_action_for(
+        &self,
+        slug: &str,
+        reported: Option<&str>,
+    ) -> Result<Option<String>, String> {
+        let tracks = self.tracks(slug)?;
+        let tuples: Vec<(String, Option<String>, Option<String>)> = tracks
+            .into_iter()
+            .map(|track| (track.track, track.desired_state, track.status))
+            .collect();
+        Ok(super::controller_honesty::honest_next_action(
+            reported, &tuples,
+        ))
+    }
+
     /// Project the mode onto an existing project record from the delivery
     /// ingestor. Unlike `set_mode`, this is **idempotent** (it does not count
     /// ticks — `wait` is passed in from the state timeline's observation count)
@@ -1000,8 +1017,26 @@ impl ProjectsStore {
         blocker: Option<&str>,
         at: Option<&str>,
     ) -> Result<(), String> {
+        let next_action = self.honest_next_action_for(slug, next_action)?;
         let now = Utc::now().to_rfc3339();
         let connection = self.lock()?;
+        let previous: Option<(Option<String>, Option<String>, i64)> = connection
+            .query_row(
+                "SELECT mode, blocker, wait_ticks FROM projects WHERE slug = ?1",
+                params![slug],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .map_err(|e| e.to_string())?;
+        let wait = match previous {
+            Some((m, b, stored)) if m.as_deref() == Some(mode) && b.as_deref() == blocker => {
+                // Same stall: never let a rephrased next= / wait=0 reset the
+                // counter. Overlapping ingest of the same delivery can still
+                // pass the same wait twice without inflating it.
+                stored.max(wait)
+            }
+            _ => wait,
+        };
         match at {
             Some(at) => {
                 let watermark: Option<String> = connection
@@ -2346,11 +2381,75 @@ mod tests {
             .expect("m3");
         assert_eq!(store.get_project("bench").unwrap().unwrap().wait_ticks, 1);
 
+        // Rephrasing next= is not a new stall.
+        store
+            .set_mode(
+                "bench",
+                "blocked",
+                Some("watch for a new Lido PR"),
+                Some("transport-cap"),
+            )
+            .expect("m3b");
+        assert_eq!(store.get_project("bench").unwrap().unwrap().wait_ticks, 2);
+
         // A changed blocker resets the counter — a new thing to be stuck on.
         store
             .set_mode("bench", "blocked", Some("x"), Some("other"))
             .expect("m4");
         assert_eq!(store.get_project("bench").unwrap().unwrap().wait_ticks, 0);
+    }
+
+    #[test]
+    fn implement_ready_track_beats_watch_idle_next_action() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("lido", None, None, None, None)
+            .expect("seed");
+        store
+            .set_track(
+                "lido",
+                "p-reserve-relational",
+                Some("implement"),
+                Some("open"),
+            )
+            .expect("track");
+        store
+            .set_mode(
+                "lido",
+                "active",
+                Some("watch for a new Lido PR or exact-head finding"),
+                None,
+            )
+            .expect("mode");
+        let project = store.get_project("lido").unwrap().unwrap();
+        assert_eq!(
+            project.next_action.as_deref(),
+            Some("implement p-reserve-relational")
+        );
+    }
+
+    #[test]
+    fn trailer_wait_zero_does_not_reset_an_existing_stall() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("lido", None, None, None, None)
+            .expect("seed");
+        store
+            .project_mode_from_signal("lido", "blocked", 4, Some("watch PRs"), Some("disk"), None)
+            .expect("first");
+        store
+            .project_mode_from_signal(
+                "lido",
+                "blocked",
+                0,
+                Some("surveiller toute nouvelle PR"),
+                Some("disk"),
+                None,
+            )
+            .expect("rephrase");
+        let project = store.get_project("lido").unwrap().unwrap();
+        assert_eq!(project.wait_ticks, 4);
+        assert_eq!(project.blocker.as_deref(), Some("disk"));
     }
 
     #[test]

--- a/src/api/session_chain.rs
+++ b/src/api/session_chain.rs
@@ -46,20 +46,78 @@ pub fn live_tip(db_path: &Path, session_id: &str) -> String {
     let mut seen: HashSet<String> = HashSet::from([current.clone()]);
 
     for _ in 0..MAX_CHAIN_DEPTH {
-        let child: Option<String> = connection
+        let Some(next) = newest_livable_child(&connection, &current) else {
+            break;
+        };
+        if !seen.insert(next.clone()) {
+            break;
+        }
+        current = next;
+    }
+    current
+}
+
+/// Newest child that is actually a conversation, not a failed compression fork.
+fn newest_livable_child(connection: &rusqlite::Connection, parent: &str) -> Option<String> {
+    match newest_livable_child_rich(connection, parent) {
+        Ok(found) => found,
+        Err(_) => connection
             .query_row(
                 "SELECT id FROM sessions WHERE parent_session_id = ?1 \
                  ORDER BY id DESC LIMIT 1",
-                [&current],
+                [parent],
                 |row| row.get(0),
             )
-            .ok();
-        match child {
-            Some(next) if seen.insert(next.clone()) => current = next,
-            _ => break,
+            .ok(),
+    }
+}
+
+fn newest_livable_child_rich(
+    connection: &rusqlite::Connection,
+    parent: &str,
+) -> Result<Option<String>, rusqlite::Error> {
+    let mut statement = connection.prepare(
+        "SELECT id, ended_at, end_reason, started_at, message_count \
+         FROM sessions WHERE parent_session_id = ?1 ORDER BY id DESC",
+    )?;
+    let rows = statement.query_map([parent], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<f64>>(1).ok().flatten(),
+            row.get::<_, Option<String>>(2).ok().flatten(),
+            row.get::<_, Option<f64>>(3).ok().flatten(),
+            row.get::<_, Option<i64>>(4).ok().flatten(),
+        ))
+    })?;
+    for row in rows.flatten() {
+        let (id, ended_at, end_reason, started_at, message_count) = row;
+        if child_is_livable(end_reason.as_deref(), started_at, ended_at, message_count) {
+            return Ok(Some(id));
         }
     }
-    current
+    Ok(None)
+}
+
+fn child_is_livable(
+    end_reason: Option<&str>,
+    started_at: Option<f64>,
+    ended_at: Option<f64>,
+    message_count: Option<i64>,
+) -> bool {
+    let reason = end_reason.unwrap_or("").trim().to_ascii_lowercase();
+    if matches!(
+        reason.as_str(),
+        "compression_exhausted" | "compression_ineffective"
+    ) {
+        return false;
+    }
+    if let (Some(start), Some(end)) = (started_at, ended_at) {
+        let lifetime = end - start;
+        if lifetime >= 0.0 && lifetime <= 5.0 && message_count.unwrap_or(0) == 0 {
+            return false;
+        }
+    }
+    true
 }
 
 /// `session_id` and its ancestors, nearest first.
@@ -136,6 +194,52 @@ mod tests {
                 .execute(
                     "INSERT INTO sessions (id, parent_session_id) VALUES (?1, ?2)",
                     rusqlite::params![id, parent],
+                )
+                .expect("insert");
+        }
+        (dir, path)
+    }
+
+    struct RichRow<'a> {
+        id: &'a str,
+        parent: Option<&'a str>,
+        started_at: f64,
+        ended_at: Option<f64>,
+        end_reason: Option<&'a str>,
+        message_count: i64,
+    }
+
+    fn rich_db(rows: &[RichRow<'_>]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("state.db");
+        let connection = rusqlite::Connection::open(&path).expect("open");
+        connection
+            .execute(
+                "CREATE TABLE sessions (\
+                    id TEXT PRIMARY KEY, \
+                    parent_session_id TEXT, \
+                    started_at REAL, \
+                    ended_at REAL, \
+                    end_reason TEXT, \
+                    message_count INTEGER\
+                )",
+                [],
+            )
+            .expect("schema");
+        for row in rows {
+            connection
+                .execute(
+                    "INSERT INTO sessions \
+                     (id, parent_session_id, started_at, ended_at, end_reason, message_count) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    rusqlite::params![
+                        row.id,
+                        row.parent,
+                        row.started_at,
+                        row.ended_at,
+                        row.end_reason,
+                        row.message_count
+                    ],
                 )
                 .expect("insert");
         }
@@ -227,6 +331,52 @@ mod tests {
             }),
             None
         );
+    }
+
+    #[test]
+    fn a_compression_exhausted_child_is_not_the_tip() {
+        let (_dir, path) = rich_db(&[
+            RichRow {
+                id: "parent",
+                parent: None,
+                started_at: 1_000.0,
+                ended_at: None,
+                end_reason: None,
+                message_count: 40,
+            },
+            RichRow {
+                id: "dead-child",
+                parent: Some("parent"),
+                started_at: 2_000.0,
+                ended_at: Some(2_003.0),
+                end_reason: Some("compression_exhausted"),
+                message_count: 0,
+            },
+        ]);
+        assert_eq!(live_tip(&path, "parent"), "parent");
+    }
+
+    #[test]
+    fn a_successful_continuation_is_the_tip() {
+        let (_dir, path) = rich_db(&[
+            RichRow {
+                id: "parent",
+                parent: None,
+                started_at: 1_000.0,
+                ended_at: Some(2_000.0),
+                end_reason: Some("compression"),
+                message_count: 40,
+            },
+            RichRow {
+                id: "child",
+                parent: Some("parent"),
+                started_at: 2_000.0,
+                ended_at: None,
+                end_reason: None,
+                message_count: 12,
+            },
+        ]);
+        assert_eq!(live_tip(&path, "parent"), "child");
     }
 
     #[test]

--- a/src/api/writer_recycle.rs
+++ b/src/api/writer_recycle.rs
@@ -1,0 +1,304 @@
+//! Refuse silent reuse of a PR writer as unrelated work.
+//!
+//! Lido 2026-08-17: mission `ebfb1fd1` stayed tagged `github_pr=…#88` /
+//! `track=pr-88-repair` while being retasked as P-RESERVE-RELATIONAL. The
+//! inventory lied. A writer may be reused only when the caller updates the
+//! identity fields that named the previous work.
+
+use super::control::canonical_github_pr;
+
+/// Identity a controller/writer is currently tagged with.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WriterIdentity {
+    pub title: Option<String>,
+    pub github_pr: Option<String>,
+    pub track: Option<String>,
+}
+
+/// What the new dispatch wants. `None` on a field means "leave unspecified"
+/// (silent). `Some(None)` means "clear". `Some(Some(v))` means "set".
+#[derive(Debug, Clone, Default)]
+pub struct WriterIdentityPatch {
+    pub title: Option<Option<String>>,
+    pub github_pr: Option<Option<String>>,
+    pub track: Option<Option<String>>,
+    /// Prompt / objective of the new turn. Used to detect that the work
+    /// changed when the caller did not retag.
+    pub work_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecycleRefusal {
+    pub error: &'static str,
+    pub message: String,
+}
+
+/// Merge `patch` onto `stored`. Refuses when the new work is different and
+/// `github_pr` / `track` were not explicitly updated.
+pub fn apply_writer_reuse(
+    stored: &WriterIdentity,
+    patch: &WriterIdentityPatch,
+) -> Result<WriterIdentity, RecycleRefusal> {
+    let work_changed = dispatch_is_different_work(stored, patch);
+    let identity_updated = patch.github_pr.is_some() || patch.track.is_some();
+    if work_changed && !identity_updated {
+        return Err(RecycleRefusal {
+            error: "writer_identity_stale",
+            message: format!(
+                "refusing silent recycle of writer tagged github_pr={} track={}; \
+                 retag github_pr/track (or clear them) before dispatching different work",
+                stored.github_pr.as_deref().unwrap_or("-"),
+                stored.track.as_deref().unwrap_or("-"),
+            ),
+        });
+    }
+
+    Ok(WriterIdentity {
+        title: merge_field(&stored.title, &patch.title),
+        github_pr: merge_field(&stored.github_pr, &patch.github_pr),
+        track: merge_field(&stored.track, &patch.track),
+    })
+}
+
+fn merge_field(stored: &Option<String>, patch: &Option<Option<String>>) -> Option<String> {
+    match patch {
+        None => stored.clone(),
+        Some(None) => None,
+        Some(Some(value)) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+    }
+}
+
+fn dispatch_is_different_work(stored: &WriterIdentity, patch: &WriterIdentityPatch) -> bool {
+    let hint = patch
+        .work_hint
+        .as_deref()
+        .or(patch.title.as_ref().and_then(|inner| inner.as_deref()))
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if hint.is_empty() {
+        return false;
+    }
+
+    let stored_pr = stored.github_pr.as_deref().map(canonical_github_pr);
+    let stored_pr_number = stored_pr
+        .as_ref()
+        .and_then(|canonical| canonical.rsplit('#').next())
+        .map(str::to_string);
+    // A follow-up that never names work ("fix the failing test") is the same
+    // writer continuing. Only a *named* different PR / campaign is a retask.
+    for number in pr_numbers_in(&hint) {
+        if stored_pr_number.as_deref() != Some(number.as_str()) {
+            return true;
+        }
+    }
+
+    let stored_track = stored.track.as_deref().unwrap_or("").to_ascii_lowercase();
+    for token in campaign_tokens_in(&hint) {
+        if !stored_identity_covers(&stored_track, stored_pr.as_deref(), &token) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn pr_numbers_in(hint: &str) -> Vec<String> {
+    let bytes = hint.as_bytes();
+    let mut numbers = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'#' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() {
+            let (number, next) = take_digits(hint, i + 1);
+            numbers.push(number);
+            i = next;
+            continue;
+        }
+        if word_at(bytes, i, b"pr") {
+            let after = i + 2;
+            if after < bytes.len() && matches!(bytes[after], b'-' | b' ' | b'#') {
+                let digits_at = after + 1;
+                if digits_at < bytes.len() && bytes[digits_at].is_ascii_digit() {
+                    let (number, next) = take_digits(hint, digits_at);
+                    numbers.push(number);
+                    i = next;
+                    continue;
+                }
+            }
+        }
+        if word_at(bytes, i, b"pull") {
+            let after = i + 4;
+            if after < bytes.len()
+                && bytes[after] == b'/'
+                && after + 1 < bytes.len()
+                && bytes[after + 1].is_ascii_digit()
+            {
+                let (number, next) = take_digits(hint, after + 1);
+                numbers.push(number);
+                i = next;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    numbers
+}
+
+fn campaign_tokens_in(hint: &str) -> Vec<String> {
+    let bytes = hint.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let at_boundary = i == 0 || !bytes[i.saturating_sub(1)].is_ascii_alphanumeric();
+        if at_boundary
+            && bytes[i] == b'p'
+            && i + 2 < bytes.len()
+            && bytes[i + 1] == b'-'
+            && bytes[i + 2].is_ascii_alphabetic()
+        {
+            let mut end = i + 2;
+            while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'-') {
+                end += 1;
+            }
+            let mut trimmed = end;
+            while trimmed > i + 2 && bytes[trimmed - 1] == b'-' {
+                trimmed -= 1;
+            }
+            tokens.push(hint[i..trimmed].to_string());
+            i = end;
+            continue;
+        }
+        i += 1;
+    }
+    tokens
+}
+
+fn stored_identity_covers(track: &str, github_pr: Option<&str>, token: &str) -> bool {
+    if !track.is_empty() {
+        let track_norm = track.replace('_', "-");
+        if track == token
+            || track_norm == token
+            || track.contains(token)
+            || token.contains(track)
+            || track_norm.starts_with(token)
+            || token.starts_with(track_norm.as_str())
+        {
+            return true;
+        }
+    }
+    github_pr.is_some_and(|pr| pr.to_ascii_lowercase().contains(token))
+}
+
+fn word_at(bytes: &[u8], i: usize, word: &[u8]) -> bool {
+    if i + word.len() > bytes.len() {
+        return false;
+    }
+    if i > 0 && bytes[i - 1].is_ascii_alphanumeric() {
+        return false;
+    }
+    bytes[i..i + word.len()].eq_ignore_ascii_case(word)
+}
+
+fn take_digits(hint: &str, start: usize) -> (String, usize) {
+    let bytes = hint.as_bytes();
+    let mut end = start;
+    while end < bytes.len() && bytes[end].is_ascii_digit() {
+        end += 1;
+    }
+    (hint[start..end].to_string(), end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stored_pr88() -> WriterIdentity {
+        WriterIdentity {
+            title: Some("Repair Lido PR #88 second current-head findings".into()),
+            github_pr: Some("lfglabs-dev/lido-srv3-proof-closure#88".into()),
+            track: Some("pr-88-repair".into()),
+        }
+    }
+
+    #[test]
+    fn silent_preserve_as_p_reserve_is_rejected() {
+        let err = apply_writer_reuse(
+            &stored_pr88(),
+            &WriterIdentityPatch {
+                work_hint: Some("Implement P-RESERVE-RELATIONAL first slice on main".into()),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect_err("must refuse");
+        assert_eq!(err.error, "writer_identity_stale");
+        assert!(err.message.contains("#88"));
+    }
+
+    #[test]
+    fn explicit_retag_allows_reuse() {
+        let next = apply_writer_reuse(
+            &stored_pr88(),
+            &WriterIdentityPatch {
+                title: Some(Some("P-RESERVE-RELATIONAL first slice".into())),
+                github_pr: Some(None),
+                track: Some(Some("p-reserve-relational".into())),
+                work_hint: Some("Implement P-RESERVE-RELATIONAL".into()),
+            },
+        )
+        .expect("retag ok");
+        assert_eq!(next.github_pr.as_deref(), None);
+        assert_eq!(next.track.as_deref(), Some("p-reserve-relational"));
+        assert_eq!(
+            next.title.as_deref(),
+            Some("P-RESERVE-RELATIONAL first slice")
+        );
+    }
+
+    #[test]
+    fn same_pr_continue_needs_no_retag() {
+        let next = apply_writer_reuse(
+            &stored_pr88(),
+            &WriterIdentityPatch {
+                work_hint: Some("Continue repair of Lido PR #88 exact-head findings".into()),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect("same work");
+        assert_eq!(next.github_pr, stored_pr88().github_pr);
+        assert_eq!(next.track, stored_pr88().track);
+    }
+
+    #[test]
+    fn followup_that_does_not_mention_pr_is_same_work() {
+        let next = apply_writer_reuse(
+            &stored_pr88(),
+            &WriterIdentityPatch {
+                work_hint: Some("fix the failing test".into()),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect("generic same-work chat must not 409");
+        assert_eq!(next.github_pr, stored_pr88().github_pr);
+        assert_eq!(next.track, stored_pr88().track);
+        assert_eq!(next.title, stored_pr88().title);
+    }
+
+    #[test]
+    fn naming_a_different_pr_is_a_retask() {
+        let err = apply_writer_reuse(
+            &stored_pr88(),
+            &WriterIdentityPatch {
+                work_hint: Some("switch this writer to PR #90".into()),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect_err("different PR is different work");
+        assert_eq!(err.error, "writer_identity_stale");
+    }
+}


### PR DESCRIPTION
## Why

Verity and Lido stalled for the same paper-quota leak: `disk-reservations-v2.json` kept `awaiting_user` / `paused` / missing-id leases (the #851 ledger already existed, but `mission_holds_disk_reservation` treated every non-terminal status as live). Admission then refused every local create (~18 TiB reserved vs ~2 TiB free). Lido recycled the `#88` writer as P-RESERVE; Verity sat on “dispatch #2276 when reservation capacity is available”.

## What

- Hold scratch leases only for `active` / `pending` / `waiting_background`. The existing v2 ledger + `reconcile` path is the single writer; GC ticks `sweep_stale_disk_reservations` so the file does not need a manual edit.
- `live_tip` skips `compression_exhausted` / `compression_ineffective` children.
- Silent `#88` → P-RESERVE recycle is `409 writer_identity_stale`; a same-work follow-up like “fix the failing test” is allowed.
- Implement-ready tracks beat “watch for a new PR”; `wait=0` / next= rephrase does not reset stall ticks.

## Test plan

- [x] `terminal_missions_release_disk_admission_reservations` (awaiting_user / paused no longer hold)
- [x] writer recycle: silent P-RESERVE refused; “fix the failing test” accepted
- [x] compression_exhausted child is not the tip
- [x] implement-ready beats watch-idle; trailer wait=0 does not reset
- After deploy: next GC/admission sweep should drop the zombie leases; Verity #2276 and a new Lido writer should admit if the disk is actually free.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes disk admission accounting and control/resume dispatch gates that affect mission creation and writer leases fleet-wide; behavior is covered by new tests but deploy impact on live quota and in-flight missions is significant.
> 
> **Overview**
> Fixes **paper disk quota** and **misleading fleet state** that blocked local mission admission and hid real work.
> 
> **Disk admission** now counts scratch leases only for `active`, `pending`, and `waiting_background` (not `awaiting_user` / `paused`). The workspace GC loop calls **`sweep_stale_disk_reservations`** on every tick—even when directory GC is dry-run—so zombie rows in `disk-reservations-v2.json` reconcile without manual edits.
> 
> **Writer identity**: new `writer_recycle` logic plus optional `github_pr` / `track` / `title` on control messages and resume. Retasking a tagged PR writer onto different work without updating those fields returns **409 `writer_identity_stale`**; generic same-work follow-ups (e.g. “fix the failing test”) still pass.
> 
> **Session chain** `live_tip` skips `compression_exhausted` / `compression_ineffective` and zero-message short-lived children so failed compression forks are not treated as the conversation tip.
> 
> **Controller honesty**: `honest_next_action` prefers an implement-ready open track over “watch for a new PR” when no open PR drain exists; project `set_mode` / ingest no longer reset **`wait_ticks`** when only `next_action` is rephrased or a trailer sends `wait=0`.
> 
> Minor mission-store return-type fixes in file/sqlite status/delete paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e119e1f0fa4ee37b649bcd0bde3c51e2c3699e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->