### PR TITLE
fix(control): treat paper disk leases as a warning, not a refuse

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7740,19 +7740,30 @@ fn mission_holds_disk_reservation(status: MissionStatus) -> bool {
     )
 }
 
+/// Hard admission budget: emergency floor + this candidate. Paper leases are
+/// not part of the hard gate — the 2026-08-17 ledger still charged ~5–18 TiB
+/// of `failed` / parked rows after deploy, so every create died while 2 TiB
+/// was actually free.
+fn disk_admission_hard_required_bytes(emergency: u64, candidate: u64) -> u64 {
+    emergency.saturating_add(candidate)
+}
+
 fn disk_admission_required_bytes(emergency: u64, reserved: u64, candidate: u64) -> u64 {
-    emergency.saturating_add(reserved).saturating_add(candidate)
+    disk_admission_hard_required_bytes(emergency, candidate).saturating_add(reserved)
 }
 
 async fn reserved_disk_bytes_for_filesystem(
     config: &Config,
     filesystem: &str,
+    live_ids: &HashSet<Uuid>,
 ) -> Result<u64, String> {
     let ledger = read_disk_reservation_ledger(config)?;
     Ok(ledger
         .reservations
         .values()
-        .filter(|reservation| reservation.filesystem == filesystem)
+        .filter(|reservation| {
+            reservation.filesystem == filesystem && live_ids.contains(&reservation.mission_id)
+        })
         .map(disk_reservation_outstanding_bytes)
         .fold(0u64, |sum, bytes| sum.saturating_add(bytes)))
 }
@@ -7817,7 +7828,7 @@ fn nonterminal_missions_in_sqlite(
         let (id, status, workspace_id, requires_local_disk) =
             row.map_err(|error| error.to_string())?;
         let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status))
