### PR TITLE
Codex: gpt-6-astra as the default model

### DIFF
--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -1013,7 +1013,7 @@ export function NewMissionDialog({
                 <p className="text-xs text-white/30 mt-1.5">
                   {selectedBackend === 'opencode'
                     ? 'Use provider/model format (e.g., openai/gpt-5.6-sol).'
-                    : 'Use the raw model ID (e.g., gpt-5.6-sol or claude-opus-5).'}
+                    : 'Use the raw model ID (e.g., gpt-6-astra or claude-opus-5).'}
                 </p>
               </div>
             )}

--- a/skills/orchestrator-boss/SKILL.md
+++ b/skills/orchestrator-boss/SKILL.md
@@ -66,7 +66,7 @@ re-prescription of the work.
 ## Backend Guide
 
 - `codex` + `gpt-5.6-terra`: default for bounded code changes
-- `codex` + `gpt-5.6-sol`: hard blockers, formal proofs, and adversarial certification
+- `codex` + `gpt-6-astra` (default; `gpt-5.6-sol` as fallback): hard blockers, formal proofs, and adversarial certification
 - `gemini` + `gemini-3.1-pro-preview` or `gemini-2.5-pro`: good for proofs and parallel analysis
 - `opencode`: cheap redundancy
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -60,8 +60,8 @@ fn role_default_model(task: &BoardTask) -> Option<&'static str> {
         return None;
     }
     Some(match task.role {
-        BoardTaskRole::Planner | BoardTaskRole::Reviewer => "gpt-5.6-sol",
-        BoardTaskRole::Reconciler if task.risk_class == "high" => "gpt-5.6-sol",
+        BoardTaskRole::Planner | BoardTaskRole::Reviewer => "gpt-6-astra",
+        BoardTaskRole::Reconciler if task.risk_class == "high" => "gpt-6-astra",
         BoardTaskRole::Worker | BoardTaskRole::Reconciler => "gpt-5.6-terra",
     })
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3376,9 +3376,16 @@ pub(crate) async fn resolve_claudecode_default_model(
 
 /// Return the default model for Codex CLI when no override is specified.
 pub(crate) fn resolve_codex_default_model() -> String {
-    // Keep aligned with Codex upstream:
-    // https://raw.githubusercontent.com/openai/codex/main/codex-rs/models-manager/models.json
-    "gpt-5.6-sol".to_string()
+    // Keep aligned with the live ChatGPT Codex catalog (`codex debug models`):
+    // gpt-6-astra listed on both prod accounts 2026-09-05 (efforts low..ultra,
+    // default medium). Owner decision: Astra is the Codex default.
+    if let Ok(model) = std::env::var("CODEX_DEFAULT_MODEL") {
+        let trimmed = model.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    "gpt-6-astra".to_string()
 }
 
 /// Return the default model for Gemini CLI when no override is specified.
@@ -7628,6 +7635,9 @@ fn normalize_model_effort(raw: &str) -> Option<String> {
         "high" => Some("high".to_string()),
         "xhigh" => Some("xhigh".to_string()),
         "max" => Some("max".to_string()),
+        // Codex-only (gpt-6-astra, gpt-5.6-sol/terra): maximum reasoning with
+        // automatic task delegation.
+        "ultra" => Some("ultra".to_string()),
         _ => None,
     }
 }
@@ -7646,7 +7656,7 @@ fn normalize_model_effort_for_backend(backend: Option<&str>, raw: &str) -> Optio
 fn supported_model_efforts_for_backend(backend: Option<&str>) -> &'static str {
     match backend {
         Some("claudecode") => "low, medium, high, xhigh, max",
-        Some("codex") => "low, medium, high, xhigh, max",
+        Some("codex") => "low, medium, high, xhigh, max, ultra",
         _ => "none",
     }
 }
@@ -7656,7 +7666,7 @@ fn codex_fast_mode_model_supported(model: Option<&str>) -> bool {
         return false;
     };
     let model = model.rsplit('/').next().unwrap_or(model);
