### PR TITLE
chore(vercel): disable automatic Git deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## What
Adds a root `vercel.json` with `git.deploymentEnabled: false`.

## Why
The Vercel project `sandboxed-dashboard` (lfglabs) currently builds automatically on every push. Disabling the Git deployment trigger stops automatic builds while keeping manual deploys (`vercel deploy --prod`) and dashboard-triggered deploys fully working. The current production deployment stays live.

## Notes
- Declarative and versioned in the repo, so it survives dashboard-side changes.
- If per-branch control is ever needed, `deploymentEnabled` accepts an array of branch names to disable selectively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment-pipeline config only; no application code, auth, or data handling changes.
> 
> **Overview**
> Adds a root **`vercel.json`** that sets **`git.deploymentEnabled`** to **`false`**, so pushes to the connected repo no longer trigger automatic Vercel builds for **`sandboxed-dashboard`**.
> 
> **Manual** deploys (`vercel deploy --prod`) and **dashboard** deploys stay available; production is unchanged. The setting is **versioned in the repo** so it isn’t lost if dashboard config changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de69d6aaa2885bb3fb229426594124a01a3d84cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->