### PR TITLE
fix: Codex lease, honest board, Grok container auth, deploy drain

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -352,6 +352,10 @@ mission that intends to test dev from accidentally deploying prod.
 
 Safety rails:
 
+- **Live writers** — refuses by default if any mission is mid-turn (`active` /
+  `pending` / `waiting_background`). Restarting SIGTERMs in-flight Codex/Grok
+  bash and produces `pending tool not replayed`. Override with `force=true`
+  only if you accept killing those turns.
 - **Self-protection** — refuses by default if the calling mission lives on
   the service being restarted. Override with `force=true` only if you
   accept that your own turn will be SIGTERM'd.

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -452,13 +452,58 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
           <div className="text-[11px] text-emerald-400/70">Connected</div>
         )}
 
+      {/* Grok Build / xAI — SuperGrok credit window + optional prepaid USD */}
+      {type === 'xai' &&
+        (usage.xai_credit_used_percent != null || usage.xai_prepaid_usd != null) && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-3 flex-wrap text-[11px] text-white/50">
+            {usage.xai_plan && (
+              <span><span className="text-white/30">Plan:</span> {usage.xai_plan}</span>
+            )}
+            {usage.xai_key_name && (
+              <span><span className="text-white/30">Key:</span> {usage.xai_key_name}</span>
+            )}
+          </div>
+          {usage.xai_credit_used_percent != null && (
+            <UsageBar
+              remaining={Math.round(100 - usage.xai_credit_used_percent)}
+              limit={100}
+              label={usage.xai_credit_label || 'Credits'}
+            />
+          )}
+          <div className="flex gap-4 text-[10px] text-white/30 flex-wrap">
+            {usage.xai_credit_reset != null && usage.xai_credit_reset > 0 && (
+              <span>
+                {usage.xai_credit_label || 'Credits'} reset:{' '}
+                {fmtResetEpoch(usage.xai_credit_reset)}
+              </span>
+            )}
+            {usage.xai_prepaid_usd != null && (
+              <span>Prepaid: ${usage.xai_prepaid_usd.toFixed(2)}</span>
+            )}
+            {usage.xai_on_demand_cap != null && usage.xai_on_demand_cap > 0 && (
+              <span>
+                On-demand: {usage.xai_on_demand_used ?? 0} / {usage.xai_on_demand_cap}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {type === 'xai' &&
+        usage.status === 'connected' &&
+        usage.xai_credit_used_percent == null &&
+        usage.xai_prepaid_usd == null && (
+          <div className="text-[11px] text-emerald-400/70">Connected</div>
+        )}
+
       {/* Google - account info only */}
       {type === 'google' && usage.status === 'connected' && !usage.account_email && (
         <div className="text-[11px] text-emerald-400/70">Connected</div>
       )}
 
       {/* Generic connected status */}
-      {!['anthropic', 'openai', 'cerebras', 'minimax', 'zai', 'google', 'kimi'].includes(type) && usage.status === 'connected' && (
+      {!['anthropic', 'openai', 'cerebras', 'minimax', 'zai', 'google', 'kimi', 'xai'].includes(type) && usage.status === 'connected' && (
         <div className="text-[11px] text-emerald-400/70">Connected</div>
       )}
     </div>

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -390,6 +390,19 @@ export interface ProviderUsage {
     remaining_percent?: number;
     reset_at?: number;
   }>;
+  // Grok Build / xAI SuperGrok credits from the CLI billing API, plus optional
+  // prepaid USD from the Management API when a management key is configured.
+  xai_plan?: string;
+  xai_credit_label?: string;
+  xai_credit_used_percent?: number;
+  xai_credit_remaining_percent?: number;
+  xai_credit_reset?: number;
+  xai_credit_window_seconds?: number;
+  xai_on_demand_used?: number;
+  xai_on_demand_cap?: number;
+  xai_prepaid_usd?: number;
+  xai_key_name?: string;
+  xai_team_id?: string;
   // Codex (OpenAI ChatGPT subscription) limits — primary = 5h window,
   // secondary = weekly (7d) window. Reset fields are unix epoch seconds.
   codex_plan_type?: string;

--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -283,6 +283,8 @@ repeated failure `repeat-loop-guard` · tool-call limits `context-budget`.
 - **Do not stamp `mode=blocked` from an inspect callback.** Inspect callbacks omit `[CTRL:]` on `awaiting_user`. A controller that copies the old trailer onto a callback is prompt drift: ingest already refuses inspect for mode, and re-emitting `mode=blocked` from a parked turn is how the board stays red after the writer moved on. Inspect, then write your own trailer from live state.
 - **Do not abandon the objective.** If dispatch is refused (disk, auth, capacity): keep the original project on its objective with a named infra blocker (`blocked:disk`, `blocked:auth`, `blocked:capacity`); open or fix the platform work under its own project (`sandboxed-sh`). Do not retitle or reuse the campaign session. Lido “Corriger et merger les PRs” becoming a P0 disk ticket is the incident — a platform outage is not a new campaign.
 - **Harness ≠ project blocked.** Missing CLI, wrong-arch binary, container `nsenter` failure: `mode=active` + `next=` switch backend / repair harness, or trailer `blocked:harness` ≤ 3 ticks then workaround. Structured write: `update_project_status(..., mode=blocked, blocker=harness)`. See the trailer rule above.
+- **Never persist `mode=blocked` + `next=inspect <uuid>`.** That is a dead writer, not a no-lane. ACK or redispatch; stay `mode=active`. A tick whose only act is inspect-without-redispatch is a defect (same as two ticks with no dispatch).
+- **No foreground `timeout` > 180s / `make test*` / `lake build` inside Codex bash.** Fire `remote-lean-build` (or an existing remote job) and poll the receipt. A 2h `make` in the Codex session stream dies on every deploy (`pending tool not replayed`).
 
 ## Optimisations d exécution (2026-08-10, leçons terrain)
 

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -373,6 +373,112 @@ fn grok_auth_paths() -> Vec<PathBuf> {
     paths
 }
 
+/// Newest host `~/.grok/auth.json` that the Grok CLI will actually accept.
+///
+/// Skips the legacy `auth_mode: "oauth"` shape older Sandboxed.sh releases
+/// wrote — Grok CLI 0.2.93 rejects it.
+fn newest_usable_grok_auth_file(candidates: &[PathBuf]) -> Option<(PathBuf, Vec<u8>)> {
+    let mut best: Option<(std::time::SystemTime, PathBuf, Vec<u8>)> = None;
+    for path in candidates {
+        let meta = match std::fs::metadata(path) {
+            Ok(meta) => meta,
+            Err(_) => continue,
+        };
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(_) => continue,
+        };
+        let Ok(auth) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            continue;
+        };
+        let Some(entry) = auth.get(GROK_OAUTH_CLIENT_KEY) else {
+            continue;
+        };
+        if entry.get("auth_mode").and_then(|value| value.as_str()) == Some("oauth") {
+            continue;
+        }
+        let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+        let replace = best
+            .as_ref()
+            .map(|(prev, _, _)| mtime > *prev)
+            .unwrap_or(true);
+        if replace {
+            best = Some((mtime, path.clone(), bytes));
+        }
+    }
+    best.map(|(_, path, bytes)| (path, bytes))
+}
+
+fn workspace_grok_auth_path(workspace: &crate::workspace::Workspace) -> PathBuf {
+    crate::workspace::resolve_workspace_home_root(
+        &workspace.path,
+        workspace.workspace_type,
+        &workspace.env_vars,
+    )
+    .join(".grok")
+    .join("auth.json")
+}
+
+/// Copy `bytes` onto `dest` atomically (mode 0600).
+fn install_grok_auth_bytes(dest: &Path, bytes: &[u8]) -> Result<(), String> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+    }
+    let tmp = dest.with_extension("json.tmp");
+    std::fs::write(&tmp, bytes).map_err(|e| format!("Failed to write {}: {e}", tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+    }
+    std::fs::rename(&tmp, dest)
+        .map_err(|e| format!("Failed to install {}: {e}", dest.display()))?;
+    Ok(())
+}
+
+pub(crate) fn sync_grok_auth_files(
+    sources: &[PathBuf],
+    dest: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let Some((source, bytes)) = newest_usable_grok_auth_file(sources) else {
+        if dest.exists() {
+            std::fs::remove_file(dest)
+                .map_err(|e| format!("Failed to remove stale Grok auth {}: {e}", dest.display()))?;
+        }
+        return Ok(None);
+    };
+
+    if source == dest {
+        return Ok(Some(dest.to_path_buf()));
+    }
+
+    install_grok_auth_bytes(dest, &bytes)?;
+    Ok(Some(dest.to_path_buf()))
+}
+
+/// Sync the host Grok CLI auth file into a workspace HOME.
+///
+/// Container missions read `/root/.grok/auth.json` inside nspawn. Reconnecting
+/// Grok in Hermes / Settings updates the host file (`/var/lib/opencode/.grok`
+/// or `$HOME/.grok`) but leaves a stale guest copy (the 2026-05-16 401). Copy
+/// the newest host file on every turn. If the host has no usable file, delete
+/// the guest copy so `XAI_API_KEY` can win.
+pub fn sync_host_grok_auth_into_workspace(
+    workspace: &crate::workspace::Workspace,
+) -> Result<Option<PathBuf>, String> {
+    let dest = workspace_grok_auth_path(workspace);
+    let installed = sync_grok_auth_files(&grok_auth_paths(), &dest)?;
+    if installed.is_some() {
+        tracing::info!(
+            workspace_id = %workspace.id,
+            dest = %dest.display(),
+            "Synced host Grok auth.json into workspace HOME"
+        );
+    }
+    Ok(installed)
+}
+
 fn read_grok_auth_entry() -> Option<serde_json::Value> {
     // Try every candidate path (home-based AND the service path
     // `/var/lib/opencode/.grok/auth.json`) — `home_dir()` for the service
@@ -580,8 +686,8 @@ mod grok_oauth_tests {
         build_response_from_store, get_xai_api_key_for_grok, grok_auth_expires_at_millis,
         grok_cli_reconcile_due, has_refreshable_cli_proxy_account_in_dirs,
         oauth_refresh_clear_dead, oauth_refresh_mark_token_dead, oauth_refresh_token_fingerprint,
-        parse_grok_device_auth_line, remove_legacy_grok_oauth_entry, ProviderStatusResponse,
-        GROK_CLI_RECONCILE_INTERVAL, GROK_OAUTH_CLIENT_KEY,
+        parse_grok_device_auth_line, remove_legacy_grok_oauth_entry, sync_grok_auth_files,
+        ProviderStatusResponse, GROK_CLI_RECONCILE_INTERVAL, GROK_OAUTH_CLIENT_KEY,
     };
     use crate::ai_providers::{AIProvider, OAuthCredentials, ProviderType};
     use std::time::{Duration as StdDuration, Instant};
@@ -667,6 +773,56 @@ mod grok_oauth_tests {
                 .and_then(|value| value.as_str()),
             Some("native-token")
         );
+    }
+
+    #[test]
+    fn syncs_newer_host_grok_auth_over_stale_workspace_copy() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let host = temp.path().join("host-auth.json");
+        let dest = temp.path().join("guest").join(".grok").join("auth.json");
+        std::fs::create_dir_all(dest.parent().unwrap()).expect("guest dir");
+        std::fs::write(
+            &dest,
+            serde_json::json!({
+                GROK_OAUTH_CLIENT_KEY: {
+                    "auth_mode": "oidc",
+                    "key": "stale-may"
+                }
+            })
+            .to_string(),
+        )
+        .expect("stale dest");
+        std::fs::write(
+            &host,
+            serde_json::json!({
+                GROK_OAUTH_CLIENT_KEY: {
+                    "auth_mode": "oidc",
+                    "key": "fresh-host"
+                }
+            })
+            .to_string(),
+        )
+        .expect("host auth");
+        let installed = sync_grok_auth_files(&[host], &dest).expect("sync");
+        assert_eq!(installed.as_deref(), Some(dest.as_path()));
+        let copied: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&dest).expect("read dest"))
+                .expect("json");
+        assert_eq!(
+            copied[GROK_OAUTH_CLIENT_KEY]["key"].as_str(),
+            Some("fresh-host")
+        );
+    }
+
+    #[test]
+    fn removes_stale_workspace_grok_auth_when_host_has_none() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dest = temp.path().join("guest-auth.json");
+        std::fs::write(&dest, "{}").expect("stale dest");
+        let missing = temp.path().join("no-such-host-auth.json");
+        let installed = sync_grok_auth_files(&[missing], &dest).expect("sync");
+        assert!(installed.is_none());
+        assert!(!dest.exists());
     }
 
     #[test]

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -8067,38 +8067,186 @@ async fn get_provider_usage(
                 "account_email": account_email,
             });
 
