### PR TITLE
feat(projects): absorb mission tracks at write time, one writer lease per track (step 4)

### DIFF
--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -156,9 +156,20 @@ and any live surface read *this*, not a parsed trailer. Once per tick:
   do not invent a new slug. Same mode vocabulary as the trailer; the store counts
   your consecutive-tick `wait`.
 - The project's **items are the only roadmap** — the right-rail checklist is
-  `project_tracks` (+ live attempts). `get_project` / `get_project_tasks` return
-  that list. `plan_project_tasks` upserts a key; `set_project_track(..., status=cancelled)`
-  retires a key. Editing `projects/active/<slug>.md` does **not** change the
+  `project_tracks` (+ live attempts). `get_situation(slug)` is the one read:
+  its `summary` (`total`, `verified_satisfied`, `claim_only`, `open`,
+  `blocked`, `live_attempts`, `cursor`) is the only progress number you may
+  quote; never recount items yourself. `claim_only` tracks were marked done
+  before receipts existed — report them as unproven, never as verified. An
+  unchanged `cursor` since your last tick means nothing moved. `get_project`
+  carries the same `summary`; `get_project_tasks` is deprecated.
+  `plan_project_tasks` upserts a key; `set_project_track(..., status=cancelled)`
+  retires a key. **A track becomes satisfied only through
+  `accept_project_track(slug, track, idempotency_key, evidence)`** with one
+  immutable handle per acceptance criterion (`owner/repo#233@<head sha>`, a
+  job id, a named operator decision). `set_project_track(status=done)` is
+  rejected. Head-bound evidence is invalidated automatically when the PR head
+  moves; `invalidate_project_track_evidence` withdraws it by hand. Editing `projects/active/<slug>.md` does **not** change the
   board. That file is narrative (IDs, heads, GRANT). If the owner says "clean
   the roadmap", mutate `project_tracks` in the same turn: cancel every obsolete
   open key, then `plan_project_tasks` the new keys. `plan_project_tasks` does
@@ -166,8 +177,18 @@ and any live surface read *this*, not a parsed trailer. Once per tick:
   cancelled. Do not create a second plan (no extra cron "roadmap watcher", no
   `/goal` as the program, no new `project=` for a workstream — that is a
   `track`).
-- For every mission you dispatch this tick, `link_mission_to_project(mission_id, slug,
-  track)` so it appears on that item. An unlinked worker is invisible.
+- Every `start_mission` on a project names its `track` (a key from
+  `get_situation`). The server resolves the key (spelling, alias, the single
+  track referencing the PR) and otherwise absorbs it as a new `origin=absorbed`
+  item — so invent keys only on purpose. Pass a stable `idempotency_key`
+  (`<slug>/<track>/<intent>/<date>`) so a retried dispatch cannot take a
+  second lease. One writer per track: a second writer gets `409 track_owned`
+  with the holder mission id — attach to it or dispatch read-only
+  (`writer=false`, or a review/certify intent). Missions created without a
+  track are absorbed under `mission-<id8>` during the transition and will be
+  rejected (`400 track_required`) once `SANDBOXED_TRACK_REQUIRED` is on.
+  `link_mission_to_project(mission_id, slug, track)` moves a mission and its
+  lease onto another item.
 - At your first tick (or after the prompt changed), read `get_project_grant(slug)` — the
   merge authority, budget, and any PAUSED live there and outrank the prompt.
 - Each tick, `set_project_track` for every **current** open in-scope item (and

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -121,12 +121,18 @@ the roster slug (`verity-core`, `verity-lido`, …) and `track` as the
 wakeup and do not wait. Report on the next tick or via the project
 route. A `cron_*` session dies with the tick; never stamp one as origin.
 
-The project's items **are** the roadmap (`get_project` / `get_project_tasks`
-are the same list: `project_tracks` + live attempts). `plan_project_tasks`
-upserts an item; `set_project_track(..., cancelled)` retires one. Editing
-`projects/active/<slug>.md` does not change the right-rail checklist. Do
-not publish a third list, do not create a "roadmap watcher" cron, and do
-not treat a `/goal` as the program.
+The project's items **are** the roadmap (`get_situation` / `get_project`
+return the same list: `project_tracks` + live attempts, with one `summary`).
+Quote `summary.verified_satisfied / summary.total`; `claim_only` is
+"marked done, unproven". `plan_project_tasks` upserts an item;
+`set_project_track(..., cancelled)` retires one; only
+`accept_project_track(..., evidence)` closes one — `status=done` is rejected.
+`start_mission` on a project always names its `track` (and a stable
+`idempotency_key`); an unknown key is absorbed as an unplanned item, a held
+writer lease answers `409 track_owned`. Editing `projects/active/<slug>.md`
+does not change the right-rail checklist. Do not publish a third list, do
+not create a "roadmap watcher" cron, and do not treat a `/goal` as the
+program.
 
 ### On callback
 

--- a/skills/sandboxed-sh-missions/SKILL.md
+++ b/skills/sandboxed-sh-missions/SKILL.md
@@ -280,7 +280,7 @@ Self-containment is the single biggest factor in mission success. The mission ag
 
 **Conversational launch** (desktop / API / TUI): `start_mission` is a worker of this chat. Hermes stamps `origin_session_id` and enrolls the mission. Confirm `pending`/`active`, then end the turn. The terminal webhook folds the result back here (ledger), or appends a `[Mission callback]` and wakes this session. Do **not** verify `PALOMA_WEBHOOK_FORWARD_URL`, do not start `fleet-heartbeat`, and do not create a `cronjob` to poll.
 
