### PR TITLE
fix(ci): accommodate Rust 1.98 result_large_err

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -551,6 +551,7 @@ fn protocol_capabilities(
 ///
 /// Accepts either the internal `SANDBOXED_PROXY_SECRET` or any user-generated
 /// proxy API key from the `ProxyApiKeyStore`.
+#[allow(clippy::result_large_err)] // Axum's Response is the endpoint error contract.
 pub(crate) async fn verify_proxy_auth(
     headers: &HeaderMap,
     state: &super::routes::AppState,

--- a/src/api/runners/chatgpt_ui/availability.rs
+++ b/src/api/runners/chatgpt_ui/availability.rs
@@ -333,6 +333,7 @@ pub fn mark_available(profile_dirs: &[PathBuf]) {
     persist(entry);
 }
 
+#[allow(clippy::result_large_err)] // AgentResult carries the terminal mission record.
 pub async fn wait_until_available(
     profile_dirs: &[PathBuf],
     mission_id: Uuid,

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -380,6 +380,7 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
 
 const RECOVERY_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
+#[allow(clippy::result_large_err)] // AgentResult carries the terminal mission record.
 async fn wait_for_available_launch_turn(
     settings: &Settings,
     mission_id: Uuid,
@@ -769,6 +770,7 @@ fn unresolved_resume_result(code: &str) -> AgentResult {
 /// the durable record names the account that holds the conversation, so pool
 /// health routing does not apply — either this slot frees up or the caller
 /// gives up via cancellation.
+#[allow(clippy::result_large_err)] // AgentResult carries the terminal mission record.
 async fn acquire_pinned_profile(
     profile_dirs: &[PathBuf],
     profile_dir: &Path,

--- a/src/api/runners/chatgpt_ui/profile_pool.rs
+++ b/src/api/runners/chatgpt_ui/profile_pool.rs
@@ -237,6 +237,7 @@ fn launch_gates() -> &'static AsyncMutex<HashMap<PathBuf, Instant>> {
 /// allowing already-submitted multi-hour turns to continue concurrently.
 /// This limits high-risk navigation/send bursts without imposing a low hard
 /// ceiling on the number of useful Pro conversations in flight.
+#[allow(clippy::result_large_err)] // AgentResult carries the terminal mission record.
 pub async fn wait_for_launch_turn(
     profile_dir: &Path,
     min_interval: Duration,
@@ -432,6 +433,7 @@ pub(crate) fn reset_registry_for_tests(profile_dirs: &[PathBuf]) {
     availability::reset_for_tests(profile_dirs);
 }
 
+#[allow(clippy::result_large_err)] // AgentResult carries the terminal mission record.
 pub async fn acquire_profile(
     profile_dirs: &[PathBuf],
     mission_id: Uuid,

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -463,6 +463,7 @@ pub(crate) fn grok_stdout_line_requests_interactive_login(line: &str) -> bool {
 /// xAI OAuth token if stale, materialize/sync the CLI auth file, and export
 /// `XAI_API_KEY` (key > OAuth access token > ambient env). Shared by the
 /// streaming-json and ACP turn paths.
+#[allow(clippy::result_large_err)] // AgentResult carries the terminal mission record.
 async fn prepare_grok_auth_env(
     workspace: &Workspace,
     app_working_dir: &std::path::Path,


### PR DESCRIPTION
Rust 1.98 made `clippy::result_large_err` part of the blocking `clippy::all` run, exposing seven existing semantic error contracts. Add narrow, documented allows at those boundaries rather than boxing Axum responses or terminal mission records solely for a heuristic.

Validated with:
- `cargo fmt --all`
- `cargo clippy --locked --workspace -- -D clippy::all`