### PR TITLE
Roadmap truth step 8: DGX Spark as a fleet node (arbiter slot provider)

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -627,3 +627,28 @@ restart shows zero drift (plan step 9 retires them).
   command after the wake collects the receipt (or attaches if still running).
   The default poll interval for the non-passive path is now 15 s
   (`REMOTE_BUILD_POLL_SECS`).
+<<<<<<< HEAD
+=======
+
+### DGX Spark in the fleet (plan step 8)
+
+The Spark is the ordinary runner node `dgx-spark` (`sandboxed-node`, labels
+`lean,gpu,high-memory`, capacity 1). What made it special — 128 GB of unified
+memory shared with vLLM and a GitHub CI runner — is handled by an external
+**slot provider** instead of a parallel job API:
+
+- `SANDBOXED_NODE_SLOT_PROVIDER=arbiter`, `SANDBOXED_NODE_ARBITER_URL`,
+  `SANDBOXED_NODE_ARBITER_TOKEN` (optional `SANDBOXED_NODE_ARBITER_PRIORITY`
+  `P0|P1`, `SANDBOXED_NODE_ARBITER_MEM`). Before a job runs, the node asks
+  `POST /slot/acquire {id, priority, mem}`; `503` means "draining, retry" and
+  the node waits (5 s) until granted or cancelled. The slot is released on
+  completion. An unreachable provider never lets a job through — that is the
+  case the provider exists for.
+- The arbiter persists granted slots (`~/.spark-arbiter/slots.json`), so a
+  restart does not restart vLLM under a running build; slots nobody released
+  expire after `ARBITER_SLOT_TTL_SEC` (6 h).
+- `spark-build lake …`/`lean …` now execs `remote-lean-build` pinned to
+  `dgx-spark` (override `SPARK_BUILD_NODE_ID`) with the same exit contract
+  (91 = fleet unavailable). Other commands still use the legacy
+  `/api/spark/offload` path until it is retired (step 9).
+>>>>>>> 7d8a390e (Step 8: DGX Spark as a fleet node — arbiter slot provider on the node, spark-build via remote-lean-build)

--- a/scripts/spark-build
+++ b/scripts/spark-build
@@ -11,6 +11,26 @@
 # (injected by the backend when the workspace has spark_offload enabled).
 set -u
 
+# Fleet path (plan step 8): the DGX Spark is the `dgx-spark` runner node, so a
+# lake/lean build goes through remote-lean-build like any other node — durable
+# job, content identity, receipts, one live job per identity. Only the legacy
+# offload (rsync + arbiter /build) remains below, for non-lake commands, until
+# /api/spark/offload is retired.
+case "$(basename "${1:-}")" in
+  lake|lean)
+    if [ -n "${REMOTE_BUILD_URL:-}" ] && [ -n "${REMOTE_BUILD_TOKEN:-}" ] && \
+       [ -n "${REMOTE_BUILD_MISSION_ID:-}" ] && command -v remote-lean-build >/dev/null 2>&1; then
+      echo "spark-build: dispatching to fleet node dgx-spark via remote-lean-build" >&2
+      REMOTE_BUILD_NODE_ID="${SPARK_BUILD_NODE_ID:-dgx-spark}" remote-lean-build "$@"
+      rc=$?
+      # remote-lean-build: 75 = fleet unavailable → keep this script's 91 contract.
+      [ "$rc" -eq 75 ] && exit 91
+      [ "$rc" -eq 90 ] && rc=1
+      exit "$rc"
+    fi
+    ;;
+esac
+
 if [ -z "${SPARK_OFFLOAD_URL:-}" ] || [ -z "${SPARK_OFFLOAD_TOKEN:-}" ] || \
    [ -z "${SPARK_OFFLOAD_MISSION_ID:-}" ] || [ -z "${SPARK_WORKSPACE_HOST_DIR:-}" ] || \
    [ -z "${SPARK_WORKSPACE_GUEST_DIR:-}" ]; then

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -6,6 +6,7 @@
 pub mod job_store;
 pub mod lean;
 pub mod runner;
