### PR TITLE
docs: define the agent-native control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ isolation. The other half is a **coordinator** that decides *what* to do and
 CLI) and its bundled **hermes-desktop** Electron app (`apps/desktop/`) — but any
 MCP-capable assistant works. The agent never runs untrusted code itself; it
 hands each unit of work to sandboxed.sh, which runs it in a throwaway
-workspace/container and streams back structured results. Four concepts tie the
-system together:
+workspace/container and streams back structured results. The canonical target
+model is the
+[agent-native control-plane architecture](docs/AGENT_CONTROL_PLANE.md):
+portfolio → project → track → attempt → action → receipt → evidence. Four
+runtime concepts explain the current integration:
 
 | Concept | What it is | Where it lives |
 |---|---|---|
@@ -248,6 +251,8 @@ deployment:
 - **[Native Installation](docs/install-native.md)** - Bare metal Ubuntu setup
 
 ### Architecture & APIs
+- **[Agent-native control plane](docs/AGENT_CONTROL_PLANE.md)** - Canonical system model, epistemic contract, abstraction tower, and design laws
+- **[Agent-native roadmap](docs/AGENT_NATIVE_ROADMAP.md)** - Phased migration to bounded situation reads, receipts, atomic actions, leases, and accretive knowledge
 - **[Hermes orchestration](docs/HERMES_ORCHESTRATION.md)** - How Hermes and sandboxed.sh run autonomous projects: sessions, missions, controllers, routes
 - **[Harness System](docs/HARNESS_SYSTEM.md)** - Backend integration architecture
 - **[ChatGPT UI harness](docs/CHATGPT_UI_HARNESS.md)** - Experimental subscription-backed browser harness

