### PR TITLE
fix(clippy): clear -D clippy::all leftovers from #865

### DIFF
--- a/src/api/controller_honesty.rs
+++ b/src/api/controller_honesty.rs
@@ -133,7 +133,7 @@ pub fn parse_inspect_mission_id(next: Option<&str>) -> Option<uuid::Uuid> {
         .strip_prefix("inspect")
         .or_else(|| raw.strip_prefix("Inspect"))
         .or_else(|| raw.strip_prefix("INSPECT"))?;
-    let token = rest.trim().split_whitespace().next()?;
+    let token = rest.split_whitespace().next()?;
     if let Ok(id) = uuid::Uuid::parse_str(token) {
         return Some(id);
     }

--- a/src/api/session_chain.rs
+++ b/src/api/session_chain.rs
@@ -113,7 +113,7 @@ fn child_is_livable(
     }
     if let (Some(start), Some(end)) = (started_at, ended_at) {
         let lifetime = end - start;
-        if lifetime >= 0.0 && lifetime <= 5.0 && message_count.unwrap_or(0) == 0 {
+        if (0.0..=5.0).contains(&lifetime) && message_count.unwrap_or(0) == 0 {
             return false;
         }
     }

--- a/src/api/xai_usage.rs
+++ b/src/api/xai_usage.rs
@@ -182,23 +182,23 @@ pub fn parse_cli_settings(payload: &Value) -> Option<String> {
 }
 
 pub fn parse_api_key_info(payload: &Value) -> XaiUsageSnapshot {
-    let mut snap = XaiUsageSnapshot::default();
-    snap.key_name = string_field(payload.get("name").or_else(|| payload.get("apiKeyName")));
-    snap.team_id = string_field(
-        payload
-            .get("teamId")
-            .or_else(|| payload.get("team_id"))
-            .or_else(|| payload.get("teamID")),
-    );
-    if let Some(cents) = number(
-        payload
-            .get("remainingCredits")
-            .or_else(|| payload.get("remaining_credits"))
-            .or_else(|| payload.get("credits")),
-    ) {
-        snap.prepaid_usd = Some(cents_to_usd(cents));
+    XaiUsageSnapshot {
+        key_name: string_field(payload.get("name").or_else(|| payload.get("apiKeyName"))),
+        team_id: string_field(
+            payload
+                .get("teamId")
+                .or_else(|| payload.get("team_id"))
+                .or_else(|| payload.get("teamID")),
+        ),
+        prepaid_usd: number(
+            payload
+                .get("remainingCredits")
+                .or_else(|| payload.get("remaining_credits"))
+                .or_else(|| payload.get("credits")),
+        )
+        .map(cents_to_usd),
+        ..Default::default()
     }
-    snap
 }
 
 /// Management prepaid ledger is inverted USD cents: a $10 top-up is `"-1000"`.
@@ -296,9 +296,9 @@ fn credit_label(window_seconds: Option<i64>, reset_at: Option<i64>, now: i64) ->
 }
 
 fn label_for_seconds(secs: i64) -> &'static str {
-    if secs >= 20 * 24 * 3600 && secs <= 40 * 24 * 3600 {
+    if (20 * 24 * 3600..=40 * 24 * 3600).contains(&secs) {
         "Monthly"
-    } else if secs >= 5 * 24 * 3600 && secs <= 10 * 24 * 3600 {
+    } else if (5 * 24 * 3600..=10 * 24 * 3600).contains(&secs) {
         "Weekly"
     } else {
         "Credits"

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1011,11 +1011,11 @@ fn stamp_custom_workspace_control_registry(workspace: &mut Workspace, working_di
     if workspace.id == DEFAULT_WORKSPACE_ID {
         return;
     }
-    if !workspace
+    if workspace
         .config
         .get(CONTROL_REGISTRY_CONFIG_KEY)
         .and_then(serde_json::Value::as_str)
-        .is_some_and(|root| !root.is_empty())
+        .is_none_or(|root| root.is_empty())
     {
         if !workspace.config.is_object() {
             workspace.config = serde_json::json!({});


### PR DESCRIPTION
## Why

#865 merged with Clippy red. CI (`cargo clippy --locked --workspace -- -D clippy::all`) failed on five lints introduced or exposed by that stack.

## What

- `controller_honesty`: drop the extra `trim()` before `split_whitespace`
- `session_chain`: use `(0.0..=5.0).contains(&lifetime)`
- `xai_usage`: initialize `XaiUsageSnapshot` in one struct literal; use inclusive range `contains` for weekly/monthly labels
- `workspace`: invert `!is_some_and` to `is_none_or` (local clippy 1.96 also flagged this)

Verified locally with the same Clippy flags as CI; `api::xai_usage` tests still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical Clippy cleanups with equivalent conditions; no auth, data, or API contract changes.
> 
> **Overview**
> Restores **CI Clippy** (`-D clippy::all`) after #865 by applying small style fixes only—no intended behavior changes.
> 
> In **`controller_honesty`**, inspect mission parsing drops a redundant `trim()` before `split_whitespace()`. **`session_chain`** and **`xai_usage`** replace chained bound checks with inclusive-range `contains` for session lifetime and credit-window labels. **`parse_api_key_info`** builds `XaiUsageSnapshot` in one struct literal instead of mutating a default. **`workspace`** rewrites the control-registry stamp guard from `!is_some_and` to **`is_none_or`**, keeping the same “stamp when missing or empty” condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e456b42fbca05fa92e0f4391f15acc4cd5df14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->