-**Controller launch** (cron tick with `deliver: project:<slug>`): pass `project` (and track / intent). Do not wait. Report on the next tick or the project route. Never stamp a `cron_*` session as origin.
+**Controller launch** (cron tick with `deliver: project:<slug>`): pass `project`, `track` (a key from `get_situation`; unknown keys are absorbed as unplanned items), `intent`, and a stable `idempotency_key`. One writer per track: `409 track_owned` names the holder — attach to it or dispatch read-only (`writer=false`). Do not wait. Report on the next tick or the project route. Never stamp a `cron_*` session as origin.
 
 **On callback:** inspect `get_mission` / `get_mission_digest` plus artifacts through the direct source before reporting. Mission self-report is not success. Notify Thomas for a user-launched completion, failure, blocker, decision, PR opened/merged, or useful research result. Stale duplicate ACKs may stay silent.
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7496,8 +7496,14 @@ pub struct CreateMissionRequest {
     pub deadline: Option<chrono::DateTime<chrono::Utc>>,
     /// Project tagging: stable project identifier (e.g. "verity-core").
     pub project: Option<String>,
-    /// Project tagging: track / workstream within the project.
+    /// Project tagging: track / workstream within the project. Resolved
+    /// against the plan (key, alias, single PR ref) and absorbed as a new
+    /// `origin = absorbed` track when unknown.
     pub track: Option<String>,
+    /// Caller-supplied idempotency key for the dispatch. Keys the track lease
+    /// so a retried create cannot take a second lease; generated per mission
+    /// when absent.
+    pub idempotency_key: Option<String>,
     /// Project tagging: intent (e.g. "review_merge_pr").
     pub intent: Option<String>,
     /// Project tagging: associated GitHub PR ref (e.g. "owner/repo#123").
@@ -8959,6 +8965,23 @@ fn find_existing_pr_writer_in_sqlite(
     Ok(None)
 }
 
+impl ControlHub {
+    /// Look a mission up across every persisted per-user store. Used by
+    /// cross-cutting sweeps (track leases) that hold a mission id but no user.
+    pub(crate) async fn find_mission_any_store(
+        &self,
+        mission_id: Uuid,
+    ) -> Result<Option<Mission>, String> {
+        let inventory = self.mission_store_inventory().await?;
+        for store in inventory.live {
+            if let Some(mission) = store.get_mission(mission_id).await? {
+                return Ok(Some(mission));
+            }
+        }
+        Ok(None)
+    }
+}
+
 async fn find_existing_pr_writer_global(
     control_hub: &ControlHub,
     github_pr: &str,
@@ -9386,6 +9409,105 @@ async fn nonterminal_missions_for_project(
         .collect()
 }
 
+/// Resolve or absorb the track for a freshly created mission and take its
+/// lease. On a held writer lease the new mission is durably interrupted
+/// (reason `track_owned`) and a 409 is returned; on a missing track under
+/// `SANDBOXED_TRACK_REQUIRED` the mission is interrupted with `track_required`
+/// and a 400 is returned. Returns the canonical track key.
+#[allow(clippy::too_many_arguments)]
+async fn bind_mission_to_track(
+    state: &Arc<AppState>,
+    control: &ControlState,
+    mission: &Mission,
+    project: &str,
+    track: Option<&str>,
+    title: Option<&str>,
+    github_pr: Option<&str>,
+    intent: Option<&str>,
+    writer_flag: Option<bool>,
+    tags: &[String],
+    request_is_writer: bool,
+    idempotency_key: Option<&str>,
+) -> Result<String, (StatusCode, String)> {
+    use super::track_leases;
+    let mission_id = mission.id.to_string();
+    let requested = match track.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(track) => track.to_string(),
+        None if track_leases::track_required() => {
+            interrupt_new_mission(control, mission.id, "track_required").await;
+            return Err((
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({
+                    "error": "track_required",
+                    "project": project,
+                    "message": "a project mission must name its track (the plan item it attempts); call get_situation and pass `track`",
+                })
+                .to_string(),
+            ));
+        }
+        None => {
+            let generated = track_leases::generated_track_key(&mission_id);
+            tracing::warn!(
+                mission_id = %mission_id,
+                project,
+                track = %generated,
+                "project mission dispatched without a track; absorbed under a generated key (compatibility window)"
+            );
+            generated
+        }
+    };
+    let pr = track_leases::pr_number(github_pr);
+    let outcome = state
+        .projects
+        .absorb_track(project, &requested, title, pr)
+        .map_err(internal_error)?;
+    if outcome.created || outcome.matched_by == "pr_ref" {
+        tracing::info!(
+            mission_id = %mission_id,
+            project,
+            requested = %requested,
+            track = %outcome.key,
+            matched_by = outcome.matched_by,
+            "mission track absorbed onto the plan"
+        );
+    }
+    let mode = if request_is_writer {
+        "writer"
+    } else {
+        track_leases::lease_mode(writer_flag, tags, intent)
+    };
+    let request =
+        track_leases::lease_request(project, &outcome.key, &mission_id, mode, idempotency_key);
+    match state.projects.acquire_track_lease(&request) {
+        Ok(_) => Ok(outcome.key),
+        Err(super::projects_store::LeaseError::Store(error)) => Err(internal_error(error)),
+        Err(error) => {
+            interrupt_new_mission(control, mission.id, "track_owned").await;
+            Err((
+                StatusCode::CONFLICT,
+                track_leases::owned_body(project, &outcome.key, &error).to_string(),
+            ))
+        }
+    }
+}
+
+/// Durably interrupt a mission that lost an admission check after creation,
+/// so it can never receive a goal or become a writer.
+async fn interrupt_new_mission(control: &ControlState, mission_id: Uuid, reason: &str) {
+    if let Err(error) = control
+        .mission_store
+        .update_mission_status_with_reason(mission_id, MissionStatus::Interrupted, Some(reason))
+        .await
+    {
+        tracing::warn!(mission_id = %mission_id, %error, reason, "could not interrupt rejected mission");
+    }
+    let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        mission_id,
+        status: MissionStatus::Interrupted,
+        summary: Some(reason.to_string()),
+    });
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -9409,6 +9531,7 @@ pub async fn create_mission(
         deadline: None,
         project: None,
         track: None,
+        idempotency_key: None,
         intent: None,
         github_pr: None,
         writer: None,
@@ -10157,12 +10280,40 @@ pub async fn create_mission(
                 })
             }),
     };
-    let track = nonblank(&req.track);
+    let mut track = nonblank(&req.track);
     let intent = nonblank(&req.intent);
     let github_pr = nonblank(&req.github_pr);
     let desired_state = nonblank(&req.desired_state);
     let next_check_at = nonblank(&req.next_check_at);
     let mut tags = normalized_request_tags;
+    // Absorb at write time: a project mission always lands on a plan row
+    // (existing key / alias / single PR ref, else a new `absorbed` track) and
+    // takes a lease on it. A held writer lease interrupts this duplicate
+    // instead of letting two writers race on one track.
+    if let Some(project_slug) = project.as_deref() {
+        match bind_mission_to_track(
+            &state,
+            &control,
+            &mission,
+            project_slug,
+            track.as_deref(),
+            req.title.as_deref(),
+            github_pr.as_deref(),
+            intent.as_deref(),
+            req.writer,
+            tags.as_deref().unwrap_or(&[]),
+            request_is_writer,
+            req.idempotency_key.as_deref(),
+        )
+        .await
+        {
+            Ok(canonical) => track = Some(canonical),
+            Err(response) => {
+                drop(pr_writer_guard);
+                return Err(response);
+            }
+        }
+    }
     if req
         .github_pr
         .as_deref()
@@ -12131,6 +12282,53 @@ pub async fn update_mission_project(
         }
     }
 