-            if api_key_opt.is_some() {
-                info.as_object_mut()
-                    .unwrap()
-                    .insert("status".to_string(), serde_json::json!("connected"));
-            } else if let Some(ref o) = oauth {
-                let refresh_rejected = provider_refresh_rejected
+            let refresh_rejected = oauth.as_ref().is_some_and(|o| {
+                provider_refresh_rejected
                     || provider_uuid
-                        .is_some_and(|uuid| oauth_refresh_token_is_dead(uuid, &o.refresh_token));
-                if refresh_rejected || oauth_token_expired(o.expires_at) {
-                    info.as_object_mut()
-                        .unwrap()
-                        .insert("status".to_string(), serde_json::json!("needs_reauth"));
-                    info.as_object_mut().unwrap().insert(
-                        "error".to_string(),
-                        serde_json::json!(if refresh_rejected {
-                            "xAI OAuth refresh token was rejected; reconnect Grok Build"
-                        } else {
-                            "xAI OAuth token expired; reconnect Grok Build"
-                        }),
-                    );
-                } else {
-                    info.as_object_mut()
-                        .unwrap()
-                        .insert("status".to_string(), serde_json::json!("connected"));
+                        .is_some_and(|uuid| oauth_refresh_token_is_dead(uuid, &o.refresh_token))
+            });
+
+            let mut oauth_token = oauth.as_ref().map(|o| o.access_token.clone());
+            if let (Some(o), Some(uuid)) = (oauth.as_ref(), provider_uuid) {
+                if !refresh_rejected
+                    && oauth_token_expired(o.expires_at)
+                    && !o.refresh_token.trim().is_empty()
+                {
+                    match refresh_oauth_token_internal(&ProviderType::Xai, &o.refresh_token).await {
+                        Ok((access, refresh, expires_at)) => {
+                            let creds = crate::ai_providers::OAuthCredentials {
+                                access_token: access.clone(),
+                                refresh_token: refresh,
+                                expires_at,
+                            };
+                            let _ = state.ai_providers.set_oauth_credentials(uuid, creds).await;
+                            oauth_token = Some(access);
+                        }
+                        Err(e) => {
+                            tracing::debug!("xAI usage token refresh failed: {e}");
+                        }
+                    }
                 }
-            } else {
-                info.as_object_mut().unwrap().insert(
-                    "error".to_string(),
-                    serde_json::json!("No credentials configured"),
-                );
             }
 
+            let mut snap = crate::api::xai_usage::XaiUsageSnapshot::default();
+
+            if let Some(token) = oauth_token.as_ref() {
+                if refresh_rejected
+                    || (oauth
+                        .as_ref()
+                        .is_some_and(|o| oauth_token_expired(o.expires_at))
+                        && oauth_token.as_deref()
+                            == oauth.as_ref().map(|o| o.access_token.as_str()))
+                {
+                    info["status"] = serde_json::json!("needs_reauth");
+                    info["error"] = serde_json::json!(if refresh_rejected {
+                        "xAI OAuth refresh token was rejected; reconnect Grok Build"
+                    } else {
+                        "xAI OAuth token expired; reconnect Grok Build"
+                    });
+                } else {
+                    let billing = client
+                        .get(crate::api::xai_usage::BILLING_URL)
+                        .header("Authorization", format!("Bearer {token}"))
+                        .header("x-xai-token-auth", crate::api::xai_usage::TOKEN_AUTH_HEADER)
+                        .header("Accept", "application/json")
+                        .send()
+                        .await;
+                    match billing {
+                        Ok(r) if r.status().is_success() => {
+                            if let Ok(payload) = r.json::<serde_json::Value>().await {
+                                snap = crate::api::xai_usage::parse_cli_billing(&payload);
+                            }
+                            info["status"] = serde_json::json!("connected");
+                        }
+                        Ok(r) => {
+                            let status = r.status().as_u16();
+                            if status == 401 || status == 403 {
+                                info["status"] = serde_json::json!("needs_reauth");
+                                info["error"] = serde_json::json!(format!(
+                                    "Grok billing endpoint returned HTTP {status}"
+                                ));
+                            } else {
+                                info["status"] = serde_json::json!("connected");
+                            }
+                        }
+                        Err(e) => {
+                            info["error"] =
+                                serde_json::json!(format!("Failed to reach Grok billing API: {e}"));
+                        }
+                    }
+
+                    if info.get("status").and_then(|v| v.as_str()) == Some("connected") {
+                        if let Ok(r) = client
+                            .get(crate::api::xai_usage::SETTINGS_URL)
+                            .header("Authorization", format!("Bearer {token}"))
+                            .header("x-xai-token-auth", crate::api::xai_usage::TOKEN_AUTH_HEADER)
+                            .header("Accept", "application/json")
+                            .send()
+                            .await
+                        {
+                            if r.status().is_success() {
+                                if let Ok(payload) = r.json::<serde_json::Value>().await {
+                                    if let Some(plan) =
+                                        crate::api::xai_usage::parse_cli_settings(&payload)
+                                    {
+                                        snap.plan = Some(plan);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if api_key_opt.is_none() {
+                info["error"] = serde_json::json!("No credentials configured");
+            }
+
+            if let Some(key) = api_key_opt.as_ref() {
+                match client
+                    .get(crate::api::xai_usage::API_KEY_INFO_URL)
+                    .header("Authorization", format!("Bearer {key}"))
+                    .header("Accept", "application/json")
+                    .send()
+                    .await
+                {
+                    Ok(r) if r.status().is_success() => {
+                        if let Ok(payload) = r.json::<serde_json::Value>().await {
+                            snap = crate::api::xai_usage::merge_snapshots(
+                                snap,
+                                crate::api::xai_usage::parse_api_key_info(&payload),
+                            );
+                        }
+                        if info.get("status").is_none() {
+                            info["status"] = serde_json::json!("connected");
+                        }
+                    }
+                    Ok(r) => {
+                        let status = r.status().as_u16();
+                        if info.get("status").is_none() {
+                            if status == 401 || status == 403 {
+                                info["status"] = serde_json::json!("needs_reauth");
+                                info["error"] = serde_json::json!(format!(
+                                    "xAI API key endpoint returned HTTP {status}"
+                                ));
+                            } else {
+                                info["status"] = serde_json::json!("connected");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        if info.get("error").is_none() && info.get("status").is_none() {
+                            info["error"] =
+                                serde_json::json!(format!("Failed to reach xAI API: {e}"));
+                        }
+                    }
+                }
+
+                if let (Some(team_id), Some(mgmt)) = (
+                    snap.team_id.as_deref(),
+                    std::env::var("XAI_MANAGEMENT_API_KEY")
+                        .ok()
+                        .filter(|s| !s.trim().is_empty()),
+                ) {
+                    if let Ok(r) = client
+                        .get(crate::api::xai_usage::prepaid_balance_url(team_id))
+                        .header("Authorization", format!("Bearer {mgmt}"))
+                        .header("Accept", "application/json")
+                        .send()
+                        .await
+                    {
+                        if r.status().is_success() {
+                            if let Ok(payload) = r.json::<serde_json::Value>().await {
+                                if let Some(usd) =
+                                    crate::api::xai_usage::parse_prepaid_balance(&payload)
+                                {
+                                    snap.prepaid_usd = Some(usd);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if snap.has_displayable_quota() || snap.key_name.is_some() || snap.team_id.is_some() {
+                if info.get("status").and_then(|v| v.as_str()) != Some("needs_reauth") {
+                    info["status"] = serde_json::json!("connected");
+                }
+                if let Some(obj) = info.as_object_mut() {
+                    if let serde_json::Value::Object(fields) = snap.to_provider_fields() {
+                        obj.extend(fields);
+                    }
+                }
+            } else if info.get("error").is_none() && info.get("status").is_none() {
+                info["status"] = serde_json::json!("connected");
+            }
             info
         }
         _ => {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -16983,9 +16983,19 @@ async fn maybe_finalize_terminal_mission(
     let Some(reason) = terminal_reason else {
         return;
     };
-    let Some((new_status, terminal_reason_str)) =
+    let transportish = final_output.or(terminal_evidence).is_some_and(|text| {
+        let lower = text.to_ascii_lowercase();
+        lower.contains("pending tool")
+            || lower.contains("not replayed")
+            || lower.contains("stream closed before mission")
+            || lower.contains("codex app-server stream closed")
+    });
+    let mapped = if transportish && matches!(reason, TerminalReason::LlmError) {
+        Some((MissionStatus::Interrupted, "transport"))
+    } else {
         mission_status_for_terminal_reason(reason, complete_turn_without_follow_up)
-    else {
+    };
+    let Some((new_status, terminal_reason_str)) = mapped else {
         tracing::debug!(
             mission_id = %mission_id,
             reason = ?reason,
@@ -17647,7 +17657,8 @@ async fn control_actor_loop(
     // One bounded same-mission retry for structured transport failures. Auth,
     // quota/capacity, source failures, stalls, and loops are deliberately not
     // eligible. Writer leases are re-acquired by the normal start path.
-    let mut transport_auto_resumed_missions: HashSet<Uuid> = HashSet::new();
+    let mut transport_auto_resumed_missions: HashMap<Uuid, u8> = HashMap::new();
+    const TRANSPORT_AUTO_RESUME_MAX: u8 = 3;
     // Track subtasks for the main runner
     let mut main_runner_subtasks: Vec<super::mission_runner::SubtaskInfo> = Vec::new();
     // Track number of in-flight tool calls on the main runner so the stall
@@ -21407,7 +21418,15 @@ async fn control_actor_loop(
                     if !completed_waiting_remote_job {
                         if let Some(mission_id) = completed_mission_id {
                         if completed_transport_failure
-                            && transport_auto_resumed_missions.insert(mission_id)
+                            && {
+                                let count = transport_auto_resumed_missions
+                                    .entry(mission_id)
+                                    .or_insert(0);
+                                *count < TRANSPORT_AUTO_RESUME_MAX && {
+                                    *count += 1;
+                                    true
+                                }
+                            }
                             && !queue_has_pending_target_mission(&queue, mission_id)
                         {
                             let resume_message = "The previous turn ended because its provider transport disconnected. Reconcile the current workspace, remote jobs, and repository head, then resume the same task. Do not duplicate an accepted job or create a replacement writer.".to_string();
@@ -21423,7 +21442,7 @@ async fn control_actor_loop(
                                 Ok(()) => {
                                     tracing::info!(
                                         %mission_id,
-                                        "Auto-resuming mission once after structured transport failure"
+                                        "Auto-resuming mission after structured transport failure"
                                     );
                                     queue.push_back((
                                         Uuid::new_v4(),
@@ -21998,11 +22017,19 @@ async fn control_actor_loop(
                                 && is_transport_failure_evidence(&completion_evidence)
                                 && !cancellation_requested
                                 && was_queue_empty
-                                && transport_auto_resumed_missions.insert(*mission_id)
+                                && {
+                                    let count = transport_auto_resumed_missions
+                                        .entry(*mission_id)
+                                        .or_insert(0);
+                                    *count < TRANSPORT_AUTO_RESUME_MAX && {
+                                        *count += 1;
+                                        true
+                                    }
+                                }
                             {
                                 tracing::info!(
                                     mission_id = %mission_id,
-                                    "Auto-resuming parallel mission once after structured transport failure"
+                                    "Auto-resuming parallel mission after structured transport failure"
                                 );
                                 runner.queue_message(
                                     Uuid::new_v4(),

--- a/src/api/controller_honesty.rs
+++ b/src/api/controller_honesty.rs
@@ -120,6 +120,38 @@ pub fn normalize_decision_question(question: &str) -> String {
         .join(" ")
 }
 
+/// `inspect <mission-uuid>` — a controller parking on a dead writer instead
+/// of redispaching. Not a project-level no-lane.
+pub fn is_inspect_next_action(next: Option<&str>) -> bool {
+    parse_inspect_mission_id(next).is_some()
+}
+
+/// Parse `inspect 51f37d4b-…` / `inspect 51f37d4b` into a UUID when possible.
+pub fn parse_inspect_mission_id(next: Option<&str>) -> Option<uuid::Uuid> {
+    let raw = next.map(str::trim).filter(|s| !s.is_empty())?;
+    let rest = raw
+        .strip_prefix("inspect")
+        .or_else(|| raw.strip_prefix("Inspect"))
+        .or_else(|| raw.strip_prefix("INSPECT"))?;
+    let token = rest.trim().split_whitespace().next()?;
+    if let Ok(id) = uuid::Uuid::parse_str(token) {
+        return Some(id);
+    }
+    // Controllers often paste the 8-char prefix. Not enough to look up.
+    None
+}
+
+/// Terminal reasons that are harness/transport, not a project blocker.
+pub fn is_harness_terminal_reason(reason: Option<&str>, evidence: Option<&str>) -> bool {
+    let blob = format!("{} {}", reason.unwrap_or(""), evidence.unwrap_or("")).to_ascii_lowercase();
+    blob.contains("llm_error")
+        || blob.contains("transport")
+        || blob.contains("server_shutdown")
+        || blob.contains("pending tool")
+        || blob.contains("not replayed")
+        || blob.contains("stream closed")
+}
+
 /// A next-action that means "idle until a PR appears" rather than do the
 /// stored roadmap item. Controllers rephrase this every tick, which used
 /// to look like progress.
@@ -253,6 +285,24 @@ mod tests {
         assert!(is_material_activity_headline(
             "Lido #81 — RÉPARATION/REVIEW EN COURS"
         ));
+    }
+
+    #[test]
+    fn inspect_next_action_parses_uuid_and_rejects_prose() {
+        let id = uuid::Uuid::parse_str("51f37d4b-7e27-466a-8c2f-fec0be2bebed").unwrap();
+        assert_eq!(
+            parse_inspect_mission_id(Some("inspect 51f37d4b-7e27-466a-8c2f-fec0be2bebed")),
+            Some(id)
+        );
+        assert!(is_inspect_next_action(Some(
+            "inspect 51f37d4b-7e27-466a-8c2f-fec0be2bebed"
+        )));
+        assert!(!is_inspect_next_action(Some("watch #2367 CI then merge")));
+        assert!(is_harness_terminal_reason(
+            Some("llm_error"),
+            Some("pending tool call exec-1 remained unresolved after thread/resume")
+        ));
+        assert!(!is_harness_terminal_reason(Some("rate_limited"), None));
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -790,7 +790,7 @@ exec "$SCRIPT_DIR/.sandboxed-sh-telegram-action.py" "$@"
 // ChatGPT/OpenAI account.
 const CODEX_ACCOUNT_CONCURRENCY_LIMIT: usize = 10;
 const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 10;
-const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
 
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
@@ -1349,6 +1349,15 @@ pub(crate) fn collect_codex_credentials(working_dir: &std::path::Path) -> Vec<Co
     creds
 }
 
+/// Fresh accounts always win over usage-capped ones, even at 0 permits.
+fn pick_codex_lease_pool<T>(fresh: Vec<T>, cooled: Vec<T>) -> Vec<T> {
+    if fresh.is_empty() {
+        cooled
+    } else {
+        fresh
+    }
+}
+
 pub(crate) async fn lease_codex_account(
     working_dir: &std::path::Path,
     tried_fingerprints: &HashSet<String>,
@@ -1373,10 +1382,11 @@ pub(crate) async fn lease_codex_account(
         return None;
     }
 
-    // Prefer credentials that aren't on a usage-cap cooldown; cooled ones stay
-    // in the list as a last resort so a single-account setup still retries
-    // instead of hard-failing. Within each group, prefer the least-loaded
-    // credential (highest available permits).
+    // Prefer credentials that aren't on a usage-cap cooldown. A cooled
+    // account is only considered when *every* remaining candidate is cooled
+    // (single-account, or all subscriptions exhausted). Mixing them used to
+    // lease the dead weekly-cap account (0 wait) while the healthy one was
+    // only at 0/10 permits — P-CONSOLIDATION-1 then died on "try again Aug 20".
     let (mut fresh, mut cooled): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|candidate| {
         codex_account_cooldown_remaining(&candidate.0.fingerprint()).is_none()
     });
@@ -1389,7 +1399,7 @@ pub(crate) async fn lease_codex_account(
         );
     }
     let candidates: Vec<(CodexCredential, Arc<Semaphore>, usize)> =
-        fresh.into_iter().chain(cooled).collect();
+        pick_codex_lease_pool(fresh, cooled);
 
     for (cred, sem, available) in &candidates {
         if let Ok(permit) = sem.clone().try_acquire_owned() {
@@ -9281,20 +9291,21 @@ mod tests {
         opencode_session_exists_in_data_home, opencode_session_token_from_line,
         overlay_opencode_auth, parse_cli_semver, parse_cli_version, parse_opencode_goal_objective,
         parse_opencode_session_token, parse_opencode_sse_event, parse_opencode_stderr_text_part,
-        preferred_model_for_cost, preferred_opencode_bin_dir, prepend_unique_path_entry,
-        record_codex_error_message, replace_filepath_artifact_with_tool_output,
-        resolve_mission_working_directory, running_health, sanitized_opencode_stdout,
-        selected_opencode_auth_path, selected_opencode_provider_auth_dir,
-        set_codex_account_cooldown, should_sync_container_opencode, stall_severity,
-        strip_ansi_codes, strip_opencode_banner_lines, strip_think_tags,
-        summarize_codex_usage_caps, summarize_recent_opencode_stderr,
-        text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer, tls_error_hint,
-        truncate_garbled_output, use_thinking_only_fallback, utf8_safe_prefix,
-        ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
-        ClaudeTurnWaitState, CopiedOpenCodeProbe, MissionHealth, MissionRunState, MissionRunner,
-        MissionStallSeverity, OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
-        CODEX_PENDING_TOOLS_ERROR_PREFIX, CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS,
-        STALL_WARN_SECS,
+        pick_codex_lease_pool, preferred_model_for_cost, preferred_opencode_bin_dir,
+        prepend_unique_path_entry, record_codex_error_message,
+        replace_filepath_artifact_with_tool_output, resolve_mission_working_directory,
+        running_health, sanitized_opencode_stdout, selected_opencode_auth_path,
+        selected_opencode_provider_auth_dir, set_codex_account_cooldown,
+        should_sync_container_opencode, stall_severity, strip_ansi_codes,
+        strip_opencode_banner_lines, strip_think_tags, summarize_codex_usage_caps,
+        summarize_recent_opencode_stderr, text_buffer_stream_looks_degenerate,
+        thinking_overlaps_visible_answer, tls_error_hint, truncate_garbled_output,
+        use_thinking_only_fallback, utf8_safe_prefix, ClaudeIncompleteTurnContext,
+        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
+        CopiedOpenCodeProbe, MissionHealth, MissionRunState, MissionRunner, MissionStallSeverity,
+        OpencodeSseState, CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT, CODEX_AUTH_ERROR_COOLDOWN,
+        CODEX_CAPACITY_COOLDOWN, CODEX_PENDING_TOOLS_ERROR_PREFIX, CODEX_RATE_LIMIT_COOLDOWN,
+        STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -10198,6 +10209,21 @@ mod tests {
         assert!(remaining > std::time::Duration::from_secs(50));
         clear_codex_account_cooldown(fp);
         assert!(codex_account_cooldown_remaining(fp).is_none());
+    }
+
+    #[test]
+    fn pick_codex_lease_pool_never_falls_through_to_cooled_when_fresh_exists() {
+        let fresh = vec!["ben"];
+        let cooled = vec!["thomas"];
+        assert_eq!(pick_codex_lease_pool(fresh, cooled), vec!["ben"]);
+        assert_eq!(
+            pick_codex_lease_pool(Vec::<&str>::new(), vec!["thomas"]),
+            vec!["thomas"]
+        );
+        assert_eq!(
+            CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT,
+            std::time::Duration::from_secs(180)
+        );
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -79,6 +79,7 @@ pub mod validation;
 pub mod webhook_markers;
 pub mod workspaces;
 pub(crate) mod writer_recycle;
+pub(crate) mod xai_usage;
 
 pub use routes::serve;
 pub use types::*;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -571,6 +571,22 @@ pub async fn get_project(
     ) {
         project.next_action = Some(derived);
     }
+    let has_live = missions
+        .iter()
+        .any(|mission| super::controller_honesty::is_live_writer_status(mission.status));
+    let needs_operator = missions.iter().any(|mission| {
+        mission.awaiting_kind.is_some()
+            && matches!(
+                mission.status,
+                crate::api::control::events::MissionStatus::AwaitingUser
+            )
+    });
+    project.mode = honest_controller_mode(
+        project.mode.as_deref(),
+        has_live,
+        needs_operator,
+        decisions.len() as u32,
+    );
     Ok(Json(serde_json::json!({
         "project": project,
         "grant": grant,
@@ -762,6 +778,54 @@ pub async fn set_project_status(
         ));
     }
     let mut blocker = req.blocker.clone();
+    let mut next_action = req.next_action.clone();
+    if mode == "blocked"
+        && super::controller_honesty::is_inspect_next_action(next_action.as_deref())
+    {
+        // "inspect <dead writer>" is harness recovery, not a no-lane. Persist
+        // active so the rail/board cannot stay red after a Codex transport
+        // death. Clear the inspect next_action so it cannot be re-displayed.
+        let inspect_id =
+            super::controller_honesty::parse_inspect_mission_id(next_action.as_deref());
+        let inspect_is_dead = match inspect_id {
+            Some(id) => {
+                let store = state.control.get_mission_store().await;
+                match store.get_mission(id).await {
+                    Ok(Some(mission)) => {
+                        matches!(
+                            mission.status,
+                            crate::api::control::events::MissionStatus::Failed
+                                | crate::api::control::events::MissionStatus::Interrupted
+                        ) && super::controller_honesty::is_harness_terminal_reason(
+                            mission.terminal_reason.as_deref(),
+                            mission.terminal_evidence.as_deref(),
+                        )
+                    }
+                    _ => true,
+                }
+            }
+            None => true,
+        };
+        if inspect_is_dead {
+            let has_live = state
+                .control
+                .collect_attention_missions_for_project(&slug)
+                .await
+                .ok()
+                .is_some_and(|missions| {
+                    missions.iter().any(|mission| {
+                        super::controller_honesty::is_live_writer_status(mission.status)
+                    })
+                });
+            mode = "active".to_string();
+            next_action = None;
+            blocker = if has_live {
+                None
+            } else {
+                Some("harness".to_string())
+            };
+        }
+    }
     if mode == "blocked" && super::controller_honesty::is_lease_blocker(blocker.as_deref()) {
         let has_live = state
             .control
@@ -780,7 +844,7 @@ pub async fn set_project_status(
     }
     state
         .projects
-        .set_mode(&slug, &mode, req.next_action.as_deref(), blocker.as_deref())
+        .set_mode(&slug, &mode, next_action.as_deref(), blocker.as_deref())
         .map_err(|error| (StatusCode::NOT_FOUND, error))?;
     let project = state.projects.get_project(&slug).map_err(store_err)?;
     Ok(Json(serde_json::json!({ "project": project })))

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -464,6 +464,7 @@ pub(crate) fn grok_stdout_line_requests_interactive_login(line: &str) -> bool {
 /// `XAI_API_KEY` (key > OAuth access token > ambient env). Shared by the
 /// streaming-json and ACP turn paths.
 async fn prepare_grok_auth_env(
+    workspace: &Workspace,
     app_working_dir: &std::path::Path,
     mission_id: Uuid,
 ) -> Result<HashMap<String, String>, AgentResult> {
@@ -513,14 +514,22 @@ async fn prepare_grok_auth_env(
     }
 
     // Grok CLI 0.2.93 rejects the legacy `auth_mode: "oauth"` shape older
-    // Sandboxed versions generated. The runner authenticates with an explicit
-    // environment key below, so never copy or overwrite the CLI's native auth
-    // file; just remove our obsolete entry when present.
+    // Sandboxed versions generated. Remove that shape on the host, then copy
+    // the newest host `~/.grok/auth.json` into the workspace HOME. Container
+    // missions otherwise keep a months-old `/root/.grok/auth.json` and 401
+    // even after Settings reconnects the host.
     if let Err(err) = crate::api::ai_providers::remove_legacy_grok_oauth_auth_entries() {
         tracing::warn!(
             mission_id = %mission_id,
             error = %err,
             "Failed to remove obsolete Grok OAuth auth entry"
+        );
+    }
+    if let Err(err) = crate::api::ai_providers::sync_host_grok_auth_into_workspace(workspace) {
+        tracing::warn!(
+            mission_id = %mission_id,
+            error = %err,
+            "Failed to sync host Grok auth.json into workspace"
         );
     }
 
@@ -741,7 +750,7 @@ async fn run_grok_streaming_json_turn(
     // capture the freshest one here and inject it below. Without it the CLI
     // falls back to an interactive browser sign-in that never completes in a
     // headless mission — the run then hangs forever ("Agent is working").
-    let env = match prepare_grok_auth_env(app_working_dir, mission_id).await {
+    let env = match prepare_grok_auth_env(workspace, app_working_dir, mission_id).await {
         Ok(env) => env,
         Err(result) => return result,
     };
@@ -1157,7 +1166,7 @@ async fn run_grok_acp_turn(
         .await
         .map_err(|e| format!("grok CLI unavailable: {e}"))?;
 
-    let env = match prepare_grok_auth_env(app_working_dir, mission_id).await {
+    let env = match prepare_grok_auth_env(workspace, app_working_dir, mission_id).await {
         Ok(env) => env,
         // Auth failures are terminal for BOTH paths — surface them directly
         // instead of falling back into the same failure.

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3722,6 +3722,9 @@ enum DeployRefusal {
     SelfTarget,
     /// Last deploy was too recent (see [`DEPLOY_DEBOUNCE_SECS`]).
     Debounced { since_secs: u64 },
+    /// Live writers are mid-turn. Restarting SIGTERMs their Codex/Grok
+    /// bash and produces the pending-tool-not-replayed inspect loop.
+    WritersLive { count: usize },
 }
 
 impl DeployRefusal {
@@ -3730,6 +3733,7 @@ impl DeployRefusal {
             DeployRefusal::WrongService { .. } => StatusCode::CONFLICT,
             DeployRefusal::SelfTarget => StatusCode::CONFLICT,
             DeployRefusal::Debounced { .. } => StatusCode::TOO_MANY_REQUESTS,
+            DeployRefusal::WritersLive { .. } => StatusCode::CONFLICT,
         }
     }
 
@@ -3751,6 +3755,11 @@ impl DeployRefusal {
                  Pass force=true to override.",
                 since_secs, DEPLOY_DEBOUNCE_SECS
             ),
+            DeployRefusal::WritersLive { count } => format!(
+                "{count} mission(s) are currently running a harness turn. \
+                 Restarting now SIGTERMs in-flight Codex/Grok tools (pending-tool-not-replayed). \
+                 Wait for them to finish, or pass force=true if you accept killing those turns."
+            ),
         }
     }
 }
@@ -3763,6 +3772,7 @@ fn evaluate_deploy_request(
     calling_mission_on_this_service: bool,
     last_deploy_secs_ago: Option<u64>,
     force: bool,
+    live_writer_count: usize,
 ) -> Option<DeployRefusal> {
     if let (Some(actual), Some(expected)) = (actual_service, expected_service) {
         if actual != expected {
@@ -3774,6 +3784,11 @@ fn evaluate_deploy_request(
     }
     if !force && calling_mission_on_this_service {
         return Some(DeployRefusal::SelfTarget);
+    }
+    if !force && live_writer_count > 0 {
+        return Some(DeployRefusal::WritersLive {
+            count: live_writer_count,
+        });
     }
     match evaluate_debounce(last_deploy_secs_ago, DEPLOY_DEBOUNCE_SECS, force) {
         DebounceDecision::Allow => None,
@@ -3823,12 +3838,33 @@ pub async fn deploy_sandboxed_sh(
     let marker = deploy_marker_path();
     let last_age = deploy_marker_age_secs(&marker);
 
+    let live_writer_count = {
+        let store = state.control.get_mission_store().await;
+        let filter = crate::api::mission_store::MissionFilter {
+            attention_only: true,
+            ..Default::default()
+        };
+        match store.list_missions_filtered(&filter, 200, 0).await {
+            Ok(page) => page
+                .iter()
+                .filter(|mission| {
+                    crate::api::controller_honesty::is_live_writer_status(mission.status)
+                })
+                .count(),
+            Err(error) => {
+                tracing::warn!(%error, "deploy: could not list live writers; treating as zero");
+                0
+            }
+        }
+    };
+
     if let Some(refusal) = evaluate_deploy_request(
         Some(&actual_service),
         req.expected_service.as_deref(),
         calling_on_self,
         last_age,
         req.force,
+        live_writer_count,
     ) {
         return Err((refusal.http_status(), refusal.message()));
     }
@@ -6338,7 +6374,7 @@ mod tests {
 
     #[test]
     fn deploy_refuses_self_target_by_default() {
-        let r = evaluate_deploy_request(None, None, true, None, false);
+        let r = evaluate_deploy_request(None, None, true, None, false, 0);
         assert_eq!(r, Some(DeployRefusal::SelfTarget));
     }
 
@@ -6347,7 +6383,10 @@ mod tests {
         // force=true bypasses self-protection (caller explicitly accepts
         // the in-flight turn dying). Still respects debounce unless the
         // debounce is also force-bypassed, which it is.
-        assert_eq!(evaluate_deploy_request(None, None, true, None, true), None);
+        assert_eq!(
+            evaluate_deploy_request(None, None, true, None, true, 0),
+            None
+        );
     }
 
     #[test]
@@ -6355,11 +6394,11 @@ mod tests {
         // calling_on_self=false → no self-target refusal, no debounce
         // hit, no refusal at all.
         assert_eq!(
-            evaluate_deploy_request(None, None, false, None, false),
+            evaluate_deploy_request(None, None, false, None, false, 0),
             None
         );
         assert_eq!(
-            evaluate_deploy_request(None, None, false, Some(10_000), false),
+            evaluate_deploy_request(None, None, false, Some(10_000), false, 0),
             None
         );
     }
@@ -6369,7 +6408,7 @@ mod tests {
         // calling_on_self=false, but a deploy fired 30s ago — debounce
         // should refuse even though the self check passed.
         assert_eq!(
-            evaluate_deploy_request(None, None, false, Some(30), false),
+            evaluate_deploy_request(None, None, false, Some(30), false, 0),
             Some(DeployRefusal::Debounced { since_secs: 30 })
         );
     }
@@ -6377,7 +6416,7 @@ mod tests {
     #[test]
     fn deploy_force_bypasses_both_self_and_debounce() {
         assert_eq!(
-            evaluate_deploy_request(None, None, true, Some(0), true),
+            evaluate_deploy_request(None, None, true, Some(0), true, 0),
             None
         );
     }
@@ -6388,8 +6427,20 @@ mod tests {
         // meaningful one (self-target) so the agent sees the actual reason
         // instead of being told "wait a bit and retry" only to discover
         // it'd kill itself.
-        let r = evaluate_deploy_request(None, None, true, Some(30), false);
+        let r = evaluate_deploy_request(None, None, true, Some(30), false, 0);
         assert_eq!(r, Some(DeployRefusal::SelfTarget));
+    }
+
+    #[test]
+    fn deploy_refuses_live_writers_unless_forced() {
+        assert_eq!(
+            evaluate_deploy_request(None, None, false, None, false, 3),
+            Some(DeployRefusal::WritersLive { count: 3 })
+        );
+        assert_eq!(
+            evaluate_deploy_request(None, None, false, None, true, 3),
+            None
+        );
     }
 
     #[test]
@@ -6400,6 +6451,7 @@ mod tests {
             false,
             None,
             false,
+            0,
         );
         assert_eq!(
             r,
@@ -6418,6 +6470,7 @@ mod tests {
             false,
             None,
             false,
+            0,
         );
         assert_eq!(r, None);
     }

--- a/src/api/usage_optimize.rs
+++ b/src/api/usage_optimize.rs
@@ -458,6 +458,27 @@ fn collect_windows(v: &Value) -> Vec<Window> {
         }
     }
 
+    // ── Grok Build / xAI SuperGrok credits (weekly or monthly pool) ──
+    // The CLI billing API reports used-percent + period end. Window length is
+    // the observed period when present, otherwise weekly/monthly from the
+    // label the handler already classified.
+    if let Some(used_pct) = get_f64(v, "xai_credit_used_percent") {
+        let label = get_str(v, "xai_credit_label").unwrap_or_else(|| "credits".to_string());
+        let window_seconds = get_i64(v, "xai_credit_window_seconds").or_else(|| {
+            if label.eq_ignore_ascii_case("weekly") {
+                Some(WEEKLY_SECONDS)
+            } else if label.eq_ignore_ascii_case("monthly") {
+                Some(30 * 24 * 3600)
+            } else {
+                None
+            }
+        });
+        let mut w = Window::new("xai_credits", label, "credits", "xai").with_used_percent(used_pct);
+        w.window_seconds = window_seconds;
+        w.reset_at = get_epoch_secs(v, "xai_credit_reset");
+        out.push(w);
+    }
+
     out
 }
 
@@ -510,6 +531,14 @@ fn observed_burn(
 
 fn get_f64(v: &Value, key: &str) -> Option<f64> {
     v.get(key).and_then(|x| x.as_f64())
+}
+
+fn get_str(v: &Value, key: &str) -> Option<String> {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
 }
 
 fn get_i64(v: &Value, key: &str) -> Option<i64> {
@@ -797,6 +826,24 @@ mod tests {
         assert_eq!(ww["pct_used"], json!(40.0));
         assert_eq!(ww["window_seconds"], json!(604800));
         assert_eq!(opt["primary_window"], json!("kimi_weekly"));
+    }
+
+    #[test]
+    fn xai_credit_window() {
+        let reset = (now() + chrono::Duration::days(4)).timestamp();
+        let v = json!({
+            "xai_credit_used_percent": 40.0,
+            "xai_credit_reset": reset,
+            "xai_credit_label": "Weekly",
+            "xai_credit_window_seconds": 604800,
+        });
+        let opt = build_optimize_block_at(&v, None, now());
+        let w = window(&opt, "xai_credits");
+        assert_eq!(w["pct_used"], json!(40.0));
+        assert_eq!(w["pct_remaining"], json!(60.0));
+        assert_eq!(w["window_seconds"], json!(604800));
+        assert_eq!(w["source"], json!("xai"));
+        assert_eq!(opt["primary_window"], json!("xai_credits"));
     }
 
     #[test]

--- a/src/api/xai_usage.rs
+++ b/src/api/xai_usage.rs
@@ -1,0 +1,500 @@
+//! Grok / xAI usage (Grok Build credits + API-key identity).
+//!
+//! SuperGrok / Grok Build (OAuth or `grok login`) reads the current credit
+//! window from the Grok CLI billing backend:
+//!   `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
+//! with `Authorization: Bearer <token>` and `x-xai-token-auth: xai-grok-cli`.
+//! The plan name lives on `GET …/v1/settings` (`subscription_tier_display`).
+//!
+//! Inference keys (`xai-…`) authenticate the official Auth endpoint
+//! `GET https://api.x.ai/v1/api-key`. Prepaid USD lives on the Management API
+//! (`GET https://management-api.x.ai/v1/billing/teams/{team_id}/prepaid/balance`)
+//! and needs a separate management key, so we only probe that when one is
+//! configured.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+pub const BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+pub const SETTINGS_URL: &str = "https://cli-chat-proxy.grok.com/v1/settings";
+pub const API_KEY_INFO_URL: &str = "https://api.x.ai/v1/api-key";
+pub const TOKEN_AUTH_HEADER: &str = "xai-grok-cli";
+
+pub fn prepaid_balance_url(team_id: &str) -> String {
+    format!("https://management-api.x.ai/v1/billing/teams/{team_id}/prepaid/balance")
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct XaiUsageSnapshot {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credit_label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credit_used_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credit_remaining_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credit_reset: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credit_window_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_demand_used: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_demand_cap: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prepaid_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+}
+
+impl XaiUsageSnapshot {
+    pub fn to_provider_fields(&self) -> Value {
+        let mut map = serde_json::Map::new();
+        if let Some(plan) = &self.plan {
+            map.insert("xai_plan".into(), json!(plan));
+        }
+        if let Some(label) = &self.credit_label {
+            map.insert("xai_credit_label".into(), json!(label));
+        }
+        if let Some(v) = self.credit_used_percent {
+            map.insert("xai_credit_used_percent".into(), json!(v));
+        }
+        if let Some(v) = self.credit_remaining_percent {
+            map.insert("xai_credit_remaining_percent".into(), json!(v));
+        }
+        if let Some(v) = self.credit_reset {
+            map.insert("xai_credit_reset".into(), json!(v));
+        }
+        if let Some(v) = self.credit_window_seconds {
+            map.insert("xai_credit_window_seconds".into(), json!(v));
+        }
+        if let Some(v) = self.on_demand_used {
+            map.insert("xai_on_demand_used".into(), json!(v));
+        }
+        if let Some(v) = self.on_demand_cap {
+            map.insert("xai_on_demand_cap".into(), json!(v));
+        }
+        if let Some(v) = self.prepaid_usd {
+            map.insert("xai_prepaid_usd".into(), json!(v));
+        }
+        if let Some(name) = &self.key_name {
+            map.insert("xai_key_name".into(), json!(name));
+        }
+        if let Some(team) = &self.team_id {
+            map.insert("xai_team_id".into(), json!(team));
+        }
+        Value::Object(map)
+    }
+
+    pub fn has_displayable_quota(&self) -> bool {
+        self.credit_used_percent.is_some() || self.prepaid_usd.is_some()
+    }
+}
+
+pub fn parse_cli_billing(payload: &Value) -> XaiUsageSnapshot {
+    let mut snap = XaiUsageSnapshot::default();
+    let config = payload.get("config").unwrap_or(payload);
+
+    snap.plan = string_field(
+        config
+            .get("subscriptionTier")
+            .or_else(|| config.get("subscription_tier"))
+            .or_else(|| payload.get("subscriptionTier"))
+            .or_else(|| payload.get("subscription_tier")),
+    )
+    .map(display_plan);
+
+    let period = config
+        .get("currentPeriod")
+        .or_else(|| config.get("current_period"));
+    let period_start = parse_time(
+        period
+            .and_then(|p| p.get("start").or_else(|| p.get("begin")))
+            .or_else(|| config.get("billingPeriodStart"))
+            .or_else(|| config.get("billing_period_start")),
+    );
+    let billing_cycle = payload
+        .get("billingCycle")
+        .or_else(|| payload.get("billing_cycle"))
+        .or_else(|| config.get("billingCycle"));
+    let period_end = parse_time(
+        period
+            .and_then(|p| p.get("end"))
+            .or_else(|| config.get("billingPeriodEnd"))
+            .or_else(|| config.get("billing_period_end"))
+            .or_else(|| billing_cycle.and_then(|c| c.get("billingPeriodEnd")))
+            .or_else(|| billing_cycle.and_then(|c| c.get("billing_period_end"))),
+    );
+    snap.credit_reset = period_end;
+    snap.credit_window_seconds = match (period_start, period_end) {
+        (Some(start), Some(end)) if end > start => Some(end - start),
+        _ => None,
+    };
+
+    if let Some(pct) = number(
+        config
+            .get("creditUsagePercent")
+            .or_else(|| config.get("credit_usage_percent")),
+    ) {
+        apply_used_percent(&mut snap, pct);
+    } else if let Some(pct) = on_demand_percent(config).or_else(|| rpc_used_percent(payload)) {
+        apply_used_percent(&mut snap, pct);
+    } else if period_end.is_some() {
+        apply_used_percent(&mut snap, 0.0);
+    }
+
+    if let Some(used) = amount_val(
+        config
+            .get("onDemandUsed")
+            .or_else(|| config.get("on_demand_used")),
+    ) {
+        snap.on_demand_used = Some(used);
+    }
+    if let Some(cap) = amount_val(
+        config
+            .get("onDemandCap")
+            .or_else(|| config.get("on_demand_cap")),
+    ) {
+        snap.on_demand_cap = Some(cap);
+    }
+
+    snap.credit_label = Some(credit_label(
+        snap.credit_window_seconds,
+        snap.credit_reset,
+        chrono::Utc::now().timestamp(),
+    ));
+    if snap.credit_window_seconds.is_none() {
+        snap.credit_window_seconds = default_window_seconds(snap.credit_label.as_deref());
+    }
+    snap
+}
+
+pub fn parse_cli_settings(payload: &Value) -> Option<String> {
+    string_field(
+        payload
+            .get("subscription_tier_display")
+            .or_else(|| payload.get("subscriptionTierDisplay")),
+    )
+    .map(display_plan)
+}
+
+pub fn parse_api_key_info(payload: &Value) -> XaiUsageSnapshot {
+    let mut snap = XaiUsageSnapshot::default();
+    snap.key_name = string_field(payload.get("name").or_else(|| payload.get("apiKeyName")));
+    snap.team_id = string_field(
+        payload
+            .get("teamId")
+            .or_else(|| payload.get("team_id"))
+            .or_else(|| payload.get("teamID")),
+    );
+    if let Some(cents) = number(
+        payload
+            .get("remainingCredits")
+            .or_else(|| payload.get("remaining_credits"))
+            .or_else(|| payload.get("credits")),
+    ) {
+        snap.prepaid_usd = Some(cents_to_usd(cents));
+    }
+    snap
+}
+
+/// Management prepaid ledger is inverted USD cents: a $10 top-up is `"-1000"`.
+pub fn parse_prepaid_balance(payload: &Value) -> Option<f64> {
+    let raw = payload
+        .get("total")
+        .and_then(|t| t.get("val").or(Some(t)))
+        .or_else(|| payload.get("val"))?;
+    let cents = number(Some(raw))?;
+    Some((-cents) / 100.0)
+}
+
+pub fn merge_snapshots(mut base: XaiUsageSnapshot, extra: XaiUsageSnapshot) -> XaiUsageSnapshot {
+    if base.plan.is_none() {
+        base.plan = extra.plan;
+    }
+    if base.credit_used_percent.is_none() {
+        base.credit_used_percent = extra.credit_used_percent;
+        base.credit_remaining_percent = extra.credit_remaining_percent;
+        base.credit_reset = extra.credit_reset.or(base.credit_reset);
+        base.credit_window_seconds = extra.credit_window_seconds.or(base.credit_window_seconds);
+        base.credit_label = extra.credit_label.or(base.credit_label);
+    }
+    if base.on_demand_used.is_none() {
+        base.on_demand_used = extra.on_demand_used;
+    }
+    if base.on_demand_cap.is_none() {
+        base.on_demand_cap = extra.on_demand_cap;
+    }
+    if base.prepaid_usd.is_none() {
+        base.prepaid_usd = extra.prepaid_usd;
+    }
+    if base.key_name.is_none() {
+        base.key_name = extra.key_name;
+    }
+    if base.team_id.is_none() {
+        base.team_id = extra.team_id;
+    }
+    base
+}
+
+fn apply_used_percent(snap: &mut XaiUsageSnapshot, pct: f64) {
+    let used = pct.clamp(0.0, 100.0);
+    snap.credit_used_percent = Some(used);
+    snap.credit_remaining_percent = Some((100.0 - used).clamp(0.0, 100.0));
+}
+
+fn on_demand_percent(config: &Value) -> Option<f64> {
+    let cap = amount_val(
+        config
+            .get("onDemandCap")
+            .or_else(|| config.get("on_demand_cap")),
+    )?;
+    if cap <= 0.0 {
+        return None;
+    }
+    let used = amount_val(
+        config
+            .get("onDemandUsed")
+            .or_else(|| config.get("on_demand_used")),
+    )?;
+    Some((used / cap * 100.0).clamp(0.0, 100.0))
+}
+
+fn rpc_used_percent(payload: &Value) -> Option<f64> {
+    let usage = payload.get("usage")?;
+    let limit = amount_val(
+        payload
+            .get("monthlyLimit")
+            .or_else(|| payload.get("monthly_limit")),
+    )?;
+    if limit <= 0.0 {
+        return None;
+    }
+    let used = amount_val(
+        usage
+            .get("totalUsed")
+            .or_else(|| usage.get("total_used"))
+            .or_else(|| usage.get("includedUsed")),
+    )?;
+    Some((used / limit * 100.0).clamp(0.0, 100.0))
+}
+
+fn credit_label(window_seconds: Option<i64>, reset_at: Option<i64>, now: i64) -> String {
+    if let Some(secs) = window_seconds {
+        return label_for_seconds(secs).to_string();
+    }
+    if let Some(reset) = reset_at {
+        let remaining = reset - now;
+        if remaining > 0 {
+            return label_for_seconds(remaining).to_string();
+        }
+    }
+    "Credits".to_string()
+}
+
+fn label_for_seconds(secs: i64) -> &'static str {
+    if secs >= 20 * 24 * 3600 && secs <= 40 * 24 * 3600 {
+        "Monthly"
+    } else if secs >= 5 * 24 * 3600 && secs <= 10 * 24 * 3600 {
+        "Weekly"
+    } else {
+        "Credits"
+    }
+}
+
+fn default_window_seconds(label: Option<&str>) -> Option<i64> {
+    match label {
+        Some("Weekly") => Some(7 * 24 * 3600),
+        Some("Monthly") => Some(30 * 24 * 3600),
+        _ => None,
+    }
+}
+
+fn display_plan(raw: String) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return raw;
+    }
+    match trimmed.to_ascii_lowercase().replace('_', " ").as_str() {
+        "supergrok" | "super grok" => "SuperGrok".to_string(),
+        "supergrok heavy" | "super grok heavy" => "SuperGrok Heavy".to_string(),
+        other if other.eq_ignore_ascii_case(trimmed) && trimmed.contains(' ') => {
+            trimmed.to_string()
+        }
+        _ => trimmed.to_string(),
+    }
+}
+
+fn amount_val(value: Option<&Value>) -> Option<f64> {
+    let value = value?;
+    number(value.get("val").or(Some(value)))
+}
+
+fn cents_to_usd(cents: f64) -> f64 {
+    if cents.abs() > 1000.0 && cents.fract() == 0.0 {
+        cents / 100.0
+    } else {
+        cents
+    }
+}
+
+fn parse_time(value: Option<&Value>) -> Option<i64> {
+    let value = value?;
+    if let Some(n) = value.as_i64() {
+        return Some(normalize_epoch(n));
+    }
+    if let Some(n) = value.as_f64() {
+        return Some(normalize_epoch(n as i64));
+    }
+    let s = value.as_str()?;
+    if let Ok(n) = s.parse::<i64>() {
+        return Some(normalize_epoch(n));
+    }
+    chrono::DateTime::parse_from_rfc3339(&s.replace('Z', "+00:00"))
+        .ok()
+        .map(|dt| dt.timestamp())
+}
+
+fn normalize_epoch(n: i64) -> i64 {
+    if n > 10_000_000_000 {
+        n / 1000
+    } else {
+        n
+    }
+}
+
+fn number(value: Option<&Value>) -> Option<f64> {
+    let value = value?;
+    value
+        .as_f64()
+        .or_else(|| value.as_i64().map(|n| n as f64))
+        .or_else(|| value.as_u64().map(|n| n as f64))
+        .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+}
+
+fn string_field(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cli_credits_percent_and_weekly_period() {
+        let payload = json!({
+            "config": {
+                "creditUsagePercent": 37.5,
+                "currentPeriod": {
+                    "start": "2026-08-10T00:00:00Z",
+                    "end": "2026-08-17T00:00:00Z"
+                },
+                "subscriptionTier": "SUPERGROK"
+            }
+        });
+        let snap = parse_cli_billing(&payload);
+        assert_eq!(snap.credit_used_percent, Some(37.5));
+        assert_eq!(snap.credit_remaining_percent, Some(62.5));
+        assert_eq!(snap.credit_reset, Some(1_786_924_800)); // 2026-08-17T00:00:00Z
+        assert_eq!(snap.credit_window_seconds, Some(7 * 24 * 3600));
+        assert_eq!(snap.credit_label.as_deref(), Some("Weekly"));
+        assert_eq!(snap.plan.as_deref(), Some("SuperGrok"));
+        let fields = snap.to_provider_fields();
+        assert_eq!(fields["xai_credit_used_percent"], 37.5);
+        assert_eq!(fields["xai_credit_label"], "Weekly");
+    }
+
+    #[test]
+    fn falls_back_to_on_demand_ratio() {
+        let payload = json!({
+            "config": {
+                "onDemandUsed": { "val": 25 },
+                "onDemandCap": { "val": 100 },
+                "billingPeriodEnd": "2026-09-01T00:00:00Z"
+            }
+        });
+        let snap = parse_cli_billing(&payload);
+        assert_eq!(snap.credit_used_percent, Some(25.0));
+        assert_eq!(snap.on_demand_used, Some(25.0));
+        assert_eq!(snap.on_demand_cap, Some(100.0));
+        assert_eq!(snap.credit_label.as_deref(), Some("Credits"));
+    }
+
+    #[test]
+    fn zero_usage_when_period_exists_without_percent() {
+        let payload = json!({
+            "config": {
+                "currentPeriod": { "end": "2026-08-20T00:00:00Z" }
+            }
+        });
+        let snap = parse_cli_billing(&payload);
+        assert_eq!(snap.credit_used_percent, Some(0.0));
+        assert_eq!(snap.credit_reset, Some(1_787_184_000));
+    }
+
+    #[test]
+    fn parses_rpc_style_usage_block() {
+        let payload = json!({
+            "monthlyLimit": { "val": 99900 },
+            "usage": { "totalUsed": { "val": 24975 } },
+            "billingCycle": { "billingPeriodEnd": "2026-09-01T00:00:00Z" }
+        });
+        let snap = parse_cli_billing(&payload);
+        assert_eq!(snap.credit_used_percent, Some(25.0));
+    }
+
+    #[test]
+    fn parses_settings_tier() {
+        assert_eq!(
+            parse_cli_settings(&json!({ "subscription_tier_display": "SuperGrok Heavy" }))
+                .as_deref(),
+            Some("SuperGrok Heavy")
+        );
+    }
+
+    #[test]
+    fn parses_api_key_info() {
+        let snap = parse_api_key_info(&json!({
+            "name": "prod",
+            "teamId": "65c1e471-205f-4566-9c5a-07198bcdf4ce",
+            "acls": ["api-key:model:*"]
+        }));
+        assert_eq!(snap.key_name.as_deref(), Some("prod"));
+        assert_eq!(
+            snap.team_id.as_deref(),
+            Some("65c1e471-205f-4566-9c5a-07198bcdf4ce")
+        );
+    }
+
+    #[test]
+    fn prepaid_balance_inverts_ledger_cents() {
+        let usd = parse_prepaid_balance(&json!({
+            "total": { "val": "-2500" }
+        }))
+        .expect("balance");
+        assert!((usd - 25.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn merge_keeps_billing_and_adds_prepaid() {
+        let billing = parse_cli_billing(&json!({
+            "config": { "creditUsagePercent": 10.0, "currentPeriod": { "end": "2026-08-17T00:00:00Z" } }
+        }));
+        let prepaid = XaiUsageSnapshot {
+            prepaid_usd: Some(12.5),
+            key_name: Some("prod".into()),
+            ..Default::default()
+        };
+        let merged = merge_snapshots(billing, prepaid);
+        assert_eq!(merged.credit_used_percent, Some(10.0));
+        assert_eq!(merged.prepaid_usd, Some(12.5));
+        assert_eq!(merged.key_name.as_deref(), Some("prod"));
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the production fleet issues that painted Verity as `blocked` / `inspect <uuid>`, killed new Codex lanes on the exhausted Thomas account, and 401'd Grok missions after reconnect.

- **Grok 401:** sync newest host `~/.grok/auth.json` into workspace HOME each turn; delete stale guest file if host has none (`/root/.grok/auth.json` from May was winning over Settings reconnect).
- **Codex quota lease:** never lease a usage-capped account while a fresh one exists (even at 0/10 permits). Wait up to 180s on the healthy account instead of dying on “try again Aug 20”.
- **Board honesty:** `POST /status` refuses `blocked` + `inspect <uuid>` for harness/transport deaths. `GET /api/projects/:slug` applies `honest_controller_mode` so a live writer cannot stay `blocked` (Hermes rail was reading raw store mode).
- **Transport:** pending-tool-not-replayed → `Interrupted` (not `Failed`); up to 3 auto-resumes.
- **Deploy:** 409 if writers are mid-turn unless `force=true`.

Hermes Desktop rail (live mission list) is a companion change in `hermes-agent`, not this tree.

## Test plan
- [x] `cargo test --lib` for new helpers (Grok sync, lease pool, inspect parse, deploy writers-live)
- [x] `cargo test --lib api::system::tests::deploy`
- [ ] After merge: deploy **dev** first, start a container Grok mission, confirm no 401
- [ ] Confirm a Codex turn does not lease the cooled account while the other is only slot-full
- [ ] `GET /api/projects/verity-core` returns `mode=active` while a writer is live

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches mission finalization, auto-resume, Codex leasing, deploy guards, and Grok auth on every turn—core orchestration paths where regressions affect all active missions.
> 
> **Overview**
> Addresses production fleet issues where projects stayed **`blocked` / `inspect`**, Codex picked exhausted accounts, Grok 401’d after reconnect, and deploys killed in-flight turns.
> 
> **Grok / xAI:** Each turn **syncs** the newest usable host `~/.grok/auth.json` into the workspace HOME (skips legacy `auth_mode: oauth`), with dashboard **SuperGrok credit bars** and optional prepaid USD from new `xai_usage` + provider usage probes (OAuth billing API, API key info, optional management prepaid).
> 
> **Codex:** Lease pool **never mixes** usage-capped accounts when a fresh one exists; **180s** wait on the healthy account instead of instant-failing on the dead weekly-cap slot.
> 
> **Board honesty:** `POST` status **rejects** `blocked` + `inspect <uuid>` when the target mission died on harness/transport; **GET** project overview applies **`honest_controller_mode`** so a live writer can’t stay blocked. New **`controller_honesty`** helpers classify inspect-next and harness terminal reasons.
> 
> **Transport:** Evidence like `pending tool` / `not replayed` maps **`LlmError` → `Interrupted`**; transport auto-resume allows **up to 3** retries per mission (was one).
> 
> **Deploy:** **`WritersLive`** refusal (409) when missions are mid-turn unless `force=true`; documented in **DEBUGGING.md**. Controller policy adds matching operational rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2665595fab739217b381ea18d21dccf044ea1e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->