-    ["gpt-5.6", "gpt-5.5", "gpt-5.4"]
+    ["gpt-6", "gpt-5.6", "gpt-5.5", "gpt-5.4"]
         .iter()
         .any(|prefix| model == *prefix || model.starts_with(&format!("{prefix}-")))
 }
@@ -7703,10 +7713,16 @@ fn normalize_model_override_for_backend(backend: Option<&str>, raw_model: &str) 
     if backend == Some("codex") && trimmed == "gpt-5.6" {
         return Some("gpt-5.6-sol".to_string());
     }
+    if backend == Some("codex") && trimmed == "gpt-6" {
+        return Some("gpt-6-astra".to_string());
+    }
     if backend != Some("opencode") {
         if let Some((_, model_id)) = trimmed.split_once('/') {
             if backend == Some("codex") && model_id == "gpt-5.6" {
                 return Some("gpt-5.6-sol".to_string());
+            }
+            if backend == Some("codex") && model_id == "gpt-6" {
+                return Some("gpt-6-astra".to_string());
             }
             return Some(model_id.to_string());
         }
@@ -31915,6 +31931,15 @@ And the report:
             normalize_model_override_for_backend(Some("codex"), "openai/gpt-5.6"),
             Some("gpt-5.6-sol".to_string())
         );
