### PR TITLE
Board attention: supersede relays, acknowledge failed missions, handoff auto-resume

### DIFF
--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -67,8 +67,12 @@ For each mission you're babysitting, every check-in:
 Match the signal to the fix. The health `recommendation` usually tells you which.
 
 - **`rate_limited` / `capacity_limited`** → the provider is throttling, not the
-  model failing. `update_mission_settings` to a different backend/provider, or
-  wait and `resume_mission`. (This is the class of "Cloudflare/routing dropped
+  model failing. Credit/quota exhaustion ("out of usage credits") is this class:
+  the runner already rotates through every configured Anthropic account inside
+  the turn; if all are dry the mission fails `rate_limited`. Then
+  `update_mission_settings` to a different backend/provider — on a failed or
+  interrupted mission the server resumes it by itself (`resume_queued: true`),
+  so a handoff is one call. Or wait and `resume_mission`. (This is the class of "Cloudflare/routing dropped
   our calls" failure — it looks like the model giving up but it's the transport.)
 - **`auth_error`** → backend credentials are bad. Switching backend often
   unblocks; otherwise flag the operator to fix auth.

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7492,6 +7492,12 @@ pub struct CreateMissionRequest {
     pub backend: Option<String>,
     /// Parent mission ID (for orchestrated worker missions)
     pub parent_mission_id: Option<Uuid>,
+    /// The attempt this mission replaces (a relay after a failure, a
+    /// backend handoff). The prior mission is tagged `superseded_by:<id>`
+    /// and acknowledged, so the board stops flagging it. Must be on the
+    /// same project.
+    #[serde(default)]
+    pub supersedes_mission_id: Option<Uuid>,
     /// Working directory override (for git worktrees etc.)
     pub working_directory: Option<String>,
     /// FLEET-001 scheduling hint: dispatch priority (higher = more important,
@@ -7600,6 +7606,19 @@ pub struct UpdateMissionSettingsRequest {
     /// Config profile. Omit to leave unchanged, null/empty string to clear.
     #[serde(default, deserialize_with = "deserialize_string_patch")]
     pub config_profile: Option<Option<String>>,
+    /// After a settings change on a Failed/Interrupted mission, queue a
+    /// resume on the new settings (default true). A handoff that leaves the
+    /// mission dead is the failure mode this exists to remove: the controller
+    /// changed the backend, the mission stayed `failed`, work stalled.
+    pub resume: Option<bool>,
+}
+
+/// Does a settings change on a mission in `previous` status queue a resume?
+/// Only terminal-but-resumable statuses; a live, paused or acknowledged
+/// mission is left exactly where it is.
+fn should_queue_resume(previous: MissionStatus, requested: Option<bool>) -> bool {
+    requested.unwrap_or(true)
+        && matches!(previous, MissionStatus::Failed | MissionStatus::Interrupted)
 }
 
 fn normalize_model_effort(raw: &str) -> Option<String> {
@@ -9559,6 +9578,7 @@ pub async fn create_mission(
         config_profile: None,
         backend: None,
         parent_mission_id: None,
+        supersedes_mission_id: None,
         working_directory: None,
         priority: None,
         not_before: None,
@@ -10538,6 +10558,22 @@ pub async fn create_mission(
                 mission_id = %mission.id,
                 %error,
                 "could not absorb prior attempts on the same item"
+            );
+        }
+    }
+    if let Some(prior_id) = req.supersedes_mission_id {
+        if let Err(error) = super::mission_horizon::supersede_explicit(
+            control.mission_store.as_ref(),
+            &mission,
+            prior_id,
+        )
+        .await
+        {
+            tracing::warn!(
+                mission_id = %mission.id,
+                %prior_id,
+                %error,
+                "supersedes_mission_id was not applied"
             );
         }
     }
@@ -12542,7 +12578,7 @@ pub async fn update_mission_settings(
     Extension(user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateMissionSettingsRequest>,
-) -> Result<Json<Mission>, (StatusCode, String)> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
     let current = control
         .mission_store
@@ -12550,6 +12586,7 @@ pub async fn update_mission_settings(
         .await
         .map_err(internal_error)?
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Mission {} not found", id)))?;
+    let previous_status = current.status;
 
     let backend = req.backend.as_ref().and_then(|backend| {
         let trimmed = backend.trim();
@@ -12700,7 +12737,7 @@ pub async fn update_mission_settings(
         .await
         .map_err(session_unavailable)?;
 
-    rx.await.map_err(recv_failed)?.map(Json).map_err(|e| {
+    let mission = rx.await.map_err(recv_failed)?.map_err(|e| {
         if e.contains("not found") {
             (StatusCode::NOT_FOUND, e)
         } else if e.contains("running") {
@@ -12708,7 +12745,44 @@ pub async fn update_mission_settings(
         } else {
             internal_error(e)
         }
-    })
+    })?;
+
+    // The settings write is durable at this point. A handoff on a dead
+    // mission continues it on the new settings; the handoff user message
+    // was logged by the command handler, so the resumed turn sees it. A
+    // resume refusal is reported, never turned into an error.
+    let mut body = serde_json::to_value(&mission).map_err(internal_error)?;
+    if should_queue_resume(previous_status, req.resume) {
+        let (tx, rx) = oneshot::channel();
+        let queued = match control
+            .cmd_tx
+            .send(ControlCommand::ResumeMission {
+                mission_id: id,
+                clean_workspace: false,
+                skip_message: false,
+                respond: tx,
+            })
+            .await
+        {
+            Ok(()) => rx
+                .await
+                .map_err(|e| e.to_string())
+                .and_then(|r| r.map(|_| ())),
+            Err(e) => Err(e.to_string()),
+        };
+        match queued {
+            Ok(()) => {
+                tracing::info!(mission_id = %id, previous = ?previous_status, "settings handoff resumed the mission");
+                body["resume_queued"] = serde_json::Value::Bool(true);
+            }
+            Err(error) => {
+                tracing::warn!(mission_id = %id, %error, "settings handoff could not resume the mission");
+                body["resume_queued"] = serde_json::Value::Bool(false);
+                body["resume_warning"] = serde_json::Value::String(error);
+            }
+        }
+    }
+    Ok(Json(body))
 }
 
 /// Load/switch to a mission.
@@ -14258,6 +14332,7 @@ pub async fn clone_mission(
         config_profile: source.config_profile.clone(),
         backend: overrides.backend.or_else(|| Some(source.backend.clone())),
         parent_mission_id,
+        supersedes_mission_id: None,
         working_directory: source.working_directory.clone(),
         priority: None,
         not_before: None,
@@ -27261,6 +27336,18 @@ pub async fn telegram_webhook_receiver(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_settings_handoff_resumes_only_dead_missions() {
+        use super::{should_queue_resume, MissionStatus};
+        assert!(should_queue_resume(MissionStatus::Failed, None));
+        assert!(should_queue_resume(MissionStatus::Interrupted, Some(true)));
+        assert!(!should_queue_resume(MissionStatus::Failed, Some(false)));
+        assert!(!should_queue_resume(MissionStatus::Active, None));
+        assert!(!should_queue_resume(MissionStatus::Paused, None));
+        assert!(!should_queue_resume(MissionStatus::Acknowledged, None));
+        assert!(!should_queue_resume(MissionStatus::Completed, None));
+    }
+
     #[test]
     fn registered_liveness_interrupt_skips_hermes_tagged_writer() {
         assert!(super::skip_idle_registered_liveness_interrupt(

--- a/src/api/mission_horizon.rs
+++ b/src/api/mission_horizon.rs
@@ -40,6 +40,90 @@ pub fn writer_role(mission: &Mission) -> WriterRole {
     }
 }
 
+/// Tag prefix recording *which* attempt replaced this one, so the board can
+/// show "relayed by …" and never count the superseded attempt as a problem.
+pub const SUPERSEDED_BY_PREFIX: &str = "superseded_by:";
+
+/// The attempt that superseded this mission, if any (from its tags).
+pub fn superseded_by(mission: &Mission) -> Option<Uuid> {
+    mission
+        .project
+        .tags
+        .iter()
+        .filter_map(|tag| tag.strip_prefix(SUPERSEDED_BY_PREFIX))
+        .filter_map(|id| Uuid::parse_str(id.trim()).ok())
+        .next_back()
+}
+
+/// Mark `prior` as replaced by `successor`: tag it (`superseded` +
+/// `superseded_by:<id>`) and, when no run is live, acknowledge it so it leaves
+/// the attention horizon. Idempotent.
+async fn absorb(store: &dyn MissionStore, prior: &Mission, successor: Uuid) -> Result<(), String> {
+    let mut tags = prior.project.tags.clone();
+    if !tags.iter().any(|tag| tag == SUPERSEDED_TAG) {
+        tags.push(SUPERSEDED_TAG.to_string());
+    }
+    let by = format!("{SUPERSEDED_BY_PREFIX}{successor}");
+    if !tags.iter().any(|tag| tag == &by) {
+        tags.retain(|tag| !tag.starts_with(SUPERSEDED_BY_PREFIX));
+        tags.push(by);
+    }
+    store
+        .update_mission_project(
+            prior.id,
+            MissionProjectPatch {
+                tags: Some(tags),
+                ..Default::default()
+            },
+        )
+        .await?;
+    if store.get_active_mission_run(prior.id).await?.is_none() {
+        if let Err(error) = store
+            .update_mission_status(prior.id, MissionStatus::Acknowledged)
+            .await
+        {
+            tracing::warn!(
+                mission_id = %prior.id,
+                %error,
+                "could not acknowledge a superseded attempt"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// An explicit relay: the caller names the attempt it replaces
+/// (`supersedes_mission_id`). Used when a controller hands work to a new
+/// mission on another backend after a failure, whatever the track tagging.
+/// Refused across projects; a mission may not absorb itself.
+pub async fn supersede_explicit(
+    store: &dyn MissionStore,
+    new_mission: &Mission,
+    prior_id: Uuid,
+) -> Result<(), String> {
+    if prior_id == new_mission.id {
+        return Err("a mission cannot supersede itself".to_string());
+    }
+    let Some(prior) = store.get_mission(prior_id).await? else {
+        return Err(format!("mission {prior_id} not found"));
+    };
+    let same_project = match (
+        prior.project.project.as_deref().map(str::trim),
+        new_mission.project.project.as_deref().map(str::trim),
+    ) {
+        (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+        (None, _) => true,
+        (Some(_), None) => false,
+    };
+    if !same_project {
+        return Err(format!(
+            "mission {prior_id} belongs to project {:?}, not {:?}",
+            prior.project.project, new_mission.project.project
+        ));
+    }
+    absorb(store, &prior, new_mission.id).await
+}
+
 fn role_label(role: WriterRole) -> Option<&'static str> {
     match role {
         WriterRole::Writer => Some("pr-writer"),
@@ -91,31 +175,7 @@ pub async fn supersede_prior_attempts(
         if prior.id == new_mission.id || writer_role(&prior) != role {
             continue;
         }
-        let mut tags = prior.project.tags.clone();
-        if !tags.iter().any(|tag| tag == SUPERSEDED_TAG) {
-            tags.push(SUPERSEDED_TAG.to_string());
-        }
-        store
-            .update_mission_project(
-                prior.id,
-                MissionProjectPatch {
-                    tags: Some(tags),
-                    ..Default::default()
-                },
-            )
-            .await?;
-        if store.get_active_mission_run(prior.id).await?.is_none() {
-            if let Err(error) = store
-                .update_mission_status(prior.id, MissionStatus::Acknowledged)
-                .await
-            {
-                tracing::warn!(
-                    mission_id = %prior.id,
-                    %error,
-                    "could not acknowledge a superseded attempt"
-                );
-            }
-        }
+        absorb(store, &prior, new_mission.id).await?;
         absorbed.push(prior.id);
     }
     Ok(absorbed)
@@ -531,6 +591,67 @@ mod tests {
             .expect("exists");
         assert_eq!(prior.status, MissionStatus::Acknowledged);
         assert!(prior.project.tags.iter().any(|tag| tag == SUPERSEDED_TAG));
+        assert_eq!(superseded_by(&prior), Some(second.id));
+    }
+
+    #[tokio::test]
+    async fn an_explicit_relay_absorbs_a_failed_attempt_without_a_track() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let failed = seed(
+            &store,
+            "fable-attempt",
+            "eip-8282",
+            "entry-reach",
+            MissionStatus::Failed,
+            &[],
+        )
+        .await;
+        // The relay carries the project but a different (or no) track.
+        let relay = seed(
+            &store,
+            "codex-relay",
+            "eip-8282",
+            "entry-reach-relay",
+            MissionStatus::Pending,
+            &[],
+        )
+        .await;
+        assert!(
+            supersede_prior_attempts(store.as_ref(), &relay)
+                .await
+                .expect("supersede")
+                .is_empty(),
+            "a different track never absorbs implicitly"
+        );
+        supersede_explicit(store.as_ref(), &relay, failed.id)
+            .await
+            .expect("explicit relay");
+        let prior = store
+            .get_mission(failed.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(prior.status, MissionStatus::Acknowledged);
+        assert_eq!(superseded_by(&prior), Some(relay.id));
+        // Idempotent and refuses nonsense.
+        supersede_explicit(store.as_ref(), &relay, failed.id)
+            .await
+            .expect("replay");
+        assert!(supersede_explicit(store.as_ref(), &relay, relay.id)
+            .await
+            .is_err());
+        let other = seed(
+            &store,
+            "elsewhere",
+            "verity-core",
+            "x",
+            MissionStatus::Failed,
+            &[],
+        )
+        .await;
+        assert!(supersede_explicit(store.as_ref(), &relay, other.id)
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -2018,6 +2018,10 @@ struct MissionChip {
     /// Qualified operator page — ack / in-grace controller waits stay false.
     #[serde(default)]
     needs_operator: bool,
+    /// The attempt that replaced this one (relay / handoff). A superseded
+    /// attempt is never a reason for attention.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    superseded_by: Option<String>,
 }
 
 /// Owned copy of what the health rollup reads.
@@ -2948,7 +2952,7 @@ impl ProjectRowBuilder {
                     matches!(
                         chip.status,
                         MissionStatus::Failed | MissionStatus::Interrupted
-                    )
+                    ) && chip.superseded_by.is_none()
                 })
                 .collect()
         };
@@ -3197,6 +3201,7 @@ fn mission_chip(
             wait_started_at,
             chrono::Utc::now(),
         ),
+        superseded_by: super::mission_horizon::superseded_by(mission).map(|id| id.to_string()),
     }
 }
 
@@ -5147,6 +5152,7 @@ mod tests {
             github_pr: None,
             last_status_change_at: None,
             needs_operator: false,
+            superseded_by: None,
         });
         let row = builder.finish(&[], None, None, "2026-08-14T06:05:00Z");
         assert_eq!(row.mode.as_deref(), Some("active"));
@@ -5334,6 +5340,7 @@ mod tests {
                 github_pr: None,
                 last_status_change_at: None,
                 needs_operator: false,
+                superseded_by: None,
             });
         }
         let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
@@ -5357,7 +5364,28 @@ mod tests {
             github_pr: None,
             last_status_change_at: None,
             needs_operator: false,
+            superseded_by: None,
         }
+    }
+
+    #[test]
+    fn a_superseded_failed_attempt_is_not_a_reason_for_attention() {
+        let mut builder = ProjectRowBuilder::new("eip-8282".into());
+        let mut chip = failed_chip("1971a723-0000-0000-0000-000000000000");
+        chip.superseded_by = Some("bc136872-0000-0000-0000-000000000000".into());
+        builder.missions.push(chip);
+        let row = builder.finish(&[], None, None, "2026-08-02T01:00:00Z");
+        assert!(
+            row.attention_reasons.is_empty(),
+            "relayed attempt still flagged: {:?}",
+            row.attention_reasons
+        );
+        let mut builder = ProjectRowBuilder::new("eip-8282".into());
+        builder
+            .missions
+            .push(failed_chip("1971a723-0000-0000-0000-000000000000"));
+        let row = builder.finish(&[], None, None, "2026-08-02T01:00:00Z");
+        assert_eq!(row.attention_reasons.len(), 1);
     }
 
     fn active_update(at: &str, blocker: Option<&str>) -> DeliveryUpdate {
@@ -5582,6 +5610,7 @@ mod tests {
             github_pr: None,
             last_status_change_at: None,
             needs_operator: true,
+            superseded_by: None,
         });
         builder
             .missions
@@ -5605,6 +5634,7 @@ mod tests {
             github_pr: None,
             last_status_change_at: None,
             needs_operator,
+            superseded_by: None,
         }
     }
 
@@ -5837,6 +5867,7 @@ mod tests {
             github_pr: None,
             last_status_change_at: None,
             needs_operator: false,
+            superseded_by: None,
         });
         builder.missions.push(MissionChip {
             id: "8cc8df04-b8f4-4003-b668-d17f7d3e8def".to_string(),
@@ -5846,6 +5877,7 @@ mod tests {
             github_pr: None,
             last_status_change_at: None,
             needs_operator: false,
+            superseded_by: None,
         });
         let row = builder.finish(&[], None, None, "2026-08-16T19:05:00Z");
         let next = row.next_action.expect("derived");

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -331,6 +331,8 @@ struct StartMissionParams {
     #[serde(default)]
     idempotency_key: Option<String>,
     #[serde(default)]
+    supersedes_mission_id: Option<String>,
+    #[serde(default)]
     intent: Option<String>,
     #[serde(default)]
     github_pr: Option<String>,
@@ -1562,6 +1564,7 @@ impl AssistantMcp {
                         "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
                         "acceptance_criteria": {"type": "array", "items": {"type": "string"}, "description": "Outcome contract used when this dispatch declares the track. Existing satisfied tracks are never reopened implicitly."},
                         "idempotency_key": {"type": "string", "description": "Stable retry key for one logical dispatch. Reusing it returns the existing mission receipt instead of starting a duplicate."},
+                        "supersedes_mission_id": {"type": "string", "description": "The failed/interrupted attempt this mission relays (same project). It is tagged superseded_by and acknowledged, so the board stops flagging it. Use this on every handoff/relay instead of a separate acknowledge_mission call."},
                         "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."},
                         "estimated_disk_gib": {"type": "integer", "minimum": 1, "maximum": 512, "description": "Expected peak local scratch use. Set this for Lean/build-heavy missions; omit for small/no-build work."},
                         "origin_session_id": {"type": "string", "description": "Hermes session id of the conversation spawning this mission. Dashboards group the mission as a worker of that session, AND the mission-status webhook carries it back so the completion is delivered into that conversation instead of an isolated webhook session — always pass it when starting a mission from a conversation. Injected automatically by the Hermes-side plugin; pass through unchanged, never another session's id."}
@@ -1618,7 +1621,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "acknowledge_mission".to_string(),
-                description: "Acknowledge a mission only after independently verifying its terminal result. This is the safe host-authenticated replacement for asking a workspace container to use the service JWT. It accepts only awaiting_user missions whose awaiting_kind is ack; decision waits and live missions are refused.".to_string(),
+                description: "Acknowledge a mission only after independently verifying its terminal result. This is the safe host-authenticated replacement for asking a workspace container to use the service JWT. It accepts awaiting_user missions whose awaiting_kind is ack, and failed/interrupted missions once you have relayed or abandoned their work (prefer start_mission with supersedes_mission_id for a relay); decision waits and live missions are refused.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
@@ -2109,7 +2112,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "update_mission_settings".to_string(),
-                description: "Change a mission's run settings for its NEXT turn: switch backend (claudecode/codex/opencode/gemini/grok/chatgpt_ui), model, reasoning effort, fast mode, or agent. Applies between turns — the mission must be idle (awaiting_user/acknowledged/interrupted), not actively running. If it is running, cancel_mission first (or wait), then update, then send_message_to_mission or resume_mission to kick the next turn. model_effort applies to claudecode/codex; fast_mode applies only to Codex GPT-5.6/5.5/5.4 and consumes ChatGPT credits faster.".to_string(),
+                description: "Change a mission's run settings for its NEXT turn: switch backend (claudecode/codex/opencode/gemini/grok/chatgpt_ui), model, reasoning effort, fast mode, or agent. On a failed or interrupted mission the server resumes it on the new settings automatically (resume_queued in the response) — a handoff is one call, no separate resume_mission. Applies between turns — the mission must be idle (awaiting_user/acknowledged/interrupted/failed), not actively running. If it is running, cancel_mission first (or wait), then update, then send_message_to_mission or resume_mission to kick the next turn. model_effort applies to claudecode/codex; fast_mode applies only to Codex GPT-5.6/5.5/5.4 and consumes ChatGPT credits faster.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
@@ -2414,6 +2417,7 @@ impl AssistantMcp {
             "project": params.project,
             "track": params.track,
             "idempotency_key": params.idempotency_key,
+            "supersedes_mission_id": params.supersedes_mission_id,
             "intent": params.intent,
             "github_pr": params.github_pr,
             "writer": writer,
@@ -4631,6 +4635,13 @@ fn mission_requires_acknowledgement(digest: &Value) -> Result<bool, String> {
     if status == "awaiting_user" && awaiting_kind == Some("ack") {
         return Ok(true);
     }
+    // A failed or interrupted attempt is terminal too: acknowledging it is
+    // how a controller that relayed the work elsewhere clears the board's
+    // "mission … is Failed" reason. Live missions and decision waits stay
+    // refused.
+    if status == "failed" || status == "interrupted" {
+        return Ok(true);
+    }
 
     Err(format!(
         "Mission cannot be ACKed from status={status}, awaiting_kind={}",
@@ -5761,6 +5772,16 @@ mod tests {
             "awaiting_kind": null
         }))
         .is_err());
+        assert!(mission_requires_acknowledgement(&json!({
+            "status": "failed",
+            "awaiting_kind": null
+        }))
+        .unwrap());
+        assert!(mission_requires_acknowledgement(&json!({
+            "status": "interrupted",
+            "awaiting_kind": null
+        }))
+        .unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Steps 2 and 3 of the board-attention reliability plan.

- `supersedes_mission_id` on mission creation (API + MCP `start_mission`): tags the prior attempt `superseded` + `superseded_by:<id>` and acknowledges it; `MissionChip.superseded_by` exposed; overview ignores superseded attempts when computing attention.
- `acknowledge_mission` accepts `failed`/`interrupted`.
- `update_mission_settings` on a Failed/Interrupted mission queues `ResumeMission` after the durable settings write (`resume: false` opts out); response is the mission JSON plus `resume_queued` / `resume_warning`.
- skill + tool descriptions updated.

Tested locally: `cargo test --lib -- mission_horizon projects_overview a_settings_handoff` (95 passed), `cargo test --bin assistant-mcp` (49 passed).