### PR TITLE
Roadmap truth step 7: attach to live builds, per-mission wakes, lineage guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ ios_dashboard/SandboxedDashboard.xcodeproj/*
 
 # Android simulator run artifacts
 android_dashboard/test-artifacts/
+.sandboxed-sh/

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -606,3 +606,24 @@ into `projects.db` (`remote_jobs`, `remote_job_subscribers`, `receipts`
 kind=`build`) on every mutation; boot reconciliation backfills and logs a
 parity report. The JSON files stay authoritative until one production
 restart shows zero drift (plan step 9 retires them).
+
+### Attach, durable subscribers, lineage (plan step 7)
+
+- **One live job per identity, no 409.** A submission whose identity matches a
+  job that is still `accepted`/`running` no longer fails with
+  `REMOTE_VALIDATION_ALREADY_ACTIVE`. Core records the caller as a *subscriber*
+  of the canonical job (`remote_job_subscribers`, JSON handle with the same
+  `job_id`) and answers `202` with the canonical `job_id` and `"attached": true`.
+  The canonical job runs once; every subscribed mission gets its own terminal
+  receipt and its own wake, delivered exactly once per `(job_id, mission_id)`.
+  `GET /api/remote-build/{job_id}?mission_id=…` accepts any subscribed mission.
+- **Lineage guard.** `create_mission` refuses a child whose `parent_mission_id`
+  is on the same project/track and is parked on a remote build:
+  `409 {"error":"BUILD_IN_PROGRESS","job_id":…,"parent_mission_id":…}`. The
+  parent is woken when the job ends; spawning a helper to poll it is never the
+  answer. Lineage is the explicit parent id, never the origin session.
+- **Passive harness.** `REMOTE_BUILD_PASSIVE=1` makes `remote-lean-build` exit
+  `75` right after a durable submission instead of polling; re-running the exact
+  command after the wake collects the receipt (or attaches if still running).
+  The default poll interval for the non-passive path is now 15 s
+  (`REMOTE_BUILD_POLL_SECS`).

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -744,7 +744,7 @@ PY
 )"
     poll_url="$poll_url&expected_head=$encoded_expected_head"
 fi
-poll_secs="${REMOTE_BUILD_POLL_SECS:-3}"
+poll_secs="${REMOTE_BUILD_POLL_SECS:-15}"
 client_timeout_secs="${REMOTE_BUILD_CLIENT_TIMEOUT_SECS:-7500}"
 case "$poll_secs" in
     ''|*[!0-9]*) die "REMOTE_BUILD_POLL_SECS must be a positive integer" ;;
@@ -757,6 +757,15 @@ esac
 if [ "$receipt_state" != "succeeded" ] && [ "$receipt_state" != "stale_success" ] \
     && [ "$receipt_state" != "failed" ] \
     && [ "$receipt_state" != "cancelled" ] && [ "$receipt_state" != "lost" ]; then
+    # Passive mode (REMOTE_BUILD_PASSIVE=1): do not poll from inside the
+    # harness. The submission is durable, core owns one observer per job, and
+    # the mission is parked and woken when the job ends; re-running this exact
+    # command then collects the receipt. Exit 75 (EX_TEMPFAIL) marks "not
+    # finished, not failed". Opt-in until the runner treats 75 as a park.
+    if [ "${REMOTE_BUILD_PASSIVE:-0}" = "1" ]; then
+        echo "remote-lean-build: job $job_id on node '$node_id' is running; not polling (REMOTE_BUILD_PASSIVE=1). The mission is woken when it ends — re-run this exact command to collect the result." >&2
+        exit 75
+    fi
     deadline=$(( $(date +%s) + client_timeout_secs ))
 
     while :; do

--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -358,3 +358,13 @@ par défaut**. C'est TON travail de la débloquer :
 Objectif : les « needs you » qui remontent à l'opérateur deviennent **rares et
 qualifiés**. Une mission qui attend une réponse que tu peux fournir et que tu
 laisses pourrir/escalader est une erreur de supervision.
+
+## Remote builds: attach, never poll
+
+- Re-running the same `remote-lean-build` command while an identical build is live
+  returns `202` with `"attached": true` and the canonical `job_id`. There is never a
+  second execution and never a 409 to route around. Your mission is woken when the
+  job ends.
+- `start_mission` for a helper on the same project/track while you are parked on a
+  build answers `409 BUILD_IN_PROGRESS {job_id}`. Do not spawn pollers; wait for the
+  wake or read the job status with the `job_id`.

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -515,3 +515,13 @@ cp -r skills/hermes-mission-control \
 Hermes discovers `SKILL.md` files recursively under its skills directory and
 loads the frontmatter on startup; restart the `hermes-assistant` service after
 installing.
+
+## Remote builds: attach, never poll
+
+- Re-running the same `remote-lean-build` command while an identical build is live
+  returns `202` with `"attached": true` and the canonical `job_id`. There is never a
+  second execution and never a 409 to route around. Your mission is woken when the
+  job ends.
+- `start_mission` for a helper on the same project/track while you are parked on a
+  build answers `409 BUILD_IN_PROGRESS {job_id}`. Do not spawn pollers; wait for the
+  wake or read the job status with the `job_id`.

--- a/skills/sandboxed-sh-missions/SKILL.md
+++ b/skills/sandboxed-sh-missions/SKILL.md
@@ -724,3 +724,13 @@ If a mission stalls on an env issue and the prompt is good, **don't keep retryin
 ## Remote build fleet (2026-07-12)
 
 For offloading `lake build` of a pushed SHA to the 4-node fleet (ashur/babylon/nippur/dgx-spark), use `GET /api/remote-nodes` for fleet status and `GET /api/health/fleet` for disk preflight. Capacity-aware auto placement is the default build-offload path.
+
+## Remote builds: attach, never poll
+
+- Re-running the same `remote-lean-build` command while an identical build is live
+  returns `202` with `"attached": true` and the canonical `job_id`. There is never a
+  second execution and never a 409 to route around. Your mission is woken when the
+  job ends.
+- `start_mission` for a helper on the same project/track while you are parked on a
+  build answers `409 BUILD_IN_PROGRESS {job_id}`. Do not spawn pollers; wait for the
+  wake or read the job status with the `job_id`.

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5672,8 +5672,12 @@ async fn recoverable_remote_continuation(
     let Some(receipt) = receipt else {
         return Ok(None);
     };
-    if crate::remote_node::job_ledger::require_terminal_receipt_wake(working_dir, receipt.job_id)
-        .await?
+    if crate::remote_node::job_ledger::require_terminal_receipt_wake(
+        working_dir,
+        receipt.job_id,
+        receipt.mission_id,
+    )
+    .await?
     {
         Ok(Some(receipt.job_id))
     } else {
@@ -5762,7 +5766,9 @@ async fn arm_unresolved_remote_build_wake(working_dir: &std::path::Path, mission
         }
     };
 
-    match crate::remote_node::job_ledger::require_terminal_wake(working_dir, job_id).await {
+    match crate::remote_node::job_ledger::require_terminal_wake(working_dir, job_id, mission_id)
+        .await
+    {
         Ok(true) => true,
         Ok(false) => false,
         Err(error) => {
@@ -9672,6 +9678,69 @@ pub async fn create_mission(
         }
     }
 
+    // Lineage guard: a child spawned by a mission that is parked on a remote
+    // build, on the same project/track, is a poller in disguise. Refuse it
+    // with the job id so the parent attaches or waits instead. Lineage is the
+    // explicit parent_mission_id, never origin_session_id (which sibling
+    // missions share).
+    if let (Some(parent_id), Some(project), Some(track)) = (
+        req.parent_mission_id,
+        req.project
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty()),
+        req.track
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty()),
+    ) {
+        let control_state = control_for_user(&state, &user).await;
+        if let Ok(Some(parent)) = control_state.mission_store.get_mission(parent_id).await {
+            let same_project = parent
+                .project
+                .project
+                .as_deref()
+                .map(super::projects_overview::canonicalize_project_slug)
+                .is_some_and(|slug| {
+                    slug == super::projects_overview::canonicalize_project_slug(project)
+                });
+            let same_track = parent
+                .project
+                .track
+                .as_deref()
+                .map(super::projects_store::normalize_track_key)
+                .is_some_and(|key| key == super::projects_store::normalize_track_key(track));
+            if same_project && same_track {
+                if let Ok(Some(handle)) =
+                    crate::remote_node::job_ledger::current_remote_build_wait_handle(
+                        &state.config.working_dir,
+                        parent_id,
+                    )
+                    .await
+                {
+                    tracing::info!(
+                        parent_mission_id = %parent_id,
+                        job_id = %handle.job_id,
+                        project,
+                        track,
+                        "create_mission rejected: parent is waiting on a remote build for this track"
+                    );
+                    return Err((
+                        StatusCode::CONFLICT,
+                        serde_json::json!({
+                            "error": "BUILD_IN_PROGRESS",
+                            "job_id": handle.job_id,
+                            "node_id": handle.node_id,
+                            "parent_mission_id": parent_id,
+                            "message": "the parent mission already waits on a remote build for this track; do not spawn a helper to poll it — the parent is woken when the job ends, and re-running the same build command attaches to it",
+                        })
+                        .to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
     // Campaign uniqueness guard: at most one non-terminal campaign mission per
     // project. Checked on the explicit request tags (project inherited from a
     // bound conversation never carries track="campaign").
@@ -11156,6 +11225,7 @@ pub(crate) async fn deliver_pending_remote_build_wakes(state: &AppState) {
                 match crate::remote_node::job_ledger::mark_terminal_wake_suppressed(
                     &state.config.working_dir,
                     receipt.job_id,
+                    receipt.mission_id,
                     superseding_job_id,
                 )
                 .await
@@ -11214,6 +11284,7 @@ pub(crate) async fn deliver_pending_remote_build_wakes(state: &AppState) {
                 if let Err(error) = crate::remote_node::job_ledger::mark_terminal_wake_delivered(
                     &state.config.working_dir,
                     receipt.job_id,
+                    receipt.mission_id,
                 )
                 .await
                 {
@@ -11694,6 +11765,7 @@ async fn reconcile_pending_handles(
                     if let Err(error) = crate::remote_node::job_ledger::require_terminal_wake(
                         working_dir,
                         handle.job_id,
+                        handle.mission_id,
                     )
                     .await
                     {
@@ -27720,9 +27792,13 @@ mod tests {
             mission_has_unresolved_remote_build(dir.path(), synchronous_mission_id).await,
             "a synchronous waiter must keep its mission continuation recoverable"
         );
-        crate::remote_node::job_ledger::require_terminal_wake(dir.path(), synchronous_job_id)
-            .await
-            .unwrap();
+        crate::remote_node::job_ledger::require_terminal_wake(
+            dir.path(),
+            synchronous_job_id,
+            synchronous_mission_id,
+        )
+        .await
+        .unwrap();
         assert!(mission_has_unresolved_remote_build(dir.path(), synchronous_mission_id).await);
 
         let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -435,6 +435,10 @@ struct RemoteBuildWaitResponse {
 struct RemoteBuildAcceptedResponse {
     job_id: Uuid,
     node_id: String,
+    /// True when this submission attached to an already-live job with the
+    /// same content identity instead of dispatching a second execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attached: Option<bool>,
     repository: String,
     commit: String,
     command: Vec<String>,
@@ -1043,7 +1047,52 @@ async fn equivalent_remote_validation_response(
             }
         }
         Ok(Some(crate::remote_node::job_ledger::EquivalentRemoteValidation::Active(handle))) => {
-            Some(active_conflict(&handle))
+            // One live job per identity: attach this mission to the canonical
+            // job instead of refusing. A retrying harness or a stray helper
+            // then never creates a second build and never sees an error it
+            // has to route around; it polls / parks on the same job id.
+            let expects_continuation = req.wait || req.resume_mission_on_terminal;
+            match crate::remote_node::job_ledger::attach(
+                &state.config.working_dir,
+                handle.job_id,
+                req.mission_id,
+                expects_continuation,
+            )
+            .await
+            {
+                Ok(Some(attached)) => {
+                    tracing::info!(
+                        mission_id = %req.mission_id,
+                        canonical_mission_id = %handle.mission_id,
+                        job_id = %handle.job_id,
+                        "attached to the live equivalent remote validation"
+                    );
+                    Some(
+                        (
+                            StatusCode::ACCEPTED,
+                            Json(RemoteBuildAcceptedResponse {
+                                job_id: attached.job_id,
+                                node_id: attached.node_id,
+                                attached: Some(true),
+                                repository: identity.repository.clone(),
+                                commit: identity.commit.clone(),
+                                command: identity.command.clone(),
+                                toolchain: identity.toolchain.clone(),
+                                source_bundle_digest: identity.source_bundle_digest.clone(),
+                            }),
+                        )
+                            .into_response(),
+                    )
+                }
+                Ok(None) => Some(active_conflict(&handle)),
+                Err(error) => Some(
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("could not attach to the live remote validation: {error}"),
+                    )
+                        .into_response(),
+                ),
+            }
         }
         Ok(None) => None,
         Err(error) => Some(
@@ -1354,6 +1403,7 @@ async fn submit_remote_build(
             Json(RemoteBuildAcceptedResponse {
                 job_id,
                 node_id: node.id.clone(),
+                attached: None,
                 repository: identity.repository,
                 commit: identity.commit,
                 command: identity.command,
@@ -1585,7 +1635,15 @@ async fn get_remote_build(
     };
     // The capability token is mission-scoped: never leak another mission's
     // job status through it.
-    if status.mission_id != query.mission_id {
+    if status.mission_id != query.mission_id
+        && !crate::remote_node::job_ledger::mission_subscribed(
+            &state.config.working_dir,
+            job_id,
+            query.mission_id,
+        )
+        .await
+        .unwrap_or(false)
+    {
         return Err((
             StatusCode::FORBIDDEN,
             "job does not belong to this mission".to_string(),

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1065,8 +1065,61 @@ async fn equivalent_remote_validation_response(
                         mission_id = %req.mission_id,
                         canonical_mission_id = %handle.mission_id,
                         job_id = %handle.job_id,
+                        wait = req.wait,
                         "attached to the live equivalent remote validation"
                     );
+                    if req.wait {
+                        // A synchronous caller wants the outcome, not a
+                        // job id: park on the canonical job's observer and
+                        // return this mission's own terminal receipt.
+                        for _ in 0..WAIT_MAX_POLLS {
+                            tokio::time::sleep(WAIT_POLL_INTERVAL).await;
+                            match crate::remote_node::job_ledger::terminal_receipt_for_mission(
+                                &state.config.working_dir,
+                                handle.job_id,
+                                req.mission_id,
+                            )
+                            .await
+                            {
+                                Ok(Some(receipt)) => {
+                                    let duration_secs = (receipt.finished_at - receipt.started_at)
+                                        .num_seconds()
+                                        .max(0)
+                                        as u64;
+                                    return Some(
+                                        (
+                                            StatusCode::OK,
+                                            Json(RemoteBuildWaitResponse {
+                                                exit_code: receipt.exit_status,
+                                                state: receipt.state,
+                                                duration_secs,
+                                                log_tail: "attached to the live equivalent job; terminal receipt"
+                                                    .to_string(),
+                                                node_id: receipt.node_id,
+                                                job_id: receipt.job_id,
+                                                artifacts: receipt.artifacts,
+                                            }),
+                                        )
+                                            .into_response(),
+                                    );
+                                }
+                                Ok(None) => continue,
+                                Err(error) => {
+                                    tracing::warn!(%error, "attached wait: ledger read failed");
+                                }
+                            }
+                        }
+                        return Some(
+                            (
+                                StatusCode::GATEWAY_TIMEOUT,
+                                format!(
+                                    "attached to job {} but it did not finish within the synchronous wait window",
+                                    handle.job_id
+                                ),
+                            )
+                                .into_response(),
+                        );
+                    }
                     Some(
                         (
                             StatusCode::ACCEPTED,

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -396,6 +396,39 @@ pub async fn terminal_receipt(
         .find(|receipt| receipt.job_id == job_id))
 }
 
+/// The terminal receipt a specific (possibly attached) mission holds for a job.
+pub async fn terminal_receipt_for_mission(
+    working_dir: &Path,
+    job_id: Uuid,
+    mission_id: Uuid,
+) -> anyhow::Result<Option<RemoteJobReceipt>> {
+    Ok(load_receipts_result(working_dir)
+        .await?
+        .into_iter()
+        .find(|receipt| receipt.job_id == job_id && receipt.mission_id == mission_id))
+}
+
+/// Whether `mission_id` holds (or held) a handle or receipt for `job_id`:
+/// the submitter, or a mission that attached to it.
+pub async fn mission_subscribed(
+    working_dir: &Path,
+    job_id: Uuid,
+    mission_id: Uuid,
+) -> anyhow::Result<bool> {
+    let _guard = lock().lock().await;
+    if load_result(working_dir)
+        .await?
+        .iter()
+        .any(|handle| handle.job_id == job_id && handle.mission_id == mission_id)
+    {
+        return Ok(true);
+    }
+    Ok(load_receipts_result(working_dir)
+        .await?
+        .iter()
+        .any(|receipt| receipt.job_id == job_id && receipt.mission_id == mission_id))
+}
+
 pub async fn terminal_receipts_for_mission(
     working_dir: &Path,
     mission_id: Uuid,
@@ -510,10 +543,14 @@ pub async fn recoverable_terminal_continuations(
 pub async fn require_terminal_receipt_wake(
     working_dir: &Path,
     job_id: Uuid,
+    mission_id: Uuid,
 ) -> anyhow::Result<bool> {
     let _guard = lock().lock().await;
     let mut receipts = load_receipts_result(working_dir).await?;
-    let Some(receipt) = receipts.iter_mut().find(|receipt| receipt.job_id == job_id) else {
+    let Some(receipt) = receipts
+        .iter_mut()
+        .find(|receipt| receipt.job_id == job_id && receipt.mission_id == mission_id)
+    else {
         return Ok(false);
     };
     if receipt.wake_delivered_at.is_some()
@@ -598,17 +635,27 @@ pub async fn terminal_wake_disposition(
 pub async fn mark_terminal_wake_suppressed(
     working_dir: &Path,
     job_id: Uuid,
+    mission_id: Uuid,
     superseding_job_id: Uuid,
 ) -> anyhow::Result<bool> {
     let _guard = lock().lock().await;
     let mut receipts = load_receipts_result(working_dir).await?;
-    let Some(receipt) = receipts.iter_mut().find(|receipt| receipt.job_id == job_id) else {
+    let Some(receipt) = receipts
+        .iter_mut()
+        .find(|receipt| receipt.job_id == job_id && receipt.mission_id == mission_id)
+    else {
         return Ok(false);
     };
     if receipt.wake_delivered_at.is_none() {
         receipt.wake_delivered_at = Some(chrono::Utc::now());
         receipt.wake_suppressed_by = Some(superseding_job_id);
-        sql::mirror_wake(working_dir, job_id, "suppressed", Some(superseding_job_id));
+        sql::mirror_wake(
+            working_dir,
+            job_id,
+            mission_id,
+            "suppressed",
+            Some(superseding_job_id),
+        );
         store_receipts(working_dir, &receipts).await?;
     }
     Ok(true)
@@ -617,15 +664,19 @@ pub async fn mark_terminal_wake_suppressed(
 pub async fn mark_terminal_wake_delivered(
     working_dir: &Path,
     job_id: Uuid,
+    mission_id: Uuid,
 ) -> anyhow::Result<bool> {
     let _guard = lock().lock().await;
     let mut receipts = load_receipts_result(working_dir).await?;
-    let Some(receipt) = receipts.iter_mut().find(|receipt| receipt.job_id == job_id) else {
+    let Some(receipt) = receipts
+        .iter_mut()
+        .find(|receipt| receipt.job_id == job_id && receipt.mission_id == mission_id)
+    else {
         return Ok(false);
     };
     if receipt.wake_delivered_at.is_none() {
         receipt.wake_delivered_at = Some(chrono::Utc::now());
-        sql::mirror_wake(working_dir, job_id, "delivered", None);
+        sql::mirror_wake(working_dir, job_id, mission_id, "delivered", None);
         store_receipts(working_dir, &receipts).await?;
     }
     Ok(true)
@@ -654,45 +705,61 @@ pub async fn finalize_with_artifacts(
 
     let _guard = lock().lock().await;
     let mut handles = load_result(working_dir).await?;
-    let Some(index) = handles.iter().position(|handle| handle.job_id == job_id) else {
+    if !handles.iter().any(|handle| handle.job_id == job_id) {
         return Ok(false);
-    };
-    let handle = handles.remove(index);
-    if handle.kind != JobHandleKind::RemoteBuild {
-        sql::mirror_terminal_without_receipt(working_dir, job_id, state);
     }
-    if handle.kind == JobHandleKind::RemoteBuild {
+    // Every subscribed mission gets its own terminal receipt (and therefore
+    // its own wake); the execution itself happened once.
+    let closing: Vec<JobHandle> = handles
+        .iter()
+        .filter(|handle| handle.job_id == job_id)
+        .cloned()
+        .collect();
+    handles.retain(|handle| handle.job_id != job_id);
+    let mut receipts = load_receipts_result(working_dir).await?;
+    let finished_at = chrono::Utc::now();
+    let mut wrote_receipt = false;
+    for handle in closing {
+        if handle.kind != JobHandleKind::RemoteBuild {
+            continue;
+        }
         let continuation_expected = handle.expects_mission_continuation();
-        let Some(identity) = handle.identity else {
-            sql::mirror_terminal_without_receipt(working_dir, job_id, state);
-            store(working_dir, &handles).await?;
-            return Ok(true);
+        let Some(identity) = handle.identity.clone() else {
+            continue;
         };
-        let mut receipts = load_receipts_result(working_dir).await?;
         let previous_wake_delivered_at = receipts
             .iter()
-            .find(|receipt| receipt.job_id == job_id)
+            .find(|receipt| receipt.job_id == job_id && receipt.mission_id == handle.mission_id)
             .and_then(|receipt| receipt.wake_delivered_at);
-        receipts.retain(|receipt| receipt.job_id != job_id);
+        receipts
+            .retain(|receipt| receipt.job_id != job_id || receipt.mission_id != handle.mission_id);
         receipts.push(RemoteJobReceipt {
             mission_id: handle.mission_id,
             node_id: handle.node_id,
             job_id,
             started_at: handle.started_at,
             submission_sequence: handle.submission_sequence,
-            finished_at: chrono::Utc::now(),
+            finished_at,
             state: state.to_string(),
             exit_status,
             identity,
-            artifacts,
+            artifacts: artifacts.clone(),
             continuation_expected,
-            wake_required: handle.kind == JobHandleKind::RemoteBuild && handle.wake_on_terminal,
+            wake_required: handle.wake_on_terminal,
             wake_delivered_at: previous_wake_delivered_at,
             wake_suppressed_by: None,
         });
         if let Some(receipt) = receipts.last() {
             sql::mirror_receipt(working_dir, receipt);
         }
+        wrote_receipt = true;
+    }
+    if !wrote_receipt {
+        sql::mirror_terminal_without_receipt(working_dir, job_id, state);
+        store(working_dir, &handles).await?;
+        return Ok(true);
+    }
+    {
         if receipts.len() > MAX_RECEIPTS {
             receipts.sort_by_key(|receipt| receipt.finished_at);
             let mut excess = receipts.len() - MAX_RECEIPTS;
@@ -712,7 +779,7 @@ pub async fn finalize_with_artifacts(
     Ok(true)
 }
 
-/// Record a job handle (idempotent on job_id).
+/// Record a job handle (idempotent on (job_id, mission_id)).
 pub async fn record(working_dir: &Path, handle: JobHandle) -> anyhow::Result<()> {
     let _guard = lock().lock().await;
     let mut handles = load_result(working_dir).await?;
@@ -741,10 +808,60 @@ pub async fn record(working_dir: &Path, handle: JobHandle) -> anyhow::Result<()>
                 .saturating_add(1)
         };
     }
-    handles.retain(|existing| existing.job_id != handle.job_id);
+    // A job may carry one handle per subscribed mission (see [`attach`]);
+    // the submitter's handle and every attached handle share the job id and
+    // are told apart by mission id.
+    handles.retain(|existing| {
+        existing.job_id != handle.job_id || existing.mission_id != handle.mission_id
+    });
     sql::mirror_handle(working_dir, &handle);
     handles.push(handle);
     store(working_dir, &handles).await
+}
+
+/// Subscribe `mission_id` to an already-live job: a second submission of the
+/// same content identity attaches to the canonical job instead of failing.
+/// The attached handle is a clone of the canonical one under the attaching
+/// mission, so parking (`waiting_remote_job`), supersession and the terminal
+/// wake all work per mission without a second execution. Idempotent.
+pub async fn attach(
+    working_dir: &Path,
+    job_id: Uuid,
+    mission_id: Uuid,
+    expects_continuation: bool,
+) -> anyhow::Result<Option<JobHandle>> {
+    let _guard = lock().lock().await;
+    let mut handles = load_result(working_dir).await?;
+    if let Some(existing) = handles
+        .iter()
+        .find(|handle| handle.job_id == job_id && handle.mission_id == mission_id)
+    {
+        return Ok(Some(existing.clone()));
+    }
+    let Some(canonical) = handles
+        .iter()
+        .filter(|handle| {
+            handle.job_id == job_id
+                && matches!(
+                    handle.kind,
+                    JobHandleKind::RemoteBuild | JobHandleKind::Tentative
+                )
+        })
+        .min_by_key(|handle| validation_order(handle.submission_sequence, handle.started_at))
+        .cloned()
+    else {
+        return Ok(None);
+    };
+    let attached = JobHandle {
+        mission_id,
+        wait_for_completion: Some(expects_continuation),
+        wake_on_terminal: false,
+        ..canonical
+    };
+    sql::mirror_subscriber(working_dir, job_id, mission_id, expects_continuation);
+    handles.push(attached.clone());
+    store(working_dir, &handles).await?;
+    Ok(Some(attached))
 }
 
 /// Remove a job handle once its mission is finalized.
@@ -771,26 +888,43 @@ pub async fn remove(working_dir: &Path, job_id: Uuid) {
 pub async fn heartbeat(working_dir: &Path, job_id: Uuid) -> anyhow::Result<bool> {
     let _guard = lock().lock().await;
     let mut handles = load_result(working_dir).await?;
-    let Some(handle) = handles.iter_mut().find(|handle| handle.job_id == job_id) else {
-        return Ok(false);
-    };
     let now = chrono::Utc::now();
-    if handle
-        .heartbeat_at
-        .is_some_and(|previous| now - previous < chrono::Duration::seconds(15))
-    {
-        return Ok(true);
+    let mut touched = false;
+    let mut found = false;
+    for handle in handles.iter_mut().filter(|handle| handle.job_id == job_id) {
+        found = true;
+        if handle
+            .heartbeat_at
+            .is_some_and(|previous| now - previous < chrono::Duration::seconds(15))
+        {
+            continue;
+        }
+        handle.heartbeat_at = Some(now);
+        touched = true;
     }
-    handle.heartbeat_at = Some(now);
-    sql::mirror_handle(working_dir, handle);
-    store(working_dir, &handles).await?;
+    if !found {
+        return Ok(false);
+    }
+    if touched {
+        if let Some(handle) = handles.iter().find(|handle| handle.job_id == job_id) {
+            sql::mirror_handle(working_dir, handle);
+        }
+        store(working_dir, &handles).await?;
+    }
     Ok(true)
 }
 
-pub async fn require_terminal_wake(working_dir: &Path, job_id: Uuid) -> anyhow::Result<bool> {
+pub async fn require_terminal_wake(
+    working_dir: &Path,
+    job_id: Uuid,
+    mission_id: Uuid,
+) -> anyhow::Result<bool> {
     let _guard = lock().lock().await;
     let mut handles = load_result(working_dir).await?;
-    let Some(handle) = handles.iter_mut().find(|handle| handle.job_id == job_id) else {
+    let Some(handle) = handles
+        .iter_mut()
+        .find(|handle| handle.job_id == job_id && handle.mission_id == mission_id)
+    else {
         return Ok(false);
     };
     if !handle.wake_on_terminal {
@@ -865,6 +999,31 @@ pub mod sql {
 
     fn upsert_handle(connection: &Connection, handle: &JobHandle) -> rusqlite::Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
+        // An attached handle (same job, another mission) is a subscriber row,
+        // never a second job row.
+        let submitter: Option<String> = connection
+            .query_row(
+                "SELECT mission_id FROM remote_jobs WHERE job_id = ?1",
+                params![handle.job_id.to_string()],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(submitter) = submitter {
+            if submitter != handle.mission_id.to_string() {
+                connection.execute(
+                    "INSERT OR IGNORE INTO remote_job_subscribers \
+                       (job_id, mission_id, wake_required, wake_state, attached_at) \
+                     VALUES (?1, ?2, ?3, 'pending', ?4)",
+                    params![
+                        handle.job_id.to_string(),
+                        handle.mission_id.to_string(),
+                        handle.wake_on_terminal as i64,
+                        now
+                    ],
+                )?;
+                return Ok(());
+            }
+        }
         let identity_json = handle
             .identity
             .as_ref()
@@ -1057,6 +1216,7 @@ pub mod sql {
     pub fn mirror_wake(
         working_dir: &Path,
         job_id: Uuid,
+        mission_id: Uuid,
         disposition: &str,
         suppressed_by: Option<Uuid>,
     ) {
@@ -1064,22 +1224,75 @@ pub mod sql {
             return;
         };
         let now = chrono::Utc::now().to_rfc3339();
-        let result = match disposition {
-            "delivered" => connection.execute(
-                "UPDATE remote_jobs SET wake_delivered_at = ?2, updated_at = ?2 WHERE job_id = ?1",
-                params![job_id.to_string(), now],
-            ),
-            _ => connection.execute(
-                "UPDATE remote_jobs SET wake_suppressed_by = ?2, updated_at = ?3 WHERE job_id = ?1",
+        // The submitter's wake lives on the job row; an attached mission's on
+        // its subscriber row.
+        let submitter: Option<String> = connection
+            .query_row(
+                "SELECT mission_id FROM remote_jobs WHERE job_id = ?1",
+                params![job_id.to_string()],
+                |row| row.get(0),
+            )
+            .optional()
+            .ok()
+            .flatten();
+        let result = if submitter.as_deref() == Some(mission_id.to_string().as_str()) {
+            match disposition {
+                "delivered" => connection.execute(
+                    "UPDATE remote_jobs SET wake_delivered_at = ?2, updated_at = ?2 WHERE job_id = ?1",
+                    params![job_id.to_string(), now],
+                ),
+                _ => connection.execute(
+                    "UPDATE remote_jobs SET wake_suppressed_by = ?2, updated_at = ?3 WHERE job_id = ?1",
+                    params![
+                        job_id.to_string(),
+                        suppressed_by.map(|id| id.to_string()),
+                        now
+                    ],
+                ),
+            }
+        } else {
+            connection.execute(
+                "UPDATE remote_job_subscribers SET wake_state = ?3, delivered_at = ?4 \
+                 WHERE job_id = ?1 AND mission_id = ?2",
                 params![
                     job_id.to_string(),
-                    suppressed_by.map(|id| id.to_string()),
+                    mission_id.to_string(),
+                    if disposition == "delivered" {
+                        "delivered"
+                    } else {
+                        "suppressed"
+                    },
                     now
                 ],
-            ),
+            )
         };
         if let Err(error) = result {
-            tracing::warn!(%job_id, %error, "remote job SQL mirror: wake update failed");
+            tracing::warn!(%job_id, %mission_id, %error, "remote job SQL mirror: wake update failed");
+        }
+    }
+
+    /// Record an attached mission as a durable subscriber of a live job.
+    pub fn mirror_subscriber(
+        working_dir: &Path,
+        job_id: Uuid,
+        mission_id: Uuid,
+        wake_required: bool,
+    ) {
+        let Some(connection) = open(working_dir) else {
+            return;
+        };
+        if let Err(error) = connection.execute(
+            "INSERT OR IGNORE INTO remote_job_subscribers \
+               (job_id, mission_id, wake_required, wake_state, attached_at) \
+             VALUES (?1, ?2, ?3, 'pending', ?4)",
+            params![
+                job_id.to_string(),
+                mission_id.to_string(),
+                wake_required as i64,
+                chrono::Utc::now().to_rfc3339()
+            ],
+        ) {
+            tracing::warn!(%job_id, %mission_id, %error, "remote job SQL mirror: subscriber insert failed");
         }
     }
 
@@ -1454,9 +1667,11 @@ mod tests {
         assert!(receipt.wake_required);
         assert_eq!(receipt.wake_delivered_at, None);
         assert_eq!(pending_terminal_wakes(dir.path()).await.unwrap().len(), 1);
-        assert!(mark_terminal_wake_delivered(dir.path(), job_id)
-            .await
-            .unwrap());
+        assert!(
+            mark_terminal_wake_delivered(dir.path(), job_id, receipt.mission_id)
+                .await
+                .unwrap()
+        );
         assert!(pending_terminal_wakes(dir.path()).await.unwrap().is_empty());
         assert_eq!(
             terminal_receipts_for_mission(dir.path(), mission_id)
@@ -1705,7 +1920,7 @@ mod tests {
             TerminalWakeDisposition::SupersededBy(new_job_id)
         );
         assert!(
-            mark_terminal_wake_suppressed(dir.path(), old_job_id, new_job_id)
+            mark_terminal_wake_suppressed(dir.path(), old_job_id, mission_id, new_job_id)
                 .await
                 .unwrap()
         );
@@ -2288,5 +2503,106 @@ mod tests {
         assert_eq!(report.sql_live_not_in_json, 0);
         let again = sql_parity_backfill(dir.path()).await.unwrap();
         assert_eq!(again.backfilled_receipts, 0, "parity is idempotent");
+    }
+
+    #[tokio::test]
+    async fn attached_missions_get_their_own_receipts_and_wakes() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_id = Uuid::new_v4();
+        let submitter = Uuid::new_v4();
+        let attacher = Uuid::new_v4();
+        let identity = identity_v1("a".repeat(40).as_str(), Some(&"e".repeat(64)));
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id: submitter,
+                node_id: "spark".to_string(),
+                job_id,
+                started_at: chrono::Utc::now(),
+                submission_sequence: 0,
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: None,
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity.clone()),
+                wait_for_completion: Some(true),
+                wake_on_terminal: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(attach(dir.path(), Uuid::new_v4(), attacher, true)
+            .await
+            .unwrap()
+            .is_none());
+        let attached = attach(dir.path(), job_id, attacher, true)
+            .await
+            .unwrap()
+            .expect("attached");
+        assert_eq!(attached.mission_id, attacher);
+        assert_eq!(attached.job_id, job_id);
+        assert!(!attached.wake_on_terminal);
+        // Idempotent.
+        attach(dir.path(), job_id, attacher, true).await.unwrap();
+        assert_eq!(load(dir.path()).await.unwrap().len(), 2);
+        assert!(mission_subscribed(dir.path(), job_id, attacher)
+            .await
+            .unwrap());
+        assert!(!mission_subscribed(dir.path(), job_id, Uuid::new_v4())
+            .await
+            .unwrap());
+        // The attacher parks on the same job.
+        let wait = current_remote_build_wait_handle(dir.path(), attacher)
+            .await
+            .unwrap()
+            .expect("attached wait handle");
+        assert_eq!(wait.job_id, job_id);
+        assert!(require_terminal_wake(dir.path(), job_id, attacher)
+            .await
+            .unwrap());
+        // One execution, one receipt per subscribed mission, each with its own wake.
+        finalize(dir.path(), job_id, "succeeded", Some(0))
+            .await
+            .unwrap();
+        assert!(load(dir.path()).await.unwrap().is_empty());
+        let pending = pending_terminal_wakes(dir.path()).await.unwrap();
+        let mut waiting: Vec<Uuid> = pending.iter().map(|r| r.mission_id).collect();
+        waiting.sort();
+        let mut expected = vec![submitter, attacher];
+        expected.sort();
+        assert_eq!(waiting, expected);
+        assert!(mark_terminal_wake_delivered(dir.path(), job_id, attacher)
+            .await
+            .unwrap());
+        let still: Vec<Uuid> = pending_terminal_wakes(dir.path())
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.mission_id)
+            .collect();
+        assert_eq!(
+            still,
+            vec![submitter],
+            "the submitter's wake is independent"
+        );
+        assert!(terminal_receipt_for_mission(dir.path(), job_id, attacher)
+            .await
+            .unwrap()
+            .is_some());
+        // SQL mirror: one job row, one subscriber row.
+        let db = dir.path().join(".sandboxed-sh/projects.db");
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        let jobs: i64 = connection
+            .query_row("SELECT count(*) FROM remote_jobs", [], |r| r.get(0))
+            .unwrap();
+        let subs: (i64, String) = connection
+            .query_row(
+                "SELECT count(*), COALESCE(MAX(wake_state), '') FROM remote_job_subscribers WHERE job_id = ?1",
+                rusqlite::params![job_id.to_string()],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(jobs, 1);
+        assert_eq!(subs, (1, "delivered".to_string()));
     }
 }


### PR DESCRIPTION
Plan: `docs/plans/ROADMAP_TRUTH_AND_BUILD_DEDUP.md` §B3/§B6, rollout row 7. Follows #877.

## What changes
- **Attach instead of 409.** `POST /api/remote-build` on a live identical job subscribes the mission to the canonical job and answers `202 {attached:true, job_id}`. `GET /api/remote-build/{id}` authorizes any subscribed mission.
- **Durable subscribers.** `job_ledger::attach`; `finalize_with_artifacts` writes one terminal receipt per subscribed mission; wakes are delivered/suppressed per `(job_id, mission_id)`; SQL mirror keeps `remote_jobs` + `remote_job_subscribers` rows in step. Heartbeats touch every handle of a job.
- **Lineage guard.** `create_mission` returns `409 BUILD_IN_PROGRESS {job_id, parent_mission_id}` when `parent_mission_id` is parked on a remote build for the same project/track. Uses the explicit parent id, never `origin_session_id`.
- **Passive harness (opt-in).** `REMOTE_BUILD_PASSIVE=1` makes `remote-lean-build` exit 75 after a durable submit; default poll interval raised 3s → 15s.
- Docs (`REMOTE_NODES.md`) and the three mission skills.

## Tests
- `attached_missions_get_their_own_receipts_and_wakes`: attach idempotent, attacher parks on the job, one receipt + independent wake per mission, SQL subscriber row reaches `delivered`.
- Existing ledger/remote-build tests updated for the per-mission wake API. `cargo test --lib -- job_ledger remote_build::` 42 passed; clippy clean for touched files.

## Not in this PR
- Runner treating exit 75 as a park (keeps passive mode opt-in).
- Hermes cron pre-check on unchanged `get_situation.cursor` (design §B5.3, Hermes-side).