### PR TITLE
feat(remote-build): versioned content identity (tree SHA) and SQL mirror of the job ledger (step 6)

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -583,3 +583,26 @@ Before production deploy, this needs remote workspace synchronization, remote
 AI backend process supervision, streamed event forwarding, durable node lease
 tracking, capacity-aware queueing, TLS or private-network enforcement, and
 operator UI for selecting nodes.
+
+
+### Content identity (plan step 6)
+
+A build's identity is a versioned, canonical document hashed byte-for-byte
+(`RemoteJobIdentity::identity_hash`): `base_tree_sha` (the root tree of the
+commit; the commit itself is provenance only), `cwd_rel`, the exact `argv`,
+sorted `artifacts`, `toolchain`, the overlay digest, `builder_image_digest`,
+`build_protocol_version` and `behavior_env_digest` (an allowlisted,
+credential-free environment digest computed by `remote-lean-build`). The
+bundled wrapper sends `base_tree_sha`, `build_protocol_version` and
+`behavior_env_digest`; the node verifies `HEAD^{tree}` against
+`base_tree_sha` before building (`BASE_TREE_MISMATCH` otherwise).
+
+Receipts written before identity v1 carry `version: 0`. They still block a
+duplicate in-flight submission but are never replayed as success for a v1
+request.
+
+The JSON ledger (`remote-jobs.json`, `remote-job-receipts.json`) is mirrored
+into `projects.db` (`remote_jobs`, `remote_job_subscribers`, `receipts`
+kind=`build`) on every mutation; boot reconciliation backfills and logs a
+parity report. The JSON files stay authoritative until one production
+restart shows zero drift (plan step 9 retires them).

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -74,6 +74,27 @@ if toolchain_path.is_file():
 expected_head = os.environ.get("REMOTE_BUILD_EXPECTED_HEAD", "").strip()
 if expected_head:
     req["expected_head"] = expected_head