-            .unwrap_or(MissionStatus::Active);
+            .unwrap_or(MissionStatus::Failed);
         if mission_holds_disk_reservation(status) {
             let id = Uuid::parse_str(&id)
                 .map_err(|error| format!("parse mission id {id} in {}: {error}", path.display()))?;
@@ -7889,7 +7900,7 @@ fn migrate_legacy_ledger_placement_in_sqlite(
 async fn reconcile_disk_reservation_ledger_under_lock(
     control_hub: &ControlHub,
     config: &Config,
-) -> Result<(), String> {
+) -> Result<HashSet<Uuid>, String> {
     let inventory = control_hub.mission_store_inventory().await?;
     let mut ledger = read_disk_reservation_ledger(config)?;
     let legacy_placement = std::mem::take(&mut ledger.legacy_requires_local_disk);
@@ -8013,7 +8024,7 @@ async fn reconcile_disk_reservation_ledger_under_lock(
     if changed {
         write_disk_reservation_ledger(config, &ledger)?;
     }
-    Ok(())
+    Ok(live_missions.keys().copied().collect())
 }
 
 /// Periodic / on-demand purge of dead leases. The workspace GC loop calls
@@ -8024,7 +8035,8 @@ pub(crate) async fn sweep_stale_disk_reservations(
     config: &Config,
 ) -> Result<(), String> {
     let _guard = acquire_durable_disk_admission_lock(config).await?;
-    reconcile_disk_reservation_ledger_under_lock(control_hub, config).await
+    reconcile_disk_reservation_ledger_under_lock(control_hub, config).await?;
+    Ok(())
 }
 
 /// The caller must retain the returned lock through mission persistence and
@@ -8037,7 +8049,19 @@ async fn reserve_local_mission_disk(
     estimate_gib: u64,
 ) -> Result<(DurableDiskAdmissionLockGuard, DiskReservation), String> {
     let guard = acquire_durable_disk_admission_lock(config).await?;
-    reconcile_disk_reservation_ledger_under_lock(control_hub, config).await?;
+    let live_ids = match reconcile_disk_reservation_ledger_under_lock(control_hub, config).await {
+        Ok(ids) => ids,
+        Err(error) => {
+            // Paper accounting must never block a host that still has real
+            // free space. A reconcile failure used to leave the stale
+            // ledger as a hard refusal (~18 TiB reserved vs ~2 TiB free).
+            tracing::warn!(
+                %error,
+                "disk reservation reconcile failed; admitting on measured free space only"
+            );
+            HashSet::new()
+        }
+    };
     let root = workspace::mission_workspace_root_for_workspace(workspace, Uuid::nil());
     if let Some(reason) = disk_admission_refusal(&root) {
         return Err(reason);
@@ -8048,27 +8072,37 @@ async fn reserve_local_mission_disk(
             root.display()
         )
     })?;
-    let reserved = reserved_disk_bytes_for_filesystem(config, &usage.filesystem).await?;
+    let reserved = reserved_disk_bytes_for_filesystem(config, &usage.filesystem, &live_ids)
+        .await
+        .unwrap_or(0);
     let estimate = estimate_gib.saturating_mul(1 << 30);
     let emergency = mission_disk_reserve_gib().saturating_mul(1 << 30);
-    let required = disk_admission_required_bytes(emergency, reserved, estimate);
-    if usage.available < required {
+    let hard_required = disk_admission_hard_required_bytes(emergency, estimate);
+    if usage.available < hard_required {
         return Err(format!(
-            "mission admission refused on filesystem {}: {} GiB free, {} GiB already reserved, {} GiB candidate estimate, {} GiB emergency reserve ({} GiB required)",
+            "mission admission refused on filesystem {}: {} GiB free, {} GiB candidate estimate, {} GiB emergency reserve ({} GiB required)",
             usage.filesystem,
             usage.available / (1 << 30),
-            reserved / (1 << 30),
             estimate_gib,
             mission_disk_reserve_gib(),
-            required / (1 << 30),
+            hard_required / (1 << 30),
         ));
+    }
+    if reserved > 0 && usage.available < hard_required.saturating_add(reserved) {
+        tracing::warn!(
+            filesystem = %usage.filesystem,
+            free_bytes = usage.available,
+            reserved_bytes = reserved,
+            candidate_bytes = estimate,
+            "paper scratch reservations exceed free space; admitting because measured disk is sufficient"
+        );
     }
     tracing::info!(
         filesystem = %usage.filesystem,
         free_bytes = usage.available,
         reserved_bytes = reserved,
         candidate_bytes = estimate,
-        required_bytes = required,
+        required_bytes = hard_required,
         "local mission disk admission reserved"
     );
     Ok((
@@ -33143,12 +33177,32 @@ Investigate <service/> failures.
 
         let emergency = 64 << 30;
         let first = 20 << 30;
-        // Exact equality leaves the emergency floor intact; a second
-        // same-filesystem admission must include the first reservation.
+        // Hard gate is emergency + candidate only. Paper reserved is a
+        // warning budget, never the refuse line.
+        assert_eq!(
+            disk_admission_hard_required_bytes(emergency, first),
+            84 << 30
+        );
         assert_eq!(disk_admission_required_bytes(emergency, 0, first), 84 << 30);
         assert_eq!(
             disk_admission_required_bytes(emergency, first, first),
             104 << 30
+        );
+    }
+
+    #[test]
+    fn paper_reservations_do_not_hard_block_when_disk_is_free() {
+        let emergency = 64 << 30;
+        let candidate = 64 << 30;
+        let paper = 5184u64 << 30;
+        let available = 2136u64 << 30;
+        assert!(
+            available >= disk_admission_hard_required_bytes(emergency, candidate),
+            "2 TiB free must admit a 64+64 GiB create"
+        );
+        assert!(
+            available < disk_admission_required_bytes(emergency, paper, candidate),
+            "the old paper-inclusive formula is what blocked Verity"
         );
     }
 


### PR DESCRIPTION
## Why

Prod still refuses every local create:

`2136 GiB free, 5184 GiB already reserved, 64 GiB candidate, 64 GiB emergency`

The v2 ledger still has **176 rows / 169 `failed`**. Paper reserved is larger than real free space, so Verity cannot start C5 / forEach / external-calls. Reducing the estimate to 4 GiB does not help.

## What

Reservations become **soft**:
- Hard refuse only when **measured** free < candidate + emergency floor.
- Live paper leases are logged; they never refuse.
- Reconcile errors fail open onto `df` instead of keeping the stale ledger as a hard gate.

A host with 2 TiB free now admits a 64+64 GiB create even if the JSON still claims 5–18 TiB.

## Test plan

- [x] `paper_reservations_do_not_hard_block_when_disk_is_free` (2136 vs 5184)
- [x] hard required is emergency + candidate only
- After deploy: create a local mission from the UI / Verity `/goal` — must no longer mention `already reserved` as a refusal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core disk admission for local mission creation—under-admission is reduced but concurrent creates could theoretically oversubscribe disk if paper leases are ignored at the hard gate.
> 
> **Overview**
> **Local mission disk admission** no longer refuses creates when the v2 reservation ledger reports huge “paper” reserved space from stale or terminal missions. The **hard gate** is now only **measured free ≥ emergency floor + candidate estimate**; ledger totals are used for logging and a **warn** when paper reservations exceed free, not for refusal.
> 
> **Ledger accounting** for “reserved” bytes now sums only reservations whose `mission_id` is in the **live** set returned from `reconcile_disk_reservation_ledger_under_lock`. Reconcile failures during `reserve_local_mission_disk` **fail open** (empty live set, `reserved` defaults to 0) so a broken ledger cannot block hosts with real free space. Unparseable mission statuses when scanning stores default to **`Failed`** instead of **`Active`**, so bad rows are less likely to keep holding leases.
> 
> Unit tests document the new hard formula and the prod-like case (2136 GiB free vs 5184 GiB paper reserved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ff12ed1143823aa8bcd1dab52d17eb62837a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->