### PR TITLE
fix: OpenCode Grok proxy route + untagged writer first message

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -1011,6 +1011,26 @@ mod campaign_guard_tests {
         assert_eq!(updated.title.as_deref(), Some("Repair Lido PR #88"));
     }
 
+    #[tokio::test]
+    async fn untagged_new_mission_opening_message_is_accepted() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(None, None, None, None, None, None, None)
+            .await
+            .expect("create");
+        let loaded = store.get_mission(mission.id).await.unwrap().unwrap();
+        apply_writer_reuse_or_conflict(
+            &store,
+            &loaded,
+            None,
+            None,
+            None,
+            Some("Continue from PR #105. Launch P-TOPUP-2 and P-ALLOC-1.".into()),
+        )
+        .await
+        .expect("blank writer first message must not 409");
+    }
+
     #[test]
     fn dispatch_gate_blocks_paused_and_archived_only() {
         // paused → 423 Locked; archived → 409 Conflict.
@@ -30902,6 +30922,23 @@ And the report:
         assert_eq!(
             normalize_model_override_for_backend(Some("opencode"), " KIMI-K3-256K "),
             Some("kimi/k3-256k".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_model_override_for_backend_maps_bare_grok_onto_xai() {
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), "grok-4.6"),
+            Some("xai/grok-4.6".to_string())
+        );
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), "xai/grok-4.6"),
+            Some("xai/grok-4.6".to_string())
+        );
+        // Native grok backend keeps the bare CLI id.
+        assert_eq!(
+            normalize_model_override_for_backend(Some("grok"), "grok-4.6"),
+            Some("grok-4.6".to_string())
         );
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11148,6 +11148,42 @@ mod tests {
         assert_eq!(mission_header, "00000000-0000-0000-0000-000000000123");
     }
 
+    #[test]
+    fn ensure_opencode_provider_builtin_accepts_xai_slash_model_id() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config_dir = temp.path().join("ws");
+        let app_dir = temp.path().join("app");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::create_dir_all(&app_dir).unwrap();
+
+        // `--model builtin/xai/grok-4.6` splits as provider=builtin,
+        // model=xai/grok-4.6. The model key must keep the slash so the
+        // proxy sees the full provider/model passthrough id.
+        ensure_opencode_provider_for_model(
+            &config_dir,
+            &app_dir,
+            "builtin/xai/grok-4.6",
+            "127.0.0.1",
+            Some("00000000-0000-0000-0000-000000000123"),
+        );
+
+        let opencode_json: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
+        )
+        .expect("parse opencode.json");
+        assert_eq!(
+            opencode_json["provider"]["builtin"]["models"]["xai/grok-4.6"]["name"],
+            "xai/grok-4.6"
+        );
+        let base_url = opencode_json["provider"]["builtin"]["options"]["baseURL"]
+            .as_str()
+            .expect("baseURL");
+        assert!(
+            base_url.starts_with("http://127.0.0.1:"),
+            "expected loopback proxy baseURL, got {base_url}"
+        );
+    }
+
     // ── extract_part_text tests ───────────────────────────────────────
 
     #[test]

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -131,7 +131,7 @@ pub async fn run_opencode_turn(
                 .ok()
                 .filter(|v| !v.trim().is_empty())
         })
-        .map(|model| normalize_opencode_model_id(&model).into_owned());
+        .map(|model| canonicalize_opencode_cli_model(&model));
     let auth_state = detect_opencode_provider_auth(Some(app_working_dir));
     let has_openai = auth_state.has_openai;
     let has_anthropic = auth_state.has_anthropic;
