### PR TITLE
fix(dashboard): poll the projects board and lead with live processes

### DIFF
--- a/dashboard/src/app/control/components/session-project-rail.tsx
+++ b/dashboard/src/app/control/components/session-project-rail.tsx
@@ -16,6 +16,7 @@ import {
   viewPendingDecisions,
 } from "@/components/projects/project-card-view";
 import { parseMode } from "@/components/projects/project-health";
+import { pollingFetchConfig } from "@/lib/swr-config";
 import { cn } from "@/lib/utils";
 
 /** Item-first project snapshot docked to the right of a bound Hermes session. */
@@ -33,13 +34,13 @@ export function SessionProjectRail({ sessionId }: { sessionId: string }) {
         return match ? { slug: match.slug, session_id: sessionId } : null;
       }
     },
-    { revalidateOnFocus: false, shouldRetryOnError: false },
+    { ...pollingFetchConfig, shouldRetryOnError: false },
   );
   const rawSlug = resolved?.slug;
   const { data: overview } = useSWR(
     rawSlug ? "projects-overview" : null,
     getProjectsOverview,
-    { revalidateOnFocus: false },
+    pollingFetchConfig,
   );
   const slug = resolveSessionProjectSlug({
     resolvedSlug: rawSlug,
@@ -49,7 +50,7 @@ export function SessionProjectRail({ sessionId }: { sessionId: string }) {
   const { data: detail } = useSWR(
     slug ? ["project-detail", slug] : null,
     () => getProject(slug!),
-    { revalidateOnFocus: false },
+    pollingFetchConfig,
   );
 
   if (!slug) {

--- a/dashboard/src/components/projects/project-card-view.test.ts
+++ b/dashboard/src/components/projects/project-card-view.test.ts
@@ -224,6 +224,45 @@ describe("cardSummary", () => {
     expect(summary.controllerBehind).toBe(false);
   });
 
+  test("a fresh controller heartbeat is a signal, not only the last LLM chapter", () => {
+    const summary = cardSummary(
+      row({
+        pending_decisions: 0,
+        controller_heartbeat_at: "2026-08-17T08:22:00Z",
+        latest_update: {
+          headline: "blocked on disk",
+          body: null,
+          session_id: "s",
+          at: "2026-08-17T07:54:00Z",
+          signature: "verity",
+          mode: "active",
+          blocker: null,
+        },
+        missions: [
+          {
+            id: "26da210b",
+            status: "active",
+            title: "Goal: close Verity C5 storage coherence #2330",
+            updated_at: "2026-08-17T08:24:00Z",
+            last_status_change_at: "2026-08-17T08:20:00Z",
+            github_pr: null,
+          },
+        ],
+        health: {
+          missions: 1,
+          active: 1,
+          failed: 0,
+          overdue: 0,
+          tracks_needing_attention: 0,
+          tracks: [],
+        },
+      }),
+    );
+    expect(summary.lastSignalAt).toBe("2026-08-17T08:22:00Z");
+    expect(summary.lastWorkAt).toBe("2026-08-17T08:20:00Z");
+    expect(summary.controllerBehind).toBe(false);
+  });
+
   test("flags next_action with zero live attempts when the owner is not asked", () => {
     const summary = cardSummary(
       row({

--- a/dashboard/src/components/projects/project-card-view.ts
+++ b/dashboard/src/components/projects/project-card-view.ts
@@ -70,8 +70,10 @@ export function cardSummary(project: ProjectRow): CardSummary {
     project.attention_reasons[0] ??
     nonblank(project.latest_update?.headline) ??
     nonblank(project.tracker?.status_line);
-  const lastSignalAt =
-    project.latest_update?.at ?? project.controller_heartbeat_at ?? null;
+  const lastSignalAt = latestTimestamp([
+    project.latest_update?.at,
+    project.controller_heartbeat_at,
+  ]);
   const lastWorkAt = latestLiveWorkAt(project);
   const liveAttempts = project.health?.active ?? 0;
   const pendingDecisions = project.pending_decisions ?? 0;
@@ -97,6 +99,13 @@ export function cardSummary(project: ProjectRow): CardSummary {
 }
 
 const CONTROLLER_BEHIND_MS = 15 * 60 * 1000;
+
+/** Missions that are actually executing right now. */
+export function viewLiveMissions(project: ProjectRow): ProjectRow["missions"] {
+  return (project.missions ?? []).filter((mission) =>
+    LIVE_ATTEMPT.has(mission.status),
+  );
+}
 
 function latestLiveWorkAt(project: ProjectRow): string | null {
   // Use when the live attempt *started*, not the last tool heartbeat.

--- a/dashboard/src/components/projects/projects-board.test.tsx
+++ b/dashboard/src/components/projects/projects-board.test.tsx
@@ -165,8 +165,6 @@ describe("ProjectsBoard", () => {
 
     renderBoard();
 
-    // Missions are behind a collapsible summary now — expand it first.
-    fireEvent.click(await screen.findByRole("button", { name: /Attempts \(1\)/ }));
     const row = await screen.findByRole("link", { name: /Phase 1C slice/ });
     expect(row).toHaveAttribute(
       "href",
@@ -318,6 +316,74 @@ describe("ProjectsBoard", () => {
     expect(
       screen.getAllByText("rebase/repair #2332 onto main after #2333").length,
     ).toBeGreaterThan(0);
+  });
+
+  test("leads the detail pane with a live process list instead of the LLM chapter", async () => {
+    mockedOverview.mockResolvedValue(
+      overview([
+        project({
+          slug: "verity-core",
+          title: "Verity",
+          mode: "active",
+          missions: [
+            {
+              id: "26da210b-aaaa-bbbb-cccc-ddddeeeeffff",
+              status: "active",
+              title: "Goal: close Verity C5 storage coherence #2330",
+              updated_at: "2026-08-17T08:24:00Z",
+              last_status_change_at: "2026-08-17T08:20:00Z",
+              github_pr: null,
+            },
+            {
+              id: "5d9f61e9-aaaa-bbbb-cccc-ddddeeeeffff",
+              status: "active",
+              title: "Goal: generic positive-body forEach correctness",
+              updated_at: "2026-08-17T08:20:53Z",
+              last_status_change_at: "2026-08-17T08:20:45Z",
+              github_pr: null,
+            },
+          ],
+          latest_update: {
+            headline: "Je reprends Verity immédiatement, avec trois lanes",
+            body: "Long controller essay that should stay collapsed.",
+            session_id: "sess-verity",
+            at: "2026-08-17T07:39:00Z",
+            signature: "verity",
+            blocker: null,
+          },
+        }),
+      ]),
+    );
+    mockedUpdates.mockResolvedValue({
+      slug: "verity-core",
+      updates: [
+        {
+          headline: "Je reprends Verity immédiatement, avec trois lanes",
+          body: "Long controller essay that should stay collapsed.",
+          session_id: "sess-verity",
+          at: "2026-08-17T07:39:00Z",
+          signature: "verity",
+          blocker: null,
+        },
+      ],
+    });
+
+    renderBoard();
+
+    expect(await screen.findByText(/Live \(2\)/)).toBeInTheDocument();
+    expect(
+      screen.getByText("Goal: close Verity C5 storage coherence #2330"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Goal: generic positive-body forEach correctness"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Je reprends Verity immédiatement, avec trois lanes")
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryByText(/Origin conversation: sess-verity/),
+    ).not.toBeInTheDocument();
   });
 
   test("selecting a project loads its updates timeline in the detail pane", async () => {

--- a/dashboard/src/components/projects/projects-board.tsx
+++ b/dashboard/src/components/projects/projects-board.tsx
@@ -48,6 +48,7 @@ import {
 import {
   cardSummary,
   viewControllerSignal,
+  viewLiveMissions,
   viewMovingItems,
   viewOpenItems,
   viewPendingDecisions,
@@ -55,6 +56,7 @@ import {
   type ViewDecision,
   type ViewItem,
 } from "./project-card-view";
+import { pollingFetchConfig } from "@/lib/swr-config";
 import {
   listHermesSessions,
   type HermesSession,
@@ -207,7 +209,13 @@ export default function ProjectsBoard() {
   const { data, error, isLoading } = useSWR(
     "projects-overview",
     getProjectsOverview,
-    { refreshInterval: 30000, revalidateOnFocus: false },
+    {
+      ...pollingFetchConfig,
+      refreshInterval: (overview) =>
+        (overview?.projects ?? []).some((project) => liveMissionCount(project) > 0)
+          ? 5000
+          : 15000,
+    },
   );
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
@@ -1021,16 +1029,17 @@ function ProjectDetail({
   const { data, error, isLoading } = useSWR(
     ["project-updates", project.slug],
     () => getProjectUpdates(project.slug, 50),
-    { revalidateOnFocus: false },
+    pollingFetchConfig,
   );
   const { data: detail } = useSWR(
     ["project-detail", project.slug],
     () => getProject(project.slug),
-    { revalidateOnFocus: false },
+    pollingFetchConfig,
   );
   const updates = data?.updates ?? [];
   const section = SECTIONS.find((s) => s.bucket === project.bucket);
   const summary = cardSummary(project);
+  const liveMissions = viewLiveMissions(project);
   const signal = detail ? viewControllerSignal(detail) : null;
   const items = detail ? viewOpenItems(detail) : [];
   const decisions = detail ? viewPendingDecisions(detail) : [];
@@ -1099,6 +1108,7 @@ function ProjectDetail({
             ))}
           </div>
         )}
+        {liveMissions.length > 0 && <LiveProcessList missions={liveMissions} />}
         {moving.length > 0 && <ItemList items={moving} heading="Moving" />}
         {stalled.length > 0 && (
           <ItemList items={stalled} heading="Stalled items" defaultExpanded={moving.length === 0} />
@@ -1111,7 +1121,12 @@ function ProjectDetail({
             <TrackHealthList health={project.health} />
           </div>
         ) : null}
-        {project.missions.length > 0 && <MissionList missions={project.missions} />}
+        {project.missions.length > 0 && (
+          <MissionList
+            missions={project.missions}
+            defaultExpanded={liveMissions.length === 0}
+          />
+        )}
       </div>
 
       <div className="flex-1 px-4 py-3 sm:px-5">
@@ -1139,7 +1154,7 @@ function ProjectDetail({
             <UpdateEntry
               key={`${update.session_id}-${update.at}-${index}`}
               update={update}
-              defaultExpanded={index === 0}
+              defaultExpanded={index === 0 && liveMissions.length === 0}
               replyToSessionId={
                 project.conversation?.source === "binding"
                   ? project.conversation.session_id
@@ -1317,9 +1332,32 @@ function ItemList({
   );
 }
 
+/** Live writers / subagents / processes — the operator-facing inventory. */
+function LiveProcessList({ missions }: { missions: ProjectMissionChip[] }) {
+  return (
+    <div className="mt-2.5">
+      <p className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-white/35">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[rgb(var(--text)/0.65)]" />
+        Live ({missions.length})
+      </p>
+      <div className="max-h-56 overflow-y-auto divide-y divide-white/[0.04] rounded-lg border border-white/[0.06] bg-white/[0.02]">
+        {missions.map((mission) => (
+          <MissionRow key={mission.id} mission={mission} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /** Collapsible attempt list — lineage, not the work inventory. */
-function MissionList({ missions }: { missions: ProjectMissionChip[] }) {
-  const [expanded, setExpanded] = useState(false);
+function MissionList({
+  missions,
+  defaultExpanded = false,
+}: {
+  missions: ProjectMissionChip[];
+  defaultExpanded?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const live = missions.filter((m) => LIVE_STATUSES.has(m.status)).length;
   const problems = missions.filter((m) => PROBLEM_STATUSES.has(m.status)).length;
   return (


### PR DESCRIPTION
## Why

Verity showed a frozen LLM chapter and \`controller behind\` until a manual refresh. The detail pane auto-expanded the last controller essay instead of the three live goals.

## What

- Poll overview every 5s while any project has live work (15s otherwise); same 5s poll on project detail, updates, and the session rail. Revalidate on focus.
- Treat a fresh controller heartbeat as a signal, so a silent tick after launch clears \`controller behind\`.
- When writers are live, the detail pane leads with a scrollable **Live** list (mission/process rows). The latest delivery stays in Updates, collapsed.

## Test plan

- [x] \`a fresh controller heartbeat is a signal\`
- [x] \`leads the detail pane with a live process list instead of the LLM chapter\`
- [x] existing board tests (40)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only SWR polling and presentation changes; no auth or API contract changes.
> 
> **Overview**
> Fixes stale project UI (frozen LLM chapter, false **controller behind**) by refreshing data automatically and surfacing live work first.
> 
> **Polling:** Projects overview, detail, updates, and the session rail now use shared `pollingFetchConfig` (5s default, revalidate on focus). Overview refresh is **5s** when any project has live missions, otherwise **15s**.
> 
> **Signals:** `lastSignalAt` is the **newer** of `latest_update.at` and `controller_heartbeat_at`, so a recent heartbeat counts even without a new delivery essay—clearing spurious **controller behind**.
> 
> **Detail pane:** When missions are executing, a scrollable **Live (N)** block (`viewLiveMissions` + `LiveProcessList`) appears above moving/stalled items. The collapsible **Attempts** list stays collapsed by default in that case, and the newest update no longer auto-expands so the controller essay doesn’t dominate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5def445d06752d7c3e72aefbc38835706daba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->