### PR TITLE
fix(opencode): route Muse Spark through native meta Responses provider

### DIFF
--- a/dashboard/src/app/control/components/HermesConversation.tsx
+++ b/dashboard/src/app/control/components/HermesConversation.tsx
@@ -455,12 +455,6 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
     ({ content }: { content: string }) => {
       const text = content.trim();
       if (!text) return;
-      if (running) {
-        setError(
-          "This conversation is still running a turn. Stop it first, then send.",
-        );
-        return;
-      }
       const entry: HermesOutboxEntry = {
         id: createHermesDeliveryId(),
         sessionId,
@@ -489,12 +483,6 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
 
   const retryUserMessage = useCallback(
     (message: { id: string; content: string }) => {
-      if (running) {
-        setError(
-          "This conversation is still running a turn. Stop it first, then send.",
-        );
-        return;
-      }
       const existing = getHermesOutbox(sessionId).find(
         (entry) => entry.id === message.id,
       );

--- a/dashboard/src/app/control/components/HermesConversation.tsx
+++ b/dashboard/src/app/control/components/HermesConversation.tsx
@@ -454,7 +454,13 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
   const handleSubmit = useCallback(
     ({ content }: { content: string }) => {
       const text = content.trim();
-      if (!text || running) return;
+      if (!text) return;
+      if (running) {
+        setError(
+          "This conversation is still running a turn. Stop it first, then send.",
+        );
+        return;
+      }
       const entry: HermesOutboxEntry = {
         id: createHermesDeliveryId(),
         sessionId,
@@ -483,7 +489,12 @@ export function HermesConversation({ sessionId }: { sessionId: string }) {
 
   const retryUserMessage = useCallback(
     (message: { id: string; content: string }) => {
-      if (running) return;
+      if (running) {
+        setError(
+          "This conversation is still running a turn. Stop it first, then send.",
+        );
+        return;
+      }
       const existing = getHermesOutbox(sessionId).find(
         (entry) => entry.id === message.id,
       );

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -39,6 +39,8 @@ STOP_CONTROL_TESTIDS = (
 SEND_BUTTON_NAME = re.compile(r"^send\b", re.I)
 STOP_BUTTON_NAME = re.compile(r"^stop\b", re.I)
 INTELLIGENCE_LABELS = ("Instant", "5.5", "Medium", "High", "Extra High", "Pro")
+# Current composer power slider: Instant, Medium, High, Extra High, Pro.
+INTELLIGENCE_SLIDER_LABELS = ("Instant", "Medium", "High", "Extra High", "Pro")
 PRO_MODEL_ALIASES = {
     "gpt-5.6-pro",
     "gpt 5.6 pro",
@@ -245,6 +247,53 @@ async def click_send_control(page) -> bool:
     raise RuntimeError("composer send control is not actionable")
 
 
+def intelligence_slider_index(label: str) -> int | None:
+    try:
+        return INTELLIGENCE_SLIDER_LABELS.index(label)
+    except ValueError:
+        return None
+
+
+async def select_intelligence_slider(page, overlay, slider, pill, label: str) -> bool:
+    """Move the composer power slider to Instant/Medium/High/Extra High/Pro."""
+    target = intelligence_slider_index(label)
+    if target is None:
+        return False
+    simple = overlay.locator('[data-testid="composer-model-picker-slider-simple-view"]')
+    try:
+        await slider.focus()
+    except Exception:
+        pass
+    for _ in range(10):
+        raw = await slider.get_attribute("aria-valuenow")
+        try:
+            now = int(raw) if raw is not None else -1
+        except (TypeError, ValueError):
+            now = -1
+        simple_text = ""
+        if await simple.count():
+            try:
+                simple_text = (await simple.inner_text()).strip()
+            except Exception:
+                simple_text = ""
+        current = simple_text.split(",")[0].strip() if simple_text else ""
+        if current == label or now == target:
+            await page.keyboard.press("Escape")
+            try:
+                await pill.get_by_text(label, exact=True).wait_for(
+                    state="visible", timeout=3_000
+                )
+            except Exception:
+                if (await pill.inner_text()).strip() != label:
+                    return False
+            return True
+        if now < 0:
+            return False
+        await slider.press("ArrowRight" if now < target else "ArrowLeft")
+        await page.wait_for_timeout(250)
+    return False
+
+
 async def choose_intelligence_model(page, label: str) -> bool:
     """Select a current composer intelligence option without touching the sidebar."""
     # The current ChatGPT shell hydrates the composer in two phases: the
@@ -280,6 +329,13 @@ async def choose_intelligence_model(page, label: str) -> bool:
                 '[data-testid="composer-intelligence-picker-content"]:visible'
             ).last
             await overlay.wait_for(state="visible", timeout=3_000)
+            slider = overlay.locator('[role="slider"]')
+            if await slider.count() and await slider.first.is_visible():
+                if await select_intelligence_slider(
+                    page, overlay, slider.first, button, label
+                ):
+                    return True
+                continue
             option = overlay.get_by_role("menuitemradio", name=label, exact=True)
             await option.wait_for(state="visible", timeout=3_000)
             await option.click()

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -71,6 +71,7 @@ ACCOUNT_PICKER_SKIP = re.compile(
     r"log in to another account|create account|remove account|sign up for free|^log in$",
     re.I,
 )
+LOGIN_BUTTON_NAME = re.compile(r"^(log in|sign in)$", re.I)
 
 
 class ResumeNotFound(Exception):
@@ -485,6 +486,31 @@ def is_saved_account_choice(label: str) -> bool:
     return bool(SAVED_ACCOUNT_EMAIL.search(text))
 
 
+async def login_chrome_visible(page) -> bool:
+    login = page.get_by_role("button", name=LOGIN_BUTTON_NAME)
+    return bool(await login.count() and await login.first.is_visible())
+
+
+async def account_shell_visible(page) -> bool:
+    """Account-only chrome. Images/Deep research also exist on the logged-out home."""
+    account_controls = page.locator(
+        '[data-testid="accounts-profile-button"], '
+        'button[aria-label*="account" i], '
+        'button[aria-label*="profile" i]'
+    )
+    for index in range(await account_controls.count()):
+        if await account_controls.nth(index).is_visible():
+            return True
+    nav_evidence = page.locator(
+        'a[href*="/library"], a[href*="/scheduled"], '
+        '[data-testid="create-scheduled-task-button"]'
+    )
+    for index in range(await nav_evidence.count()):
+        if await nav_evidence.nth(index).is_visible():
+            return True
+    return False
+
+
 async def wait_out_cloudflare(page, timeout_ms: int = 45_000) -> None:
     """Wait for ChatGPT's Cloudflare interstitial to clear.
 
@@ -526,14 +552,12 @@ async def complete_saved_account_picker(page, timeout_ms: int = 25_000) -> bool:
     ``auth_required``.
     """
     heading = page.get_by_text(ACCOUNT_PICKER_HEADING)
-    login = page.get_by_role("button", name=re.compile(r"^(log in|sign in)$", re.I))
     appeared = False
     for _ in range(max(1, timeout_ms // 250)):
         if await heading.count() and await heading.first.is_visible():
             appeared = True
             break
-        login_up = bool(await login.count() and await login.first.is_visible())
-        if not login_up:
+        if not await login_chrome_visible(page):
             return False
         await page.wait_for_timeout(250)
     if not appeared:
@@ -553,11 +577,20 @@ async def complete_saved_account_picker(page, timeout_ms: int = 25_000) -> bool:
             continue
         await button.click(timeout=8_000)
         emit("diagnostic", message="stage=account_picker_selected")
-        for _ in range(40):
-            if not await heading.count() or not await heading.first.is_visible():
+        for _ in range(80):
+            heading_up = bool(
+                await heading.count() and await heading.first.is_visible()
+            )
+            if (
+                not heading_up
+                and not await login_chrome_visible(page)
+                and await account_shell_visible(page)
+            ):
                 return True
             await page.wait_for_timeout(250)
-        return True
+        if await account_shell_visible(page):
+            return True
+        raise PermissionError("login required")
     raise PermissionError(
         "welcome-back account picker is visible but no saved account could be selected"
     )
@@ -565,42 +598,16 @@ async def complete_saved_account_picker(page, timeout_ms: int = 25_000) -> bool:
 
 async def verify_authentication(page) -> None:
     """Require account-only evidence of an authenticated session."""
-    login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
-    if "/auth/" in page.url or (await login.count() and await login.is_visible()):
+    if "/auth/" in page.url or await login_chrome_visible(page):
         if await complete_saved_account_picker(page):
-            login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
-        if "/auth/" in page.url or (await login.count() and await login.is_visible()):
-            raise PermissionError("login required")
-
-    # Anonymous ChatGPT can expose a working composer, so its presence is not
-    # authentication evidence. Require an account-only control and fail closed
-    # when a UI rollout makes that evidence unavailable.
-    account_controls = page.locator(
-        '[data-testid="accounts-profile-button"], '
-        'button[aria-label*="account" i], '
-        'button[aria-label*="profile" i]'
-    )
-    for index in range(await account_controls.count()):
-        if await account_controls.nth(index).is_visible():
             emit("diagnostic", message="stage=account_confirmed")
             return
+        if "/auth/" in page.url or await login_chrome_visible(page):
+            raise PermissionError("login required")
 
-    # A UI rollout renamed the profile button and this check began failing
-    # closed on PROVISIONED profiles: measured 2026-08-06, all 12 pool
-    # profiles held session cookies valid for ~90 days while every mission
-    # died in seconds with "login is required". The sidebar's Library and
-    # Scheduled entries are account-only surfaces (anonymous ChatGPT has
-    # neither) and survive the rename — accept them as evidence before
-    # concluding the account is gone.
-    nav_evidence = page.locator(
-        'a[href*="/library"], a[href*="/scheduled"], '
-        '[data-testid="create-scheduled-task-button"], '
-        '[data-testid="accounts-profile-button"]'
-    )
-    for index in range(await nav_evidence.count()):
-        if await nav_evidence.nth(index).is_visible():
-            emit("diagnostic", message="stage=account_confirmed_via_nav")
-            return
+    if await account_shell_visible(page):
+        emit("diagnostic", message="stage=account_confirmed")
+        return
     # Guard contract: name what was probed and where. Without this, the
     # 2026-08-06 false positive read as "login required" and the dispatching
     # agent asked the operator to re-provision 12 accounts that were fine.

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -61,6 +61,16 @@ RATE_LIMIT_MODAL_TESTID = "modal-conversation-history-rate-limit"
 # durability protocol ever emits — never titles, prompts, or response text.
 CONVERSATION_PATH_RE = re.compile(r"^/c/[A-Za-z0-9-]{8,64}$")
 CHATGPT_HOSTS = {"chatgpt.com", "chat.openai.com"}
+CLOUDFLARE_TITLE = re.compile(r"just a moment|verifying", re.I)
+CLOUDFLARE_BODY = re.compile(
+    r"verify you are human|verifying\.\.\.|just a moment", re.I
+)
+ACCOUNT_PICKER_HEADING = re.compile(r"choose an account to continue", re.I)
+SAVED_ACCOUNT_EMAIL = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+ACCOUNT_PICKER_SKIP = re.compile(
+    r"log in to another account|create account|remove account|sign up for free|^log in$",
+    re.I,
+)
 
 
 class ResumeNotFound(Exception):
@@ -463,11 +473,89 @@ async def close_context_quietly(context) -> None:
         pass
 
 
+def is_cloudflare_challenge_title(title: str | None) -> bool:
+    return bool(CLOUDFLARE_TITLE.search(title or ""))
+
+
+def is_saved_account_choice(label: str) -> bool:
+    """True for a welcome-back saved-account card, never for Log in / Sign up."""
+    text = (label or "").strip()
+    if not text or ACCOUNT_PICKER_SKIP.search(text):
+        return False
+    return bool(SAVED_ACCOUNT_EMAIL.search(text))
+
+
+async def wait_out_cloudflare(page, timeout_ms: int = 45_000) -> None:
+    """Wait for ChatGPT's Cloudflare interstitial to clear.
+
+    Headed Chromium through the DGX SOCKS exit often sits on
+    ``Just a moment...`` / ``Verifying...`` for several seconds. Treating
+    that page as a logout quarantines every pool slot.
+    """
+    waited = False
+    for _ in range(max(1, timeout_ms // 500)):
+        title = ""
+        try:
+            title = await page.title()
+        except Exception:
+            title = ""
+        body = ""
+        try:
+            body = await page.inner_text("body")
+        except Exception:
+            body = ""
+        if not is_cloudflare_challenge_title(title) and not CLOUDFLARE_BODY.search(body or ""):
+            if waited:
+                emit("diagnostic", message="stage=cloudflare_cleared")
+            return
+        if not waited:
+            emit("diagnostic", message="stage=cloudflare_wait")
+            waited = True
+        await page.wait_for_timeout(500)
+    raise TransportUnavailable("Cloudflare interstitial did not clear")
+
+
+async def complete_saved_account_picker(page) -> bool:
+    """Click the stored account on ChatGPT's welcome-back picker.
+
+    After a CF challenge (or a cookie refresh) ChatGPT shows
+    ``Welcome back / Choose an account to continue`` with the profile's
+    saved account. A visible ``Log in`` chrome on that overlay used to
+    be classified as ``auth_required``.
+    """
+    heading = page.get_by_text(ACCOUNT_PICKER_HEADING)
+    if not await heading.count():
+        return False
+    emit("diagnostic", message="stage=account_picker")
+    buttons = page.locator("button:visible")
+    for index in range(await buttons.count()):
+        button = buttons.nth(index)
+        try:
+            label = await button.inner_text()
+        except Exception:
+            continue
+        if not is_saved_account_choice(label):
+            continue
+        await button.click(timeout=8_000)
+        emit("diagnostic", message="stage=account_picker_selected")
+        for _ in range(40):
+            if not await heading.count() or not await heading.first.is_visible():
+                return True
+            await page.wait_for_timeout(250)
+        return True
+    raise PermissionError(
+        "welcome-back account picker is visible but no saved account could be selected"
+    )
+
+
 async def verify_authentication(page) -> None:
     """Require account-only evidence of an authenticated session."""
     login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
     if "/auth/" in page.url or (await login.count() and await login.is_visible()):
-        raise PermissionError("login required")
+        if await complete_saved_account_picker(page):
+            login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
+        if "/auth/" in page.url or (await login.count() and await login.is_visible()):
+            raise PermissionError("login required")
 
     # Anonymous ChatGPT can expose a working composer, so its presence is not
     # authentication evidence. Require an account-only control and fail closed
@@ -490,8 +578,9 @@ async def verify_authentication(page) -> None:
     # neither) and survive the rename — accept them as evidence before
     # concluding the account is gone.
     nav_evidence = page.locator(
-        'a[href*="/library"], a[href*="/scheduled"], '
-        '[data-testid="create-scheduled-task-button"]'
+        'a[href*="/library"], a[href*="/scheduled"], a[href*="/images"], '
+        '[data-testid="create-scheduled-task-button"], '
+        '[data-testid="accounts-profile-button"]'
     )
     for index in range(await nav_evidence.count()):
         if await nav_evidence.nth(index).is_visible():
@@ -525,6 +614,8 @@ async def establish_resumed_chat(page, conversation_path: str, message: str) -> 
         timeout=60_000,
     )
     emit("diagnostic", message="stage=resume_route")
+    await wait_out_cloudflare(page)
+    await complete_saved_account_picker(page)
     await raise_if_rate_limited(page)
     await verify_authentication(page)
     # Unknown or deleted conversations redirect away from the recorded route.
@@ -553,6 +644,8 @@ async def establish_continued_chat(page, conversation_path: str) -> int:
         timeout=60_000,
     )
     emit("diagnostic", message="stage=continuation_route")
+    await wait_out_cloudflare(page)
+    await complete_saved_account_picker(page)
     await raise_if_rate_limited(page)
     await verify_authentication(page)
     parsed = urlparse(page.url)
@@ -582,6 +675,8 @@ async def establish_fresh_chat(page) -> int:
     """Prove an authenticated, settled blank chat before observing responses."""
     await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
     emit("diagnostic", message="stage=page_loaded")
+    await wait_out_cloudflare(page)
+    await complete_saved_account_picker(page)
     await raise_if_rate_limited(page)
     await verify_authentication(page)
 

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -515,22 +515,37 @@ async def wait_out_cloudflare(page, timeout_ms: int = 45_000) -> None:
     raise TransportUnavailable("Cloudflare interstitial did not clear")
 
 
-async def complete_saved_account_picker(page) -> bool:
+async def complete_saved_account_picker(page, timeout_ms: int = 25_000) -> bool:
     """Click the stored account on ChatGPT's welcome-back picker.
 
     After a CF challenge (or a cookie refresh) ChatGPT shows
     ``Welcome back / Choose an account to continue`` with the profile's
-    saved account. A visible ``Log in`` chrome on that overlay used to
-    be classified as ``auth_required``.
+    saved account. The card is a ``div[role=button]``, not a ``<button>``,
+    and the overlay often lands 15–20s after ``domcontentloaded``. A visible
+    ``Log in`` chrome on that overlay used to be classified as
+    ``auth_required``.
     """
     heading = page.get_by_text(ACCOUNT_PICKER_HEADING)
-    if not await heading.count():
+    login = page.get_by_role("button", name=re.compile(r"^(log in|sign in)$", re.I))
+    appeared = False
+    for _ in range(max(1, timeout_ms // 250)):
+        if await heading.count() and await heading.first.is_visible():
+            appeared = True
+            break
+        login_up = bool(await login.count() and await login.first.is_visible())
+        if not login_up:
+            return False
+        await page.wait_for_timeout(250)
+    if not appeared:
         return False
     emit("diagnostic", message="stage=account_picker")
-    buttons = page.locator("button:visible")
+    # Native ``<button>`` and the welcome-back account card (div role=button).
+    buttons = page.get_by_role("button")
     for index in range(await buttons.count()):
         button = buttons.nth(index)
         try:
+            if not await button.is_visible():
+                continue
             label = await button.inner_text()
         except Exception:
             continue
@@ -578,7 +593,7 @@ async def verify_authentication(page) -> None:
     # neither) and survive the rename — accept them as evidence before
     # concluding the account is gone.
     nav_evidence = page.locator(
-        'a[href*="/library"], a[href*="/scheduled"], a[href*="/images"], '
+        'a[href*="/library"], a[href*="/scheduled"], '
         '[data-testid="create-scheduled-task-button"], '
         '[data-testid="accounts-profile-button"]'
     )

--- a/scripts/chatgpt_ui_pool_health.py
+++ b/scripts/chatgpt_ui_pool_health.py
@@ -61,10 +61,14 @@ DOM_PROBE = """() => {
     .map((e) => (e.innerText || '').trim())
     .filter(Boolean);
   const body = document.body ? document.body.innerText || '' : '';
+  const title = document.title || '';
   return {
     login_visible: texts.some((t) => /^(log in|se connecter|sign up|s'inscrire)$/i.test(t)),
-    authed_nav: texts.includes('Library') && texts.includes('Scheduled'),
+    authed_nav: texts.includes('Library') || texts.includes('Images') || texts.includes('Scheduled')
+      || texts.includes('Deep research'),
+    account_picker: /choose an account to continue|welcome back/i.test(body),
     challenge: /verify you are human|verifying\\.\\.\\.|just a moment/i.test(body)
+      || /just a moment|verifying/i.test(title)
       || !!document.querySelector('iframe[src*="challenges.cloudflare.com"]'),
   };
 }"""
@@ -168,6 +172,11 @@ def probe(profile_dir: str, proxy: str, settle_ms: int) -> str:
 
     if found.get("challenge"):
         return "challenge"
+    # A welcome-back picker means the profile still has a saved session.
+    # The driver clicks through it; treating the overlay Log in chrome as
+    # logout quarantines every slot.
+    if found.get("account_picker"):
+        return "logged_in"
     if found.get("login_visible"):
         return "logged_out"
     if found.get("authed_nav"):

--- a/scripts/chatgpt_ui_pool_health.py
+++ b/scripts/chatgpt_ui_pool_health.py
@@ -64,8 +64,7 @@ DOM_PROBE = """() => {
   const title = document.title || '';
   return {
     login_visible: texts.some((t) => /^(log in|se connecter|sign up|s'inscrire)$/i.test(t)),
-    authed_nav: texts.includes('Library') || texts.includes('Images') || texts.includes('Scheduled')
-      || texts.includes('Deep research'),
+    authed_nav: texts.includes('Library') || texts.includes('Scheduled'),
     account_picker: /choose an account to continue|welcome back/i.test(body),
     challenge: /verify you are human|verifying\\.\\.\\.|just a moment/i.test(body)
       || /just a moment|verifying/i.test(title)
@@ -159,9 +158,19 @@ def probe(profile_dir: str, proxy: str, settle_ms: int) -> str:
             try:
                 page = context.pages[0] if context.pages else context.new_page()
                 page.goto("https://chatgpt.com/", wait_until="domcontentloaded", timeout=90_000)
-                # Empty text right after domcontentloaded is paint timing.
-                page.wait_for_timeout(settle_ms)
-                found = page.evaluate(DOM_PROBE)
+                # The welcome-back picker is often 15–20s after domcontentloaded.
+                # Classifying at the first paint treats overlay Log in as logout.
+                deadline = time.time() + max(settle_ms, 0) / 1000.0
+                found = {"challenge": False, "account_picker": False, "login_visible": False, "authed_nav": False}
+                while True:
+                    found = page.evaluate(DOM_PROBE)
+                    if found.get("account_picker") or (
+                        found.get("authed_nav") and not found.get("login_visible")
+                    ):
+                        break
+                    if time.time() >= deadline:
+                        break
+                    page.wait_for_timeout(500)
             finally:
                 context.close()
     except Exception as exc:  # noqa: BLE001 - a probe failure is never fatal
@@ -255,7 +264,7 @@ def main() -> int:
         default=float(os.environ.get("CHATGPT_POOL_HEALTH_PACE_SECONDS", "25")),
         help="delay between probes; back-to-back launches trip Cloudflare",
     )
-    parser.add_argument("--settle-ms", type=int, default=8000)
+    parser.add_argument("--settle-ms", type=int, default=25000)
     parser.add_argument("--slot", action="append", help="probe these slots instead of rotating")
     args = parser.parse_args()
 

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -286,6 +286,16 @@ class FakePickerButton:
     async def inner_text(self) -> str:
         return self.text
 
+    async def is_visible(self) -> bool:
+        return True
+
+    @property
+    def first(self):
+        return self
+
+    async def count(self) -> int:
+        return 1
+
     async def click(self, **_kwargs) -> None:
         self.clicked = True
 
@@ -317,23 +327,33 @@ class AccountPickerHeading:
 
 
 class AccountPickerPage:
-    def __init__(self) -> None:
-        self.heading_visible = True
+    def __init__(self, heading_visible: bool = True, picker_after: int = 0) -> None:
+        self.heading_visible = heading_visible
+        self.picker_after = picker_after
+        self.waits = 0
         self.login = FakePickerButton("Log in")
-        self.saved = FakePickerButton("Fricoben\nben@example.com")
+        self.saved = FakePickerButton("Ada\nada@example.com")
         self.other = FakePickerButton("Log in to another account")
 
     def get_by_text(self, _text, exact=False):
         return AccountPickerHeading(self)
 
+    def get_by_role(self, role, name=None, exact=False):
+        if role != "button":
+            raise AssertionError(role)
+        if name is not None:
+            return self.login
+        return FakePickerButtons([self.login, self.saved, self.other])
+
     def locator(self, selector):
-        if selector == "button:visible":
-            return FakePickerButtons([self.login, self.saved, self.other])
         raise AssertionError(selector)
 
     async def wait_for_timeout(self, _timeout) -> None:
+        self.waits += 1
         if self.saved.clicked:
             self.heading_visible = False
+        elif self.picker_after and self.waits >= self.picker_after:
+            self.heading_visible = True
 
 
 class ChatGptUiDriverTests(unittest.TestCase):
@@ -344,7 +364,7 @@ class ChatGptUiDriverTests(unittest.TestCase):
         self.assertFalse(is_cloudflare_challenge_title(None))
 
     def test_saved_account_choice_ignores_login_chrome(self) -> None:
-        self.assertTrue(is_saved_account_choice("Fricoben\nben@example.com"))
+        self.assertTrue(is_saved_account_choice("Ada\nada@example.com"))
         self.assertFalse(is_saved_account_choice("Log in"))
         self.assertFalse(is_saved_account_choice("Log in to another account"))
         self.assertFalse(is_saved_account_choice("Create account"))
@@ -369,6 +389,13 @@ class ChatGptUiDriverTests(unittest.TestCase):
         self.assertFalse(page.login.clicked)
         self.assertFalse(page.other.clicked)
         self.assertFalse(page.heading_visible)
+
+    def test_saved_account_picker_waits_for_late_welcome_back_overlay(self) -> None:
+        page = AccountPickerPage(heading_visible=False, picker_after=3)
+        selected = asyncio.run(complete_saved_account_picker(page, timeout_ms=2_000))
+        self.assertTrue(selected)
+        self.assertGreaterEqual(page.waits, 3)
+        self.assertTrue(page.saved.clicked)
 
     def test_explicit_rate_limit_heading_is_classified(self) -> None:
         page = FakeComposerPage(False, False, rate_limited=True)

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -4,6 +4,10 @@ import asyncio
 import unittest
 
 from scripts.chatgpt_ui_driver import (
+    complete_saved_account_picker,
+    is_cloudflare_challenge_title,
+    is_saved_account_choice,
+    wait_out_cloudflare,
     MODEL_PICKER_READY_TIMEOUT_MS,
     SEND_BUTTON_NAME,
     SEND_CONTROL_TESTIDS,
@@ -11,6 +15,7 @@ from scripts.chatgpt_ui_driver import (
     STOP_CONTROL_TESTIDS,
     RateLimited,
     RATE_LIMIT_MODAL_TESTID,
+    TransportUnavailable,
     choose_intelligence_model,
     click_send_control,
     close_context_quietly,
@@ -213,6 +218,12 @@ class HydratingConversationPage:
     async def goto(self, url, **_kwargs) -> None:
         self.url = url
 
+    async def title(self) -> str:
+        return "ChatGPT"
+
+    async def inner_text(self, _selector) -> str:
+        return ""
+
     def locator(self, selector):
         if selector == f'[data-testid="{RATE_LIMIT_MODAL_TESTID}"]:visible':
             return HydratingLocator([0])
@@ -240,7 +251,125 @@ class HydratingConversationPage:
         return HydratingLocator([0 if exact else 0])
 
 
+class CloudflareClearingPage:
+    def __init__(self) -> None:
+        self.titles = ["Just a moment...", "Just a moment...", "ChatGPT"]
+        self.bodies = ["Verifying...", "Verifying...", "Welcome back"]
+        self.index = 0
+
+    async def title(self) -> str:
+        return self.titles[min(self.index, len(self.titles) - 1)]
+
+    async def inner_text(self, _selector) -> str:
+        return self.bodies[min(self.index, len(self.bodies) - 1)]
+
+    async def wait_for_timeout(self, _timeout) -> None:
+        self.index += 1
+
+
+class StuckCloudflarePage:
+    async def title(self) -> str:
+        return "Just a moment..."
+
+    async def inner_text(self, _selector) -> str:
+        return "Verify you are human"
+
+    async def wait_for_timeout(self, _timeout) -> None:
+        return None
+
+
+class FakePickerButton:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.clicked = False
+
+    async def inner_text(self) -> str:
+        return self.text
+
+    async def click(self, **_kwargs) -> None:
+        self.clicked = True
+
+
+class FakePickerButtons:
+    def __init__(self, buttons) -> None:
+        self.buttons = buttons
+
+    async def count(self) -> int:
+        return len(self.buttons)
+
+    def nth(self, index):
+        return self.buttons[index]
+
+
+class AccountPickerHeading:
+    def __init__(self, page) -> None:
+        self.page = page
+
+    async def count(self) -> int:
+        return 1 if self.page.heading_visible else 0
+
+    @property
+    def first(self):
+        return self
+
+    async def is_visible(self) -> bool:
+        return self.page.heading_visible
+
+
+class AccountPickerPage:
+    def __init__(self) -> None:
+        self.heading_visible = True
+        self.login = FakePickerButton("Log in")
+        self.saved = FakePickerButton("Fricoben\nben@example.com")
+        self.other = FakePickerButton("Log in to another account")
+
+    def get_by_text(self, _text, exact=False):
+        return AccountPickerHeading(self)
+
+    def locator(self, selector):
+        if selector == "button:visible":
+            return FakePickerButtons([self.login, self.saved, self.other])
+        raise AssertionError(selector)
+
+    async def wait_for_timeout(self, _timeout) -> None:
+        if self.saved.clicked:
+            self.heading_visible = False
+
+
 class ChatGptUiDriverTests(unittest.TestCase):
+    def test_cloudflare_challenge_titles_are_classified(self) -> None:
+        self.assertTrue(is_cloudflare_challenge_title("Just a moment..."))
+        self.assertTrue(is_cloudflare_challenge_title("Verifying..."))
+        self.assertFalse(is_cloudflare_challenge_title("ChatGPT"))
+        self.assertFalse(is_cloudflare_challenge_title(None))
+
+    def test_saved_account_choice_ignores_login_chrome(self) -> None:
+        self.assertTrue(is_saved_account_choice("Fricoben\nben@example.com"))
+        self.assertFalse(is_saved_account_choice("Log in"))
+        self.assertFalse(is_saved_account_choice("Log in to another account"))
+        self.assertFalse(is_saved_account_choice("Create account"))
+        self.assertFalse(is_saved_account_choice("Sign up for free"))
+        self.assertFalse(is_saved_account_choice("Remove account"))
+        self.assertFalse(is_saved_account_choice(""))
+
+    def test_cloudflare_wait_returns_once_the_interstitial_clears(self) -> None:
+        page = CloudflareClearingPage()
+        asyncio.run(wait_out_cloudflare(page, timeout_ms=2_000))
+        self.assertGreaterEqual(page.index, 2)
+
+    def test_cloudflare_wait_fails_closed_when_stuck(self) -> None:
+        with self.assertRaises(TransportUnavailable):
+            asyncio.run(wait_out_cloudflare(StuckCloudflarePage(), timeout_ms=1_000))
+
+    def test_saved_account_picker_clicks_the_email_card_not_log_in(self) -> None:
+        page = AccountPickerPage()
+        selected = asyncio.run(complete_saved_account_picker(page))
+        self.assertTrue(selected)
+        self.assertTrue(page.saved.clicked)
+        self.assertFalse(page.login.clicked)
+        self.assertFalse(page.other.clicked)
+        self.assertFalse(page.heading_visible)
+
     def test_explicit_rate_limit_heading_is_classified(self) -> None:
         page = FakeComposerPage(False, False, rate_limited=True)
 

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -5,6 +5,7 @@ import unittest
 
 from scripts.chatgpt_ui_driver import (
     complete_saved_account_picker,
+    intelligence_slider_index,
     is_cloudflare_challenge_title,
     is_saved_account_choice,
     wait_out_cloudflare,
@@ -437,6 +438,10 @@ class ChatGptUiDriverTests(unittest.TestCase):
         self.assertEqual(model_selection("GPT-5.6 Pro"), ("Pro", "gpt-5.6-pro"))
         self.assertEqual(model_selection("Extra High"), ("Extra High", "Extra High"))
         self.assertGreaterEqual(MODEL_PICKER_READY_TIMEOUT_MS, 45_000)
+        self.assertEqual(intelligence_slider_index("Pro"), 4)
+        self.assertEqual(intelligence_slider_index("Instant"), 0)
+        self.assertEqual(intelligence_slider_index("High"), 2)
+        self.assertIsNone(intelligence_slider_index("5.5"))
 
     def test_model_picker_waits_for_hydration_and_accepts_current_selection(
         self,

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -279,22 +279,23 @@ class StuckCloudflarePage:
 
 
 class FakePickerButton:
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, visible: bool = True) -> None:
         self.text = text
+        self.visible = visible
         self.clicked = False
 
     async def inner_text(self) -> str:
         return self.text
 
     async def is_visible(self) -> bool:
-        return True
+        return self.visible
 
     @property
     def first(self):
         return self
 
     async def count(self) -> int:
-        return 1
+        return 1 if self.visible else 0
 
     async def click(self, **_kwargs) -> None:
         self.clicked = True
@@ -346,12 +347,17 @@ class AccountPickerPage:
         return FakePickerButtons([self.login, self.saved, self.other])
 
     def locator(self, selector):
+        if "library" in selector or "scheduled" in selector or "accounts-profile" in selector:
+            if self.heading_visible:
+                return FakePickerButtons([])
+            return FakePickerButtons([FakePickerButton("Library")])
         raise AssertionError(selector)
 
     async def wait_for_timeout(self, _timeout) -> None:
         self.waits += 1
         if self.saved.clicked:
             self.heading_visible = False
+            self.login.visible = False
         elif self.picker_after and self.waits >= self.picker_after:
             self.heading_visible = True
 

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -181,7 +181,7 @@ impl ProviderType {
             "github-copilot" => Some(Self::GithubCopilot),
             "zai" => Some(Self::Zai),
             "minimax" => Some(Self::Minimax),
-            "muse" => Some(Self::Muse),
+            "muse" | "meta" => Some(Self::Muse),
             "kimi" => Some(Self::Kimi),
             "custom" => Some(Self::Custom),
             _ => None,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -30926,6 +30926,18 @@ And the report:
     }
 
     #[test]
+    fn test_normalize_model_override_for_backend_maps_muse_spark_onto_meta() {
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), "muse-spark-1.2"),
+            Some("meta/muse-spark-1.2".to_string())
+        );
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), "muse/muse-spark-1.2"),
+            Some("meta/muse-spark-1.2".to_string())
+        );
+    }
+
+    #[test]
     fn test_normalize_model_override_for_backend_maps_bare_grok_onto_xai() {
         assert_eq!(
             normalize_model_override_for_backend(Some("opencode"), "grok-4.6"),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -1011,6 +1011,26 @@ mod campaign_guard_tests {
         assert_eq!(updated.title.as_deref(), Some("Repair Lido PR #88"));
     }
 
+    #[tokio::test]
+    async fn untagged_new_mission_opening_message_is_accepted() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(None, None, None, None, None, None, None)
+            .await
+            .expect("create");
+        let loaded = store.get_mission(mission.id).await.unwrap().unwrap();
+        apply_writer_reuse_or_conflict(
+            &store,
+            &loaded,
+            None,
+            None,
+            None,
+            Some("Continue from PR #105. Launch P-TOPUP-2 and P-ALLOC-1.".into()),
+        )
+        .await
+        .expect("blank writer first message must not 409");
+    }
+
     #[test]
     fn dispatch_gate_blocks_paused_and_archived_only() {
         // paused → 423 Locked; archived → 409 Conflict.
@@ -30902,6 +30922,23 @@ And the report:
         assert_eq!(
             normalize_model_override_for_backend(Some("opencode"), " KIMI-K3-256K "),
             Some("kimi/k3-256k".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_model_override_for_backend_maps_bare_grok_onto_xai() {
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), "grok-4.6"),
+            Some("xai/grok-4.6".to_string())
+        );
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), "xai/grok-4.6"),
+            Some("xai/grok-4.6".to_string())
+        );
+        // Native grok backend keeps the bare CLI id.
+        assert_eq!(
+            normalize_model_override_for_backend(Some("grok"), "grok-4.6"),
+            Some("grok-4.6".to_string())
         );
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -277,6 +277,33 @@ pub(crate) fn message_activates_mission(status: MissionStatus) -> bool {
     )
 }
 
+/// Stash a newly arrived operator message as the mission's deferred goal.
+///
+/// Pending missions have not run yet, so multiple pre-dispatch messages
+/// concatenate. A Failed/Interrupted/… mission already executed its original
+/// prompt (left in `deferred_goal` on purpose for a capacity-race retry).
+/// Concatenating a follow-up onto that prompt buries the operator's message
+/// and the scheduler never re-dispatches non-Pending rows, so the follow-up
+/// is lost. Replace instead.
+pub(crate) fn deferred_goal_for_incoming_message(
+    status: MissionStatus,
+    previous_goal: Option<&str>,
+    content: &str,
+) -> String {
+    if status == MissionStatus::Pending {
+        match previous_goal {
+            Some(prev) if !prev.is_empty() => format!("{prev}\n{content}"),
+            _ => content.to_string(),
+        }
+    } else {
+        content.to_string()
+    }
+}
+
+fn follow_up_should_requeue_as_pending(status: MissionStatus) -> bool {
+    message_activates_mission(status) && status != MissionStatus::Pending
+}
+
 fn queued_delivery_requires_activation(
     target_mission_id: Option<Uuid>,
     source: Option<&str>,
@@ -8918,6 +8945,12 @@ async fn activate_mission_for_message(
         store
             .update_mission_status(mission.id, MissionStatus::Active)
             .await?;
+        // The original create prompt stays in deferred_goal after first
+        // dispatch so a capacity-race retry can re-inject it while still
+        // Pending. Once a later operator message activates the mission,
+        // that stale prompt must not be re-dispatched (or concatenated onto)
+        // after the next failure.
+        let _ = store.set_deferred_goal(mission.id, None).await;
         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
             mission_id: mission.id,
             status: MissionStatus::Active,
@@ -18350,12 +18383,11 @@ async fn control_actor_loop(
                                                 .await
                                                 .ok()
                                                 .flatten();
-                                            let combined = match previous_goal.as_deref() {
-                                                Some(prev) if !prev.is_empty() => {
-                                                    format!("{prev}\n{content}")
-                                                }
-                                                _ => content.clone(),
-                                            };
+                                            let combined = deferred_goal_for_incoming_message(
+                                                m.status,
+                                                previous_goal.as_deref(),
+                                                &content,
+                                            );
                                             if let Err(e) = mission_store
                                                 .set_deferred_goal(tid, Some(combined))
                                                 .await
@@ -18645,15 +18677,39 @@ async fn control_actor_loop(
                                         .await
                                         .ok()
                                         .flatten();
-                                    let combined = match previous_goal.as_deref() {
-                                        Some(prev) if !prev.is_empty() => {
-                                            format!("{prev}\n{content}")
-                                        }
-                                        _ => content.clone(),
-                                    };
+                                    let combined = deferred_goal_for_incoming_message(
+                                        mission.status,
+                                        previous_goal.as_deref(),
+                                        &content,
+                                    );
                                     match mission_store.set_deferred_goal(tid, Some(combined)).await
                                     {
                                         Ok(()) => {
+                                            if follow_up_should_requeue_as_pending(mission.status) {
+                                                if let Err(error) = mission_store
+                                                    .update_mission_status(
+                                                        tid,
+                                                        MissionStatus::Pending,
+                                                    )
+                                                    .await
+                                                {
+                                                    tracing::warn!(
+                                                        mission_id = %tid,
+                                                        "At capacity: stashed follow-up but could not requeue as pending: {error}"
+                                                    );
+                                                } else {
+                                                    let _ = events_tx.send(
+                                                        AgentEvent::MissionStatusChanged {
+                                                            mission_id: tid,
+                                                            status: MissionStatus::Pending,
+                                                            summary: Some(
+                                                                "Operator follow-up queued until a runner slot is free"
+                                                                    .to_string(),
+                                                            ),
+                                                        },
+                                                    );
+                                                }
+                                            }
                                             tracing::info!(
                                                 mission_id = %tid,
                                                 max_parallel,
@@ -32114,6 +32170,22 @@ Investigate <service/> failures.
             mission_status_for_terminal_reason(TerminalReason::Completed, true),
             Some((MissionStatus::Completed, "completed"))
         );
+    }
+
+    #[test]
+    fn deferred_goal_replaces_stale_prompt_on_failed_follow_up() {
+        let original = "You are GPT-5.6 Pro with web search. Research…";
+        let follow_up = "retry now, chatgpt ui is fixed";
+        assert_eq!(
+            deferred_goal_for_incoming_message(MissionStatus::Failed, Some(original), follow_up),
+            follow_up
+        );
+        assert_eq!(
+            deferred_goal_for_incoming_message(MissionStatus::Pending, Some(original), follow_up),
+            format!("{original}\n{follow_up}")
+        );
+        assert!(follow_up_should_requeue_as_pending(MissionStatus::Failed));
+        assert!(!follow_up_should_requeue_as_pending(MissionStatus::Pending));
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4954,6 +4954,7 @@ pub(crate) fn detect_opencode_provider_auth(
         if !value.trim().is_empty() {
             has_other = true;
             configured_providers.insert("muse".to_string());
+            configured_providers.insert("meta".to_string());
         }
     }
 
@@ -5401,27 +5402,11 @@ pub(crate) fn ensure_opencode_provider_for_model(
                 }
             }))
         }
-        "muse" => {
-            // Unlike minimax/xai, "muse" is not in OpenCode's built-in
-            // provider registry, so the key must be referenced explicitly.
-            // `{env:META_MODEL_API_KEY}` is expanded by OpenCode from the
-            // mission process env, which apply_opencode_auth_env populates
-            // from the provider store / server env (enum-driven via
-            // ProviderType::env_var_name).
-            let base_url = std::env::var("MUSE_BASE_URL")
-                .unwrap_or_else(|_| "https://api.meta.ai/v1".to_string());
-            Some(serde_json::json!({
-                "npm": "@ai-sdk/openai-compatible",
-                "name": "Meta Muse",
-                "models": {
-                    model_id: { "name": model_id }
-                },
-                "options": {
-                    "baseURL": base_url,
-                    "apiKey": "{env:META_MODEL_API_KEY}"
-                }
-            }))
-        }
+        // OpenCode 1.18+ ships a native `meta` provider that calls
+        // `sdk.responses()` and applies the Meta system prompt. Do not inject
+        // an openai-compatible `muse` block — that forced Chat Completions and
+        // skipped encrypted reasoning / the Spark 1.2 coding prompt.
+        "muse" | "meta" => None,
         "cerebras" => Some(serde_json::json!({
             "npm": "@ai-sdk/cerebras",
             "name": "Cerebras",
@@ -5738,15 +5723,21 @@ fn build_opencode_auth_from_ai_providers(
         }
         let keys: Vec<&str> = match provider.provider_type {
             crate::ai_providers::ProviderType::OpenAI => vec!["openai", "codex"],
+            crate::ai_providers::ProviderType::Muse => vec!["muse", "meta"],
             _ => vec![provider.provider_type.id()],
         };
         if let Some(api_key) = provider.api_key {
-            let entry = serde_json::json!({
-                "type": "api_key",
-                "key": api_key,
-            });
             for key in &keys {
-                map.insert((*key).to_string(), entry.clone());
+                // OpenCode 1.18 native Auth only loads `type: "api"`. Keep
+                // `api_key` on the legacy `muse` alias for older CLIs.
+                let auth_type = if *key == "meta" { "api" } else { "api_key" };
+                map.insert(
+                    (*key).to_string(),
+                    serde_json::json!({
+                        "type": auth_type,
+                        "key": api_key,
+                    }),
+                );
             }
         } else if let Some(oauth) = provider.oauth {
             let entry = serde_json::json!({
@@ -5894,6 +5885,7 @@ pub(crate) fn sync_opencode_auth_to_workspace(
         "cerebras",
         "minimax",
         "muse",
+        "meta",
     ];
     if let (Some(src_dir), Some(dest_dir)) =
         (host_opencode_provider_auth_dir(), provider_auth_dir.clone())
@@ -9267,12 +9259,13 @@ fn cleanup_old_debug_files(
 #[cfg(test)]
 mod tests {
     use super::{
-        actual_cost_cents_from_total_cost_usd, apply_terminal_result_text, bind_command_params,
-        classify_copied_opencode_probe, claudecode_idle_timeout_for_state,
-        claudecode_incomplete_turn_message, claudecode_install_command,
-        claudecode_malformed_startup_message, claudecode_pre_turn_transport_message,
-        claudecode_resume_current_session_message, claudecode_transport_failure_data,
-        claudecode_transport_failure_stage, claudecode_transport_failure_stage_for_incomplete_turn,
+        actual_cost_cents_from_total_cost_usd, apply_opencode_auth_env, apply_terminal_result_text,
+        bind_command_params, build_opencode_auth_from_ai_providers, classify_copied_opencode_probe,
+        claudecode_idle_timeout_for_state, claudecode_incomplete_turn_message,
+        claudecode_install_command, claudecode_malformed_startup_message,
+        claudecode_pre_turn_transport_message, claudecode_resume_current_session_message,
+        claudecode_transport_failure_data, claudecode_transport_failure_stage,
+        claudecode_transport_failure_stage_for_incomplete_turn,
         claudecode_transport_recovery_strategy, clear_codex_account_cooldown,
         codex_account_cooldown_remaining, codex_chatgpt_fallback_for_result,
         codex_chatgpt_fallback_model, codex_cooldown_for_reason, codex_error_message_to_surface,
@@ -9698,6 +9691,47 @@ mod tests {
         assert_eq!(merged["anthropic"]["access"], "fresh");
         assert_eq!(merged["anthropic"]["expires"], 2);
         assert_eq!(merged["unmanaged"]["key"], "preserved");
+    }
+
+    #[test]
+    fn muse_provider_auth_is_written_under_opencode_meta_key() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let store = temp.path().join(".sandboxed-sh");
+        fs::create_dir_all(&store).expect("store");
+        let mut provider = crate::ai_providers::AIProvider::new(
+            crate::ai_providers::ProviderType::Muse,
+            "Meta Muse".to_string(),
+        );
+        provider.api_key = Some("sk-meta-test".to_string());
+        fs::write(
+            store.join("ai_providers.json"),
+            serde_json::to_string(&vec![provider]).expect("serialize"),
+        )
+        .expect("write store");
+
+        let auth = build_opencode_auth_from_ai_providers(temp.path()).expect("auth");
+        assert_eq!(auth["meta"]["type"], "api");
+        assert_eq!(auth["meta"]["key"], "sk-meta-test");
+        assert_eq!(auth["muse"]["type"], "api_key");
+        assert_eq!(auth["muse"]["key"], "sk-meta-test");
+
+        let mut env = std::collections::HashMap::new();
+        let providers = apply_opencode_auth_env(&auth, &mut env);
+        assert_eq!(
+            env.get("META_MODEL_API_KEY").map(String::as_str),
+            Some("sk-meta-test")
+        );
+        assert!(providers.contains(&"muse"));
+
+        let meta_only = serde_json::json!({
+            "meta": { "type": "api_key", "key": "sk-meta-only" }
+        });
+        let mut env = std::collections::HashMap::new();
+        apply_opencode_auth_env(&meta_only, &mut env);
+        assert_eq!(
+            env.get("META_MODEL_API_KEY").map(String::as_str),
+            Some("sk-meta-only")
+        );
     }
 
     #[test]
@@ -11146,6 +11180,51 @@ mod tests {
             .as_str()
             .expect("mission id header");
         assert_eq!(mission_header, "00000000-0000-0000-0000-000000000123");
+    }
+
+    #[test]
+    fn ensure_opencode_provider_does_not_inject_muse_chat_adapter() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config_dir = temp.path().join("ws");
+        let app_dir = temp.path().join("app");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::create_dir_all(&app_dir).unwrap();
+
+        ensure_opencode_provider_for_model(
+            &config_dir,
+            &app_dir,
+            "meta/muse-spark-1.2",
+            "127.0.0.1",
+            None,
+        );
+        ensure_opencode_provider_for_model(
+            &config_dir,
+            &app_dir,
+            "muse/muse-spark-1.2",
+            "127.0.0.1",
+            None,
+        );
+
+        let path = config_dir.join("opencode.json");
+        if path.exists() {
+            let opencode_json: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&path).expect("opencode.json"))
+                    .expect("parse");
+            assert!(
+                opencode_json
+                    .get("provider")
+                    .and_then(|p| p.get("muse"))
+                    .is_none(),
+                "must not inject a muse openai-compatible block"
+            );
+            assert!(
+                opencode_json
+                    .get("provider")
+                    .and_then(|p| p.get("meta"))
+                    .is_none(),
+                "must not override OpenCode's native meta Responses provider"
+            );
+        }
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11148,6 +11148,42 @@ mod tests {
         assert_eq!(mission_header, "00000000-0000-0000-0000-000000000123");
     }
 
+    #[test]
+    fn ensure_opencode_provider_builtin_accepts_xai_slash_model_id() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config_dir = temp.path().join("ws");
+        let app_dir = temp.path().join("app");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::create_dir_all(&app_dir).unwrap();
+
+        // `--model builtin/xai/grok-4.6` splits as provider=builtin,
+        // model=xai/grok-4.6. The model key must keep the slash so the
+        // proxy sees the full provider/model passthrough id.
+        ensure_opencode_provider_for_model(
+            &config_dir,
+            &app_dir,
+            "builtin/xai/grok-4.6",
+            "127.0.0.1",
+            Some("00000000-0000-0000-0000-000000000123"),
+        );
+
+        let opencode_json: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
+        )
+        .expect("parse opencode.json");
+        assert_eq!(
+            opencode_json["provider"]["builtin"]["models"]["xai/grok-4.6"]["name"],
+            "xai/grok-4.6"
+        );
+        let base_url = opencode_json["provider"]["builtin"]["options"]["baseURL"]
+            .as_str()
+            .expect("baseURL");
+        assert!(
+            base_url.starts_with("http://127.0.0.1:"),
+            "expected loopback proxy baseURL, got {base_url}"
+        );
+    }
+
     // ── extract_part_text tests ───────────────────────────────────────
 
     #[test]

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -524,14 +524,34 @@ pub async fn get_project(
     if !is_plain_key(&slug) {
         return Err(bad_slug());
     }
-    let Some(slug) = resolve_roster_slug(&state.projects, &slug).map_err(store_err)? else {
-        return Err((StatusCode::NOT_FOUND, format!("unknown project '{slug}'")));
+    let requested = slug;
+    let resolved = resolve_roster_slug(&state.projects, &requested).map_err(store_err)?;
+    let lookup = resolved.as_deref().unwrap_or(&requested).to_string();
+    let missions = match state
+        .control
+        .collect_attention_missions_for_project(&lookup)
+        .await
+    {
+        Ok(missions) => missions,
+        Err(error) => {
+            tracing::warn!(project = %lookup, %error, "get_project: attention collect failed");
+            Vec::new()
+        }
     };
-    let project = state
-        .projects
-        .get_project(&slug)
-        .map_err(store_err)?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("unknown project '{slug}'")))?;
+    let slug = match resolved {
+        Some(slug) => slug,
+        None if !missions.is_empty() => lookup.clone(),
+        None => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                format!("unknown project '{requested}'"),
+            ));
+        }
+    };
+    let project = match state.projects.get_project(&slug).map_err(store_err)? {
+        Some(project) => project,
+        None => synthetic_project_record(&slug),
+    };
     let grant = state.projects.get_grant(&slug).map_err(store_err)?;
     let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
     let decisions = state.projects.open_decisions(&slug).map_err(store_err)?;
@@ -545,17 +565,6 @@ pub async fn get_project(
         .map_err(store_err)?
         .map(follow_live_conversation);
     let items = load_project_items(&state, &slug).await?;
-    let missions = match state
-        .control
-        .collect_attention_missions_for_project(&slug)
-        .await
-    {
-        Ok(missions) => missions,
-        Err(error) => {
-            tracing::warn!(project = %slug, %error, "get_project: attention collect failed");
-            Vec::new()
-        }
-    };
     let mut project = project;
     if let Some(derived) = next_action_from_live_titles(
         missions
@@ -2315,6 +2324,26 @@ pub(crate) fn humanize_slug(slug: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Board-visible mission-tag project that has no roster row yet.
+fn synthetic_project_record(slug: &str) -> super::projects_store::ProjectRecord {
+    let now = chrono::Utc::now().to_rfc3339();
+    super::projects_store::ProjectRecord {
+        slug: slug.to_string(),
+        title: Some(humanize_slug(slug)),
+        objective: None,
+        status: "active".to_string(),
+        mode: None,
+        wait_ticks: 0,
+        next_action: None,
+        blocker: None,
+        controller_cron_id: None,
+        repository: None,
+        created_at: now.clone(),
+        updated_at: now,
+        mode_signal_at: None,
+    }
 }
 
 /// Roster/CTRL mode is the default; live work and parked decisions win.

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1230,7 +1230,7 @@ fn default_providers_config() -> ProvidersConfig {
                 id: "muse".to_string(),
                 name: "Meta Muse".to_string(),
                 billing: "api_key".to_string(),
-                description: "Meta's Muse family via api.meta.ai (OpenAI-compatible)".to_string(),
+                description: "Meta's Muse family via api.meta.ai (OpenCode native meta Responses provider)".to_string(),
                 // Verified live against /models on 2026-08-06; the catalog
                 // refresh overwrites this with the fetched list when the key
                 // is present.
@@ -1238,12 +1238,17 @@ fn default_providers_config() -> ProvidersConfig {
                     ProviderModel {
                         id: "muse-spark-1.2".to_string(),
                         name: "Muse Spark 1.2".to_string(),
-                        description: Some("Fast reasoning model".to_string()),
+                        description: Some("Coding-focused Spark 1.2".to_string()),
                     },
                     ProviderModel {
                         id: "muse-spark-1.1".to_string(),
                         name: "Muse Spark 1.1".to_string(),
                         description: None,
+                    },
+                    ProviderModel {
+                        id: "muse-spark-1.2-contributor".to_string(),
+                        name: "Muse Spark 1.2 Contributor".to_string(),
+                        description: Some("Lower-cost Spark 1.2 tier".to_string()),
                     },
                 ],
             },

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1289,7 +1289,12 @@ async fn native_protocol_proxy(
         };
         let credential = credential.as_str();
         supported_entries += 1;
-        let upstream_body = match rewrite_model(&body, &entry.model_id) {
+        let rewrite_model_id = if via_cli_proxy && provider_type == ProviderType::Xai {
+            cli_proxy_xai_model_id(&entry.model_id)
+        } else {
+            entry.model_id.as_str()
+        };
+        let upstream_body = match rewrite_model(&body, rewrite_model_id) {
             Ok(body) => body,
             Err(error) => {
                 return error_response(
@@ -1736,7 +1741,8 @@ pub(crate) async fn chat_completions_inner(
                 build_cli_proxy_headers(),
             )
         } else if use_xai_oauth_cli_proxy_adapter {
-            let upstream_body = match rewrite_model(&body, &entry.model_id) {
+            let upstream_model = cli_proxy_xai_model_id(&entry.model_id);
+            let upstream_body = match rewrite_model(&body, upstream_model) {
                 Ok(b) => b,
                 Err(e) => {
                     tracing::error!("Failed to rewrite model in request body: {}", e);
@@ -3193,6 +3199,19 @@ fn rewrite_model(body: &[u8], new_model: &str) -> Result<bytes::Bytes, String> {
     serde_json::to_vec(&value)
         .map(bytes::Bytes::from)
         .map_err(|e| format!("Failed to serialize: {}", e))
+}
+
+/// CLIProxyAPI's xAI executor keys models by exact id. Official rolling
+/// aliases in our catalog (`grok-4.6-latest`) are not CLI-proxy IDs — it
+/// returns HTTP 502 `unknown provider for model grok-4.6-latest` in a few
+/// milliseconds, which the waterfall then surfaces as "chain unavailable".
+fn cli_proxy_xai_model_id(model_id: &str) -> &str {
+    match model_id {
+        "grok-4.6-latest" => "grok-4.6",
+        "grok-4.5-latest" => "grok-4.5",
+        "grok-build-latest" => "grok-4.5",
+        other => other,
+    }
 }
 
 /// Newer Opus models reject explicit sampling params (`temperature`, `top_p`,
@@ -6544,6 +6563,15 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn cli_proxy_xai_model_id_maps_rolling_aliases() {
+        assert_eq!(cli_proxy_xai_model_id("grok-4.6-latest"), "grok-4.6");
+        assert_eq!(cli_proxy_xai_model_id("grok-4.6"), "grok-4.6");
+        assert_eq!(cli_proxy_xai_model_id("grok-4.5-latest"), "grok-4.5");
+        assert_eq!(cli_proxy_xai_model_id("grok-build-latest"), "grok-4.5");
+        assert_eq!(cli_proxy_xai_model_id("grok-4.3"), "grok-4.3");
     }
 
     #[test]

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -206,7 +206,12 @@ fn safe_driver_diagnostic(message: &str) -> Option<&str> {
         | "compatibility=chatgpt-ui-v2; browser=firefox"
         | "compatibility=chatgpt-ui-v2; browser=webkit"
         | "stage=page_loaded"
+        | "stage=cloudflare_wait"
+        | "stage=cloudflare_cleared"
+        | "stage=account_picker"
+        | "stage=account_picker_selected"
         | "stage=account_confirmed"
+        | "stage=account_confirmed_via_nav"
         | "stage=blank_route"
         | "stage=composer_ready"
         | "stage=send_button_fallback"
@@ -1406,6 +1411,18 @@ mod tests {
         assert_eq!(
             safe_driver_diagnostic("stage=stop_button_fallback"),
             Some("stage=stop_button_fallback")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("stage=cloudflare_wait"),
+            Some("stage=cloudflare_wait")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("stage=account_picker_selected"),
+            Some("stage=account_picker_selected")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("stage=account_confirmed_via_nav"),
+            Some("stage=account_confirmed_via_nav")
         );
         assert_eq!(
             safe_driver_diagnostic("stage=page_loaded account=user@example.com"),

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -131,7 +131,7 @@ pub async fn run_opencode_turn(
                 .ok()
                 .filter(|v| !v.trim().is_empty())
         })
-        .map(|model| normalize_opencode_model_id(&model).into_owned());
+        .map(|model| canonicalize_opencode_cli_model(&model));
     let auth_state = detect_opencode_provider_auth(Some(app_working_dir));
     let has_openai = auth_state.has_openai;
     let has_anthropic = auth_state.has_anthropic;
@@ -146,6 +146,10 @@ pub async fn run_opencode_turn(
     let configured_providers = &auth_state.configured_providers;
     let provider_available = |provider: &str| -> bool {
         match provider {
+            // Injected per mission and backed by the sandboxed proxy / CLI-proxy.
+            // Must not require an OpenCode auth.json account (subscription Grok
+            // is OAuth inside CLIProxyAPI, not an xAI API key).
+            "builtin" => true,
             "anthropic" | "claude" => has_anthropic,
             "openai" | "codex" => has_openai,
             "google" | "gemini" => has_google,
@@ -281,7 +285,7 @@ pub async fn run_opencode_turn(
     let mut total_cache_creation_input_tokens: u64 = 0;
     let mut total_cache_read_input_tokens: u64 = 0;
     let agent_model = resolve_opencode_model_from_config(&opencode_config_dir_host, agent)
-        .map(|model| normalize_opencode_model_id(&model).into_owned());
+        .map(|model| canonicalize_opencode_cli_model(&model));
     if resolved_model.is_none() {
         resolved_model = agent_model.clone();
     }
@@ -2184,6 +2188,15 @@ fn opencode_model_argument(model: Option<&str>) -> Cow<'_, str> {
     }
 }
 
+/// Normalize aliases then wrap proxy-routed Grok/xAI ids as `builtin/…`
+/// *before* the runner inspects the first path segment as an OpenCode
+/// provider. Otherwise `xai/grok-4.6` is dropped when OpenCode auth.json
+/// has no xAI API key (subscription Grok is CLI-proxy OAuth).
+fn canonicalize_opencode_cli_model(model: &str) -> String {
+    let canonical = normalize_opencode_model_id(model);
+    opencode_model_argument(Some(canonical.as_ref())).into_owned()
+}
+
 fn model_is_xai_provider_id(model: &str) -> bool {
     model
         .split_once('/')
@@ -2211,7 +2224,10 @@ fn opencode_path(
 
 #[cfg(test)]
 mod path_tests {
-    use super::{normalize_opencode_model_id, opencode_model_argument, opencode_path};
+    use super::{
+        canonicalize_opencode_cli_model, normalize_opencode_model_id, opencode_model_argument,
+        opencode_path,
+    };
 
     #[test]
     fn legacy_kimi_k3_aliases_are_canonicalized() {
@@ -2271,6 +2287,26 @@ mod path_tests {
         assert_eq!(
             opencode_model_argument(Some("xai/grok-4.6")),
             "builtin/xai/grok-4.6"
+        );
+        // Wrap happens before the provider-availability check so the first
+        // path segment is `builtin`, not catalog `xai` (which is absent when
+        // Grok is CLI-proxy OAuth only).
+        assert_eq!(
+            canonicalize_opencode_cli_model("grok-4.6"),
+            "builtin/xai/grok-4.6"
+        );
+        assert_eq!(
+            canonicalize_opencode_cli_model("xai/grok-4.6"),
+            "builtin/xai/grok-4.6"
+        );
+        let provider = canonicalize_opencode_cli_model("grok-4.6")
+            .split_once('/')
+            .map(|(p, _)| p.to_string())
+            .expect("slash");
+        assert_eq!(provider, "builtin");
+        assert!(
+            !crate::api::providers::DEFAULT_CATALOG_PROVIDER_IDS.contains(&provider.as_str()),
+            "builtin must not be treated as a catalog provider that requires OpenCode auth"
         );
     }
 

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -38,11 +38,21 @@ const PROXY_STREAM_INACTIVITY_CAP: std::time::Duration = std::time::Duration::fr
 /// Older Hermes skills used `kimi-k3`. OpenCode parses a slash-less value as
 /// a provider name with an empty model and fails with `Model not found:
 /// kimi-k3/`, even when the Kimi subscription itself is healthy.
+///
+/// Bare Grok ids (`grok-4.6`, `grok-4.5`, …) have the same trap: OpenCode
+/// records `providerID=grok-4.6, id=""` and the local server returns the
+/// opaque `Unexpected server error` that killed probe `b3dd8b65`. Map them
+/// onto the xAI provider prefix so the CLI argument can then be wrapped
+/// through `builtin/` (CLI-proxy OAuth + stream liveness).
 pub(crate) fn normalize_opencode_model_id(model: &str) -> Cow<'_, str> {
     let model = model.trim();
-    match model.to_ascii_lowercase().as_str() {
+    let lower = model.to_ascii_lowercase();
+    match lower.as_str() {
         "kimi-k3" => Cow::Borrowed("kimi/k3"),
         "kimi-k3-256k" => Cow::Borrowed("kimi/k3-256k"),
+        _ if !lower.contains('/') && lower.starts_with("grok-") => {
+            Cow::Owned(format!("xai/{lower}"))
+        }
         _ => Cow::Borrowed(model),
     }
 }
@@ -370,6 +380,26 @@ pub async fn run_opencode_turn(
     };
 
     let opencode_model = opencode_model_argument(resolved_model.as_deref());
+    // OpenCode's `--model` parser splits on the first `/`. A slash-less
+    // value becomes provider=<id> model="" and the CLI's local server
+    // answers with a generic 500 (`Unexpected server error`) instead of
+    // `Model not found`. Fail here with the actual id so a mis-dispatched
+    // probe is diagnosable.
+    if !opencode_model.contains('/') {
+        let err_msg = format!(
+            "OpenCode model '{opencode_model}' has no provider prefix. \
+             OpenCode treats the first path segment as the provider, so this \
+             becomes '{opencode_model}/' and fails with an opaque server error. \
+             Use provider/model (e.g. xai/grok-4.6, builtin/smart, zai/glm-5.2)."
+        );
+        tracing::error!(mission_id = %mission_id, "{}", err_msg);
+        let _ = events_tx.send(AgentEvent::Error {
+            message: err_msg.clone(),
+            mission_id: Some(mission_id),
+            resumable: true,
+        });
+        return AgentResult::failure(err_msg, 0).with_terminal_reason(TerminalReason::LlmError);
+    }
     if opencode_model.starts_with("builtin/") {
         ensure_opencode_provider_for_model(
             &opencode_config_dir_host,
@@ -2132,13 +2162,32 @@ pub async fn run_opencode_turn(
 /// the remainder as the upstream model. Route the exact Grok CLI bridge model
 /// through the existing `builtin` provider so the proxy receives the complete
 /// `grok-cli/grok-4.5` chain id instead of the ambiguous bare `grok-4.5`.
+///
+/// Direct `xai/grok-*` is wrapped the same way. OpenCode's native `@ai-sdk/xai`
+/// adapter talks to `api.x.ai` with an API key (or, worse, an OAuth token
+/// stuffed into `XAI_API_KEY`). Subscription Grok lives on CLIProxyAPI's
+/// Responses transport; going through `builtin` is what:
+///   1. authenticates with the loopback proxy (OAuth stays inside CLIProxyAPI),
+///   2. sends `x-sandboxed-mission-id` so reasoning chunks reset the idle
+///      watchdog (`proxy_liveness`) instead of dying after 300s of harness
+///      silence — the stall that killed writer `4d823bd9` gen1.
 fn opencode_model_argument(model: Option<&str>) -> Cow<'_, str> {
     let model = model.unwrap_or("builtin/fast");
-    if crate::api::grok_tool_bridge::is_bridge_model(model) {
+    if model.starts_with("builtin/") {
+        Cow::Borrowed(model)
+    } else if crate::api::grok_tool_bridge::is_bridge_model(model)
+        || model_is_xai_provider_id(model)
+    {
         Cow::Owned(format!("builtin/{model}"))
     } else {
         Cow::Borrowed(model)
     }
+}
+
+fn model_is_xai_provider_id(model: &str) -> bool {
+    model
+        .split_once('/')
+        .is_some_and(|(provider, rest)| provider.eq_ignore_ascii_case("xai") && !rest.is_empty())
 }
 
 fn opencode_path(
@@ -2187,9 +2236,42 @@ mod path_tests {
         );
         assert_eq!(
             opencode_model_argument(Some("xai/grok-4.5")),
-            "xai/grok-4.5"
+            "builtin/xai/grok-4.5"
+        );
+        assert_eq!(
+            opencode_model_argument(Some("builtin/xai/grok-4.6")),
+            "builtin/xai/grok-4.6"
         );
         assert_eq!(opencode_model_argument(None), "builtin/fast");
+    }
+
+    #[test]
+    fn bare_grok_ids_are_canonicalized_onto_xai_then_builtin_proxy() {
+        assert_eq!(normalize_opencode_model_id("grok-4.6"), "xai/grok-4.6");
+        assert_eq!(
+            normalize_opencode_model_id(" Grok-4.6-latest "),
+            "xai/grok-4.6-latest"
+        );
+        assert_eq!(normalize_opencode_model_id("grok-4.5"), "xai/grok-4.5");
+        assert_eq!(
+            normalize_opencode_model_id("grok-build-0.1"),
+            "xai/grok-build-0.1"
+        );
+        // Already-prefixed ids must not be double-wrapped at normalize time.
+        assert_eq!(normalize_opencode_model_id("xai/grok-4.6"), "xai/grok-4.6");
+        assert_eq!(
+            normalize_opencode_model_id("grok-cli/grok-4.5"),
+            "grok-cli/grok-4.5"
+        );
+        let canonical = normalize_opencode_model_id("grok-4.6");
+        assert_eq!(
+            opencode_model_argument(Some(canonical.as_ref())),
+            "builtin/xai/grok-4.6"
+        );
+        assert_eq!(
+            opencode_model_argument(Some("xai/grok-4.6")),
+            "builtin/xai/grok-4.6"
+        );
     }
 
     #[test]

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -53,6 +53,13 @@ pub(crate) fn normalize_opencode_model_id(model: &str) -> Cow<'_, str> {
         _ if !lower.contains('/') && lower.starts_with("grok-") => {
             Cow::Owned(format!("xai/{lower}"))
         }
+        // OpenCode 1.18+ ships a native `meta` provider (`sdk.responses`,
+        // Meta system prompt). Bare Muse Spark ids and the legacy `muse/`
+        // prefix must not stay as provider=muse (openai-compatible chat).
+        _ if !lower.contains('/') && lower.starts_with("muse-spark") => {
+            Cow::Owned(format!("meta/{lower}"))
+        }
+        _ if lower.starts_with("muse/") => Cow::Owned(format!("meta/{}", &lower["muse/".len()..])),
         _ => Cow::Borrowed(model),
     }
 }
@@ -153,6 +160,11 @@ pub async fn run_opencode_turn(
             "anthropic" | "claude" => has_anthropic,
             "openai" | "codex" => has_openai,
             "google" | "gemini" => has_google,
+            // OpenCode's native id is `meta`; we also mark `muse` when the
+            // META_MODEL_API_KEY / Muse provider row is present.
+            "muse" | "meta" => {
+                configured_providers.contains("muse") || configured_providers.contains("meta")
+            }
             // For known catalog providers (xai, zai, cerebras), check if they are actually configured
             p if crate::api::providers::DEFAULT_CATALOG_PROVIDER_IDS.contains(&p) => {
                 configured_providers.contains(p)
@@ -720,10 +732,9 @@ pub async fn run_opencode_turn(
 
     if let Some(auth) = opencode_auth.as_ref() {
         let providers = apply_opencode_auth_env(auth, &mut env);
-        // Server-env fallback for Muse: the key may live only in
-        // META_MODEL_API_KEY on the service (no provider row), and the
-        // opencode provider block references {env:META_MODEL_API_KEY}.
-        // Without this, a store-less deployment silently loses the key.
+        // Server-env fallback for Muse/Meta: OpenCode's native `meta`
+        // provider (and any leftover muse adapter) reads META_MODEL_API_KEY.
+        // The key may live only on the service with no provider-store row.
         if !env.contains_key("META_MODEL_API_KEY") {
             if let Ok(value) = std::env::var("META_MODEL_API_KEY") {
                 if !value.trim().is_empty() {
@@ -2238,6 +2249,26 @@ mod path_tests {
         );
         assert_eq!(normalize_opencode_model_id("kimi/k3"), "kimi/k3");
         assert_eq!(normalize_opencode_model_id("zai/glm-5"), "zai/glm-5");
+    }
+
+    #[test]
+    fn muse_spark_ids_use_opencode_native_meta_provider() {
+        assert_eq!(
+            normalize_opencode_model_id("muse-spark-1.2"),
+            "meta/muse-spark-1.2"
+        );
+        assert_eq!(
+            normalize_opencode_model_id("muse/muse-spark-1.2"),
+            "meta/muse-spark-1.2"
+        );
+        assert_eq!(
+            normalize_opencode_model_id("meta/muse-spark-1.2"),
+            "meta/muse-spark-1.2"
+        );
+        assert_eq!(
+            canonicalize_opencode_cli_model("muse-spark-1.2"),
+            "meta/muse-spark-1.2"
+        );
     }
 
     #[test]

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -35,7 +35,7 @@ use crate::workspace::{Workspace, WorkspaceStatus, WorkspaceType};
 
 /// Git remote used for sandboxed.sh self-updates
 const SANDBOXED_REPO_REMOTE: &str = "https://github.com/Th0rgal/sandboxed.sh.git";
-const MIN_SUPPORTED_OPENCODE_VERSION: &str = "1.1.59";
+const MIN_SUPPORTED_OPENCODE_VERSION: &str = "1.18.0";
 
 /// Information about a system component.
 #[derive(Debug, Clone, Serialize)]

--- a/src/api/writer_recycle.rs
+++ b/src/api/writer_recycle.rs
@@ -86,6 +86,14 @@ fn dispatch_is_different_work(stored: &WriterIdentity, patch: &WriterIdentityPat
         return false;
     }
 
+    // An untagged mission has no previous identity to protect. The first
+    // prompt on a new writer routinely names a PR (`#105`) or campaign
+    // (`P-TOPUP-2`); treating that as a silent recycle 409s the operator's
+    // opening message (mission 374fac82, 2026-08-19).
+    if !stored_has_writer_identity(stored) {
+        return false;
+    }
+
     let stored_pr = stored.github_pr.as_deref().map(canonical_github_pr);
     let stored_pr_number = stored_pr
         .as_ref()
@@ -177,6 +185,14 @@ fn campaign_tokens_in(hint: &str) -> Vec<String> {
         i += 1;
     }
     tokens
+}
+
+fn stored_has_writer_identity(stored: &WriterIdentity) -> bool {
+    field_nonempty(&stored.github_pr) || field_nonempty(&stored.track)
+}
+
+fn field_nonempty(value: &Option<String>) -> bool {
+    value.as_deref().is_some_and(|s| !s.trim().is_empty())
 }
 
 fn stored_identity_covers(track: &str, github_pr: Option<&str>, token: &str) -> bool {
@@ -300,5 +316,38 @@ mod tests {
         )
         .expect_err("different PR is different work");
         assert_eq!(err.error, "writer_identity_stale");
+    }
+
+    #[test]
+    fn untagged_new_mission_may_name_a_pr_and_campaign() {
+        let next = apply_writer_reuse(
+            &WriterIdentity::default(),
+            &WriterIdentityPatch {
+                work_hint: Some(
+                    "Base: continue from PR #105. Launch P-TOPUP-2 and P-ALLOC-1.".into(),
+                ),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect("first message on a blank writer is not a recycle");
+        assert_eq!(next.github_pr, None);
+        assert_eq!(next.track, None);
+    }
+
+    #[test]
+    fn whitespace_only_tags_are_untagged() {
+        let stored = WriterIdentity {
+            github_pr: Some("  ".into()),
+            track: Some("".into()),
+            title: None,
+        };
+        apply_writer_reuse(
+            &stored,
+            &WriterIdentityPatch {
+                work_hint: Some("Implement P-SSZ-1 on PR #105".into()),
+                ..WriterIdentityPatch::default()
+            },
+        )
+        .expect("blank tags are not a stale identity");
     }
 }

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -371,20 +371,23 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         aliases: &["minimax-m3"],
         pricing: pricing(600, 2_400, Some(375), Some(60)),
     },
-    // Meta Muse (api.meta.ai). TODO: replace with published per-token prices —
-    // none were available at integration time (2026-08-06); zero entries here
-    // would be SILENT zero-cost accounting, so this placeholder uses
-    // MiniMax-M3-class rates as a conservative stand-in and must be corrected
-    // when Meta publishes pricing.
+    // Meta Muse (api.meta.ai). models.dev / OpenCode catalog, checked 2026-08-19.
+    // Contributor must sit above the 1.2 family alias so "-contributor" does not
+    // inherit standard Spark rates via the `muse-spark` prefix.
+    PricingEntry {
+        canonical: "muse-spark-1.2-contributor",
+        aliases: &["muse-spark-1.2-contributor"],
+        pricing: pricing(100, 200, None, Some(2)),
+    },
     PricingEntry {
         canonical: "muse-spark-1.2",
-        aliases: &["muse-spark-1.2", "muse-spark"],
-        pricing: pricing(600, 2_400, None, None),
+        aliases: &["muse-spark-1.2"],
+        pricing: pricing(1_250, 4_250, None, Some(150)),
     },
     PricingEntry {
         canonical: "muse-spark-1.1",
         aliases: &["muse-spark-1.1"],
-        pricing: pricing(600, 2_400, None, None),
+        pricing: pricing(1_250, 4_250, None, Some(150)),
     },
     PricingEntry {
         canonical: "minimax-m2.7-highspeed",
@@ -655,6 +658,12 @@ mod tests {
             "minimax-m2.5-highspeed"
         );
         assert_eq!(normalize_model("minimax/MiniMax-M2.5"), "minimax-m2.5");
+        assert_eq!(normalize_model("meta/muse-spark-1.2"), "muse-spark-1.2");
+        assert_eq!(
+            normalize_model("muse/muse-spark-1.2-contributor"),
+            "muse-spark-1.2-contributor"
+        );
+        assert_eq!(normalize_model("muse-spark-1.1"), "muse-spark-1.1");
     }
 
     #[test]
@@ -697,6 +706,13 @@ mod tests {
         assert!(pricing_for_model("minimax/MiniMax-M3").is_some());
         assert!(pricing_for_model("minimax/MiniMax-M2.5-highspeed").is_some());
         assert!(pricing_for_model("minimax/MiniMax-M2.5").is_some());
+        let spark = pricing_for_model("meta/muse-spark-1.2").expect("spark 1.2");
+        assert_eq!(spark.input_nano_per_token, 1_250);
+        assert_eq!(spark.output_nano_per_token, 4_250);
+        let contributor =
+            pricing_for_model("muse-spark-1.2-contributor").expect("spark 1.2 contributor");
+        assert_eq!(contributor.input_nano_per_token, 100);
+        assert_eq!(contributor.output_nano_per_token, 200);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
OpenCode 1.18+ has a native `meta` provider that calls `sdk.responses()` and applies Meta’s Spark coding prompt. Sandboxed.sh was still injecting an openai-compatible `muse` Chat Completions block, so Spark 1.2 skipped encrypted reasoning and the native system prompt.

This maps `muse-spark*` / `muse/…` onto `meta/…`, writes OpenCode auth under both `muse` and `meta` (`type: api` for 1.18), and stops overriding the native provider.

## Host
Prod OpenCode on agent-core is already upgraded **1.17.18 → 1.18.18**. `opencode models meta` lists:
- `meta/muse-spark-1.2`
- `meta/muse-spark-1.2-contributor`
- `meta/muse-spark-1.1`

A live `opencode run --model meta/muse-spark-1.2` hit `https://api.meta.ai/v1/responses` (the native Responses path). Meta returned HTTP 402 `billing_not_configured` — routing is correct; the API key’s billing is not.

## Also
- Min supported OpenCode is now `1.18.0`
- Spark 1.2 / 1.1 / contributor pricing updated from models.dev
- Catalog includes `muse-spark-1.2-contributor`

## Test plan
- [x] Unit tests for model remap, no muse inject, meta auth key, pricing
- [x] Host CLI lists native meta Spark models
- [x] Host CLI reaches Meta Responses API
- [ ] Deploy this SHA to prod