@@ -146,6 +146,10 @@ pub async fn run_opencode_turn(
     let configured_providers = &auth_state.configured_providers;
     let provider_available = |provider: &str| -> bool {
         match provider {
+            // Injected per mission and backed by the sandboxed proxy / CLI-proxy.
+            // Must not require an OpenCode auth.json account (subscription Grok
+            // is OAuth inside CLIProxyAPI, not an xAI API key).
+            "builtin" => true,
             "anthropic" | "claude" => has_anthropic,
             "openai" | "codex" => has_openai,
             "google" | "gemini" => has_google,
@@ -281,7 +285,7 @@ pub async fn run_opencode_turn(
     let mut total_cache_creation_input_tokens: u64 = 0;
     let mut total_cache_read_input_tokens: u64 = 0;
     let agent_model = resolve_opencode_model_from_config(&opencode_config_dir_host, agent)
-        .map(|model| normalize_opencode_model_id(&model).into_owned());
+        .map(|model| canonicalize_opencode_cli_model(&model));
     if resolved_model.is_none() {
         resolved_model = agent_model.clone();
     }
@@ -2184,6 +2188,15 @@ fn opencode_model_argument(model: Option<&str>) -> Cow<'_, str> {
     }
 }
 
+/// Normalize aliases then wrap proxy-routed Grok/xAI ids as `builtin/…`
+/// *before* the runner inspects the first path segment as an OpenCode
+/// provider. Otherwise `xai/grok-4.6` is dropped when OpenCode auth.json
+/// has no xAI API key (subscription Grok is CLI-proxy OAuth).
+fn canonicalize_opencode_cli_model(model: &str) -> String {
+    let canonical = normalize_opencode_model_id(model);
+    opencode_model_argument(Some(canonical.as_ref())).into_owned()
+}
+
 fn model_is_xai_provider_id(model: &str) -> bool {
     model
         .split_once('/')
@@ -2211,7 +2224,10 @@ fn opencode_path(
 
 #[cfg(test)]
 mod path_tests {
-    use super::{normalize_opencode_model_id, opencode_model_argument, opencode_path};
+    use super::{
+        canonicalize_opencode_cli_model, normalize_opencode_model_id, opencode_model_argument,
+        opencode_path,
+    };
 
     #[test]
     fn legacy_kimi_k3_aliases_are_canonicalized() {
@@ -2271,6 +2287,26 @@ mod path_tests {
         assert_eq!(
             opencode_model_argument(Some("xai/grok-4.6")),
             "builtin/xai/grok-4.6"
+        );
+        // Wrap happens before the provider-availability check so the first
+        // path segment is `builtin`, not catalog `xai` (which is absent when
+        // Grok is CLI-proxy OAuth only).
+        assert_eq!(
+            canonicalize_opencode_cli_model("grok-4.6"),
+            "builtin/xai/grok-4.6"
+        );
+        assert_eq!(
+            canonicalize_opencode_cli_model("xai/grok-4.6"),
+            "builtin/xai/grok-4.6"
+        );
+        let provider = canonicalize_opencode_cli_model("grok-4.6")
+            .split_once('/')
+            .map(|(p, _)| p.to_string())
+            .expect("slash");
+        assert_eq!(provider, "builtin");
+        assert!(
+            !crate::api::providers::DEFAULT_CATALOG_PROVIDER_IDS.contains(&provider.as_str()),
+            "builtin must not be treated as a catalog provider that requires OpenCode auth"
         );
     }
 

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -38,11 +38,21 @@ const PROXY_STREAM_INACTIVITY_CAP: std::time::Duration = std::time::Duration::fr
 /// Older Hermes skills used `kimi-k3`. OpenCode parses a slash-less value as
 /// a provider name with an empty model and fails with `Model not found:
 /// kimi-k3/`, even when the Kimi subscription itself is healthy.
+///
+/// Bare Grok ids (`grok-4.6`, `grok-4.5`, …) have the same trap: OpenCode
+/// records `providerID=grok-4.6, id=""` and the local server returns the
+/// opaque `Unexpected server error` that killed probe `b3dd8b65`. Map them
+/// onto the xAI provider prefix so the CLI argument can then be wrapped
+/// through `builtin/` (CLI-proxy OAuth + stream liveness).
 pub(crate) fn normalize_opencode_model_id(model: &str) -> Cow<'_, str> {
     let model = model.trim();
-    match model.to_ascii_lowercase().as_str() {
+    let lower = model.to_ascii_lowercase();
+    match lower.as_str() {
         "kimi-k3" => Cow::Borrowed("kimi/k3"),
         "kimi-k3-256k" => Cow::Borrowed("kimi/k3-256k"),
+        _ if !lower.contains('/') && lower.starts_with("grok-") => {
+            Cow::Owned(format!("xai/{lower}"))
+        }
         _ => Cow::Borrowed(model),
     }
 }
@@ -370,6 +380,26 @@ pub async fn run_opencode_turn(
     };
 
     let opencode_model = opencode_model_argument(resolved_model.as_deref());
+    // OpenCode's `--model` parser splits on the first `/`. A slash-less
+    // value becomes provider=<id> model="" and the CLI's local server
+    // answers with a generic 500 (`Unexpected server error`) instead of
+    // `Model not found`. Fail here with the actual id so a mis-dispatched
+    // probe is diagnosable.
+    if !opencode_model.contains('/') {
+        let err_msg = format!(
+            "OpenCode model '{opencode_model}' has no provider prefix. \
+             OpenCode treats the first path segment as the provider, so this \
+             becomes '{opencode_model}/' and fails with an opaque server error. \
+             Use provider/model (e.g. xai/grok-4.6, builtin/smart, zai/glm-5.2)."
+        );
+        tracing::error!(mission_id = %mission_id, "{}", err_msg);
+        let _ = events_tx.send(AgentEvent::Error {
+            message: err_msg.clone(),
+            mission_id: Some(mission_id),
+            resumable: true,
+        });
+        return AgentResult::failure(err_msg, 0).with_terminal_reason(TerminalReason::LlmError);
+    }
     if opencode_model.starts_with("builtin/") {
         ensure_opencode_provider_for_model(
             &opencode_config_dir_host,
@@ -2132,13 +2162,32 @@ pub async fn run_opencode_turn(
 /// the remainder as the upstream model. Route the exact Grok CLI bridge model
 /// through the existing `builtin` provider so the proxy receives the complete
 /// `grok-cli/grok-4.5` chain id instead of the ambiguous bare `grok-4.5`.
+///
+/// Direct `xai/grok-*` is wrapped the same way. OpenCode's native `@ai-sdk/xai`
+/// adapter talks to `api.x.ai` with an API key (or, worse, an OAuth token
+/// stuffed into `XAI_API_KEY`). Subscription Grok lives on CLIProxyAPI's
+/// Responses transport; going through `builtin` is what:
+///   1. authenticates with the loopback proxy (OAuth stays inside CLIProxyAPI),
+///   2. sends `x-sandboxed-mission-id` so reasoning chunks reset the idle
+///      watchdog (`proxy_liveness`) instead of dying after 300s of harness
+///      silence — the stall that killed writer `4d823bd9` gen1.
 fn opencode_model_argument(model: Option<&str>) -> Cow<'_, str> {
     let model = model.unwrap_or("builtin/fast");
-    if crate::api::grok_tool_bridge::is_bridge_model(model) {
+    if model.starts_with("builtin/") {
+        Cow::Borrowed(model)
+    } else if crate::api::grok_tool_bridge::is_bridge_model(model)
+        || model_is_xai_provider_id(model)
+    {
         Cow::Owned(format!("builtin/{model}"))
     } else {
         Cow::Borrowed(model)
     }
+}
+
+fn model_is_xai_provider_id(model: &str) -> bool {
+    model
+        .split_once('/')
+        .is_some_and(|(provider, rest)| provider.eq_ignore_ascii_case("xai") && !rest.is_empty())
 }
 
 fn opencode_path(
@@ -2187,9 +2236,42 @@ mod path_tests {
         );
         assert_eq!(
             opencode_model_argument(Some("xai/grok-4.5")),
-            "xai/grok-4.5"
+            "builtin/xai/grok-4.5"
+        );
+        assert_eq!(
+            opencode_model_argument(Some("builtin/xai/grok-4.6")),
+            "builtin/xai/grok-4.6"
         );
         assert_eq!(opencode_model_argument(None), "builtin/fast");
+    }
+
+    #[test]
+    fn bare_grok_ids_are_canonicalized_onto_xai_then_builtin_proxy() {
+        assert_eq!(normalize_opencode_model_id("grok-4.6"), "xai/grok-4.6");
+        assert_eq!(
+            normalize_opencode_model_id(" Grok-4.6-latest "),
+            "xai/grok-4.6-latest"
+        );
+        assert_eq!(normalize_opencode_model_id("grok-4.5"), "xai/grok-4.5");
+        assert_eq!(
+            normalize_opencode_model_id("grok-build-0.1"),
+            "xai/grok-build-0.1"
+        );
+        // Already-prefixed ids must not be double-wrapped at normalize time.
+        assert_eq!(normalize_opencode_model_id("xai/grok-4.6"), "xai/grok-4.6");
+        assert_eq!(
+            normalize_opencode_model_id("grok-cli/grok-4.5"),
+            "grok-cli/grok-4.5"
+        );
+        let canonical = normalize_opencode_model_id("grok-4.6");
+        assert_eq!(
+            opencode_model_argument(Some(canonical.as_ref())),
+            "builtin/xai/grok-4.6"
+        );
+        assert_eq!(
+            opencode_model_argument(Some("xai/grok-4.6")),
+            "builtin/xai/grok-4.6"
+        );
     }
 
     #[test]

--- a/src/api/writer_recycle.rs
+++ b/src/api/writer_recycle.rs
@@ -86,6 +86,14 @@ fn dispatch_is_different_work(stored: &WriterIdentity, patch: &WriterIdentityPat
         return false;
     }
 
+    // An untagged mission has no previous identity to protect. The first
+    // prompt on a new writer routinely names a PR (`#105`) or campaign
+    // (`P-TOPUP-2`); treating that as a silent recycle 409s the operator's
+    // opening message (mission 374fac82, 2026-08-19).
+    if !stored_has_writer_identity(stored) {
+        return false;
+    }
+
     let stored_pr = stored.github_pr.as_deref().map(canonical_github_pr);
     let stored_pr_number = stored_pr
         .as_ref()
@@ -177,6 +185,14 @@ fn campaign_tokens_in(hint: &str) -> Vec<String> {
         i += 1;
     }
     tokens
+}
+
+fn stored_has_writer_identity(stored: &WriterIdentity) -> bool {
+    field_nonempty(&stored.github_pr) || field_nonempty(&stored.track)
+}
+
+fn field_nonempty(value: &Option<String>) -> bool {
+    value.as_deref().is_some_and(|s| !s.trim().is_empty())
 }
 
 fn stored_identity_covers(track: &str, github_pr: Option<&str>, token: &str) -> bool {
@@ -300,5 +316,38 @@ mod tests {
         )
         .expect_err("different PR is different work");
         assert_eq!(err.error, "writer_identity_stale");
+    }
+
+    #[test]
+    fn untagged_new_mission_may_name_a_pr_and_campaign() {
+        let next = apply_writer_reuse(
+            &WriterIdentity::default(),
+            &WriterIdentityPatch {
+                work_hint: Some(
+                    "Base: continue from PR #105. Launch P-TOPUP-2 and P-ALLOC-1.".into(),
+                ),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect("first message on a blank writer is not a recycle");
+        assert_eq!(next.github_pr, None);
+        assert_eq!(next.track, None);
+    }
+
+    #[test]
+    fn whitespace_only_tags_are_untagged() {
+        let stored = WriterIdentity {
+            github_pr: Some("  ".into()),
+            track: Some("".into()),
+            title: None,
+        };
+        apply_writer_reuse(
+            &stored,
+            &WriterIdentityPatch {
+                work_hint: Some("Implement P-SSZ-1 on PR #105".into()),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect("blank tags are not a stale identity");
     }
 }


### PR DESCRIPTION
## Summary

- **OpenCode Grok:** bare `grok-4.6` was parsed as `providerID=grok-4.6, id=""` and died with `Unexpected server error` (probe `b3dd8b65`). Canonicalize `grok-*` to `xai/grok-*` and wrap `xai/*` as `builtin/xai/*` so subscription Grok goes through the sandboxed proxy (CLI-proxy OAuth + stream liveness). That also stops the 300s idle SIGTERM on real writers (`4d823bd9` gen1) where `@ai-sdk/xai` never reported proxy chunks.
- **Writer recycle:** `POST /api/control/message` 409'd a brand-new untagged mission (`374fac82`) because the plan named `PR #105` and `P-TOPUP-2`. The stale-identity guard now only fires when `github_pr`/`track` already name previous work.

## Test plan

- [x] `cargo test --lib writer_recycle untagged_new_mission path_tests`
- [x] Live CLI-proxy `grok-4.6` on prod: HTTP 200 / `PROBE OK` (confirms upstream was never down)
- [ ] After deploy: resend the `/plan` message to mission `374fac82` — must not 409
- [ ] Optional: OpenCode probe with `model=grok-4.6` should run as `builtin/xai/grok-4.6` and produce text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenCode model dispatch and proxy wiring for Grok runs plus control-message writer identity gating; wrong routing could break probes/writers, but behavior is covered by new unit/integration tests.
> 
> **Overview**
> **OpenCode Grok routing** now treats bare `grok-*` ids as `xai/grok-*`, wraps `xai/*` (and existing bridge models) as `builtin/xai/*` so subscription Grok uses the loopback CLI-proxy with mission stream liveness instead of the native xAI adapter. A pre-flight check rejects slash-less `--model` values with a clear error instead of an opaque 500. Control-layer `normalize_model_override_for_backend` picks up the same canonicalization for the OpenCode backend.
> 
> **Writer recycle** only treats a message as “different work” when the mission already has a non-empty `github_pr` or `track`; opening plans that mention PRs or campaign codes on a blank writer no longer return `writer_identity_stale` (409). Whitespace-only tags count as untagged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02a0d7543c1a6f07e14ed7a54f0673d1da8c7b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->