--- a/docs/AGENT_CONTROL_PLANE.md
+++ b/docs/AGENT_CONTROL_PLANE.md
@@ -16,9 +16,12 @@ intent -> observe -> decide -> act -> receive receipt -> reconcile -> learn
 ```
 
 Every Paloma component exists to make one edge of this loop reliable. Hermes
-holds intent and judgment. sandboxed.sh holds execution, observations, and
-receipts. Skills supply policy. Projections make the whole loop legible to an
-agent and operator without creating another source of truth.
+holds the operator conversation and the coordinator's working judgment;
+sandboxed.sh owns canonical structured project intent, authority, execution,
+observations, and receipts. Hermes proposes intent changes through project
+commands rather than maintaining a second writable intent store. Skills supply
+policy. Projections make the whole loop legible to an agent and operator
+without creating another source of truth.
 
 ## The design objective
 
@@ -255,6 +258,15 @@ never an implicit retry. Successive steer or plan-revision commands therefore
 use distinct action IDs even within one attempt generation; controllers may
 derive deterministic IDs from the transition or wake event they are handling.
 
+Idempotency crosses the crash boundary. Before an external effect, the command
+service durably records the action as `prepared` with its ID, fingerprint,
+target, and expected outcome. It then uses the provider's idempotency token when
+available and advances the record through `dispatched` to `confirmed` with the
+receipt. Recovery reconciles `prepared` or `dispatched` records against the
+provider or target before retrying. If the outcome cannot be proved, the action
+becomes `ambiguous` and blocks automatic repetition until reconciliation or an
+explicit operator decision. An in-memory receipt cache is never sufficient.
+
 ### Wake conditions
 
 Waiting is data:
@@ -295,8 +307,14 @@ Ownership uses explicit leases over semantic mutation domains:
 - repository/branch writer lease;
 - scarce provider or compute slot lease.
 
-Leases have holders, scopes, expiry, and renewal evidence. “Another controller
-owns it” is true only when a live lease or observable action says so.
+Leases have holders, scopes, expiry, renewal evidence, and a monotonically
+increasing fencing generation. Every mutation gateway validates the presented
+generation against the current scope before accepting a write, so an expired
+holder cannot resume and mutate after reassignment. Where a target cannot
+validate fencing (for example, a direct Git credential), Paloma must revoke or
+terminate the old writer and prove that revocation before granting the next
+lease. Expiry alone never authorizes concurrent writers. “Another controller
+owns it” is true only when a live fenced lease or observable action says so.
 
 Resource policy should expose constraints and marginal cost, not a giant raw
 fleet dump. Placement returns a reasoned receipt: chosen node/provider,
@@ -329,9 +347,16 @@ precedence order so every surface projects the same result:
 2. `complete`: project acceptance is satisfied;
 3. `paused`: the grant says pause;
 4. `executing`: at least one valid live owner;
-5. `ready`: an unblocked track has no owner;
-6. `waiting`: every open track has a valid wake condition;
-7. `blocked`: every open track lacks both a ready action and a valid wake path.
+5. `ready`: at least one unblocked track has no owner;
+6. `blocked`: with no executing or ready track, at least one open track lacks a
+   valid wake path;
+7. `waiting`: every open track has a valid wake condition.
+
+These predicates are total under the project invariants: after excluding an
+owner and a ready action, any track without a wake path makes the aggregate
+`blocked`; otherwise all open tracks are waiting. No open tracks without
+satisfied project acceptance is an invariant violation and therefore
+`inconsistent`.
 
 For example, a project with an owned running track and a second unowned ready
 track is `executing`, while retaining `ready_track_count > 0` as a facet for

--- a/docs/AGENT_CONTROL_PLANE.md
+++ b/docs/AGENT_CONTROL_PLANE.md
@@ -1,0 +1,413 @@
+# The agent-native Paloma control plane
+
+Status: target architecture and design constitution. The implementation sequence
+is in [`AGENT_NATIVE_ROADMAP.md`](AGENT_NATIVE_ROADMAP.md).
+
+Paloma should feel to a controlling agent like one coherent instrument, not a
+collection of databases, dashboards, skills, crons, and mission tools. The
+agent's job is to choose the best next intervention. The system's job is to
+make the relevant reality cheap to perceive, safe to change, and hard to
+misrepresent.
+
+The governing loop is:
+
+```text
+intent -> observe -> decide -> act -> receive receipt -> reconcile -> learn
+```
+
+Every Paloma component exists to make one edge of this loop reliable. Hermes
+holds intent and judgment. sandboxed.sh holds execution, observations, and
+receipts. Skills supply policy. Projections make the whole loop legible to an
+agent and operator without creating another source of truth.
+
+## The design objective
+
+Optimize for **verified progress per unit of attention, context, compute,
+money, and operator interruption**.
+
+This produces seven requirements:
+
+1. The cheapest normal read returns a faithful, bounded situation.
+2. Declared intent is never confused with observed reality.
+3. Every consequential action has one owner, an authority basis, an
+   idempotency key, and a receipt.
+4. Completion means accepted evidence satisfies an explicit condition, not
+   that an agent said it finished.
+5. Waiting is represented as a wake condition, not recurring thought.
+6. Detail is progressively disclosed; routine ticks do not replay history.
+7. Experience accretes into reusable system knowledge with evidence, scope,
+   tests, and decay—not ever-growing prompt folklore.
+
+## The abstraction tower
+
+Each layer answers one question and has one canonical identity. Higher layers
+refer to lower layers by stable handles; they do not copy lower-layer state.
+
+```text
+Portfolio                    What deserves attention across the whole system?
+  Project                    What durable outcome are we pursuing, under what grant?
+    Track                    What independently satisfiable condition remains?
+      Attempt (mission/job)  Who is trying which bounded intervention right now?
+        Action               What external mutation or computation was requested?
+          Receipt            What does the system prove happened?
+            Evidence         Which immutable observation supports the claim?
+
+Conversation route          Where does judgment and operator communication continue?
+Resource lease              What scarce capacity/authority is temporarily reserved?
+Knowledge item              What reusable lesson was promoted from experience?
+```
+
+The side objects are orthogonal. A conversation is not a project, a mission is
+not a track, a track is not a branch, and a transcript is not evidence.
+
+### Current-to-target map
+
+The target model evolves the existing system; it does not discard it.
+
+| Current mechanism | Target interpretation | Remaining gap |
+|---|---|---|
+| `projects` + `project_grant` | project intent and authority | typed success/abandonment conditions and revisions |
+| `project_tracks`, proposals, boss-board tasks | track | one canonical track contract and verifier-bound acceptance |
+| mission row | attempt | explicit generation, owner lease, and causal action |
+| mission event / terminal evidence / PR or job handle | evidence candidate | normalized evidence references, freshness, and acceptance |
+| decision row + tool response + placement record | partial action receipt | one durable receipt schema across all action kinds |
+| `project_bindings` + Hermes route replica | conversation route | visible lag/reconciliation behind one authority contract |
+| mission caps, writer flag, fleet slots | partial resource/ownership lease | uniform scoped leases with expiry and holder evidence |
+| skills, runbooks, tests, incident notes | knowledge | provenance, promotion, supersession, and review lifecycle |
+
+Compatibility projections may preserve old shapes during migration, but new
+concepts should enter at the target layer rather than create another parallel
+representation.
+
+### Portfolio
+
+The portfolio is a projection, not a new store. It ranks projects by attention
+need and opportunity. It should answer, in one bounded read:
+
+- what needs the operator;
+- what can make progress now;
+- what is consuming resources without progress;
+- what changed since the previous cursor;
+- where capacity would have the highest expected value.
+
+### Project
+
+A project is the durable control envelope:
+
+- a stable slug and objective;
+- success and abandonment conditions;
+- autonomy and resource grant;
+- active tracks and their dependencies;
+- one canonical control-conversation route;
+- open decisions and current attention state.
+
+The project stores intent and authority. It does not duplicate mission logs,
+GitHub state, or host health.
+
+### Track
+
+A track is the smallest durable unit that can independently become satisfied,
+blocked, cancelled, or obsolete. It carries:
+
+- a stable key and desired condition;
+- machine-checkable acceptance criteria where possible;
+- dependencies on other tracks or external conditions;
+- exactly one semantic owner or an explicit `unowned` state;
+- a current attempt, if any;
+- a wake condition and next-check deadline when waiting;
+- an evidence policy describing what can close it.
+
+“Fix PR #42” can be a track. “Campaign” is usually a project. “Run Codex” is
+an attempt, not a track.
+
+### Attempt
+
+A mission is one attempt to advance a track. Attempts are disposable and may
+fail without corrupting the project model. They inherit the track's objective
+and constraints but record their own backend, workspace, model, resource
+lease, branch, and terminal outcome.
+
+At most one attempt owns a mutation domain such as a branch. Parallel readers
+are fine. Parallel writers require disjoint leases.
+
+### Action, receipt, and evidence
+
+An action is a requested mutation or computation. Its result is a receipt, not
+a prose assertion. A useful receipt records:
+
+- action kind, target, actor, authority basis, and idempotency key;
+- start/end timestamps and terminal disposition;
+- immutable external handles: mission UUID, commit SHA, PR URL/head, build ID,
+  node/job ID, deployment version;
+- evidence references and verification time;
+- cost and resource usage when available.
+
+Evidence is immutable or content-addressed whenever practical. It has a source,
+observation time, freshness class, and verifier. A mission transcript can point
+to evidence; it is not automatically evidence itself.
+
+## One situation model
+
+The primary agent read should be `get_situation`, exposed through the MCP and a
+matching HTTP endpoint. It is a materialized projection over existing stores,
+not a new authority. Its response is bounded and layered:
+
+```json
+{
+  "as_of": "...",
+  "cursor": "opaque-monotonic-cursor",
+  "scope": {"project": "verity-core"},
+  "attention": [{"kind": "decision", "ref": "...", "severity": "high"}],
+  "intent": {"objective": "...", "grant_version": 7},
+  "tracks": [{
+    "key": "parser-soundness",
+    "desired": "all acceptance checks pass at an immutable head",
+    "derived_state": "executing",
+    "owner": {"attempt_id": "...", "lease_until": "..."},
+    "wake": null,
+    "acceptance": {"satisfied": 2, "total": 4},
+    "latest_receipts": ["receipt:..."]
+  }],
+  "resources": {"binding_constraints": [], "warnings": []},
+  "changes": [],
+  "omitted": {"tracks": 0, "receipts": 14},
+  "links": {"track_detail": "...", "evidence": "..."}
+}
+```
+
+The response separates four epistemic classes:
+
+| Class | Meaning | Examples |
+|---|---|---|
+| **intent** | what should be true | objective, desired state, grant |
+| **observation** | what a source measured | PR head, process exit, node capacity |
+| **derivation** | deterministic conclusion from observations | overdue, lease conflict, acceptance 3/4 |
+| **judgment** | a controller's defeasible interpretation | best next action, hypothesis, priority |
+
+Every observation includes `observed_at`, source, and freshness. Every
+derivation exposes its inputs or rule version. Judgment is explicitly labeled
+and never overwrites observation.
+
+### Progressive disclosure
+
+Normal operation uses three read depths:
+
+1. `get_situation(scope, since_cursor)` — attention, deltas, and the working
+   set; target a small fixed payload.
+2. `get_track(key)` / `get_attempt(id)` — one bounded object with recent
+   receipts and omissions declared.
+3. `get_evidence(ref)` / paged events — raw detail only for dispute,
+   diagnosis, or audit.
+
+All list APIs should support `since_cursor`, server-side filters, stable sort,
+caps, and explicit omission counts. An empty result must distinguish “nothing
+matched,” “source unavailable,” and “not checked.”
+
+## The control protocol
+
+A controller tick should be a cheap transaction against a changing world:
+
+1. Read `get_situation(project, since_cursor)`.
+2. If there is a pending callback or operator decision, reconcile it first.
+3. Select the highest-value ready track without a valid owner.
+4. Preview the intended action when it crosses policy or resource boundaries.
+5. Execute one idempotent control command.
+6. Persist the returned receipt and expected wake condition.
+7. End. Do not poll while the system can wake the conversation on change.
+
+The next tick receives the previous cursor and a compact delta. A full snapshot
+is required only after cursor expiry, schema change, or detected inconsistency.
+
+### Intent-level commands
+
+The long-term MCP should expose a small control vocabulary:
+
+- `get_situation`
+- `get_track`
+- `propose_action`
+- `execute_action`
+- `reconcile_receipt`
+- `answer_decision`
+- `get_evidence`
+
+`execute_action` is a typed command such as `dispatch_attempt`, `steer_attempt`,
+`merge_pr`, `pause_project`, or `revise_plan`. The server resolves lower-level
+calls, validates the grant and leases, assigns an idempotency key, applies all
+related writes atomically, and returns a receipt.
+
+Existing granular tools remain as implementation primitives and compatibility
+surfaces. Agents should not have to remember that dispatch currently means
+`start_mission` followed by `link_mission_to_project`, a decision-ledger write,
+and a status update. One logical act must not require four fallible writes.
+
+### Optimistic concurrency and idempotency
+
+Every mutable project object has a revision. Commands accept the revision or
+situation cursor they were based on. A stale command fails with a compact
+conflict response containing the changed fields and a fresh cursor.
+
+Every external mutation has an idempotency key derived from project, track,
+action kind, and generation. Retrying after a timeout returns the original
+receipt rather than launching a duplicate mission or repeating a merge.
+
+### Wake conditions
+
+Waiting is data:
+
+```json
+{
+  "kind": "github_check_terminal",
+  "subject": "owner/repo#42@abc123",
+  "deadline": "...",
+  "fallback": "reconcile_ci_timeout"
+}
+```
+
+Event delivery wakes the bound conversation when the condition changes.
+Deadlines are safety nets, not polling intervals. A controller that has no
+ready action and a valid wake condition should consume no model turn.
+
+## Authority, ownership, and resources
+
+The grant should be typed and compositional. Its effective authority is the
+intersection of:
+
+- operator grant;
+- project scope;
+- action-kind policy;
+- target-specific restrictions;
+- current resource budget;
+- separation-of-duties requirements.
+
+The system computes and returns `allowed`, `requires_review`, or `forbidden`
+with the exact rule and remediation. Models should not infer authority by
+re-reading prose.
+
+Ownership uses explicit leases over semantic mutation domains:
+
+- project controller lease;
+- track owner lease;
+- repository/branch writer lease;
+- scarce provider or compute slot lease.
+
+Leases have holders, scopes, expiry, and renewal evidence. “Another controller
+owns it” is true only when a live lease or observable action says so.
+
+Resource policy should expose constraints and marginal cost, not a giant raw
+fleet dump. Placement returns a reasoned receipt: chosen node/provider,
+alternatives considered, binding constraint, expected cost, and fallback.
+
+Budgets are enforced at action boundaries and aggregated by project, track,
+attempt, provider, and outcome. The useful metric is cost per accepted receipt,
+not merely token count or mission count.
+
+## Completion and truth
+
+Each acceptance criterion declares a verifier class:
+
+- `external_state`: GitHub/API/database state;
+- `command`: command, environment identity, exit status, artifact digest;
+- `review`: reviewer identity plus immutable head;
+- `operator`: explicit owner decision;
+- `manual`: named evidence and expiration.
+
+A track becomes `satisfied` only when all required criteria have fresh accepted
+evidence at the governed artifact version. If automation advances a PR head,
+head-bound evidence becomes stale automatically. A terminal mission merely ends
+an attempt.
+
+Project mode should be a derivation wherever possible:
+
+- `executing`: at least one valid live owner;
+- `ready`: an unblocked track has no owner;
+- `waiting`: every open track has a valid wake condition;
+- `blocked`: every open track lacks both a ready action and a valid wake path;
+- `paused`: the grant says pause;
+- `complete`: project acceptance is satisfied;
+- `inconsistent`: authoritative sources disagree or are unavailable.
+
+Human-friendly `active` can remain a display grouping. The richer derived state
+prevents “active but doing nothing” from being a valid steady state.
+
+## Failure semantics
+
+Failures are typed by layer:
+
+- `transport`: the request could not reach or complete with the service;
+- `rejection`: the service answered and refused the request;
+- `execution`: the attempt ran and failed;
+- `verification`: claimed output could not be proved;
+- `policy`: authority or safety denied the action;
+- `capacity`: a resource was unavailable;
+- `inconsistency`: sources disagree;
+- `unknown`: required evidence was not collected.
+
+Each failure carries observed evidence, retryability, blast radius, and a
+recommended next control action. Guards report observations and blind spots;
+they never fabricate a root cause.
+
+## Accretive intelligence
+
+Paloma should improve from operation without turning every incident into more
+prompt text. Knowledge promotion follows a ladder:
+
+```text
+episode -> candidate lesson -> validated pattern -> policy/guard -> regression
+```
+
+A knowledge item records:
+
+- the triggering receipts and evidence;
+- the generalized rule and its scope;
+- counterexamples and invalidation conditions;
+- confidence, owner, review date, and supersedes links;
+- its executable form, if any: test, linter, policy rule, tool description,
+  routing hint, or runbook.
+
+Promotion rules:
+
+1. Keep one-off facts in the episode/receipt, not a global skill.
+2. Promote repeated or high-severity patterns only after independent evidence.
+3. Prefer an executable guard or schema constraint over prose.
+4. Keep the smallest skill text that explains when and why to use the guard.
+5. Attach a regression or expiry review to every promoted operational rule.
+6. Record supersession; do not append contradictory folklore indefinitely.
+
+Successful plans accrete too. A completed track graph can become a versioned
+template with parameterized acceptance criteria, resource profile, and outcome
+statistics. Future planning retrieves the closest validated template rather
+than replaying old transcripts.
+
+## Component boundaries
+
+| Component | Owns | Must not own |
+|---|---|---|
+| Hermes | conversation, judgment, controller scheduling, operator interaction | mission truth, fleet truth, duplicated project execution state |
+| sandboxed.sh | project intent store, attempts, leases, observations, receipts, projections, isolated execution | autonomous prioritization or unreviewed judgment |
+| mission harness | bounded work in one workspace | project authority, canonical status, final verification |
+| Library/skills | versioned policies and reusable procedures | volatile project state or secrets |
+| dashboard/mobile/CLI | projections and explicit commands | independent business logic or shadow state |
+| fleet/arbiter | capacity, placement, job receipts | project priority beyond supplied policy inputs |
+
+The system may replicate for availability or integration, but every replicated
+field must name its authority, reconciliation direction, lag signal, and repair
+mechanism. “One bind, two readers” is acceptable; two writable truths are not.
+
+## Design laws
+
+1. One concept, one canonical identifier, one authority.
+2. Intent, observation, derivation, and judgment stay distinguishable.
+3. One logical action produces one atomic state transition and one receipt.
+4. No success without evidence; no blocker without a failed available action or
+   an explicit unavailable dependency.
+5. No silent omission: unavailable and unchecked are data.
+6. No polling when a durable wake condition exists.
+7. No broad scan when a cursor or indexed projection can answer.
+8. No prose-only invariant when a type, constraint, lease, or test can enforce it.
+9. No permanent lesson without provenance, scope, and a retirement path.
+10. Human and agent surfaces read the same projections and invoke the same
+    commands.
+
+These laws are the test for future features. A feature that adds another state
+store, asks the model to join raw records, or requires periodic reasoning to
+notice a deterministic condition should be redesigned before implementation.

--- a/docs/AGENT_CONTROL_PLANE.md
+++ b/docs/AGENT_CONTROL_PLANE.md
@@ -203,8 +203,13 @@ Normal operation uses three read depths:
    diagnosis, or audit.
 
 All list APIs should support `since_cursor`, server-side filters, stable sort,
-caps, and explicit omission counts. An empty result must distinguish “nothing
-matched,” “source unavailable,” and “not checked.”
+caps, and explicit omission counts. Capped reads use a stable snapshot and
+return a page cursor that advances through exactly the last delivered change,
+plus a continuation flag. The client repeats from that cursor until the
+snapshot is drained; only then does the server return the new high-water
+cursor. Omitted changes are therefore neither skipped nor replayed forever.
+An empty result must distinguish “nothing matched,” “source unavailable,” and
+“not checked.”
 
 ## The control protocol
 
@@ -347,7 +352,8 @@ precedence order so every surface projects the same result:
 2. `complete`: project acceptance is satisfied;
 3. `paused`: the grant says pause;
 4. `executing`: at least one valid live owner;
-5. `ready`: at least one unblocked track has no owner;
+5. `ready`: at least one unblocked, ownerless track has an immediately
+   actionable next transition (not merely a valid future wake condition);
 6. `blocked`: with no executing or ready track, at least one open track lacks a
    valid wake path;
 7. `waiting`: every open track has a valid wake condition.

--- a/docs/AGENT_CONTROL_PLANE.md
+++ b/docs/AGENT_CONTROL_PLANE.md
@@ -246,9 +246,14 @@ Every mutable project object has a revision. Commands accept the revision or
 situation cursor they were based on. A stale command fails with a compact
 conflict response containing the changed fields and a fresh cursor.
 
-Every external mutation has an idempotency key derived from project, track,
-action kind, and generation. Retrying after a timeout returns the original
-receipt rather than launching a duplicate mission or repeating a merge.
+Every external mutation carries a stable logical `action_id` and a canonical
+request fingerprint. The effective idempotency key is derived from project,
+`action_id`, and fingerprint. Retrying the same action after a timeout returns
+the original receipt rather than launching a duplicate mission or repeating a
+merge. Reusing an `action_id` with a different fingerprint is a typed conflict,
+never an implicit retry. Successive steer or plan-revision commands therefore
+use distinct action IDs even within one attempt generation; controllers may
+derive deterministic IDs from the transition or wake event they are handling.
 
 ### Wake conditions
 
@@ -316,15 +321,21 @@ evidence at the governed artifact version. If automation advances a PR head,
 head-bound evidence becomes stale automatically. A terminal mission merely ends
 an attempt.
 
-Project mode should be a derivation wherever possible:
+Project mode should be a derivation wherever possible. The underlying facts are
+independent facets; the single display mode evaluates them in this explicit
+precedence order so every surface projects the same result:
 
-- `executing`: at least one valid live owner;
-- `ready`: an unblocked track has no owner;
-- `waiting`: every open track has a valid wake condition;
-- `blocked`: every open track lacks both a ready action and a valid wake path;
-- `paused`: the grant says pause;
-- `complete`: project acceptance is satisfied;
-- `inconsistent`: authoritative sources disagree or are unavailable.
+1. `inconsistent`: authoritative sources disagree or are unavailable;
+2. `complete`: project acceptance is satisfied;
+3. `paused`: the grant says pause;
+4. `executing`: at least one valid live owner;
+5. `ready`: an unblocked track has no owner;
+6. `waiting`: every open track has a valid wake condition;
+7. `blocked`: every open track lacks both a ready action and a valid wake path.
+
+For example, a project with an owned running track and a second unowned ready
+track is `executing`, while retaining `ready_track_count > 0` as a facet for
+scheduling and diagnostics. Mode does not erase the facts used to derive it.
 
 Human-friendly `active` can remain a display grouping. The richer derived state
 prevents “active but doing nothing” from being a valid steady state.

--- a/docs/AGENT_NATIVE_ROADMAP.md
+++ b/docs/AGENT_NATIVE_ROADMAP.md
@@ -1,0 +1,204 @@
+# Agent-native Paloma roadmap
+
+This plan implements the architecture in
+[`AGENT_CONTROL_PLANE.md`](AGENT_CONTROL_PLANE.md). It is ordered by leverage:
+first make reality cheap and unambiguous to read, then make actions atomic,
+then automate verification and learning. Existing APIs remain compatible until
+their consumers have migrated.
+
+## Success measures
+
+The redesign is successful when:
+
+- a routine controller tick uses one bounded situation read and at most one
+  intent-level mutation;
+- unchanged waiting projects consume no model turns;
+- duplicate dispatches and branch-writer conflicts are rejected by construction;
+- every completion shown as successful links to accepted evidence at the exact
+  governed artifact version;
+- every operator escalation states the unavailable authority or missing fact;
+- project, dashboard, desktop, and controller surfaces agree from one projection;
+- median context, model calls, and wall-clock cost per accepted track decrease
+  without reducing verified completion rate;
+- operational lessons have provenance and executable coverage, and obsolete
+  rules can be found and retired.
+
+Baseline these before Phase 1: tool calls and bytes per tick, full mission-list
+scans, duplicate attempts, polling ticks, unrouted callbacks, stale-head false
+completions, unverified terminal claims, operator questions, and cost per
+accepted track.
+
+## Phase 0 — Name the constitution
+
+Goal: stop conceptual drift while implementation continues.
+
+- Adopt the abstraction tower and epistemic classes from the architecture doc.
+- Publish a glossary/schema map for existing fields to target concepts.
+- Mark each replicated field with authority and reconciliation direction.
+- Classify current docs as constitutional, operational, API reference,
+  historical migration, or incident record.
+- Add architecture checks to design review: source of truth, identifier,
+  receipt, freshness, idempotency, wake path, and retirement path.
+
+Exit: new design work can name its layer and cannot introduce an unnamed
+writable truth.
+
+## Phase 1 — One bounded situation read
+
+Goal: remove reconstruction work from the model.
+
+- Add `GET /api/control/situation` and MCP `get_situation` for portfolio and
+  project scopes.
+- Project existing roster, grant, tracks, decisions, mission horizon, route,
+  fleet constraints, and latest receipts into the four epistemic classes.
+- Add monotonic cursors, `since_cursor`, deterministic ordering, caps, omission
+  counts, and `source_unavailable` diagnostics.
+- Add a server-derived attention queue and richer states: ready, executing,
+  waiting, blocked, paused, complete, inconsistent.
+- Make `get_project` a compatibility projection over the same builder.
+- Add contract tests that compare dashboard, MCP, and HTTP projections.
+
+Exit: a controller can choose its next action without scanning tracker markdown,
+global missions, raw events, or GitHub independently in the normal case.
+
+## Phase 2 — Receipts and evidence
+
+Goal: make truth and completion explicit.
+
+- Introduce stable receipt and evidence-reference schemas.
+- Normalize existing mission IDs, terminal evidence, PR heads, build/job IDs,
+  deployment versions, decision rows, and placement records into receipts.
+- Give acceptance criteria verifier types and artifact-version binding.
+- Derive track satisfaction from accepted evidence.
+- Invalidate head-bound evidence automatically when the governed head changes.
+- Surface “not checked,” “source unavailable,” and “claim only” distinctly.
+
+Exit: every satisfied track explains which evidence closed each criterion; a
+terminal mission without evidence cannot close a track.
+
+## Phase 3 — Atomic intent-level actions
+
+Goal: make the safe path the shortest path.
+
+- Add `propose_action` and `execute_action` with typed action kinds.
+- Fold dispatch, project/track linkage, owner lease, decision declaration,
+  callback route, and status effects into one transaction.
+- Add object revisions and stale-write conflict responses.
+- Add durable idempotency keys and return prior receipts on retries.
+- Compute effective grant server-side and return the exact permitting or
+  denying rule.
+- Retain granular MCP tools as primitives, but route agent-facing skills to the
+  intent-level surface.
+
+Exit: a dispatch cannot become invisible between `start_mission` and
+`link_mission_to_project`, and retrying a timed-out mutation cannot duplicate it.
+
+## Phase 4 — Ownership, leases, and event-driven waiting
+
+Goal: eliminate phantom owners and reasoning-as-polling.
+
+- Add controller, track, writer-domain, provider, and compute leases with
+  holder, scope, expiry, and renewal evidence.
+- Derive unowned-ready work and lease conflicts in the situation projection.
+- Represent waits as typed predicates plus deadline and fallback action.
+- Wake bound conversations on predicate transitions; coalesce duplicate events.
+- Suppress cron model turns when the situation cursor has not changed and no
+  deadline or ready work exists.
+- Make callbacks carry the causal action/receipt and follow route continuations.
+
+Exit: “owned,” “waiting,” and “ready” are machine-verifiable; an unchanged wait
+costs storage and timers, not inference.
+
+## Phase 5 — Resource and economic control
+
+Goal: spend where it changes the outcome.
+
+- Enforce typed per-project and per-action budgets at dispatch boundaries.
+- Return placement decisions with binding constraints, alternatives, predicted
+  cost, and fallback.
+- Attribute tokens, wall time, provider quota, compute, retries, and operator
+  interruptions to project/track/action/receipt.
+- Rank ready work using expected value, urgency, confidence, marginal cost, and
+  unlock value; preserve operator priority as an explicit input.
+- Add circuit breakers at shared failure domains so one adapter defect does not
+  burn every provider route.
+
+Exit: the portfolio can explain both why work was selected and what accepted
+progress cost.
+
+## Phase 6 — Accretive knowledge
+
+Goal: turn operations into a self-improving but governable system.
+
+- Add a knowledge-item registry with provenance, scope, confidence,
+  counterexamples, supersession, review date, and executable attachment.
+- Generate candidate lessons from incident clusters and successful receipts;
+  require review or repeated evidence before promotion.
+- Prefer promotion into schemas, tests, guards, routing policy, and tool
+  descriptions; keep skills as the compact decision layer.
+- Mine completed track graphs into versioned planning templates with empirical
+  success and cost statistics.
+- Add staleness reports for rules whose evidence, APIs, model names, or fleet
+  assumptions have expired.
+
+Exit: Paloma can answer “what did we learn, why do we believe it, where is it
+enforced, and when should it be reconsidered?”
+
+## Phase 7 — Converge every surface
+
+Goal: remove compatibility debt and shadow logic.
+
+- Move dashboard, mobile, desktop, `palomactl`, and controller skills onto the
+  shared situation/action contracts.
+- Remove parsed text trailers after all consumers read structured state.
+- Remove markdown as operational state; retain it for authored narrative and
+  generated exports.
+- Collapse route replicas behind one authority plus observable repair.
+- Deprecate granular agent-facing mutations after telemetry shows no consumers.
+- Archive historical migration docs and generate API/reference docs from the
+  schemas where practical.
+
+Exit: every surface shows the same situation and performs the same validated
+commands; no dual-write compatibility path remains.
+
+## Workstream ownership
+
+| Workstream | Primary home | Dependencies |
+|---|---|---|
+| situation projection, receipts, actions, leases | `sandboxed_sh` | project and mission stores |
+| conversation wakes, cursor-aware controller scheduling | `hermes-agent` | situation and callback contracts |
+| policies and knowledge promotion | Library + Hermes skills | action/grant schemas |
+| compute receipts and resource costs | `sandboxed_sh` + `dgx-spark-arbiter` | receipt schema |
+| operator projections | dashboard/mobile/desktop | situation/action APIs |
+| reconciliation/export | `palomactl` | shared projection |
+
+Each phase should ship vertically for one canary project before fleet-wide
+migration. The canary must exercise rollover routing, one writer lease, a
+waiting predicate, a failed attempt, exact-head evidence invalidation, and a
+successful accepted receipt.
+
+## Non-goals and constraints
+
+- Do not move prioritization into sandboxed.sh; deterministic derivation there
+  supports, but does not replace, Hermes judgment.
+- Do not create a universal event-sourced rewrite before the projections and
+  receipts prove their value. Existing stores can be adapted incrementally.
+- Do not inject full histories into controller context.
+- Do not make confidence a decorative model-generated number; derive it from
+  evidence class and verifier where possible.
+- Do not let learning mutate policy automatically across scopes without a
+  promotion gate and rollback path.
+- Do not couple migration to production restarts; follow the existing guarded
+  deployment path and restart Hermes only after compatible MCP deployment.
+
+## Required tests per phase
+
+Every phase needs:
+
+- schema/contract tests for omissions, unavailable sources, and old clients;
+- idempotency and crash-between-writes tests for mutations;
+- continuation and callback-routing tests;
+- stale-head and evidence-invalidation tests;
+- property tests for grant intersection and lease conflict;
+- cost/context regression telemetry;
+- one end-to-end canary receipt that an operator can independently replay.

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -5,6 +5,18 @@ se réveille toutes les N minutes, charge le skill `controllers-policy`, et fait
 avancer **un** projet : il dispatche des missions, merge des PRs, met à jour son
 tracker, et te livre un rapport.
 
+Le modèle système canonique est
+[`AGENT_CONTROL_PLANE.md`](AGENT_CONTROL_PLANE.md), avec sa migration dans
+[`AGENT_NATIVE_ROADMAP.md`](AGENT_NATIVE_ROADMAP.md). En particulier : projet →
+track → tentative/mission → action → reçu → preuve. Le contrôleur porte le
+jugement ; il ne doit pas reconstruire la réalité à partir de prose ni prendre
+la fin d'une mission pour la réussite d'un track.
+
+L'interface actuelle ci-dessous est la couche de compatibilité. Sa cible est un
+tick `get_situation(project, since_cursor)` → une action typée et idempotente →
+un reçu → un réveil sur condition. Tant que ces primitives ne sont pas livrées,
+le skill conserve les lectures et dual-writes explicites décrits ici.
+
 ## Créer un contrôleur
 
 Trois choses, dans cet ordre.
@@ -115,6 +127,11 @@ Un callback d'inspect (`awaiting_user`, mission parkée) ne pose pas
 `mode=blocked` : ces statuts omettent le `[CTRL:]`. Recopier l'ancien
 trailer est une dérive de prompt.
 
+À terme, `mode` devient une projection déterministe plus précise : `ready`,
+`executing`, `waiting`, `blocked`, `paused`, `complete`, ou `inconsistent`.
+`active` reste un regroupement d'affichage. Cela rend impossible l'état stable
+« active mais sans propriétaire, action ni condition de réveil ».
+
 Si le dispatch est refusé (disque, auth, capacité), le projet **garde son
 objectif** avec un blocker infra nommé (`blocked:disk`, …). Le travail
 plateforme s'ouvre sous `sandboxed-sh`. On ne retitre pas, on ne réutilise
@@ -162,6 +179,12 @@ Si un contrôleur ticque `ok` mais que rien ne bouge, la question à poser est
 *quel est son mode*. `active` sans mission créée pendant deux ticks est un défaut
 qu'il doit signaler lui-même ; `blocked` avec un `wait=` qui grimpe veut dire que
 le contournement a échoué et que l'escalade arrive.
+
+Un système agent-native ne doit finalement plus consommer un tick pour constater
+qu'une attente n'a pas changé. Toute attente doit devenir un prédicat durable
+(mission terminale, check GitHub, job fini, date atteinte) qui réveille la
+conversation ; le cron n'est plus qu'un filet de sécurité pour les échéances et
+la réconciliation.
 
 ## Coordination between controllers
 

--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -1,17 +1,22 @@
 # Hermes Assistant Migration
 
-This document captures the target architecture for replacing the built-in
-Telegram assistant path with a standalone Hermes assistant connected to
-sandboxed.sh over MCP.
+This document is the historical migration and deployment contract for replacing
+the built-in Telegram assistant path with a standalone Hermes assistant
+connected to sandboxed.sh over MCP. The cutover established the runtime split;
+it is not the current system design roadmap.
 
 > This is the migration plan. For how the two systems operate together once
 > migrated — sessions, missions, controllers, project routes, and what makes
 > progress visible — see
 > [`HERMES_ORCHESTRATION.md`](HERMES_ORCHESTRATION.md).
+> The target agent-native control-plane architecture and its implementation
+> sequence are
+> [`AGENT_CONTROL_PLANE.md`](AGENT_CONTROL_PLANE.md) and
+> [`AGENT_NATIVE_ROADMAP.md`](AGENT_NATIVE_ROADMAP.md).
 
-## Current Architecture
+## Pre-cutover Architecture
 
-The existing Telegram assistant is not just a workspace. It is a backend-owned
+The pre-cutover Telegram assistant was not just a workspace. It was a backend-owned
 assistant stack:
 
 - `src/api/telegram.rs` owns Telegram webhook routing, trigger filtering,
@@ -29,7 +34,7 @@ This makes Telegram the assistant runtime. The agent loop, memory policy,
 Telegram transport, mission steering, and proactive notification logic are all
 coupled inside sandboxed.sh.
 
-## Target Architecture
+## Cutover Architecture
 
 Hermes should become the assistant runtime. Sandboxed.sh should become the
 workspace, mission, model-routing, and control provider.

--- a/docs/PALOMACTL.md
+++ b/docs/PALOMACTL.md
@@ -1,8 +1,15 @@
 # palomactl v0
 
-`palomactl` is a small CLI-first control-plane for Paloma/Thomas project state.
-It treats project markdown as durable operator intent and keeps volatile live
-state in generated files under `.paloma/`.
+`palomactl` is a small CLI-first reconciliation surface for Paloma/Thomas
+project state. It treats project markdown as durable operator-authored
+narrative and keeps volatile live state in generated files under `.paloma/`.
+
+Architecturally it is a reconciliation and export surface, not a competing
+project store. The canonical agent model is defined in
+[`AGENT_CONTROL_PLANE.md`](AGENT_CONTROL_PLANE.md): structured project intent,
+tracks, grants, receipts, and evidence are authoritative; markdown is authored
+narrative or a generated view. `palomactl` must never infer a successful action
+from prose or write volatile runtime state back into tracker notes.
 
 ## Data layout
 


### PR DESCRIPTION
## Summary
- define one abstraction tower from portfolio through evidence
- separate intent, observation, derivation, and judgment
- specify bounded situation reads, atomic actions, receipts, leases, wake predicates, and knowledge promotion
- add a phased migration roadmap and align controller/migration/reference docs

## Validation
- local Markdown link validation
- `git diff --cached --check`

## Scope
Documentation and design contract only; implementation is staged in the roadmap.