+pub mod slot;
 
 pub use job_store::{JobRecord, JobState, JobStore};
 pub use lean::{cached_toolchains, lean_runtime_ready, spawn_cache_gc};

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -76,6 +76,9 @@ pub struct JobRunner {
     cancels: Mutex<HashMap<Uuid, CancellationToken>>,
     queued: AtomicU32,
     active: AtomicU32,
+    /// External slot provider (`SANDBOXED_NODE_SLOT_PROVIDER`); `None` means
+    /// the node admits on its own.
+    slot_provider: Option<Arc<super::slot::SlotProvider>>,
 }
 
 impl JobRunner {
@@ -122,6 +125,13 @@ impl JobRunner {
             cancels: Mutex::new(HashMap::new()),
             queued: AtomicU32::new(0),
             active: AtomicU32::new(0),
+            slot_provider: match super::slot::SlotProvider::from_env() {
+                Ok(provider) => provider.map(Arc::new),
+                Err(error) => {
+                    tracing::error!(%error, "slot provider misconfigured; node admits on its own");
+                    None
+                }
+            },
         });
         let dispatcher = Arc::clone(&runner);
         tokio::spawn(async move {
@@ -305,6 +315,12 @@ impl JobRunner {
         token: &CancellationToken,
     ) -> anyhow::Result<(JobState, Option<i32>, Option<String>, Option<String>)> {
         let log_path = self.log_path(job.id);
+        // Ask the external slot provider (the Spark arbiter) to make room
+        // before anything runs; the lease releases the slot when we return.
+        let _slot = match &self.slot_provider {
+            Some(provider) => Some(provider.acquire(job.id, token).await?),
+            None => None,
+        };
         match &job.payload {
             JobPayload::RawCommand {
                 command,

--- a/src/node/slot.rs
+++ b/src/node/slot.rs
@@ -1,0 +1,184 @@
+//! Optional external slot provider for a node.
+//!
+//! A node normally owns its own admission (`SANDBOXED_NODE_CAPACITY`). On a
+//! box that also hosts inference or a CI runner, something else has to make
+//! room before a build starts: on the DGX Spark that is the arbiter, which
+//! stops vLLM, pauses the GitHub runner and gates on free memory. With
+//! `SANDBOXED_NODE_SLOT_PROVIDER=arbiter` the runner asks the arbiter for a
+//! slot before executing a job and releases it afterwards. The job itself
+//! runs on the node as usual; the arbiter never runs commands for us.
+//!
+//! Failure policy: a provider that is unreachable is *not* a reason to run the
+//! job anyway — that is exactly the situation (memory full of a model) the
+//! provider exists for. The job waits and retries until cancelled or until the
+//! job's own timeout is spent.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+const RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Clone)]
+pub struct SlotProvider {
+    base_url: String,
+    token: String,
+    client: reqwest::Client,
+    /// Priority forwarded to the provider (`P0` preempts CI, `P1` queues
+    /// behind it).
+    priority: String,
+    /// Memory hint forwarded to the provider (e.g. `16G`).
+    mem: Option<String>,
+}
+
+/// Held for the duration of a job; releases the slot on drop.
+pub struct SlotLease {
+    provider: SlotProvider,
+    job_id: Uuid,
+}
+
+impl Drop for SlotLease {
+    fn drop(&mut self) {
+        let provider = self.provider.clone();
+        let job_id = self.job_id;
+        tokio::spawn(async move {
+            if let Err(error) = provider.release(job_id).await {
+                tracing::warn!(%job_id, %error, "slot provider: release failed");
+            }
+        });
+    }
+}
+
+impl SlotProvider {
+    /// `SANDBOXED_NODE_SLOT_PROVIDER=arbiter` with `SANDBOXED_NODE_ARBITER_URL`
+    /// and `SANDBOXED_NODE_ARBITER_TOKEN`; anything else → `None` (the node
+    /// admits on its own).
+    pub fn from_env() -> anyhow::Result<Option<Self>> {
+        let provider = std::env::var("SANDBOXED_NODE_SLOT_PROVIDER").unwrap_or_default();
+        match provider.trim().to_ascii_lowercase().as_str() {
+            "" | "none" | "off" => Ok(None),
+            "arbiter" => {
+                let base_url = std::env::var("SANDBOXED_NODE_ARBITER_URL")
+                    .ok()
+                    .map(|url| url.trim().trim_end_matches('/').to_string())
+                    .filter(|url| !url.is_empty())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "SANDBOXED_NODE_ARBITER_URL is required with SLOT_PROVIDER=arbiter"
+                        )
+                    })?;
+                let token = std::env::var("SANDBOXED_NODE_ARBITER_TOKEN")
+                    .ok()
+                    .map(|token| token.trim().to_string())
+                    .filter(|token| !token.is_empty())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "SANDBOXED_NODE_ARBITER_TOKEN is required with SLOT_PROVIDER=arbiter"
+                        )
+                    })?;
+                let priority = std::env::var("SANDBOXED_NODE_ARBITER_PRIORITY")
+                    .ok()
+                    .map(|p| p.trim().to_ascii_uppercase())
+                    .filter(|p| p == "P0" || p == "P1")
+                    .unwrap_or_else(|| "P0".to_string());
+                let mem = std::env::var("SANDBOXED_NODE_ARBITER_MEM")
+                    .ok()
+                    .map(|m| m.trim().to_string())
+                    .filter(|m| !m.is_empty());
+                Ok(Some(Self::new(base_url, token, priority, mem)))
+            }
+            other => Err(anyhow::anyhow!(
+                "unknown SANDBOXED_NODE_SLOT_PROVIDER '{other}' (expected 'arbiter' or unset)"
+            )),
+        }
+    }
+
+    pub fn new(base_url: String, token: String, priority: String, mem: Option<String>) -> Self {
+        Self {
+            base_url,
+            token,
+            client: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .expect("reqwest client"),
+            priority,
+            mem,
+        }
+    }
+
+    /// Block until the provider grants a slot for `job_id`, or the token is
+    /// cancelled. Idempotent on the provider side: re-asking for a slot we
+    /// already hold is a grant.
+    pub async fn acquire(
+        self: &Arc<Self>,
+        job_id: Uuid,
+        token: &CancellationToken,
+    ) -> anyhow::Result<SlotLease> {
+        let mut attempts: u64 = 0;
+        loop {
+            if token.is_cancelled() {
+                anyhow::bail!("cancelled while waiting for a slot");
+            }
+            let body = serde_json::json!({
+                "id": job_id.to_string(),
+                "priority": self.priority,
+                "mem": self.mem,
+            });
+            match self
+                .client
+                .post(format!("{}/slot/acquire", self.base_url))
+                .bearer_auth(&self.token)
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => {
+                    tracing::info!(%job_id, attempts, "slot provider: slot granted");
+                    return Ok(SlotLease {
+                        provider: (**self).clone(),
+                        job_id,
+                    });
+                }
+                Ok(response) if response.status().as_u16() == 503 => {
+                    if attempts.is_multiple_of(12) {
+                        let reason = response.text().await.unwrap_or_default();
+                        tracing::info!(%job_id, attempts, reason, "slot provider: busy, waiting");
+                    }
+                }
+                Ok(response) => {
+                    let status = response.status();
+                    let text = response.text().await.unwrap_or_default();
+                    anyhow::bail!("slot provider refused: {status} {text}");
+                }
+                Err(error) => {
+                    if attempts.is_multiple_of(12) {
+                        tracing::warn!(%job_id, %error, "slot provider unreachable; waiting");
+                    }
+                }
+            }
+            attempts += 1;
+            tokio::select! {
+                _ = token.cancelled() => anyhow::bail!("cancelled while waiting for a slot"),
+                _ = tokio::time::sleep(RETRY_INTERVAL) => {}
+            }
+        }
+    }
+
+    pub async fn release(&self, job_id: Uuid) -> anyhow::Result<()> {
+        let response = self
+            .client
+            .post(format!("{}/slot/release", self.base_url))
+            .bearer_auth(&self.token)
+            .json(&serde_json::json!({ "id": job_id.to_string() }))
+            .send()
+            .await?;
+        if response.status().is_success() || response.status().as_u16() == 404 {
+            Ok(())
+        } else {
+            anyhow::bail!("slot release: {}", response.status())
+        }
+    }
+}


### PR DESCRIPTION
Plan: `docs/plans/ROADMAP_TRUTH_AND_BUILD_DEDUP.md` §B4, rollout row 8. Pairs with Th0rgal/dgx-spark-arbiter#1 (slot API + persistence).

The Spark already runs `sandboxed-node` as `dgx-spark` in the prod fleet. This PR removes the reason for the parallel `/build` path:
- **Node slot provider.** `SANDBOXED_NODE_SLOT_PROVIDER=arbiter` (+ `_ARBITER_URL`, `_ARBITER_TOKEN`): the runner asks the arbiter for a slot before executing a job (503 → wait 5 s, retry; cancellation honoured) and releases it on completion. Unreachable provider = wait, never bypass.
- **`spark-build`** for `lake`/`lean` argv execs `remote-lean-build` pinned to `dgx-spark`, preserving the 90/91 exit contract. Other commands keep the legacy offload until step 9.
- `src/api/spark.rs` stays routable (canary gate).

Tests: `cargo test --lib -- node::` green; arbiter slot API smoke-tested (grant, idempotent re-grant, slot cap, release, restart recovery). Rollout: update the arbiter on the Spark, add the three env vars to `/etc/sandboxed-node.env`, rebuild the aarch64 node binary there.