+        assert_eq!(
+            normalize_model_override_for_backend(Some("codex"), "gpt-6"),
+            Some("gpt-6-astra".to_string())
+        );
+        assert_eq!(
+            normalize_model_override_for_backend(Some("codex"), "openai/gpt-6"),
+            Some("gpt-6-astra".to_string())
+        );
+        assert_eq!(resolve_codex_default_model(), "gpt-6-astra");
         assert_eq!(
             normalize_model_override_for_backend(Some("opencode"), "openai/gpt-5.6"),
             Some("openai/gpt-5.6".to_string())

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -83,6 +83,7 @@ const OPENROUTER_SEED_MODEL_IDS: &[&str] = &[
     "anthropic/claude-opus-5",
     "anthropic/claude-sonnet-4.6",
     "google/gemini-3.1-pro-preview",
+    "openai/gpt-6-astra",
     "openai/gpt-5.6",
     "openai/gpt-5.6-sol",
     "openai/gpt-5.5",
@@ -879,6 +880,14 @@ fn default_providers_config() -> ProvidersConfig {
                     // removed — gpt-5.3-codex now 404s ("model not supported when
                     // using Codex with a ChatGPT account"), and everything older
                     // than it is dead too. Newest first.
+                    ProviderModel {
+                        id: "gpt-6-astra".to_string(),
+                        name: "GPT-6 Astra".to_string(),
+                        description: Some(
+                            "OpenAI's GPT-6 flagship in Codex (efforts low..ultra). Default."
+                                .to_string(),
+                        ),
+                    },
                     ProviderModel {
                         id: "gpt-5.6".to_string(),
                         name: "GPT-5.6".to_string(),
@@ -2940,6 +2949,8 @@ fn is_codex_backend_model_id(model_id: &str) -> bool {
         || matches!(
             model_id,
             "gpt-daybreak-blue-latest"
+                | "gpt-6-astra"
+                | "gpt-6"
                 | "gpt-5.5"
                 | "gpt-5.6"
                 | "gpt-5.6-sol"
@@ -3230,6 +3241,7 @@ mod tests {
 
         for id in [
             "gpt-daybreak-blue-latest",
+            "gpt-6-astra",
             "gpt-5.6",
             "gpt-5.6-sol",
             "gpt-5.6-terra",

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -1480,7 +1480,7 @@ pub async fn run_codex_turn(
     if lower_final.contains("does not exist or you do not have access")
         || lower_final.contains("model_not_found")
     {
-        final_message.push_str("\n\nTry model `gpt-5.6-sol` or `gpt-5-codex` for Codex missions.");
+        final_message.push_str("\n\nTry model `gpt-6-astra` or `gpt-5.6-sol` for Codex missions.");
         if matches!(
             model,
             Some("gpt-5.3-codex" | "gpt-5.4-codex" | "gpt-5.5-codex")

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -5387,7 +5387,10 @@ fn is_env_name_char(ch: char) -> bool {
 fn hermes_uses_native_codex(model: Option<&str>, base_url: Option<&str>) -> bool {
     let model_is_codex = model.is_some_and(|m| {
         let value = m.to_ascii_lowercase();
-        value.contains("openai-codex") || value.contains("gpt-5.6") || value.contains("gpt-5.5")
+        value.contains("openai-codex")
+            || value.contains("gpt-6")
+            || value.contains("gpt-5.6")
+            || value.contains("gpt-5.5")
     });
     let base_url_is_codex = base_url.is_some_and(|url| {
         url.to_ascii_lowercase()

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -369,7 +369,7 @@ struct MergeBranchParams {
     /// Backend for the auto-registered conflict-resolver task (default codex)
     #[serde(default)]
     resolver_backend: Option<String>,
-    /// Model for the resolver task (default gpt-5.6-sol)
+    /// Model for the resolver task (default gpt-6-astra)
     #[serde(default)]
     resolver_model: Option<String>,
 }
@@ -718,7 +718,7 @@ impl OrchestratorMcp {
                         "push": { "type": "boolean", "description": "Push target to origin after a clean merge" },
                         "delete_source": { "type": "boolean", "description": "Delete the source branch after a clean merge" },
                         "resolver_backend": { "type": "string", "description": "Backend for the auto conflict-resolver task (default codex)" },
-                        "resolver_model": { "type": "string", "description": "Model for the resolver task (default gpt-5.6-sol)" }
+                        "resolver_model": { "type": "string", "description": "Model for the resolver task (default gpt-6-astra)" }
                     }
                 }),
             },
@@ -2330,7 +2330,7 @@ impl OrchestratorMcp {
                     model_override: Some(
                         params
                             .resolver_model
-                            .unwrap_or_else(|| "gpt-5.6-sol".to_string()),
+                            .unwrap_or_else(|| "gpt-6-astra".to_string()),
                     ),
                     model_effort: Some("high".to_string()),
                     working_directory: Some(repo_dir.clone()),

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -166,6 +166,13 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         aliases: &["gpt-5-mini"],
         pricing: pricing(250, 2_000, None, Some(25)),
     },
+    // GPT-6 Astra (Codex, ChatGPT catalog 2026-09-05). No public rate yet:
+    // carries the GPT-5.6 Sol rates until models.dev lists it.
+    PricingEntry {
+        canonical: "gpt-6-astra",
+        aliases: &["gpt-6-astra", "gpt-6"],
+        pricing: pricing(5_000, 30_000, Some(6_250), Some(500)),
+    },
     PricingEntry {
         canonical: "gpt-5.6-sol",
         aliases: &["gpt-5.6", "gpt-5-6", "gpt-5.6-sol", "gpt-5-6-sol"],
@@ -645,6 +652,8 @@ mod tests {
         assert_eq!(normalize_model("gpt-4o-2024-08-06"), "gpt-4o");
         assert_eq!(normalize_model("gpt-5.3-codex"), "gpt-5.3");
         assert_eq!(normalize_model("openai/gpt-5.6"), "gpt-5.6-sol");
+        assert_eq!(normalize_model("openai/gpt-6-astra"), "gpt-6-astra");
+        assert_eq!(normalize_model("gpt-6"), "gpt-6-astra");
         assert_eq!(normalize_model("gpt-5.6-2026-07-09"), "gpt-5.6-sol");
         assert_eq!(normalize_model("openai/gpt-5.6-sol"), "gpt-5.6-sol");
         assert_eq!(normalize_model("openai/gpt-5.6-terra"), "gpt-5.6-terra");


### PR DESCRIPTION
GPT-6 Astra is now served to both prod Codex accounts (verified with `codex debug models` and a live completion on each). Default model → `gpt-6-astra` (env `CODEX_DEFAULT_MODEL` overrides), `gpt-6` alias, catalog + allowlist + pricing (Sol rates until published) + fast-mode support + `ultra` effort; board roles and orchestrator resolver default follow. Tests: cost/providers/control normalize green locally.