### PR TITLE
chore(patches): type mission-callback rows for display (hermes mirror)

### DIFF
--- a/patches/hermes/mission_status_route.py
+++ b/patches/hermes/mission_status_route.py
@@ -36,6 +36,13 @@ _TERMINAL = {
 # looks dead (Lido/EIP-8282, 2026-08-24). Only a compression lock skips.
 PROJECT_OPERATOR_WAKE_MESSAGE_CAP = 80
 
+# Display typing for the rows this route writes. The desktop renders
+# `mission_callback` under a "mission finished" divider, `mission_callback_wake`
+# as a timeline line (never the prompt text), and `hidden` not at all.
+MISSION_CALLBACK_DISPLAY_KIND = "mission_callback"
+MISSION_CALLBACK_WAKE_DISPLAY_KIND = "mission_callback_wake"
+MISSION_CALLBACK_SEPARATOR_DISPLAY_KIND = "hidden"
+
 MISSION_CALLBACK_WAKE_PROMPT = (
     "A routed mission-complete callback was just appended to this conversation. "
     "In one or two sentences, tell the operator what finished and whether they "
@@ -274,6 +281,43 @@ def format_mission_callback(payload: dict) -> str:
     return "\n".join(lines)
 
 
+def mission_callback_display_metadata(payload: dict) -> dict:
+    """Compact, renderable facts about the callback for ``display_metadata``.
+
+    Lets a client show "mission finished · title · status" and open the mission
+    without parsing the prose — and even when the woken model ignores the
+    one-or-two-sentence instruction.
+    """
+    metadata = {
+        "mission_id": str(payload.get("mission_id") or "").strip(),
+        "status": extract_status(payload),
+        "title": str(payload.get("title") or "mission").strip(),
+        "project": extract_project_slug(payload) or None,
+    }
+    event_id = extract_event_id(payload)
+    if event_id:
+        metadata["event_id"] = event_id
+    workspace = str(payload.get("workspace_name") or "").strip()
+    if workspace:
+        metadata["workspace"] = workspace
+    summary = str(
+        payload.get("result_summary") or payload.get("short_description") or ""
+    ).strip()
+    if summary:
+        metadata["summary"] = summary[:400]
+    return {k: v for k, v in metadata.items() if v is not None}
+
+
+def _append_typed(session_db: Any, **kwargs: Any) -> None:
+    """``append_message`` with display typing, tolerating older DB shims."""
+    try:
+        session_db.append_message(**kwargs)
+    except TypeError:
+        kwargs.pop("display_kind", None)
+        kwargs.pop("display_metadata", None)
+        session_db.append_message(**kwargs)
+
+
 def _last_message_role(session_db: Any, session_id: str) -> Optional[str]:
     reader = getattr(session_db, "get_messages", None) or getattr(
         session_db, "list_messages", None
@@ -348,13 +392,24 @@ def append_mission_callback(
                 )
                 return live, False
     content = format_mission_callback(payload)
+    metadata = mission_callback_display_metadata(payload)
     if _last_message_role(session_db, live) == "assistant":
-        session_db.append_message(
+        _append_typed(
+            session_db,
             session_id=live,
             role="user",
             content="A mission you started has finished. The result follows.",
+            display_kind=MISSION_CALLBACK_SEPARATOR_DISPLAY_KIND,
+            display_metadata=metadata,
         )
-    session_db.append_message(session_id=live, role="assistant", content=content)
+    _append_typed(
+        session_db,
+        session_id=live,
+        role="assistant",
+        content=content,
+        display_kind=MISSION_CALLBACK_DISPLAY_KIND,
+        display_metadata=metadata,
+    )
     return live, True
 
 

--- a/patches/hermes/test_mission_status_route.py
+++ b/patches/hermes/test_mission_status_route.py
@@ -278,3 +278,82 @@ def test_wake_prompt_does_not_order_an_inspect_loop():
     assert "do not run tools" in lower
     assert "continue autonomously" not in lower
     assert "if you can continue" not in lower
+
+
+class _TypedDB:
+    """Records every append with its display typing."""
+
+    def __init__(self, last_role=None):
+        self.appended = []
+        self._last_role = last_role
+
+    def get_session(self, session_id):
+        return {"id": session_id}
+
+    def get_messages(self, session_id):
+        if self._last_role is None:
+            return []
+        return [{"role": self._last_role, "content": "x"}]
+
+    def append_message(self, **kwargs):
+        self.appended.append(kwargs)
+
+
+def test_callback_rows_are_typed_for_display():
+    from gateway.platforms.mission_status_route import (
+        MISSION_CALLBACK_DISPLAY_KIND,
+        MISSION_CALLBACK_SEPARATOR_DISPLAY_KIND,
+        append_mission_callback,
+        mission_callback_display_metadata,
+    )
+
+    payload = {
+        "mission_id": "693cc6e8-a6cf-4491-86a7-6585625db99e",
+        "status": "completed",
+        "title": "PR #233 repair",
+        "project": "verity-lido",
+        "workspace_name": "verity",
+        "short_description": "prove SUCCESS, GitHub CLEAN",
+        "event_id": "evt-233",
+    }
+    db = _TypedDB(last_role="assistant")
+    live, appended = append_mission_callback("s1", payload, db)
+    assert appended and live == "s1"
+    separator, callback = db.appended
+    assert separator["role"] == "user"
+    assert separator["display_kind"] == MISSION_CALLBACK_SEPARATOR_DISPLAY_KIND == "hidden"
+    assert callback["role"] == "assistant"
+    assert callback["display_kind"] == MISSION_CALLBACK_DISPLAY_KIND == "mission_callback"
+    meta = callback["display_metadata"]
+    assert meta == mission_callback_display_metadata(payload)
+    assert meta["mission_id"] == payload["mission_id"]
+    assert meta["status"] == "completed"
+    assert meta["title"] == "PR #233 repair"
+    assert meta["project"] == "verity-lido"
+    assert meta["event_id"] == "evt-233"
+    assert meta["workspace"] == "verity"
+    assert meta["summary"] == "prove SUCCESS, GitHub CLEAN"
+    # The prose still carries the machine trailer for the controller.
+    assert "[Mission callback: PR #233 repair]" in callback["content"]
+
+
+def test_callback_typing_tolerates_an_old_db_shim():
+    from gateway.platforms.mission_status_route import append_mission_callback
+
+    class _OldDB:
+        def __init__(self):
+            self.appended = []
+
+        def get_session(self, session_id):
+            return {"id": session_id}
+
+        def get_messages(self, session_id):
+            return []
+
+        def append_message(self, session_id, role, content):
+            self.appended.append((session_id, role, content))
+
+    db = _OldDB()
+    append_mission_callback("s1", {"mission_id": "m1", "status": "failed"}, db)
+    assert len(db.appended) == 1
+    assert db.appended[0][1] == "assistant"


### PR DESCRIPTION
Mirror of the hermes-agent PR (feat/mission-callback-display) for `patches/hermes/mission_status_route.py` and its test: callback rows get `display_kind` (`mission_callback` / `hidden`) and `display_metadata`, so the desktop renders the wake as a timeline line and the callback under a divider instead of user bubbles. Also carries the mirror's newer wake policy (only a compression lock skips the wake). Land together with the hermes-agent PR; the patch copy is what gets layered on deploy.