### PR TITLE
Meta Muse: Spark 1.3 on the contributor tier by default

### DIFF
--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1244,6 +1244,18 @@ fn default_providers_config() -> ProvidersConfig {
                 // is present.
                 models: vec![
                     ProviderModel {
+                        id: "muse-spark-1.3-contributor".to_string(),
+                        name: "Muse Spark 1.3 Contributor".to_string(),
+                        description: Some(
+                            "Spark 1.3, data-sharing tier (~12x cheaper). Default.".to_string(),
+                        ),
+                    },
+                    ProviderModel {
+                        id: "muse-spark-1.3".to_string(),
+                        name: "Muse Spark 1.3".to_string(),
+                        description: Some("Spark 1.3, no-training tier".to_string()),
+                    },
+                    ProviderModel {
                         id: "muse-spark-1.2".to_string(),
                         name: "Muse Spark 1.2".to_string(),
                         description: Some("Coding-focused Spark 1.2".to_string()),

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -377,8 +377,22 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         pricing: pricing(600, 2_400, Some(375), Some(60)),
     },
     // Meta Muse (api.meta.ai). models.dev / OpenCode catalog, checked 2026-08-19.
-    // Contributor must sit above the 1.2 family alias so "-contributor" does not
+    // Contributor must sit above the family alias so "-contributor" does not
     // inherit standard Spark rates via the `muse-spark` prefix.
+    //
+    // Spark 1.3 appeared on /models on 2026-09-03; models.dev had no rates for
+    // it yet, so it carries the 1.2 tiers (contributor = the data-sharing tier,
+    // ~12x cheaper). Re-check models.dev and correct if Meta priced it apart.
+    PricingEntry {
+        canonical: "muse-spark-1.3-contributor",
+        aliases: &["muse-spark-1.3-contributor"],
+        pricing: pricing(100, 200, None, Some(2)),
+    },
+    PricingEntry {
+        canonical: "muse-spark-1.3",
+        aliases: &["muse-spark-1.3"],
+        pricing: pricing(1_250, 4_250, None, Some(150)),
+    },
     PricingEntry {
         canonical: "muse-spark-1.2-contributor",
         aliases: &["muse-spark-1.2-contributor"],
@@ -671,6 +685,10 @@ mod tests {
             "muse-spark-1.2-contributor"
         );
         assert_eq!(normalize_model("muse-spark-1.1"), "muse-spark-1.1");
+        assert_eq!(
+            normalize_model("meta/muse-spark-1.3-contributor"),
+            "muse-spark-1.3-contributor"
+        );
     }
 
     #[test]

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -700,6 +700,31 @@ pub struct ChainEntry {
 }
 
 /// A named model chain (fallback sequence).
+/// The Meta Muse model every chain should ride: the current Spark on the
+/// contributor tier. See `migrate_muse_entries`.
+pub const MUSE_DEFAULT_MODEL: &str = "muse-spark-1.3-contributor";
+
+/// Rewrite superseded / full-price Muse entries to [`MUSE_DEFAULT_MODEL`].
+/// Returns whether anything changed.
+pub fn migrate_muse_entries(chain: &mut ModelChain) -> bool {
+    let mut migrated = false;
+    for entry in &mut chain.entries {
+        if entry.provider_id == "muse"
+            && matches!(
+                entry.model_id.as_str(),
+                "muse-spark-1.1"
+                    | "muse-spark-1.2"
+                    | "muse-spark-1.2-contributor"
+                    | "muse-spark-1.3"
+            )
+        {
+            entry.model_id = MUSE_DEFAULT_MODEL.to_string();
+            migrated = true;
+        }
+    }
+    migrated
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelChain {
     /// Unique chain ID (e.g., "builtin/smart", "user/fast").
@@ -919,7 +944,7 @@ impl ModelChainStore {
                     },
                     ChainEntry {
                         provider_id: "muse".to_string(),
-                        model_id: "muse-spark-1.2".to_string(),
+                        model_id: MUSE_DEFAULT_MODEL.to_string(),
                     },
                 ],
                 is_default: true,
@@ -929,6 +954,17 @@ impl ModelChainStore {
             });
             changed = true;
         } else {
+            // Meta Muse tier policy (owner decision 2026-09-03): every chain
+            // rides the current Spark on the contributor (data-sharing) tier,
+            // ~12x cheaper than the no-training tier. Older Spark ids and the
+            // full-price id are rewritten in place, order preserved.
+            for chain in chains.iter_mut() {
+                if migrate_muse_entries(chain) {
+                    chain.updated_at = now;
+                    changed = true;
+                    tracing::info!(chain = %chain.id, "Migrated Meta Muse entries to {MUSE_DEFAULT_MODEL}");
+                }
+            }
             // Built-in chains are managed defaults. Preserve configured order
             // and extra fallbacks, but keep their stock model IDs current.
             if let Some(chain) = chains.iter_mut().find(|c| c.id == "builtin/smart") {
@@ -971,10 +1007,10 @@ impl ModelChainStore {
                 {
                     chain.entries.push(ChainEntry {
                         provider_id: "muse".to_string(),
-                        model_id: "muse-spark-1.2".to_string(),
+                        model_id: MUSE_DEFAULT_MODEL.to_string(),
                     });
                     migrated = true;
-                    tracing::info!("Appended muse/muse-spark-1.2 to builtin/smart");
+                    tracing::info!("Appended muse/{MUSE_DEFAULT_MODEL} to builtin/smart");
                 }
                 if migrated {
                     chain.updated_at = now;
@@ -1862,7 +1898,7 @@ mod tests {
                 ("cerebras".to_string(), "zai-glm-4.7".to_string()),
                 // The 2026-08-06 migration appends Meta Muse as a tail
                 // fallback to persisted chains, never reordering them.
-                ("muse".to_string(), "muse-spark-1.2".to_string()),
+                ("muse".to_string(), MUSE_DEFAULT_MODEL.to_string()),
             ]
         );
 


### PR DESCRIPTION
Key verified live (`/models` lists muse-spark-1.3 and muse-spark-1.3-contributor; a 5-token completion on each returned 200). Adds both to the catalog and pricing (contributor 0.10/0.20 per M, standard 1.25/4.25, 1.2 rates carried over until models.dev publishes 1.3), and migrates every persisted chain's Muse entry to `muse-spark-1.3-contributor` at boot. Tests: provider_health / cost / providers green locally (one env-dependent xAI CLI-proxy test is flaky on this machine).