+    // Track move: resolve/absorb the new key, take its lease, release the
+    // old ones. A held writer lease is a 409 and the patch is not applied.
+    let effective_project = effective_string(&project, &current.project.project);
+    let effective_track = effective_string(&track, &current.project.track);
+    let track_changed = track.is_some() || project.is_some();
+    let track = if let (true, Some(slug), Some(key)) = (
+        track_changed,
+        effective_project.as_deref(),
+        effective_track.as_deref(),
+    ) {
+        let pr = super::track_leases::pr_number(effective_github_pr.as_deref());
+        let outcome = state
+            .projects
+            .absorb_track(slug, key, current.title.as_deref(), pr)
+            .map_err(internal_error)?;
+        let mode = if becomes_writer {
+            "writer"
+        } else {
+            super::track_leases::lease_mode(
+                req.writer,
+                &effective_tags,
+                effective_intent.as_deref(),
+            )
+        };
+        let request =
+            super::track_leases::lease_request(slug, &outcome.key, &id.to_string(), mode, None);
+        match state.projects.acquire_track_lease(&request) {
+            Ok(_) => {}
+            Err(super::projects_store::LeaseError::Store(error)) => {
+                return Err(internal_error(error))
+            }
+            Err(error) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    super::track_leases::owned_body(slug, &outcome.key, &error).to_string(),
+                ));
+            }
+        }
+        state
+            .projects
+            .release_leases_except(&id.to_string(), slug, &outcome.key)
+            .map_err(internal_error)?;
+        Some(Some(outcome.key))
+    } else {
+        track
+    };
+
     control
         .mission_store
         .update_mission_project(
@@ -13887,6 +14085,7 @@ pub async fn clone_mission(
         // grouped under the same project/track/intent.
         project: source.project.project.clone(),
         track: source.project.track.clone(),
+        idempotency_key: None,
         intent: source.project.intent.clone(),
         github_pr: source.project.github_pr.clone(),
         writer: None,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -9481,7 +9481,11 @@ async fn bind_mission_to_track(
     match state.projects.acquire_track_lease(&request) {
         Ok(_) => Ok(outcome.key),
         Err(super::projects_store::LeaseError::Store(error)) => Err(internal_error(error)),
-        Err(error) => {
+        Err(super::projects_store::LeaseError::NotFound) => Err(internal_error(format!(
+            "track '{}' of '{project}' vanished between absorption and lease",
+            outcome.key
+        ))),
+        Err(error @ super::projects_store::LeaseError::Owned { .. }) => {
             interrupt_new_mission(control, mission.id, "track_owned").await;
             Err((
                 StatusCode::CONFLICT,
@@ -12313,7 +12317,13 @@ pub async fn update_mission_project(
             Err(super::projects_store::LeaseError::Store(error)) => {
                 return Err(internal_error(error))
             }
-            Err(error) => {
+            Err(super::projects_store::LeaseError::NotFound) => {
+                return Err(internal_error(format!(
+                    "track '{}' of '{slug}' vanished between absorption and lease",
+                    outcome.key
+                )))
+            }
+            Err(error @ super::projects_store::LeaseError::Owned { .. }) => {
                 return Err((
                     StatusCode::CONFLICT,
                     super::track_leases::owned_body(slug, &outcome.key, &error).to_string(),
@@ -12326,6 +12336,14 @@ pub async fn update_mission_project(
             .map_err(internal_error)?;
         Some(Some(outcome.key))
     } else {
+        if track_changed {
+            // The mission left its project or cleared its track: whatever it
+            // held no longer governs anything.
+            state
+                .projects
+                .release_leases_for_attempt(&id.to_string())
+                .map_err(internal_error)?;
+        }
         track
     };
 

--- a/src/api/evidence_watch.rs
+++ b/src/api/evidence_watch.rs
@@ -157,6 +157,18 @@ pub fn spawn(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(WATCH_INTERVAL_SECS)).await;
+            match super::track_leases::sweep(&state).await {
+                Ok(report)
+                    if report.released_terminal
+                        + report.released_missing
+                        + report.expired_overdue
+                        > 0 =>
+                {
+                    tracing::info!(?report, "track leases swept")
+                }
+                Ok(_) => {}
+                Err(error) => tracing::warn!(%error, "track lease sweep failed"),
+            }
             match run_once(&state).await {
                 Ok(0) => {}
                 Ok(count) => {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -76,6 +76,7 @@ pub(crate) mod spark;
 pub(crate) mod supervision;
 pub mod system;
 pub mod telegram;
+pub mod track_leases;
 pub mod tracker_import;
 pub mod types;
 pub mod usage_optimize;

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -3287,7 +3287,14 @@ pub(crate) async fn load_project_situation(
     };
     let items = super::mission_horizon::project_items(&tracks, &proposals, &missions);
     let as_of = chrono::Utc::now().to_rfc3339();
-    super::situation::build(slug, &items, &source, &as_of)
+    let mut situation = super::situation::build(slug, &items, &source, &as_of);
+    match state.projects.live_leases(Some(slug)) {
+        Ok(leases) => super::situation::apply_leases(&mut situation, &leases),
+        Err(error) => {
+            tracing::warn!(project = %slug, %error, "situation: leases unavailable");
+        }
+    }
+    situation
 }
 
 fn accept_err(error: super::projects_store::AcceptError) -> (StatusCode, String) {

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -204,10 +204,14 @@ CREATE TABLE IF NOT EXISTS track_leases (
     mode             TEXT NOT NULL CHECK (mode IN ('reader','writer')),
     state            TEXT NOT NULL CHECK (state IN ('reserved','active','released','expired')),
     lease_until      TEXT NOT NULL,
-    idempotency_key  TEXT NOT NULL UNIQUE,
+    idempotency_key  TEXT NOT NULL,
     created_at       TEXT NOT NULL,
     updated_at       TEXT NOT NULL
 );
+-- One live lease per dispatch key; a released/expired row keeps its key as
+-- history and never satisfies a retry.
+CREATE UNIQUE INDEX IF NOT EXISTS track_leases_live_key
+    ON track_leases(idempotency_key) WHERE state IN ('reserved','active');
 CREATE INDEX IF NOT EXISTS track_leases_domain
     ON track_leases(track_id, mutation_domain, state, lease_until);
 CREATE INDEX IF NOT EXISTS track_leases_attempt
@@ -2577,16 +2581,31 @@ impl ProjectsStore {
             .execute_batch("BEGIN IMMEDIATE")
             .map_err(|e| LeaseError::Store(e.to_string()))?;
         let result = (|| -> Result<TrackLease, LeaseError> {
+            // Idempotent replay only for a *live* lease of the *same* attempt.
+            // A released/expired row is history; a live row under the same key
+            // held by another attempt means the dispatch key was reused by a
+            // retry that created a second mission — exactly the duplicate the
+            // lease exists to refuse.
             if let Some(existing) = connection
                 .query_row(
-                    &format!("{LEASE_SELECT} WHERE l.idempotency_key = ?1"),
-                    params![request.idempotency_key],
+                    &format!(
+                        "{LEASE_SELECT} WHERE l.idempotency_key = ?1 \
+                           AND l.state IN ('reserved','active') AND l.lease_until > ?2"
+                    ),
+                    params![request.idempotency_key, now_text],
                     lease_from_row,
                 )
                 .optional()
                 .map_err(|e| LeaseError::Store(e.to_string()))?
             {
-                return Ok(existing);
+                if existing.attempt_id == request.attempt_id {
+                    return Ok(existing);
+                }
+                return Err(LeaseError::Owned {
+                    holder_attempt_id: existing.attempt_id,
+                    lease_until: existing.lease_until,
+                    lease_id: existing.id,
+                });
             }
             let Some(track_id) =
                 Self::resolve_track_id_on(&connection, &request.slug, &request.track)
@@ -6068,10 +6087,21 @@ mod tests {
             Err(LeaseError::NotFound)
         ));
         assert_eq!(store.live_leases(Some("lido")).unwrap().len(), 2);
+        // The same dispatch key from another attempt (a retried create that
+        // made a second mission) is the duplicate, not a replay.
+        assert!(matches!(
+            store.acquire_track_lease(&lease("lido", "ux1", "m9", "writer", "k1")),
+            Err(LeaseError::Owned { ref holder_attempt_id, .. }) if holder_attempt_id == "m1"
+        ));
         assert_eq!(store.release_leases_for_attempt("m1").unwrap(), 1);
         store
             .acquire_track_lease(&lease("lido", "ux1", "m2", "writer", "k2b"))
             .expect("writer after release");
+        // A released row never satisfies its old key again; the key can be
+        // taken by a fresh lease (partial unique index on live rows only).
+        store
+            .acquire_track_lease(&lease("lido", "ux1", "m2", "reader", "k1"))
+            .expect("old key reusable once its lease is released");
         assert!(
             !store.expire_lease(&first.id).unwrap(),
             "released is not live"

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -192,6 +192,27 @@ CREATE TABLE IF NOT EXISTS project_track_refs (
     PRIMARY KEY (track_id, kind, repository, number)
 );
 
+-- Who may mutate a track right now. A mission (attempt) holds at most one
+-- writer lease per (track, mutation_domain); readers coexist. Ownership is
+-- derived from live leases — never copied onto the track row.
+CREATE TABLE IF NOT EXISTS track_leases (
+    id               TEXT PRIMARY KEY,
+    slug             TEXT NOT NULL,
+    track_id         TEXT NOT NULL REFERENCES project_tracks(id) ON DELETE CASCADE,
+    mutation_domain  TEXT NOT NULL,
+    attempt_id       TEXT NOT NULL,                        -- mission id
+    mode             TEXT NOT NULL CHECK (mode IN ('reader','writer')),
+    state            TEXT NOT NULL CHECK (state IN ('reserved','active','released','expired')),
+    lease_until      TEXT NOT NULL,
+    idempotency_key  TEXT NOT NULL UNIQUE,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS track_leases_domain
+    ON track_leases(track_id, mutation_domain, state, lease_until);
+CREATE INDEX IF NOT EXISTS track_leases_attempt
+    ON track_leases(attempt_id, state);
+
 -- One row per (source, content hash, parser): the importer is idempotent.
 CREATE TABLE IF NOT EXISTS project_imports (
     slug            TEXT NOT NULL,
@@ -1422,7 +1443,12 @@ impl ProjectsStore {
                 params![slug],
             )
             .map_err(|e| e.to_string())?;
-        for table in ["project_imports", "project_track_aliases", "receipts"] {
+        for table in [
+            "project_imports",
+            "project_track_aliases",
+            "track_leases",
+            "receipts",
+        ] {
             let column = if table == "receipts" {
                 "project_slug"
             } else {
@@ -1506,6 +1532,7 @@ impl ProjectsStore {
             "project_bindings",
             "project_tracks",
             "project_track_aliases",
+            "track_leases",
             "project_imports",
             "project_state_events",
             "project_decisions",
@@ -2422,6 +2449,309 @@ impl ProjectsStore {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()
+            .map_err(|e| e.to_string())
+    }
+
+    // ── Absorption and leases ───────────────────────────────────────────
+
+    /// Resolve a mission's track tag onto the plan, creating an `absorbed`
+    /// row when nothing matches. Resolution order: normalized key, alias,
+    /// then — only when exactly one track references the mission's PR — that
+    /// track (a shared PR is a hint; two tracks on one PR is ambiguous and
+    /// falls through to absorption).
+    pub fn absorb_track(
+        &self,
+        slug: &str,
+        key: &str,
+        title_hint: Option<&str>,
+        pr_number: Option<i64>,
+    ) -> Result<AbsorbOutcome, String> {
+        let normalized = normalize_track_key(key);
+        if normalized.is_empty() {
+            return Err(format!("track key '{key}' is empty after normalization"));
+        }
+        let now = Utc::now().to_rfc3339();
+        let mut connection = self.lock()?;
+        let tx = connection.transaction().map_err(|e| e.to_string())?;
+        if let Some(id) = Self::resolve_track_id_on(&tx, slug, key)? {
+            let canonical: String = tx
+                .query_row(
+                    "SELECT track FROM project_tracks WHERE id = ?1",
+                    params![id],
+                    |row| row.get(0),
+                )
+                .map_err(|e| e.to_string())?;
+            let matched_by = if canonical == normalized {
+                "key"
+            } else {
+                "alias"
+            };
+            tx.commit().map_err(|e| e.to_string())?;
+            return Ok(AbsorbOutcome {
+                key: canonical,
+                track_id: id,
+                created: false,
+                matched_by,
+            });
+        }
+        if let Some(number) = pr_number {
+            let mut statement = tx
+                .prepare(
+                    "SELECT t.id, t.track FROM project_track_refs r \
+                     JOIN project_tracks t ON t.id = r.track_id \
+                     WHERE t.slug = ?1 AND r.kind = 'pr' AND r.number = ?2 AND t.lifecycle = 'active'",
+                )
+                .map_err(|e| e.to_string())?;
+            let matches: Vec<(String, String)> = statement
+                .query_map(params![slug, number], |row| Ok((row.get(0)?, row.get(1)?)))
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+            drop(statement);
+            if matches.len() == 1 {
+                let (id, canonical) = matches.into_iter().next().unwrap();
+                tx.execute(
+                    "INSERT OR IGNORE INTO project_track_aliases \
+                       (slug, alias_key, track_id, reason, created_at) VALUES (?1, ?2, ?3, 'pr_match', ?4)",
+                    params![slug, key.trim(), id, now],
+                )
+                .map_err(|e| e.to_string())?;
+                tx.commit().map_err(|e| e.to_string())?;
+                return Ok(AbsorbOutcome {
+                    key: canonical,
+                    track_id: id,
+                    created: false,
+                    matched_by: "pr_ref",
+                });
+            }
+        }
+        let id = Uuid::new_v4().to_string();
+        let title = title_hint
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| humanize_track_key(key));
+        tx.execute(
+            "INSERT INTO project_tracks \
+               (id, slug, track, title, desired_state, lifecycle, origin, explicit_blocker, \
+                acceptance_criteria, depends_on, revision, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, NULL, 'active', 'absorbed', NULL, '[]', '[]', 0, ?5, ?5)",
+            params![id, slug, normalized, title, now],
+        )
+        .map_err(|e| e.to_string())?;
+        if normalized != key.trim() {
+            tx.execute(
+                "INSERT OR IGNORE INTO project_track_aliases \
+                   (slug, alias_key, track_id, reason, created_at) VALUES (?1, ?2, ?3, 'renamed', ?4)",
+                params![slug, key.trim(), id, now],
+            )
+            .map_err(|e| e.to_string())?;
+        }
+        if let Some(number) = pr_number {
+            tx.execute(
+                "INSERT OR IGNORE INTO project_track_refs \
+                   (track_id, kind, repository, number, url, created_at) VALUES (?1, 'pr', '', ?2, NULL, ?3)",
+                params![id, number, now],
+            )
+            .map_err(|e| e.to_string())?;
+        }
+        tx.commit().map_err(|e| e.to_string())?;
+        Ok(AbsorbOutcome {
+            key: normalized,
+            track_id: id,
+            created: true,
+            matched_by: "created",
+        })
+    }
+
+    /// Take a lease on a track's mutation domain for an attempt. Writers are
+    /// exclusive per domain; readers always coexist. Idempotent on
+    /// `idempotency_key`. Runs under `BEGIN IMMEDIATE` so two creators cannot
+    /// both see "no writer" and both win.
+    pub fn acquire_track_lease(&self, request: &LeaseRequest) -> Result<TrackLease, LeaseError> {
+        let now = Utc::now();
+        let now_text = now.to_rfc3339();
+        let until = (now + chrono::Duration::seconds(request.ttl_secs.max(60) as i64)).to_rfc3339();
+        let connection = self.lock().map_err(LeaseError::Store)?;
+        connection
+            .execute_batch("BEGIN IMMEDIATE")
+            .map_err(|e| LeaseError::Store(e.to_string()))?;
+        let result = (|| -> Result<TrackLease, LeaseError> {
+            if let Some(existing) = connection
+                .query_row(
+                    &format!("{LEASE_SELECT} WHERE l.idempotency_key = ?1"),
+                    params![request.idempotency_key],
+                    lease_from_row,
+                )
+                .optional()
+                .map_err(|e| LeaseError::Store(e.to_string()))?
+            {
+                return Ok(existing);
+            }
+            let Some(track_id) =
+                Self::resolve_track_id_on(&connection, &request.slug, &request.track)
+                    .map_err(LeaseError::Store)?
+            else {
+                return Err(LeaseError::NotFound);
+            };
+            if request.mode == "writer" {
+                let holder = connection
+                    .query_row(
+                        &format!(
+                            "{LEASE_SELECT} WHERE l.track_id = ?1 AND l.mutation_domain = ?2 \
+                               AND l.mode = 'writer' AND l.state IN ('reserved','active') \
+                               AND l.lease_until > ?3 AND l.attempt_id != ?4 \
+                             ORDER BY l.created_at LIMIT 1"
+                        ),
+                        params![
+                            track_id,
+                            request.mutation_domain,
+                            now_text,
+                            request.attempt_id
+                        ],
+                        lease_from_row,
+                    )
+                    .optional()
+                    .map_err(|e| LeaseError::Store(e.to_string()))?;
+                if let Some(holder) = holder {
+                    return Err(LeaseError::Owned {
+                        holder_attempt_id: holder.attempt_id,
+                        lease_until: holder.lease_until,
+                        lease_id: holder.id,
+                    });
+                }
+            }
+            let id = Uuid::new_v4().to_string();
+            connection
+                .execute(
+                    "INSERT INTO track_leases \
+                       (id, slug, track_id, mutation_domain, attempt_id, mode, state, lease_until, \
+                        idempotency_key, created_at, updated_at) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active', ?7, ?8, ?9, ?9)",
+                    params![
+                        id,
+                        request.slug,
+                        track_id,
+                        request.mutation_domain,
+                        request.attempt_id,
+                        request.mode,
+                        until,
+                        request.idempotency_key,
+                        now_text
+                    ],
+                )
+                .map_err(|e| LeaseError::Store(e.to_string()))?;
+            connection
+                .query_row(
+                    &format!("{LEASE_SELECT} WHERE l.id = ?1"),
+                    params![id],
+                    lease_from_row,
+                )
+                .map_err(|e| LeaseError::Store(e.to_string()))
+        })();
+        match result {
+            Ok(lease) => {
+                connection
+                    .execute_batch("COMMIT")
+                    .map_err(|e| LeaseError::Store(e.to_string()))?;
+                Ok(lease)
+            }
+            Err(error) => {
+                let _ = connection.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
+    /// Release every live lease held by an attempt (mission). Returns how
+    /// many were released.
+    pub fn release_leases_for_attempt(&self, attempt_id: &str) -> Result<usize, String> {
+        let connection = self.lock()?;
+        connection
+            .execute(
+                "UPDATE track_leases SET state = 'released', updated_at = ?2 \
+                 WHERE attempt_id = ?1 AND state IN ('reserved','active')",
+                params![attempt_id, Utc::now().to_rfc3339()],
+            )
+            .map_err(|e| e.to_string())
+    }
+
+    /// Release the live leases of an attempt on tracks other than `keep_key`
+    /// (used when a mission moves to another track).
+    pub fn release_leases_except(
+        &self,
+        attempt_id: &str,
+        slug: &str,
+        keep_key: &str,
+    ) -> Result<usize, String> {
+        let connection = self.lock()?;
+        let keep_id = Self::resolve_track_id_on(&connection, slug, keep_key)?;
+        connection
+            .execute(
+                "UPDATE track_leases SET state = 'released', updated_at = ?2 \
+                 WHERE attempt_id = ?1 AND state IN ('reserved','active') \
+                   AND (?3 IS NULL OR track_id != ?3)",
+                params![attempt_id, Utc::now().to_rfc3339(), keep_id],
+            )
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn renew_lease(&self, lease_id: &str, ttl_secs: u64) -> Result<bool, String> {
+        let now = Utc::now();
+        let until = (now + chrono::Duration::seconds(ttl_secs.max(60) as i64)).to_rfc3339();
+        let connection = self.lock()?;
+        connection
+            .execute(
+                "UPDATE track_leases SET lease_until = ?2, updated_at = ?3 \
+                 WHERE id = ?1 AND state IN ('reserved','active')",
+                params![lease_id, until, now.to_rfc3339()],
+            )
+            .map(|changed| changed > 0)
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn expire_lease(&self, lease_id: &str) -> Result<bool, String> {
+        let connection = self.lock()?;
+        connection
+            .execute(
+                "UPDATE track_leases SET state = 'expired', updated_at = ?2 \
+                 WHERE id = ?1 AND state IN ('reserved','active')",
+                params![lease_id, Utc::now().to_rfc3339()],
+            )
+            .map(|changed| changed > 0)
+            .map_err(|e| e.to_string())
+    }
+
+    /// Live (reserved/active, unexpired) leases; all projects when `slug` is None.
+    pub fn live_leases(&self, slug: Option<&str>) -> Result<Vec<TrackLease>, String> {
+        let connection = self.lock()?;
+        let now = Utc::now().to_rfc3339();
+        let mut statement = connection
+            .prepare(&format!(
+                "{LEASE_SELECT} WHERE l.state IN ('reserved','active') AND l.lease_until > ?1 \
+                   AND (?2 IS NULL OR l.slug = ?2) ORDER BY l.created_at"
+            ))
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map(params![now, slug], lease_from_row)
+            .map_err(|e| e.to_string())?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())
+    }
+
+    /// Leases still marked live whose `lease_until` has passed.
+    pub fn overdue_leases(&self) -> Result<Vec<TrackLease>, String> {
+        let connection = self.lock()?;
+        let now = Utc::now().to_rfc3339();
+        let mut statement = connection
+            .prepare(&format!(
+                "{LEASE_SELECT} WHERE l.state IN ('reserved','active') AND l.lease_until <= ?1"
+            ))
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map(params![now], lease_from_row)
+            .map_err(|e| e.to_string())?;
+        rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| e.to_string())
     }
 
@@ -3573,6 +3903,96 @@ impl std::fmt::Display for AcceptError {
             ),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AbsorbOutcome {
+    /// Canonical key the mission is now attached to.
+    pub key: String,
+    pub track_id: String,
+    /// True when an `absorbed` row was created.
+    pub created: bool,
+    /// `key` | `alias` | `pr_ref` | `created`
+    pub matched_by: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseRequest {
+    pub slug: String,
+    pub track: String,
+    pub mutation_domain: String,
+    pub attempt_id: String,
+    /// `reader` | `writer`
+    pub mode: String,
+    pub idempotency_key: String,
+    pub ttl_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TrackLease {
+    pub id: String,
+    pub slug: String,
+    pub track_id: String,
+    /// Canonical track key (joined for convenience).
+    pub track: String,
+    pub mutation_domain: String,
+    pub attempt_id: String,
+    pub mode: String,
+    pub state: String,
+    pub lease_until: String,
+    pub idempotency_key: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LeaseError {
+    NotFound,
+    Owned {
+        holder_attempt_id: String,
+        lease_until: String,
+        lease_id: String,
+    },
+    Store(String),
+}
+
+impl std::fmt::Display for LeaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("no such track"),
+            Self::Owned {
+                holder_attempt_id,
+                lease_until,
+                ..
+            } => write!(
+                f,
+                "track is owned by mission {holder_attempt_id} until {lease_until}"
+            ),
+            Self::Store(message) => f.write_str(message),
+        }
+    }
+}
+
+const LEASE_SELECT: &str =
+    "SELECT l.id, l.slug, l.track_id, t.track, l.mutation_domain, l.attempt_id, l.mode, \
+     l.state, l.lease_until, l.idempotency_key, l.created_at, l.updated_at \
+     FROM track_leases l JOIN project_tracks t ON t.id = l.track_id";
+
+fn lease_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackLease> {
+    Ok(TrackLease {
+        id: row.get(0)?,
+        slug: row.get(1)?,
+        track_id: row.get(2)?,
+        track: row.get(3)?,
+        mutation_domain: row.get(4)?,
+        attempt_id: row.get(5)?,
+        mode: row.get(6)?,
+        state: row.get(7)?,
+        lease_until: row.get(8)?,
+        idempotency_key: row.get(9)?,
+        created_at: row.get(10)?,
+        updated_at: row.get(11)?,
+    })
 }
 
 /// An immutable receipt row.
@@ -5533,6 +5953,130 @@ mod tests {
         assert_eq!(track.revision, 3);
         assert_eq!(store.active_accept_receipts("pr").unwrap().len(), 0);
         assert_eq!(store.receipts_for_track("lido", "ux1").unwrap().len(), 4);
+    }
+
+    fn lease(slug: &str, track: &str, attempt: &str, mode: &str, key: &str) -> LeaseRequest {
+        LeaseRequest {
+            slug: slug.into(),
+            track: track.into(),
+            mutation_domain: "track".into(),
+            attempt_id: attempt.into(),
+            mode: mode.into(),
+            idempotency_key: key.into(),
+            ttl_secs: 3600,
+        }
+    }
+
+    #[test]
+    fn absorb_resolves_key_alias_and_single_pr_ref_else_creates() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("lido", None, None, None, None)
+            .expect("seed");
+        store
+            .patch_track("lido", "UX1", None, Some("open"), Some("UX1"), None, None)
+            .expect("declare");
+        store
+            .add_track_ref("lido", "ux1", "pr", None, 229, None)
+            .expect("ref");
+
+        let by_key = store.absorb_track("lido", "ux1", None, None).expect("key");
+        assert_eq!(
+            (by_key.key.as_str(), by_key.created, by_key.matched_by),
+            ("ux1", false, "key")
+        );
+        // Case is normalization, not an alias.
+        assert_eq!(
+            store
+                .absorb_track("lido", "UX1", None, None)
+                .unwrap()
+                .matched_by,
+            "key"
+        );
+        store
+            .add_track_alias("lido", "ux1", "legacy-ux", "imported_code")
+            .expect("alias");
+        let by_alias = store
+            .absorb_track("lido", "legacy-ux", None, None)
+            .expect("alias");
+        assert_eq!(
+            (by_alias.key.as_str(), by_alias.matched_by),
+            ("ux1", "alias")
+        );
+        // A mission tagged `repair-pr-229` on PR 229 attaches to ux1 instead
+        // of creating a phantom row.
+        let by_pr = store
+            .absorb_track("lido", "repair-pr-229", Some("repair"), Some(229))
+            .expect("pr");
+        assert_eq!(
+            (by_pr.key.as_str(), by_pr.created, by_pr.matched_by),
+            ("ux1", false, "pr_ref")
+        );
+        assert_eq!(
+            store.resolve_track_key("lido", "repair-pr-229").unwrap(),
+            Some("ux1".into())
+        );
+        // Two tracks on the same PR: ambiguous, so a new key is absorbed.
+        store
+            .patch_track("lido", "ux2", None, Some("open"), Some("UX2"), None, None)
+            .expect("declare 2");
+        store
+            .add_track_ref("lido", "ux2", "pr", None, 230, None)
+            .expect("ref");
+        store
+            .add_track_ref("lido", "ux1", "pr", None, 230, None)
+            .expect("ref");
+        let created = store
+            .absorb_track("lido", "pr-230-repair", None, Some(230))
+            .expect("created");
+        assert!(created.created);
+        assert_eq!(created.matched_by, "created");
+        let track = store.track("lido", "pr-230-repair").unwrap().unwrap();
+        assert_eq!(track.origin, "absorbed");
+        assert_eq!(track.title.as_deref(), Some("PR 230 Repair"));
+        assert_eq!(store.tracks("lido").unwrap().len(), 3);
+    }
+
+    #[test]
+    fn writer_leases_are_exclusive_readers_coexist_and_release_frees() {
+        let store = ProjectsStore::open_in_memory().expect("store");
+        store
+            .upsert_project("lido", None, None, None, None)
+            .expect("seed");
+        store
+            .patch_track("lido", "ux1", None, Some("open"), Some("UX1"), None, None)
+            .expect("declare");
+        let first = store
+            .acquire_track_lease(&lease("lido", "ux1", "m1", "writer", "k1"))
+            .expect("first writer");
+        assert_eq!(first.state, "active");
+        let again = store
+            .acquire_track_lease(&lease("lido", "ux1", "m1", "writer", "k1"))
+            .expect("idempotent");
+        assert_eq!(again.id, first.id);
+        let conflict = store
+            .acquire_track_lease(&lease("lido", "UX1", "m2", "writer", "k2"))
+            .expect_err("second writer");
+        assert!(
+            matches!(conflict, LeaseError::Owned { ref holder_attempt_id, .. } if holder_attempt_id == "m1")
+        );
+        store
+            .acquire_track_lease(&lease("lido", "ux1", "m3", "reader", "k3"))
+            .expect("reader coexists");
+        assert!(matches!(
+            store.acquire_track_lease(&lease("lido", "nope", "m4", "writer", "k4")),
+            Err(LeaseError::NotFound)
+        ));
+        assert_eq!(store.live_leases(Some("lido")).unwrap().len(), 2);
+        assert_eq!(store.release_leases_for_attempt("m1").unwrap(), 1);
+        store
+            .acquire_track_lease(&lease("lido", "ux1", "m2", "writer", "k2b"))
+            .expect("writer after release");
+        assert!(
+            !store.expire_lease(&first.id).unwrap(),
+            "released is not live"
+        );
+        assert!(store.overdue_leases().unwrap().is_empty());
     }
 
     #[test]

--- a/src/api/reconcile.rs
+++ b/src/api/reconcile.rs
@@ -407,6 +407,15 @@ pub struct ReconcileReport {
 pub async fn run(state: &Arc<AppState>) -> ReconcileReport {
     let mut report = ReconcileReport::default();
 
+    // Track leases: release those whose mission is terminal or gone, renew
+    // the live ones. Repairs the create-mission crash windows at boot.
+    match super::track_leases::sweep(state).await {
+        Ok(leases) => {
+            tracing::info!(?leases, "reconcile: track leases swept");
+        }
+        Err(error) => tracing::warn!(%error, "reconcile: track lease sweep failed"),
+    }
+
     // ---- Phase 1: scopes ----
     let units = match try_list_sandboxed_scope_units().await {
         Ok(units) => {

--- a/src/api/situation.rs
+++ b/src/api/situation.rs
@@ -438,6 +438,40 @@ pub fn build(
     }
 }
 
+/// Overlay live leases onto the items: the owner is whoever holds the writer
+/// lease (with its expiry), falling back to the live attempt when no lease
+/// exists yet (compatibility window).
+pub fn apply_leases(
+    situation: &mut ProjectSituation,
+    leases: &[super::projects_store::TrackLease],
+) {
+    for item in &mut situation.items {
+        let writer = leases
+            .iter()
+            .find(|lease| lease.track == item.key && lease.mode == "writer");
+        if let Some(lease) = writer {
+            let status = item
+                .attempts
+                .iter()
+                .find(|attempt| attempt.id.to_string() == lease.attempt_id)
+                .map(|attempt| attempt.status.clone())
+                .unwrap_or_else(|| "leased".to_string());
+            item.owner = Some(ItemOwner {
+                attempt_id: lease.attempt_id.clone(),
+                status,
+                lease_until: Some(lease.lease_until.clone()),
+            });
+        } else if let Some(owner) = &mut item.owner {
+            if let Some(lease) = leases
+                .iter()
+                .find(|lease| lease.track == item.key && lease.attempt_id == owner.attempt_id)
+            {
+                owner.lease_until = Some(lease.lease_until.clone());
+            }
+        }
+    }
+}
+
 /// The `/tasks` checklist vocabulary (accepted / running / failed / proposed /
 /// pending), derived from the canonical state so the compatibility endpoint
 /// and the canonical one can never disagree.

--- a/src/api/track_leases.rs
+++ b/src/api/track_leases.rs
@@ -151,9 +151,13 @@ pub fn owned_body(slug: &str, track: &str, error: &LeaseError) -> serde_json::Va
 pub struct LeaseSweepReport {
     pub live: usize,
     pub renewed: usize,
+    /// Missions (not leases) released because they ended.
     pub released_terminal: usize,
+    /// Missions released because no store knows them.
     pub released_missing: usize,
     pub expired_overdue: usize,
+    /// Leases whose attempt id is not a mission id.
+    pub expired_invalid: usize,
 }
 
 /// One pass: renew leases of live missions, release those whose mission is
@@ -162,10 +166,15 @@ pub async fn sweep(state: &Arc<AppState>) -> Result<LeaseSweepReport, String> {
     let mut report = LeaseSweepReport::default();
     let leases: Vec<TrackLease> = state.projects.live_leases(None)?;
     report.live = leases.len();
+    // A mission may hold several leases; look it up and count it once.
+    let mut released: std::collections::HashSet<String> = std::collections::HashSet::new();
     for lease in &leases {
+        if released.contains(&lease.attempt_id) {
+            continue;
+        }
         let Ok(mission_id) = uuid::Uuid::parse_str(&lease.attempt_id) else {
             state.projects.expire_lease(&lease.id)?;
-            report.expired_overdue += 1;
+            report.expired_invalid += 1;
             continue;
         };
         match state.control.find_mission_any_store(mission_id).await {
@@ -174,6 +183,7 @@ pub async fn sweep(state: &Arc<AppState>) -> Result<LeaseSweepReport, String> {
                     state
                         .projects
                         .release_leases_for_attempt(&lease.attempt_id)?;
+                    released.insert(lease.attempt_id.clone());
                     report.released_terminal += 1;
                 } else if state.projects.renew_lease(&lease.id, LEASE_TTL_SECS)? {
                     report.renewed += 1;
@@ -183,6 +193,7 @@ pub async fn sweep(state: &Arc<AppState>) -> Result<LeaseSweepReport, String> {
                 state
                     .projects
                     .release_leases_for_attempt(&lease.attempt_id)?;
+                released.insert(lease.attempt_id.clone());
                 report.released_missing += 1;
             }
             Err(error) => {

--- a/src/api/track_leases.rs
+++ b/src/api/track_leases.rs
@@ -1,0 +1,244 @@
+//! Track ownership leases: acquisition helpers for the control plane and the
+//! periodic sweep that keeps them honest.
+//!
+//! A lease says "this mission may mutate this track right now". It is taken
+//! when a mission is created or re-tagged, renewed while the mission is live,
+//! and released when the mission ends. Because the mission store and
+//! `projects.db` are separate authorities, the two crash windows (mission
+//! created but lease never taken; lease taken but mission gone) are repaired
+//! here rather than pretended away with a single transaction.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use super::control::events::MissionStatus;
+use super::projects_store::{LeaseError, LeaseRequest, TrackLease};
+use super::routes::AppState;
+
+/// How long a lease lives without renewal. Missions run for days; the sweep
+/// renews live ones every pass, so this only has to outlast a restart.
+pub const LEASE_TTL_SECS: u64 = 6 * 60 * 60;
+
+/// Intents that never mutate the governed artifact. A mission with one of
+/// these takes a reader lease and coexists with the writer. Anything else —
+/// including no intent at all — is a writer.
+const READONLY_INTENTS: &[&str] = &[
+    "review",
+    "review_pr",
+    "review_merge_pr",
+    "audit",
+    "inspect",
+    "certify",
+    "certification",
+    "verify",
+    "validate",
+    "watch",
+    "monitor",
+    "report",
+    "research",
+    "read",
+    "readonly",
+    "triage",
+];
+
+/// Server-side decision: reader or writer. The caller's `writer: false` is
+/// honoured (it can only make a mission *less* powerful); `writer: true` or
+/// a `pr-writer` tag forces writer; otherwise the intent decides.
+pub fn lease_mode(
+    writer_flag: Option<bool>,
+    tags: &[String],
+    intent: Option<&str>,
+) -> &'static str {
+    if writer_flag == Some(false) || tags.iter().any(|tag| tag == "pr-readonly") {
+        return "reader";
+    }
+    if writer_flag == Some(true) || tags.iter().any(|tag| tag == "pr-writer") {
+        return "writer";
+    }
+    let intent = intent
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+    if READONLY_INTENTS.iter().any(|candidate| {
+        intent == *candidate
+            || intent.starts_with(&format!("{candidate}_"))
+            || intent.starts_with(&format!("{candidate}-"))
+    }) {
+        "reader"
+    } else {
+        "writer"
+    }
+}
+
+/// `SANDBOXED_TRACK_REQUIRED=1`: a project-tagged mission without a track is
+/// rejected instead of absorbed under a generated key.
+pub fn track_required() -> bool {
+    matches!(
+        std::env::var("SANDBOXED_TRACK_REQUIRED")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "on" | "yes"
+    )
+}
+
+/// Generated key for a legacy untagged mission during the compatibility
+/// window. Stable per mission so retries do not fan out.
+pub fn generated_track_key(mission_id: &str) -> String {
+    format!("mission-{}", mission_id.chars().take(8).collect::<String>())
+}
+
+/// PR number out of a free-form `github_pr` reference (`owner/repo#233`,
+/// `#233`, `233`, a PR URL).
+pub fn pr_number(github_pr: Option<&str>) -> Option<i64> {
+    let text = github_pr?.trim();
+    if text.is_empty() {
+        return None;
+    }
+    let tail = text.rsplit(['#', '/']).next().unwrap_or(text).trim();
+    tail.parse::<i64>().ok().filter(|n| *n > 0)
+}
+
+pub fn lease_request(
+    slug: &str,
+    track: &str,
+    mission_id: &str,
+    mode: &str,
+    idempotency_key: Option<&str>,
+) -> LeaseRequest {
+    LeaseRequest {
+        slug: slug.to_string(),
+        track: track.to_string(),
+        mutation_domain: "track".to_string(),
+        attempt_id: mission_id.to_string(),
+        mode: mode.to_string(),
+        idempotency_key: idempotency_key
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .map(|key| format!("lease:{key}"))
+            .unwrap_or_else(|| format!("lease:mission:{mission_id}:{slug}:{track}")),
+        ttl_secs: LEASE_TTL_SECS,
+    }
+}
+
+/// The 409 body for a held track.
+pub fn owned_body(slug: &str, track: &str, error: &LeaseError) -> serde_json::Value {
+    match error {
+        LeaseError::Owned {
+            holder_attempt_id,
+            lease_until,
+            lease_id,
+        } => serde_json::json!({
+            "error": "track_owned",
+            "project": slug,
+            "track": track,
+            "holder_mission_id": holder_attempt_id,
+            "lease_until": lease_until,
+            "lease_id": lease_id,
+            "message": format!(
+                "track '{track}' of '{slug}' is owned by mission {holder_attempt_id} until {lease_until}; \
+                 attach to it (send_message_to_mission), wait for it to end, or dispatch a read-only \
+                 intent (writer=false)"
+            ),
+        }),
+        other => serde_json::json!({ "error": "lease_failed", "message": other.to_string() }),
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct LeaseSweepReport {
+    pub live: usize,
+    pub renewed: usize,
+    pub released_terminal: usize,
+    pub released_missing: usize,
+    pub expired_overdue: usize,
+}
+
+/// One pass: renew leases of live missions, release those whose mission is
+/// terminal or gone, expire overdue ones nobody renewed.
+pub async fn sweep(state: &Arc<AppState>) -> Result<LeaseSweepReport, String> {
+    let mut report = LeaseSweepReport::default();
+    let leases: Vec<TrackLease> = state.projects.live_leases(None)?;
+    report.live = leases.len();
+    for lease in &leases {
+        let Ok(mission_id) = uuid::Uuid::parse_str(&lease.attempt_id) else {
+            state.projects.expire_lease(&lease.id)?;
+            report.expired_overdue += 1;
+            continue;
+        };
+        match state.control.find_mission_any_store(mission_id).await {
+            Ok(Some(mission)) => {
+                if mission.status.is_terminal() || mission.status == MissionStatus::Acknowledged {
+                    state
+                        .projects
+                        .release_leases_for_attempt(&lease.attempt_id)?;
+                    report.released_terminal += 1;
+                } else if state.projects.renew_lease(&lease.id, LEASE_TTL_SECS)? {
+                    report.renewed += 1;
+                }
+            }
+            Ok(None) => {
+                state
+                    .projects
+                    .release_leases_for_attempt(&lease.attempt_id)?;
+                report.released_missing += 1;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    lease = %lease.id,
+                    mission = %lease.attempt_id,
+                    %error,
+                    "lease sweep: mission store unavailable; leaving lease"
+                );
+            }
+        }
+    }
+    for lease in state.projects.overdue_leases()? {
+        if state.projects.expire_lease(&lease.id)? {
+            report.expired_overdue += 1;
+        }
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn readonly_intents_take_reader_leases_unless_forced() {
+        assert_eq!(lease_mode(None, &[], Some("review_merge_pr")), "reader");
+        assert_eq!(lease_mode(None, &[], Some("Certify")), "reader");
+        assert_eq!(lease_mode(None, &[], Some("repair-build")), "writer");
+        assert_eq!(lease_mode(None, &[], None), "writer");
+        assert_eq!(lease_mode(Some(false), &[], Some("repair")), "reader");
+        assert_eq!(lease_mode(Some(true), &[], Some("review")), "writer");
+        assert_eq!(
+            lease_mode(None, &["pr-writer".into()], Some("review")),
+            "writer"
+        );
+    }
+
+    #[test]
+    fn pr_numbers_come_out_of_any_reference_shape() {
+        assert_eq!(pr_number(Some("lfglabs-dev/verity#233")), Some(233));
+        assert_eq!(pr_number(Some("#233")), Some(233));
+        assert_eq!(pr_number(Some("233")), Some(233));
+        assert_eq!(
+            pr_number(Some("https://github.com/o/r/pull/233")),
+            Some(233)
+        );
+        assert_eq!(pr_number(Some("main")), None);
+        assert_eq!(pr_number(None), None);
+    }
+
+    #[test]
+    fn generated_keys_are_stable_per_mission() {
+        assert_eq!(
+            generated_track_key("693cc6e8-a6cf-4491-86a7-6585625db99e"),
+            "mission-693cc6e8"
+        );
+    }
+}

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -305,6 +305,8 @@ struct StartMissionParams {
     #[serde(default)]
     track: Option<String>,
     #[serde(default)]
+    idempotency_key: Option<String>,
+    #[serde(default)]
     intent: Option<String>,
     #[serde(default)]
     github_pr: Option<String>,
@@ -1508,6 +1510,7 @@ impl AssistantMcp {
                         "agent": {"type": "string"},
                         "project": {"type": "string", "description": "Stable project id (e.g. \"verity\")."},
                         "track": {"type": "string", "description": "Track/workstream (e.g. \"core-c3\")."},
+                        "idempotency_key": {"type": "string", "description": "Stable key for this dispatch (e.g. '<project>/<track>/<intent>/<date>'). A retry with the same key cannot take a second track lease."},
                         "intent": {"type": "string", "description": "Intent (e.g. \"review_merge_pr\")."},
                         "github_pr": {"type": "string", "description": "Associated PR ref (e.g. \"owner/repo#123\")."},
                         "writer": {"type": "boolean", "description": "Capability boundary for the associated PR. Use false for every reviewer/certifier (server-enforced read-only git/gh); use true for any branch, comment, thread, approval, or merge mutation. Concurrent writers for one PR are rejected."},
@@ -2331,6 +2334,7 @@ impl AssistantMcp {
             // metadata (Paloma watchdogs then route by these, not titles).
             "project": params.project,
             "track": params.track,
+            "idempotency_key": params.idempotency_key,
             "intent": params.intent,
             "github_pr": params.github_pr,
             "writer": params.writer,


### PR DESCRIPTION
Stacked on #874. Step 4 of `docs/plans/ROADMAP_TRUTH_AND_BUILD_DEDUP.md`: write-time absorption (key / alias / single PR ref / new `absorbed` row), `track_leases` with exclusive writers and coexisting readers (`409 track_owned`), idempotency key on dispatch, lease sweep at boot and every 10 min, lease holder as the situation item `owner`, skill updates. Compatibility window: untracked project missions absorb under `mission-<id8>`; `SANDBOXED_TRACK_REQUIRED=1` rejects them. See the commit message for details. Verified: `cargo fmt --check`, no new clippy warnings, `cargo test --bins`, lib tests green except the known Linux-only ones.