+# Content identity: the root tree, not the commit. Same tree under a
+# different commit message is the same build and reuses its receipt.
+req["base_tree_sha"] = subprocess.check_output(
+    ["git", "-C", str(repo_root), "rev-parse", f"{commit}^{{tree}}"], text=True
+).strip().lower()
+req["build_protocol_version"] = "1"
+# Behaviour-affecting, non-secret environment only (allowlist), hashed so a
+# changed Lean/Lake setting cannot reuse a stale receipt. Anything that looks
+# like a credential is excluded even when it matches the prefixes.
+_env_prefixes = ("LEAN_", "LAKE_", "ELAN_", "SANDBOXED_COMPUTE_POLICY")
+_secretish = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL")
+_behavior_env = sorted(
+    (k, v)
+    for k, v in os.environ.items()
+    if k.startswith(_env_prefixes) and not any(marker in k.upper() for marker in _secretish)
+)
+if _behavior_env:
+    _digest = hashlib.sha256()
+    for k, v in _behavior_env:
+        _digest.update(f"{k}={v}\0".encode("utf-8", "surrogateescape"))
+    req["behavior_env_digest"] = _digest.hexdigest()
 if os.environ.get("REMOTE_BUILD_FORCE_NEW", "0") == "1":
     req["force_new"] = True
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -27788,6 +27788,11 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
                 identity: Some(crate::remote_node::job_ledger::RemoteJobIdentity {
+                    version: 0,
+                    base_tree_sha: None,
+                    builder_image_digest: None,
+                    build_protocol_version: None,
+                    behavior_env_digest: None,
                     repository: "https://example.invalid/repo.git".to_string(),
                     commit: "abc123".to_string(),
                     cwd_rel_known: true,
@@ -27898,6 +27903,11 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
                 identity: Some(crate::remote_node::job_ledger::RemoteJobIdentity {
+                    version: 0,
+                    base_tree_sha: None,
+                    builder_image_digest: None,
+                    build_protocol_version: None,
+                    behavior_env_digest: None,
                     repository: "https://example.invalid/repo.git".to_string(),
                     commit: "def456".to_string(),
                     cwd_rel_known: true,

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -29,12 +29,58 @@ pub const SCHEMA_VERSION: i64 = 2;
 /// Tracker parser revision recorded on every import row.
 pub const TRACKER_PARSER_VERSION: i64 = 1;
 
+/// Remote build job mirror tables. Shared with `remote_node::job_ledger::sql`,
+/// which opens the same database from the ledger's working dir.
+pub const REMOTE_JOBS_SCHEMA: &str = r#"
+-- Remote build jobs and their subscribers (mirror of the JSON ledger during
+-- the dual-write window; see remote_node::job_ledger). Terminal outcomes are
+-- also written to `receipts` as kind='build'.
+CREATE TABLE IF NOT EXISTS remote_jobs (
+    job_id              TEXT PRIMARY KEY,
+    mission_id          TEXT NOT NULL,
+    node_id             TEXT NOT NULL,
+    kind                TEXT NOT NULL,                     -- mission|remote_build|tentative
+    state               TEXT NOT NULL CHECK (state IN
+                          ('submitting','accepted','running','succeeded','failed','cancelled','lost')),
+    identity_version    INTEGER NOT NULL DEFAULT 0,
+    identity_hash       TEXT,
+    identity_json       TEXT,
+    submission_sequence INTEGER NOT NULL DEFAULT 0,
+    started_at          TEXT NOT NULL,
+    accepted_at         TEXT,
+    heartbeat_at        TEXT,
+    finished_at         TEXT,
+    exit_status         INTEGER,
+    artifacts_json      TEXT NOT NULL DEFAULT '[]',
+    wake_required       INTEGER NOT NULL DEFAULT 0,
+    wake_delivered_at   TEXT,
+    wake_suppressed_by  TEXT,
+    updated_at          TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS one_live_job_per_identity
+    ON remote_jobs(identity_hash)
+    WHERE state IN ('submitting','accepted','running') AND identity_hash IS NOT NULL;
+CREATE INDEX IF NOT EXISTS remote_jobs_mission ON remote_jobs(mission_id, state);
+
+CREATE TABLE IF NOT EXISTS remote_job_subscribers (
+    job_id          TEXT NOT NULL REFERENCES remote_jobs(job_id) ON DELETE CASCADE,
+    mission_id      TEXT NOT NULL,
+    wake_required   INTEGER NOT NULL DEFAULT 0,
+    wake_state      TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (wake_state IN ('pending','delivered','suppressed')),
+    attached_at     TEXT NOT NULL,
+    delivered_at    TEXT,
+    PRIMARY KEY (job_id, mission_id)
+);
+
+"#;
+
 pub type SharedProjectsStore = Arc<ProjectsStore>;
 
 pub const TRACK_VERIFIER_CLASSES: [&str; 5] =
     ["external_state", "command", "review", "operator", "manual"];
 
-const SCHEMA: &str = r#"
+pub(crate) const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS project_bindings (
     slug               TEXT PRIMARY KEY NOT NULL,
     control_session_id TEXT NOT NULL,
@@ -375,6 +421,7 @@ impl ProjectsStore {
     /// column must be reconciled explicitly.
     fn initialize(connection: &Connection) -> rusqlite::Result<()> {
         connection.execute_batch(SCHEMA)?;
+        connection.execute_batch(REMOTE_JOBS_SCHEMA)?;
         // project_state_events.session_id (2026-08: the overview builds
         // latest_update from the store, so the delivery's session rides along).
         Self::ensure_column(

--- a/src/api/reconcile.rs
+++ b/src/api/reconcile.rs
@@ -408,6 +408,13 @@ pub struct ReconcileReport {
 pub async fn run(state: &Arc<AppState>) -> ReconcileReport {
     let mut report = ReconcileReport::default();
 
+    // Remote job ledger: mirror JSON handles/receipts into SQL and report
+    // drift (dual-write window, plan step 6). Never deletes.
+    match crate::remote_node::job_ledger::sql_parity_backfill(&state.config.working_dir).await {
+        Ok(parity) => tracing::info!(?parity, "reconcile: remote job ledger parity"),
+        Err(error) => tracing::warn!(%error, "reconcile: remote job ledger parity failed"),
+    }
+
     // Track leases: release those whose mission is terminal or gone, renew
     // the live ones. Repairs the create-mission crash windows at boot.
     match super::track_leases::sweep(state).await {

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -404,6 +404,20 @@ pub struct RemoteBuildRequest {
     /// successful build.
     #[serde(default)]
     pub artifacts: Vec<String>,
+    /// Root tree of `commit` (`git rev-parse <commit>^{tree}`). Content
+    /// identity: two commits with the same tree are the same build. The node
+    /// verifies the checkout against it.
+    #[serde(default)]
+    pub base_tree_sha: Option<String>,
+    /// Builder image digest, when the wrapper knows it.
+    #[serde(default)]
+    pub builder_image_digest: Option<String>,
+    /// Wrapper build-protocol revision.
+    #[serde(default)]
+    pub build_protocol_version: Option<String>,
+    /// Digest over the allowlisted behaviour-affecting environment.
+    #[serde(default)]
+    pub behavior_env_digest: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -454,9 +468,18 @@ fn repository_url_has_credentials(repo: &str) -> bool {
 fn remote_job_identity(
     req: &RemoteBuildRequest,
 ) -> crate::remote_node::job_ledger::RemoteJobIdentity {
+    let clean = |value: &Option<String>| {
+        value
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(str::to_string)
+    };
     crate::remote_node::job_ledger::RemoteJobIdentity {
+        version: crate::remote_node::job_ledger::IDENTITY_VERSION,
         repository: repository_identity(&req.repo),
         commit: req.commit.clone(),
+        base_tree_sha: clean(&req.base_tree_sha).map(|tree| tree.to_ascii_lowercase()),
         cwd_rel_known: true,
         cwd_rel: req.cwd_rel.clone(),
         command: req.command.clone(),
@@ -466,6 +489,19 @@ fn remote_job_identity(
             .source_bundle
             .as_ref()
             .map(source_bundle_identity_digest),
+        builder_image_digest: clean(&req.builder_image_digest),
+        build_protocol_version: clean(&req.build_protocol_version),
+        behavior_env_digest: clean(&req.behavior_env_digest),
+    }
+}
+
+fn validate_base_tree_sha(value: Option<&str>) -> Result<(), String> {
+    match value.map(str::trim).filter(|v| !v.is_empty()) {
+        Some(tree) if tree.len() == 40 && tree.chars().all(|c| c.is_ascii_hexdigit()) => Ok(()),
+        Some(tree) => Err(format!(
+            "base_tree_sha must be a 40-char hex tree id, got '{tree}'"
+        )),
+        None => Ok(()),
     }
 }
 
@@ -1058,6 +1094,9 @@ async fn submit_remote_build(
     if let Err(message) = validate_expected_head(&req.commit, req.expected_head.as_deref()) {
         return (StatusCode::CONFLICT, message).into_response();
     }
+    if let Err(error) = validate_base_tree_sha(req.base_tree_sha.as_deref()) {
+        return (StatusCode::BAD_REQUEST, error).into_response();
+    }
     let max_estimated_disk_bytes =
         env_gib("REMOTE_BUILD_MAX_ESTIMATED_DISK_GB", MAX_ESTIMATED_DISK_GB);
     if req.estimated_disk_bytes == 0 || req.estimated_disk_bytes > max_estimated_disk_bytes {
@@ -1147,6 +1186,12 @@ async fn submit_remote_build(
                 commit: req.commit.clone(),
                 archive: req.source_archive.clone().map(Box::new),
                 bundle: req.source_bundle.clone(),
+                base_tree_sha: req
+                    .base_tree_sha
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                    .map(|v| v.to_ascii_lowercase()),
             }),
             cwd_rel: req.cwd_rel.clone(),
             command: req.command.clone(),
@@ -2088,6 +2133,11 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                 state: "succeeded".to_string(),
                 exit_status: Some(0),
                 identity: crate::remote_node::job_ledger::RemoteJobIdentity {
+                    version: 0,
+                    base_tree_sha: None,
+                    builder_image_digest: None,
+                    build_protocol_version: None,
+                    behavior_env_digest: None,
                     repository: "https://github.com/example/verity.git".to_string(),
                     commit: "a".repeat(40),
                     cwd_rel_known: true,

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -781,6 +781,7 @@ mod tests {
                 lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
                 payload: sandboxed_sh::remote_node::JobPayload::LeanBuild {
                     source: Box::new(sandboxed_sh::remote_node::JobSource {
+                        base_tree_sha: None,
                         repo: "/node/local/repo".to_string(),
                         commit: "a".repeat(40),
                         archive: None,

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -476,6 +476,38 @@ fn sha256_hex(bytes: &[u8]) -> String {
 }
 
 /// Content-addressed checkout directory for `(repo, commit)`.
+/// The submitter pinned a root tree; the checkout must have exactly that
+/// tree or the receipt would prove something about different content.
+/// Legacy submissions carry no tree and skip the check.
+async fn verify_base_tree(source: &JobSource, checkout: &Path) -> anyhow::Result<()> {
+    let Some(expected) = source
+        .base_tree_sha
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+    let output = tokio::process::Command::new("git")
+        .args(["rev-parse", "HEAD^{tree}"])
+        .current_dir(checkout)
+        .output()
+        .await?;
+    if !output.status.success() {
+        anyhow::bail!("could not resolve the checked-out tree for base tree verification");
+    }
+    let actual = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_ascii_lowercase();
+    if actual != expected.to_ascii_lowercase() {
+        anyhow::bail!(
+            "BASE_TREE_MISMATCH: submitter pinned tree {expected} but commit {} checks out tree {actual}",
+            source.commit
+        );
+    }
+    Ok(())
+}
+
 pub fn checkout_dir(work_root: &Path, repo: &str, commit: &str) -> PathBuf {
     let repo_hash = sha256_hex(repo.as_bytes());
     work_root
@@ -1102,6 +1134,7 @@ async fn import_source_archive(
         token,
     )
     .await?;
+    verify_base_tree(source, tmp).await?;
     tokio::fs::write(
         tmp.join(".git/sandboxed-source-archive"),
         format!("{}\n", archive.sha256),
@@ -1215,6 +1248,7 @@ async fn ensure_checkout(
             token,
         )
         .await?;
+        verify_base_tree(source, &tmp).await?;
         // Best-effort: many Lean repos have no submodules and lakefile deps
         // are fetched by lake itself.
         let _ = run_git_step(
@@ -1863,6 +1897,7 @@ mod tests {
             commit: commit.to_string(),
             archive: None,
             bundle: None,
+            base_tree_sha: None,
         }
     }
 
@@ -1988,6 +2023,7 @@ mod tests {
         let work_root = tempfile::tempdir().unwrap();
         let log = work_root.path().join("job.log");
         let mut source = JobSource {
+            base_tree_sha: None,
             repo: "https://127.0.0.1:9/private/repository.git".to_string(),
             commit: commit.clone(),
             archive: Some(Box::new(archive)),
@@ -2075,6 +2111,7 @@ mod tests {
         let (_source_repo, commit, archive) = committed_archive();
         let other_commit = "b".repeat(40);
         let mut source = JobSource {
+            base_tree_sha: None,
             repo: "https://127.0.0.1:9/private/repository.git".to_string(),
             commit: other_commit.clone(),
             archive: Some(Box::new(archive.clone())),
@@ -2448,6 +2485,7 @@ mod tests {
             assert!(
                 validate_lean_build(
                     &JobSource {
+                        base_tree_sha: None,
                         repo: bad.to_string(),
                         commit: "a".repeat(40),
                         archive: None,
@@ -2470,6 +2508,7 @@ mod tests {
             assert!(
                 validate_lean_build(
                     &JobSource {
+                        base_tree_sha: None,
                         repo: good.to_string(),
                         commit: "a".repeat(40),
                         archive: None,
@@ -2664,18 +2703,21 @@ mod tests {
     fn lake_cache_key_is_partitioned_by_project_and_target() {
         let dependency_key = "same-toolchain-and-manifest";
         let source_a = JobSource {
+            base_tree_sha: None,
             repo: "https://example.com/a.git".to_string(),
             commit: "a".repeat(40),
             archive: None,
             bundle: None,
         };
         let source_a_next_commit = JobSource {
+            base_tree_sha: None,
             repo: source_a.repo.clone(),
             commit: "b".repeat(40),
             archive: None,
             bundle: None,
         };
         let source_b = JobSource {
+            base_tree_sha: None,
             repo: "https://example.com/b.git".to_string(),
             commit: "a".repeat(40),
             archive: None,

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -786,6 +786,7 @@ mod tests {
                     data_base64: "private-source-data".to_string(),
                 })),
                 bundle: None,
+                base_tree_sha: None,
             }),
             cwd_rel: None,
             command: vec!["lake".to_string(), "build".to_string()],

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -608,6 +608,7 @@ pub async fn mark_terminal_wake_suppressed(
     if receipt.wake_delivered_at.is_none() {
         receipt.wake_delivered_at = Some(chrono::Utc::now());
         receipt.wake_suppressed_by = Some(superseding_job_id);
+        sql::mirror_wake(working_dir, job_id, "suppressed", Some(superseding_job_id));
         store_receipts(working_dir, &receipts).await?;
     }
     Ok(true)

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -35,8 +35,17 @@ pub enum JobHandleKind {
 /// exactly what was validated without persisting clone credentials.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RemoteJobIdentity {
+    /// Identity schema version. `0` = legacy (commit-keyed, no tree); such
+    /// receipts are never replayed as success for a newer identity.
+    #[serde(default)]
+    pub version: u32,
     pub repository: String,
     pub commit: String,
+    /// Root tree of `commit`. When present it, not the commit, is the content
+    /// identity: the same tree under a different commit message is the same
+    /// build.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_tree_sha: Option<String>,
     /// `false` means this identity predates cwd persistence. Such receipts are
     /// intentionally not equal to new root-cwd requests because their actual
     /// execution directory is unknowable after upgrade.
@@ -54,6 +63,77 @@ pub struct RemoteJobIdentity {
     pub toolchain: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_bundle_digest: Option<String>,
+    /// Builder image / toolchain container digest, when the node runs one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builder_image_digest: Option<String>,
+    /// Wire/build protocol revision of the submitting wrapper.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_protocol_version: Option<String>,
+    /// Digest of the allowlisted, behaviour-affecting, non-secret environment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub behavior_env_digest: Option<String>,
+}
+
+/// Current identity schema version written by core.
+pub const IDENTITY_VERSION: u32 = 1;
+
+impl RemoteJobIdentity {
+    /// Canonical, byte-stable hash of the identity. `base_tree_sha` replaces
+    /// the commit when present; artifacts are sorted and de-duplicated; the
+    /// version is part of the hash so a schema change can never alias.
+    pub fn identity_hash(&self) -> String {
+        use sha2::Digest;
+        let mut artifacts = self.artifacts.clone();
+        artifacts.sort();
+        artifacts.dedup();
+        let content = match self.base_tree_sha.as_deref().map(str::trim) {
+            Some(tree) if !tree.is_empty() => format!("tree:{}", tree.to_ascii_lowercase()),
+            _ => format!("commit:{}", self.commit.to_ascii_lowercase()),
+        };
+        let canonical = serde_json::json!({
+            "v": self.version,
+            "repository": self.repository,
+            "content": content,
+            "cwd_rel": self.cwd_rel,
+            "cwd_rel_known": self.cwd_rel_known,
+            "argv": self.command,
+            "artifacts": artifacts,
+            "toolchain": self.toolchain,
+            "bundle": self.source_bundle_digest,
+            "image": self.builder_image_digest,
+            "protocol": self.build_protocol_version,
+            "env": self.behavior_env_digest,
+        });
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(b"sandboxed-remote-job-identity\0");
+        hasher.update(canonical.to_string().as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    /// Same build for exclusion purposes. Two identities of the same version
+    /// compare by hash. A legacy (v0) identity on either side falls back to
+    /// the legacy field equality so an in-flight pre-upgrade job still
+    /// blocks a duplicate — conservatively, never the other way round.
+    pub fn excludes(&self, other: &RemoteJobIdentity) -> bool {
+        if self.version == other.version {
+            return self.identity_hash() == other.identity_hash();
+        }
+        self.repository == other.repository
+            && self.commit.eq_ignore_ascii_case(&other.commit)
+            && self.cwd_rel == other.cwd_rel
+            && self.command == other.command
+            && self.artifacts == other.artifacts
+            && self.toolchain == other.toolchain
+            && self.source_bundle_digest == other.source_bundle_digest
+    }
+
+    /// Whether a successful receipt with this identity may be replayed for a
+    /// request with `other`: same version (never v0) and same hash.
+    pub fn reusable_for(&self, other: &RemoteJobIdentity) -> bool {
+        self.version >= 1
+            && self.version == other.version
+            && self.identity_hash() == other.identity_hash()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -342,7 +422,7 @@ pub async fn equivalent_remote_validation(
     if let Some(receipt) = receipts
         .into_iter()
         .filter(|receipt| {
-            receipt.identity == *identity
+            receipt.identity.reusable_for(identity)
                 && (identity.artifacts.is_empty() || !receipt.artifacts.is_empty())
                 && receipt.state == "succeeded"
                 && receipt.exit_status == Some(0)
@@ -355,7 +435,10 @@ pub async fn equivalent_remote_validation(
         .await?
         .into_iter()
         .filter(|handle| {
-            handle.identity.as_ref() == Some(identity)
+            handle
+                .identity
+                .as_ref()
+                .is_some_and(|existing| existing.excludes(identity))
                 && matches!(
                     handle.kind,
                     JobHandleKind::RemoteBuild | JobHandleKind::Tentative
@@ -379,7 +462,10 @@ pub async fn active_equivalent_remote_validation(
         .await?
         .into_iter()
         .filter(|handle| {
-            handle.identity.as_ref() == Some(identity)
+            handle
+                .identity
+                .as_ref()
+                .is_some_and(|existing| existing.excludes(identity))
                 && matches!(
                     handle.kind,
                     JobHandleKind::RemoteBuild | JobHandleKind::Tentative
@@ -538,6 +624,7 @@ pub async fn mark_terminal_wake_delivered(
     };
     if receipt.wake_delivered_at.is_none() {
         receipt.wake_delivered_at = Some(chrono::Utc::now());
+        sql::mirror_wake(working_dir, job_id, "delivered", None);
         store_receipts(working_dir, &receipts).await?;
     }
     Ok(true)
@@ -570,9 +657,13 @@ pub async fn finalize_with_artifacts(
         return Ok(false);
     };
     let handle = handles.remove(index);
+    if handle.kind != JobHandleKind::RemoteBuild {
+        sql::mirror_terminal_without_receipt(working_dir, job_id, state);
+    }
     if handle.kind == JobHandleKind::RemoteBuild {
         let continuation_expected = handle.expects_mission_continuation();
         let Some(identity) = handle.identity else {
+            sql::mirror_terminal_without_receipt(working_dir, job_id, state);
             store(working_dir, &handles).await?;
             return Ok(true);
         };
@@ -598,6 +689,9 @@ pub async fn finalize_with_artifacts(
             wake_delivered_at: previous_wake_delivered_at,
             wake_suppressed_by: None,
         });
+        if let Some(receipt) = receipts.last() {
+            sql::mirror_receipt(working_dir, receipt);
+        }
         if receipts.len() > MAX_RECEIPTS {
             receipts.sort_by_key(|receipt| receipt.finished_at);
             let mut excess = receipts.len() - MAX_RECEIPTS;
@@ -647,6 +741,7 @@ pub async fn record(working_dir: &Path, handle: JobHandle) -> anyhow::Result<()>
         };
     }
     handles.retain(|existing| existing.job_id != handle.job_id);
+    sql::mirror_handle(working_dir, &handle);
     handles.push(handle);
     store(working_dir, &handles).await
 }
@@ -664,6 +759,7 @@ pub async fn remove(working_dir: &Path, job_id: Uuid) {
     let before = handles.len();
     handles.retain(|h| h.job_id != job_id);
     if handles.len() != before {
+        sql::mirror_remove(working_dir, job_id);
         if let Err(err) = store(working_dir, &handles).await {
             tracing::warn!(?err, "remote job ledger removal failed");
         }
@@ -685,6 +781,7 @@ pub async fn heartbeat(working_dir: &Path, job_id: Uuid) -> anyhow::Result<bool>
         return Ok(true);
     }
     handle.heartbeat_at = Some(now);
+    sql::mirror_handle(working_dir, handle);
     store(working_dir, &handles).await?;
     Ok(true)
 }
@@ -700,6 +797,397 @@ pub async fn require_terminal_wake(working_dir: &Path, job_id: Uuid) -> anyhow::
         store(working_dir, &handles).await?;
     }
     Ok(true)
+}
+
+/// SQL mirror of the JSON ledger (`projects.db`: `remote_jobs`,
+/// `remote_job_subscribers`, `receipts` kind=`build`).
+///
+/// Dual-write window (plan step 6): the JSON files stay authoritative and
+/// every mutation is mirrored here best-effort; startup runs
+/// [`sql_parity_backfill`] so a mirror that fell behind converges. Reads move
+/// to SQL in step 7, once a production restart has shown zero drift.
+pub mod sql {
+    use std::path::{Path, PathBuf};
+
+    use rusqlite::{params, Connection, OptionalExtension};
+    use serde::Serialize;
+    use uuid::Uuid;
+
+    use super::{JobHandle, JobHandleKind, RemoteJobReceipt};
+
+    fn db_path(working_dir: &Path) -> PathBuf {
+        working_dir.join(".sandboxed-sh").join("projects.db")
+    }
+
+    fn open(working_dir: &Path) -> Option<Connection> {
+        let path = db_path(working_dir);
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let connection = Connection::open(&path)
+            .map_err(|error| tracing::warn!(%error, "remote job SQL mirror: open failed"))
+            .ok()?;
+        let _ = connection.busy_timeout(std::time::Duration::from_secs(5));
+        let _ = connection.pragma_update(None, "journal_mode", "WAL");
+        // Idempotent: the store normally created these already; a fresh
+        // working dir (tests, first boot before the store opened) gets them
+        // here so a mirror write can never race the store's initialize.
+        for schema in [
+            crate::api::projects_store::SCHEMA,
+            crate::api::projects_store::REMOTE_JOBS_SCHEMA,
+        ] {
+            if let Err(error) = connection.execute_batch(schema) {
+                tracing::warn!(%error, "remote job SQL mirror: schema failed");
+                return None;
+            }
+        }
+        Some(connection)
+    }
+
+    fn kind_label(kind: JobHandleKind) -> &'static str {
+        match kind {
+            JobHandleKind::Mission => "mission",
+            JobHandleKind::RemoteBuild => "remote_build",
+            JobHandleKind::Tentative => "tentative",
+        }
+    }
+
+    fn handle_state(handle: &JobHandle) -> &'static str {
+        if handle.kind == JobHandleKind::Tentative || handle.accepted_at.is_none() {
+            "submitting"
+        } else if handle.heartbeat_at.is_some() {
+            "running"
+        } else {
+            "accepted"
+        }
+    }
+
+    fn upsert_handle(connection: &Connection, handle: &JobHandle) -> rusqlite::Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let identity_json = handle
+            .identity
+            .as_ref()
+            .and_then(|identity| serde_json::to_string(identity).ok());
+        let identity_hash = handle
+            .identity
+            .as_ref()
+            .map(|identity| identity.identity_hash());
+        let identity_version = handle
+            .identity
+            .as_ref()
+            .map(|identity| identity.version)
+            .unwrap_or(0);
+        connection.execute(
+            "INSERT INTO remote_jobs \
+               (job_id, mission_id, node_id, kind, state, identity_version, identity_hash, identity_json, \
+                submission_sequence, started_at, accepted_at, heartbeat_at, wake_required, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
+             ON CONFLICT(job_id) DO UPDATE SET \
+               node_id = excluded.node_id, kind = excluded.kind, \
+               state = CASE WHEN remote_jobs.state IN ('succeeded','failed','cancelled','lost') \
+                            THEN remote_jobs.state ELSE excluded.state END, \
+               identity_version = excluded.identity_version, identity_hash = excluded.identity_hash, \
+               identity_json = excluded.identity_json, \
+               submission_sequence = CASE WHEN excluded.submission_sequence > 0 \
+                                          THEN excluded.submission_sequence ELSE remote_jobs.submission_sequence END, \
+               accepted_at = COALESCE(excluded.accepted_at, remote_jobs.accepted_at), \
+               heartbeat_at = COALESCE(excluded.heartbeat_at, remote_jobs.heartbeat_at), \
+               wake_required = MAX(remote_jobs.wake_required, excluded.wake_required), \
+               updated_at = excluded.updated_at",
+            params![
+                handle.job_id.to_string(),
+                handle.mission_id.to_string(),
+                handle.node_id,
+                kind_label(handle.kind),
+                handle_state(handle),
+                identity_version,
+                identity_hash,
+                identity_json,
+                handle.submission_sequence as i64,
+                handle.started_at.to_rfc3339(),
+                handle.accepted_at.map(|at| at.to_rfc3339()),
+                handle.heartbeat_at.map(|at| at.to_rfc3339()),
+                handle.wake_on_terminal as i64,
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Mirror a live handle. A unique-index violation means a second live
+    /// job for the same identity slipped past the JSON check: logged loudly
+    /// (the JSON path is still the authority in the dual-write window).
+    pub fn mirror_handle(working_dir: &Path, handle: &JobHandle) {
+        let Some(connection) = open(working_dir) else {
+            return;
+        };
+        if let Err(error) = upsert_handle(&connection, handle) {
+            tracing::warn!(
+                job_id = %handle.job_id,
+                mission_id = %handle.mission_id,
+                %error,
+                "remote job SQL mirror: handle upsert failed (duplicate live identity?)"
+            );
+        }
+    }
+
+    fn upsert_receipt(connection: &Connection, receipt: &RemoteJobReceipt) -> rusqlite::Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let state = match receipt.state.as_str() {
+            "succeeded" | "failed" | "cancelled" | "lost" => receipt.state.as_str(),
+            _ => "failed",
+        };
+        let artifacts = serde_json::to_string(&receipt.artifacts).unwrap_or_else(|_| "[]".into());
+        let identity_json = serde_json::to_string(&receipt.identity).ok();
+        connection.execute(
+            "INSERT INTO remote_jobs \
+               (job_id, mission_id, node_id, kind, state, identity_version, identity_hash, identity_json, \
+                submission_sequence, started_at, finished_at, exit_status, artifacts_json, wake_required, \
+                wake_delivered_at, wake_suppressed_by, updated_at) \
+             VALUES (?1, ?2, ?3, 'remote_build', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16) \
+             ON CONFLICT(job_id) DO UPDATE SET \
+               state = excluded.state, finished_at = excluded.finished_at, exit_status = excluded.exit_status, \
+               artifacts_json = excluded.artifacts_json, identity_version = excluded.identity_version, \
+               identity_hash = excluded.identity_hash, identity_json = excluded.identity_json, \
+               wake_required = excluded.wake_required, wake_delivered_at = excluded.wake_delivered_at, \
+               wake_suppressed_by = excluded.wake_suppressed_by, updated_at = excluded.updated_at",
+            params![
+                receipt.job_id.to_string(),
+                receipt.mission_id.to_string(),
+                receipt.node_id,
+                state,
+                receipt.identity.version,
+                receipt.identity.identity_hash(),
+                identity_json,
+                receipt.submission_sequence as i64,
+                receipt.started_at.to_rfc3339(),
+                receipt.finished_at.to_rfc3339(),
+                receipt.exit_status,
+                artifacts,
+                receipt.wake_required as i64,
+                receipt.wake_delivered_at.map(|at| at.to_rfc3339()),
+                receipt.wake_suppressed_by.map(|id| id.to_string()),
+                now,
+            ],
+        )?;
+        // Immutable evidence: one build receipt per job (idempotent).
+        let outcome = match state {
+            "succeeded" => "succeeded",
+            "cancelled" => "cancelled",
+            _ => "failed",
+        };
+        let payload = serde_json::json!({
+            "identity": receipt.identity,
+            "identity_hash": receipt.identity.identity_hash(),
+            "node_id": receipt.node_id,
+            "mission_id": receipt.mission_id,
+            "exit_status": receipt.exit_status,
+            "artifacts": receipt.artifacts,
+            "started_at": receipt.started_at,
+            "finished_at": receipt.finished_at,
+        });
+        let request_hash = {
+            use sha2::Digest;
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(payload.to_string().as_bytes());
+            hex::encode(hasher.finalize())
+        };
+        connection.execute(
+            "INSERT OR IGNORE INTO receipts \
+               (id, idempotency_key, request_hash, kind, project_slug, track_id, criterion_id, subject_type, \
+                subject_id, outcome, actor_type, actor_id, verifier, supersedes_receipt_id, observed_at, \
+                payload, created_at) \
+             VALUES (?1, ?2, ?3, 'build', NULL, NULL, NULL, 'build', ?4, ?5, 'system', ?6, ?7, NULL, ?8, ?9, ?10)",
+            params![
+                Uuid::new_v4().to_string(),
+                format!("build:{}", receipt.job_id),
+                request_hash,
+                receipt.job_id.to_string(),
+                outcome,
+                format!("node:{}", receipt.node_id),
+                receipt.identity.toolchain,
+                receipt.finished_at.to_rfc3339(),
+                payload.to_string(),
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn mirror_receipt(working_dir: &Path, receipt: &RemoteJobReceipt) {
+        let Some(connection) = open(working_dir) else {
+            return;
+        };
+        if let Err(error) = upsert_receipt(&connection, receipt) {
+            tracing::warn!(job_id = %receipt.job_id, %error, "remote job SQL mirror: receipt upsert failed");
+        }
+    }
+
+    /// A mission / tentative handle finalized without a receipt.
+    pub fn mirror_terminal_without_receipt(working_dir: &Path, job_id: Uuid, state: &str) {
+        let Some(connection) = open(working_dir) else {
+            return;
+        };
+        let state = match state {
+            "succeeded" | "failed" | "cancelled" | "lost" => state,
+            _ => "failed",
+        };
+        if let Err(error) = connection.execute(
+            "UPDATE remote_jobs SET state = ?2, finished_at = ?3, updated_at = ?3 WHERE job_id = ?1",
+            params![job_id.to_string(), state, chrono::Utc::now().to_rfc3339()],
+        ) {
+            tracing::warn!(%job_id, %error, "remote job SQL mirror: terminal update failed");
+        }
+    }
+
+    pub fn mirror_remove(working_dir: &Path, job_id: Uuid) {
+        let Some(connection) = open(working_dir) else {
+            return;
+        };
+        // Only a still-live row is removed; terminal rows are history.
+        if let Err(error) = connection.execute(
+            "DELETE FROM remote_jobs WHERE job_id = ?1 AND state IN ('submitting','accepted','running')",
+            params![job_id.to_string()],
+        ) {
+            tracing::warn!(%job_id, %error, "remote job SQL mirror: remove failed");
+        }
+    }
+
+    pub fn mirror_wake(
+        working_dir: &Path,
+        job_id: Uuid,
+        disposition: &str,
+        suppressed_by: Option<Uuid>,
+    ) {
+        let Some(connection) = open(working_dir) else {
+            return;
+        };
+        let now = chrono::Utc::now().to_rfc3339();
+        let result = match disposition {
+            "delivered" => connection.execute(
+                "UPDATE remote_jobs SET wake_delivered_at = ?2, updated_at = ?2 WHERE job_id = ?1",
+                params![job_id.to_string(), now],
+            ),
+            _ => connection.execute(
+                "UPDATE remote_jobs SET wake_suppressed_by = ?2, updated_at = ?3 WHERE job_id = ?1",
+                params![
+                    job_id.to_string(),
+                    suppressed_by.map(|id| id.to_string()),
+                    now
+                ],
+            ),
+        };
+        if let Err(error) = result {
+            tracing::warn!(%job_id, %error, "remote job SQL mirror: wake update failed");
+        }
+    }
+
+    #[derive(Debug, Default, Clone, Serialize)]
+    pub struct ParityReport {
+        pub json_handles: usize,
+        pub json_receipts: usize,
+        pub sql_live: usize,
+        pub sql_terminal: usize,
+        pub backfilled_handles: usize,
+        pub backfilled_receipts: usize,
+        pub sql_live_not_in_json: usize,
+    }
+
+    /// Compare the JSON ledger with the mirror and backfill what the mirror
+    /// lacks. Live SQL rows with no JSON handle are reported, not deleted:
+    /// in the dual-write window the JSON file is the authority and a
+    /// disagreement is the signal the removal gate waits on.
+    pub fn parity_backfill(
+        working_dir: &Path,
+        handles: &[JobHandle],
+        receipts: &[RemoteJobReceipt],
+    ) -> ParityReport {
+        let mut report = ParityReport {
+            json_handles: handles.len(),
+            json_receipts: receipts.len(),
+            ..ParityReport::default()
+        };
+        let Some(connection) = open(working_dir) else {
+            return report;
+        };
+        let exists = |job_id: &Uuid| -> bool {
+            connection
+                .query_row(
+                    "SELECT 1 FROM remote_jobs WHERE job_id = ?1",
+                    params![job_id.to_string()],
+                    |_| Ok(()),
+                )
+                .optional()
+                .ok()
+                .flatten()
+                .is_some()
+        };
+        for handle in handles {
+            if !exists(&handle.job_id) && upsert_handle(&connection, handle).is_ok() {
+                report.backfilled_handles += 1;
+            }
+        }
+        for receipt in receipts {
+            let terminal: Option<String> = connection
+                .query_row(
+                    "SELECT state FROM remote_jobs WHERE job_id = ?1",
+                    params![receipt.job_id.to_string()],
+                    |row| row.get(0),
+                )
+                .optional()
+                .ok()
+                .flatten();
+            let needs = !matches!(
+                terminal.as_deref(),
+                Some("succeeded" | "failed" | "cancelled" | "lost")
+            );
+            if needs && upsert_receipt(&connection, receipt).is_ok() {
+                report.backfilled_receipts += 1;
+            }
+        }
+        report.sql_live = connection
+            .query_row(
+                "SELECT count(*) FROM remote_jobs WHERE state IN ('submitting','accepted','running')",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(0) as usize;
+        report.sql_terminal = connection
+            .query_row(
+                "SELECT count(*) FROM remote_jobs WHERE state IN ('succeeded','failed','cancelled','lost')",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(0) as usize;
+        let live_ids: Vec<String> = connection
+            .prepare(
+                "SELECT job_id FROM remote_jobs WHERE state IN ('submitting','accepted','running')",
+            )
+            .and_then(|mut statement| {
+                statement
+                    .query_map([], |row| row.get::<_, String>(0))
+                    .map(|rows| rows.filter_map(Result::ok).collect())
+            })
+            .unwrap_or_default();
+        report.sql_live_not_in_json = live_ids
+            .iter()
+            .filter(|id| {
+                !handles
+                    .iter()
+                    .any(|handle| handle.job_id.to_string() == **id)
+            })
+            .count();
+        report
+    }
+}
+
+/// Boot-time parity pass: mirror anything the JSON ledger has that SQL lacks
+/// and report drift. Never deletes.
+pub async fn sql_parity_backfill(working_dir: &Path) -> anyhow::Result<sql::ParityReport> {
+    let _guard = lock().lock().await;
+    let handles = load_result(working_dir).await?;
+    let receipts = load_receipts_result(working_dir).await?;
+    Ok(sql::parity_backfill(working_dir, &handles, &receipts))
 }
 
 #[cfg(test)]
@@ -888,6 +1376,11 @@ mod tests {
             disk_reservation_bytes: 0,
             kind: JobHandleKind::RemoteBuild,
             identity: Some(RemoteJobIdentity {
+                version: 0,
+                base_tree_sha: None,
+                builder_image_digest: None,
+                build_protocol_version: None,
+                behavior_env_digest: None,
                 repository: "https://example.invalid/repo.git".to_string(),
                 commit: "a".repeat(40),
                 cwd_rel_known: true,
@@ -915,6 +1408,11 @@ mod tests {
         let job_id = Uuid::new_v4();
         let mission_id = Uuid::new_v4();
         let identity = RemoteJobIdentity {
+            version: 0,
+            base_tree_sha: None,
+            builder_image_digest: None,
+            build_protocol_version: None,
+            behavior_env_digest: None,
             repository: "https://example.invalid/repo.git".to_string(),
             commit: "a".repeat(40),
             cwd_rel_known: true,
@@ -977,6 +1475,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let job_id = Uuid::new_v4();
         let identity = RemoteJobIdentity {
+            version: IDENTITY_VERSION,
+            base_tree_sha: None,
+            builder_image_digest: None,
+            build_protocol_version: None,
+            behavior_env_digest: None,
             repository: "https://example.invalid/repo.git".to_string(),
             commit: "a".repeat(40),
             cwd_rel_known: true,
@@ -1132,6 +1635,11 @@ mod tests {
         let old_started_at = chrono::Utc::now() - chrono::Duration::minutes(2);
         let new_started_at = chrono::Utc::now() - chrono::Duration::minutes(1);
         let identity = |commit: char| RemoteJobIdentity {
+            version: 0,
+            base_tree_sha: None,
+            builder_image_digest: None,
+            build_protocol_version: None,
+            behavior_env_digest: None,
             repository: "https://example.invalid/verity.git".to_string(),
             commit: commit.to_string().repeat(40),
             cwd_rel_known: true,
@@ -1228,6 +1736,11 @@ mod tests {
             disk_reservation_bytes: 0,
             kind: JobHandleKind::RemoteBuild,
             identity: Some(RemoteJobIdentity {
+                version: 0,
+                base_tree_sha: None,
+                builder_image_digest: None,
+                build_protocol_version: None,
+                behavior_env_digest: None,
                 repository: "https://example.invalid/verity.git".to_string(),
                 commit: job_id.to_string(),
                 cwd_rel_known: true,
@@ -1274,6 +1787,11 @@ mod tests {
         let continuation_job_id = Uuid::new_v4();
         let detached_job_id = Uuid::new_v4();
         let identity = |commit: char| RemoteJobIdentity {
+            version: 0,
+            base_tree_sha: None,
+            builder_image_digest: None,
+            build_protocol_version: None,
+            behavior_env_digest: None,
             repository: "https://example.invalid/verity.git".to_string(),
             commit: commit.to_string().repeat(40),
             cwd_rel_known: true,
@@ -1409,6 +1927,11 @@ mod tests {
         let active_started_at = chrono::Utc::now() - chrono::Duration::minutes(2);
         let receipt_started_at = chrono::Utc::now() - chrono::Duration::minutes(1);
         let identity = RemoteJobIdentity {
+            version: 0,
+            base_tree_sha: None,
+            builder_image_digest: None,
+            build_protocol_version: None,
+            behavior_env_digest: None,
             repository: "https://example.invalid/verity.git".to_string(),
             commit: "a".repeat(40),
             cwd_rel_known: true,
@@ -1467,6 +1990,11 @@ mod tests {
         let old_started_at = chrono::Utc::now() - chrono::Duration::minutes(2);
         let new_started_at = chrono::Utc::now() - chrono::Duration::minutes(1);
         let identity = RemoteJobIdentity {
+            version: 0,
+            base_tree_sha: None,
+            builder_image_digest: None,
+            build_protocol_version: None,
+            behavior_env_digest: None,
             repository: "https://example.invalid/verity.git".to_string(),
             commit: "a".repeat(40),
             cwd_rel_known: true,
@@ -1551,6 +2079,11 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::Tentative,
                 identity: Some(RemoteJobIdentity {
+                    version: 0,
+                    base_tree_sha: None,
+                    builder_image_digest: None,
+                    build_protocol_version: None,
+                    behavior_env_digest: None,
                     repository: "https://example.invalid/verity.git".to_string(),
                     commit: "a".repeat(40),
                     cwd_rel_known: true,
@@ -1577,5 +2110,182 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    fn identity_v1(commit: &str, tree: Option<&str>) -> RemoteJobIdentity {
+        RemoteJobIdentity {
+            version: IDENTITY_VERSION,
+            repository: "github.com/lfglabs-dev/verity".to_string(),
+            commit: commit.to_string(),
+            base_tree_sha: tree.map(str::to_string),
+            cwd_rel_known: true,
+            cwd_rel: Some("verity".to_string()),
+            command: vec!["lake".to_string(), "build".to_string()],
+            artifacts: vec!["b.olean".to_string(), "a.olean".to_string()],
+            toolchain: Some("leanprover/lean4:v4.19.0".to_string()),
+            source_bundle_digest: None,
+            builder_image_digest: None,
+            build_protocol_version: Some("1".to_string()),
+            behavior_env_digest: None,
+        }
+    }
+
+    #[test]
+    fn identity_hash_is_content_not_commit_and_every_input_matters() {
+        let tree = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let a = identity_v1("a".repeat(40).as_str(), Some(tree));
+        let b = identity_v1("b".repeat(40).as_str(), Some(tree));
+        assert_eq!(
+            a.identity_hash(),
+            b.identity_hash(),
+            "same tree, different commit: same build"
+        );
+        assert!(a.reusable_for(&b));
+        assert!(a.excludes(&b));
+
+        let other_tree = identity_v1("a".repeat(40).as_str(), Some(&"f".repeat(64)));
+        assert_ne!(a.identity_hash(), other_tree.identity_hash());
+
+        let mut env = a.clone();
+        env.behavior_env_digest = Some("abc".into());
+        assert_ne!(a.identity_hash(), env.identity_hash());
+        let mut image = a.clone();
+        image.builder_image_digest = Some("sha256:1".into());
+        assert_ne!(a.identity_hash(), image.identity_hash());
+        let mut argv = a.clone();
+        argv.command = vec!["lake".into(), "build".into(), "-K".into()];
+        assert_ne!(a.identity_hash(), argv.identity_hash());
+        let mut sorted = a.clone();
+        sorted.artifacts = vec!["a.olean".into(), "b.olean".into()];
+        assert_eq!(
+            a.identity_hash(),
+            sorted.identity_hash(),
+            "artifact order is not identity"
+        );
+
+        // No tree: the commit is the content.
+        let c1 = identity_v1("c".repeat(40).as_str(), None);
+        let c2 = identity_v1("d".repeat(40).as_str(), None);
+        assert_ne!(c1.identity_hash(), c2.identity_hash());
+    }
+
+    #[test]
+    fn legacy_v0_receipts_never_replay_but_still_exclude() {
+        let mut legacy = identity_v1("a".repeat(40).as_str(), None);
+        legacy.version = 0;
+        legacy.base_tree_sha = None;
+        legacy.build_protocol_version = None;
+        let current = identity_v1("a".repeat(40).as_str(), Some(&"e".repeat(64)));
+        assert!(
+            !legacy.reusable_for(&current),
+            "a pre-upgrade success is not evidence for v1"
+        );
+        assert!(
+            !legacy.reusable_for(&legacy),
+            "v0 never replays, even against itself"
+        );
+        let mut current_same_fields = current.clone();
+        current_same_fields.build_protocol_version = None;
+        assert!(
+            legacy.excludes(&current_same_fields),
+            "an in-flight v0 job still blocks a v1 duplicate"
+        );
+        let mut other_cwd = current_same_fields.clone();
+        other_cwd.cwd_rel = Some("elsewhere".into());
+        assert!(!legacy.excludes(&other_cwd));
+    }
+
+    #[tokio::test]
+    async fn sql_mirror_tracks_handles_receipts_and_backfills() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_id = Uuid::new_v4();
+        let mission_id = Uuid::new_v4();
+        let identity = identity_v1("a".repeat(40).as_str(), Some(&"e".repeat(64)));
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id,
+                node_id: "spark".to_string(),
+                job_id,
+                started_at: chrono::Utc::now(),
+                submission_sequence: 0,
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: None,
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity.clone()),
+                wait_for_completion: Some(true),
+                wake_on_terminal: true,
+            },
+        )
+        .await
+        .unwrap();
+        let db = dir.path().join(".sandboxed-sh/projects.db");
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        let (state, hash): (String, String) = connection
+            .query_row(
+                "SELECT state, identity_hash FROM remote_jobs WHERE job_id = ?1",
+                rusqlite::params![job_id.to_string()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(state, "accepted");
+        assert_eq!(hash, identity.identity_hash());
+
+        // A second live job with the same identity trips the unique index in
+        // SQL (logged, not fatal in the dual-write window).
+        let duplicate = Uuid::new_v4();
+        sql::mirror_handle(
+            dir.path(),
+            &JobHandle {
+                mission_id: Uuid::new_v4(),
+                node_id: "spark".to_string(),
+                job_id: duplicate,
+                started_at: chrono::Utc::now(),
+                submission_sequence: 0,
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: None,
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity.clone()),
+                wait_for_completion: None,
+                wake_on_terminal: false,
+            },
+        );
+        let live: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM remote_jobs WHERE state IN ('submitting','accepted','running')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(live, 1, "the unique index keeps one live job per identity");
+
+        finalize(dir.path(), job_id, "succeeded", Some(0))
+            .await
+            .unwrap();
+        let (state, outcome): (String, String) = connection
+            .query_row(
+                "SELECT j.state, r.outcome FROM remote_jobs j \
+                 JOIN receipts r ON r.subject_type = 'build' AND r.subject_id = j.job_id \
+                 WHERE j.job_id = ?1",
+                rusqlite::params![job_id.to_string()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (state.as_str(), outcome.as_str()),
+            ("succeeded", "succeeded")
+        );
+
+        // Wipe the mirror; the boot parity pass rebuilds it from JSON.
+        connection.execute("DELETE FROM remote_jobs", []).unwrap();
+        let report = sql_parity_backfill(dir.path()).await.unwrap();
+        assert_eq!(report.json_receipts, 1);
+        assert_eq!(report.backfilled_receipts, 1);
+        assert_eq!(report.sql_terminal, 1);
+        assert_eq!(report.sql_live_not_in_json, 0);
+        let again = sql_parity_backfill(dir.path()).await.unwrap();
+        assert_eq!(again.backfilled_receipts, 0, "parity is idempotent");
     }
 }

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -136,6 +136,11 @@ pub struct JobSource {
     /// pushing a Git commit.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bundle: Option<SourceBundle>,
+    /// Root tree of `commit` as the submitter saw it. The node verifies the
+    /// checked-out `HEAD^{tree}` against it before building, so content
+    /// identity (tree, not commit) is what a receipt proves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_tree_sha: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -514,6 +519,7 @@ mod tests {
     fn lean_build_payload_round_trips_with_defaults() {
         let payload = JobPayload::LeanBuild {
             source: Box::new(JobSource {
+                base_tree_sha: None,
                 repo: "https://github.com/example/verity.git".to_string(),
                 commit: "a".repeat(40),
                 archive: None,


### PR DESCRIPTION
Stacked on #875. Step 6 of `docs/plans/ROADMAP_TRUTH_AND_BUILD_DEDUP.md`: identity v1 keyed on the root tree (not the commit) with image/protocol/env digests and a canonical hash; the node verifies the tree after checkout; the wrapper sends tree + protocol + allowlisted env digest; the JSON ledger is mirrored into projects.db (`remote_jobs`, `remote_job_subscribers`, build receipts) with a boot parity/backfill pass. JSON stays authoritative for reads until a production restart shows zero drift (removal gate in step 9). Legacy v0 receipts never replay as success. See the commit message and `docs/REMOTE_NODES.md` (Content identity). Verified: `cargo fmt --check`, no new clippy warnings, `cargo test --bins`, ledger/remote-build/node/store tests green.