### PR TITLE
fix(remote-build): support pinned submodules in full-source transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-target-test-harness-
 
+      - name: Test full-source transport (no Lean compilation)
+        run: python3 scripts/test_remote_lean_build_source.py -v
+
       - name: Run tests
         run: cargo test --locked --workspace
 

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -444,13 +444,38 @@ remote-lean-build lake build Verity
 
 It derives `repo` (`git remote get-url origin`), `commit`
 (`git rev-parse HEAD`), the Lean toolchain, and `cwd_rel`
-(`git rev-parse --show-prefix`). Dirty Lean sources and build metadata are sent
-as a bounded hashed overlay; unsupported deletions/renames fail before
-submission. For a private repository, set
+(`git rev-parse --show-prefix`). Local tracked edits and allowlisted untracked
+Lean/build metadata are sent as a bounded hashed overlay; tracked deletions and
+renames use explicit delete/file operations. For a private repository, set
 `REMOTE_BUILD_SOURCE_MODE=full`: the wrapper sends a content-addressed snapshot
 of all tracked files (plus the same narrow untracked Lean/build metadata
 allowlist), and the node materializes it without any Git fetch or repository
 credential. The receipt binds both the declared commit and the snapshot digest.
+Full mode recursively includes initialized Git submodules, including non-Lean
+tracked files at every level. Each submodule's `HEAD` must match its parent's
+pinned gitlink, and every repository's indexed gitlinks must match its pinned
+tree. Initialize sources first
+with `git submodule update --init --recursive` in an authorized source checkout;
+missing initialization, wrong revisions, sparse missing files, unmerged index
+entries, or uncommitted gitlink changes fail locally before submission with a
+repair instruction. The wrapper does not fetch submodules or forward their Git
+metadata or credentials.
+Full mode ignores replacement refs and disables lazy fetching of missing Git
+objects; materialize those objects in the authorized source checkout first.
+Commit intended gitlink changes before submitting them. Ordinary local file
+edits and the untracked Lean/build metadata allowlist apply recursively;
+tracked file deletions are represented by omission. Files are globally sorted
+and hashed using the existing complete-bundle and executable-operation digests.
+The existing aggregate file/byte limits and path restrictions still apply to
+the entire recursive snapshot; symlinks, including parent directories, are
+rejected. Neither `.git` metadata nor `.lake` caches are transported.
+
+This is source transport, not dependency download policy. Complete bundles
+materialize without fetching the source repositories, but Lake/Elan may still
+need permitted dependency/toolchain downloads or existing caches. This mode
+does not supply runner credentials, transport dependency caches, or change
+network policy. It uses the existing complete-bundle protocol (node v4 or newer).
+
 It submits asynchronously to
 `$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,
 persists the returned job/node receipt under

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -44,6 +44,28 @@ import base64, hashlib, json, os, pathlib, subprocess, sys
 from urllib.parse import urlsplit, urlunsplit
 mission_id, token, repo, commit, cwd_rel = sys.argv[1:6]
 command = sys.argv[6:]
+source_mode = os.environ.get("REMOTE_BUILD_SOURCE_MODE", "overlay").strip().lower()
+if source_mode not in {"overlay", "full"}:
+    raise SystemExit("REMOTE_BUILD_SOURCE_MODE must be 'overlay' or 'full'")
+if source_mode == "full":
+    # Inspect the actual pinned objects, never local replacement refs. Missing
+    # promisor objects must not trigger a credential-bearing lazy fetch.
+    os.environ["GIT_NO_REPLACE_OBJECTS"] = "1"
+    os.environ["GIT_NO_LAZY_FETCH"] = "1"
+    os.environ["GIT_ALLOW_PROTOCOL"] = ""
+
+def source_git(root, *args):
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(root), *args], stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError:
+        raise SystemExit(
+            f"cannot inspect pinned Git source in {root}; "
+            "materialize the required Git objects in an authorized source checkout "
+            "before retrying"
+        )
+
 parsed_repo = urlsplit(repo)
 if parsed_repo.scheme in {"http", "https"}:
     host = parsed_repo.hostname or ""
@@ -66,7 +88,31 @@ req = {
 repo_root = pathlib.Path(
     subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
 ).resolve()
-toolchain_path = repo_root / "lean-toolchain"
+def validate_path(rel):
+    components = rel.split("/")
+    if (
+        not rel
+        or any(
+            not component
+            or component == ".."
+            or component.startswith("-")
+            or component in {".git", ".lake"}
+            or any(not (ch.isascii() and (ch.isalnum() or ch in "_.-")) for ch in component)
+            for component in components
+        )
+    ):
+        raise SystemExit(f"unsafe source bundle path: {rel!r}")
+
+def checked_path(rel):
+    validate_path(rel)
+    path = repo_root
+    for component in rel.split("/"):
+        path = path / component
+        if path.is_symlink():
+            raise SystemExit(f"source bundle path must not traverse a symlink: {rel}")
+    return path
+
+toolchain_path = checked_path("lean-toolchain")
 if toolchain_path.is_file():
     toolchain = toolchain_path.read_text(encoding="utf-8").strip()
     if toolchain:
@@ -76,9 +122,9 @@ if expected_head:
     req["expected_head"] = expected_head
 # Content identity: the root tree, not the commit. Same tree under a
 # different commit message is the same build and reuses its receipt.
-req["base_tree_sha"] = subprocess.check_output(
-    ["git", "-C", str(repo_root), "rev-parse", f"{commit}^{{tree}}"], text=True
-).strip().lower()
+req["base_tree_sha"] = source_git(
+    repo_root, "rev-parse", f"{commit}^{{tree}}"
+).decode("ascii").strip().lower()
 req["build_protocol_version"] = "1"
 # Behaviour-affecting, non-secret environment only (allowlist), hashed so a
 # changed Lean/Lake setting cannot reuse a stale receipt. Anything that looks
@@ -97,10 +143,6 @@ if _behavior_env:
     req["behavior_env_digest"] = _digest.hexdigest()
 if os.environ.get("REMOTE_BUILD_FORCE_NEW", "0") == "1":
     req["force_new"] = True
-
-source_mode = os.environ.get("REMOTE_BUILD_SOURCE_MODE", "overlay").strip().lower()
-if source_mode not in {"overlay", "full"}:
-    raise SystemExit("REMOTE_BUILD_SOURCE_MODE must be 'overlay' or 'full'")
 
 # Send the complete pinned Git snapshot as an object pack. Unlike forwarding a
 # credential or asking the node to fetch `origin`, this contains only immutable
@@ -177,10 +219,97 @@ def git_paths(*args):
     raw = subprocess.check_output(["git", "-C", str(repo_root), *args])
     return [item.decode("utf-8") for item in raw.split(b"\0") if item]
 
+def full_source_paths(root, revision, prefix=""):
+    # Gitlinks belong to the parent's immutable tree, not to this repository's
+    # object database. Never fetch here or follow .gitmodules URLs: only inspect
+    # already initialized checkouts, and bind every level to its parent's pin.
+    def git(*args):
+        return source_git(root, *args)
+
+    pins = {}
+    for record in git("ls-tree", "-r", "-z", revision).split(b"\0"):
+        if record:
+            metadata, name = record.split(b"\t", 1)
+            mode, kind, oid = metadata.split()
+            if mode == b"160000":
+                pins[name.decode("utf-8")] = oid.decode("ascii")
+    tracked = []
+    indexed_pins = {}
+    for record in git("ls-files", "--stage", "-t", "--full-name", "-z").split(b"\0"):
+        if not record:
+            continue
+        metadata, name = record.split(b"\t", 1)
+        tag, mode, oid, stage = metadata.split()
+        rel = name.decode("utf-8")
+        validate_path(prefix + rel)
+        if stage != b"0":
+            raise SystemExit(f"unmerged source path: {prefix + rel}; resolve the index first")
+        if tag == b"S" and not checked_path(prefix + rel).exists():
+            raise SystemExit(
+                f"sparse source path is missing: {prefix + rel}; "
+                "materialize the full checkout (git sparse-checkout disable) before retrying"
+            )
+        if mode == b"160000":
+            indexed_pins[rel] = oid.decode("ascii")
+        else:
+            tracked.append(prefix + rel)
+    if indexed_pins != pins:
+        raise SystemExit(
+            f"submodule gitlinks differ from pinned commit in {prefix or '.'}; "
+            "commit the intended gitlink changes or restore the index before full-source transport"
+        )
+    for rel, pin in sorted(pins.items()):
+        child_rel = prefix + rel
+        child = checked_path(child_rel)
+        repair = (
+            "initialize the pinned sources with git submodule update --init --recursive "
+            "in an authorized source checkout before retrying (transport never fetches)"
+        )
+        if not child.is_dir() or not (child / ".git").exists():
+            raise SystemExit(f"submodule {child_rel} is not initialized at {pin}; {repair}")
+        try:
+            top = subprocess.check_output(
+                ["git", "-C", str(child), "rev-parse", "--show-toplevel"],
+                stderr=subprocess.DEVNULL, text=True,
+            ).strip()
+            head = subprocess.check_output(
+                ["git", "-C", str(child), "rev-parse", "HEAD"],
+                stderr=subprocess.DEVNULL, text=True,
+            ).strip()
+        except subprocess.CalledProcessError:
+            raise SystemExit(f"submodule {child_rel} is not a usable checkout; {repair}")
+        if pathlib.Path(top).resolve() != child or head != pin:
+            raise SystemExit(
+                f"submodule {child_rel} revision mismatch: expected {pin}, found {head}; {repair}"
+            )
+        tracked.extend(full_source_paths(child, pin, child_rel + "/"))
+    untracked = [
+        prefix + name.decode("utf-8")
+        for name in git("ls-files", "--full-name", "--others", "--exclude-standard", "-z").split(b"\0")
+        if name
+    ]
+    tracked.extend(select_untracked_sources(untracked))
+    return tracked
+
+def select_untracked_sources(untracked):
+    sources = [
+        path for path in untracked
+        if path.endswith(".lean")
+        or pathlib.PurePosixPath(path).name in {
+            "lakefile.toml", "lake-manifest.json", "lean-toolchain"
+        }
+    ]
+    ignored = sorted(set(untracked) - set(sources))
+    if ignored:
+        print(
+            "remote-lean-build: ignoring untracked non-Lean files: "
+            + ", ".join(ignored[:8]), file=sys.stderr,
+        )
+    return sources
+
 if source_mode == "full":
-    # A complete snapshot carries the whole tracked tree; deletions are
-    # represented by omission, so no explicit delete operations are needed.
-    tracked, deleted = git_paths("ls-files", "--full-name", "-z"), []
+    # Local source edits remain supported; tracked deletions are omissions.
+    tracked, deleted = full_source_paths(repo_root, commit), []
 else:
     status_items = git_paths("diff", "--name-status", "-z", "--find-renames", "HEAD")
     tracked, deleted = [], []
@@ -206,21 +335,9 @@ else:
                 deleted.append(path)
             else:
                 tracked.append(path)
-untracked = git_paths("ls-files", "--full-name", "--others", "--exclude-standard", "-z")
-untracked_source = [
-    path for path in untracked
-    if path.endswith(".lean")
-    or pathlib.PurePosixPath(path).name in {
-        "lakefile.toml", "lake-manifest.json", "lean-toolchain"
-    }
-]
-ignored_untracked = sorted(set(untracked) - set(untracked_source))
-if ignored_untracked:
-    print(
-        "remote-lean-build: ignoring untracked non-Lean files: "
-        + ", ".join(ignored_untracked[:8]),
-        file=sys.stderr,
-    )
+untracked_source = [] if source_mode == "full" else select_untracked_sources(
+    git_paths("ls-files", "--full-name", "--others", "--exclude-standard", "-z")
+)
 paths = sorted(set(tracked + untracked_source))
 deleted = sorted(set(deleted) - set(paths))
 default_max_files = "4096" if source_mode == "full" else "256"
@@ -242,29 +359,16 @@ manifest_domain = (
 )
 manifest = hashlib.sha256(manifest_domain)
 operations = hashlib.sha256(b"sandboxed-source-bundle-ops-v1\n")
-def validate_path(rel):
-    components = rel.split("/")
-    if (
-        not rel
-        or any(
-            not component
-            or component == ".."
-            or component.startswith("-")
-            or component in {".git", ".lake"}
-            or any(not (ch.isascii() and (ch.isalnum() or ch in "_.-")) for ch in component)
-            for component in components
-        )
-    ):
-        raise SystemExit(f"unsafe source bundle path: {rel!r}")
 for rel in paths:
-    validate_path(rel)
-    path = repo_root / rel
+    path = checked_path(rel)
     if source_mode == "full" and not path.exists():
         # A complete snapshot represents tracked deletions by omission.
         continue
     if path.is_symlink() or not path.is_file():
         raise SystemExit(f"source bundle path must be a regular file, not a symlink: {rel}")
-    data = path.read_bytes()
+    # Bound allocation as well as the encoded payload, including growing files.
+    with path.open("rb") as source:
+        data = source.read(max_bytes - total + 1)
     total += len(data)
     if total > max_bytes:
         raise SystemExit(f"source bundle is {total} bytes; maximum is {max_bytes}")
@@ -290,6 +394,8 @@ for rel in deleted:
     operations.update(b"delete\0")
     operations.update(rel.encode())
     operations.update(b"\n")
+if source_mode == "full" and not files:
+    raise SystemExit("full-source bundle has no files; materialize the source checkout before retrying")
 if files or deleted:
     req["source_bundle"] = {
         "manifest_sha256": manifest.hexdigest(),

--- a/scripts/test_remote_lean_build_source.py
+++ b/scripts/test_remote_lean_build_source.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Offline full-source transport tests; fake curl captures the actual wire request.
+
+Run: python3 scripts/test_remote_lean_build_source.py
+--emit-fixture prints one captured recursive request for the Rust receiver test.
+"""
+import base64
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+WRAPPER = Path(__file__).with_name("remote-lean-build").resolve()
+
+
+class SourceTransportTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.base = Path(self.temp.name)
+        self.bin = self.base / "bin"
+        self.bin.mkdir()
+        self.capture = self.base / "request.gz"
+        self.trace = self.base / "git-trace"
+        self.env = {
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+            "HOME": str(self.base / "home"),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_AUTHOR_DATE": "2026-01-01T00:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-01-01T00:00:00Z",
+            "REMOTE_BUILD_URL": "http://example.invalid/api/remote-build",
+            "REMOTE_BUILD_TOKEN": "test-capability",
+            "REMOTE_BUILD_MISSION_ID": "00000000-0000-0000-0000-000000000001",
+            "REMOTE_BUILD_SOURCE_MODE": "full",
+            "REMOTE_BUILD_STATE_DIR": str(self.base / "state"),
+            "REMOTE_BUILD_TEST_CAPTURE": str(self.capture),
+        }
+        (self.bin / "curl").write_text('''#!/bin/sh
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) shift; output="$1" ;;
+        --data-binary) shift; data="$1" ;;
+    esac
+    shift
+done
+cp "${data#@}" "$REMOTE_BUILD_TEST_CAPTURE"
+printf 'test runner unavailable' > "$output"
+printf '503'
+''')
+        (self.bin / "curl").chmod(0o755)
+        nested = self.new_repo("nested-origin", {
+            "Nested.lean": b"nested\n", "assets/data.bin": b"\x00\xffnested\n",
+            "run.sh": b"#!/bin/sh\nexit 0\n", "Gone.lean": b"gone\n",
+        })
+        (nested / "run.sh").chmod(0o755)
+        self.commit(nested)
+        sub = self.new_repo("sub-origin", {"Sub.lean": b"sub\n"})
+        self.git(sub, "-c", "protocol.file.allow=always", "submodule", "add", str(nested), "vendor/nested")
+        self.commit(sub)
+        self.repo = self.new_repo("repo", {
+            "Root.lean": b"root\n", "Theory/Proof.lean": b"proof\n",
+            "lean-toolchain": b"leanprover/lean4:v4.19.0\n",
+            "lakefile.toml": b"name = 'fixture'\n",
+        })
+        self.git(self.repo, "-c", "protocol.file.allow=always", "submodule", "add", str(sub), "deps/sub")
+        self.commit(self.repo)
+        self.git(self.repo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+        self.sub = self.repo / "deps/sub"
+        self.nested = self.sub / "vendor/nested"
+        self.git(self.repo, "remote", "add", "origin", "https://user:root-secret@example.invalid/private.git?token=query-secret#fragment")
+        for checkout in (self.repo, self.sub, self.nested):
+            self.git(checkout, "config", "credential.helper", "!echo credential-helper-must-not-run >&2; exit 1")
+            self.git(checkout, "config", "test.secret", "git-config-secret")
+
+    def git(self, repo, *args):
+        result = subprocess.run(["git", "-C", str(repo), *args], env=self.env,
+                                capture_output=True, check=True)
+        return result.stdout.decode().strip()
+
+    def new_repo(self, name, files):
+        repo = self.base / name
+        repo.mkdir()
+        self.git(repo, "init", "--quiet")
+        self.git(repo, "config", "user.name", "Source Test")
+        self.git(repo, "config", "user.email", "source@example.invalid")
+        for name, data in files.items():
+            path = repo / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+        self.commit(repo)
+        return repo
+
+    def commit(self, repo):
+        self.git(repo, "add", "-A")
+        self.git(repo, "-c", "commit.gpgsign=false", "commit", "--quiet", "--allow-empty", "-m", "fixture")
+
+    def run_wrapper(self, cwd=None, **env):
+        self.capture.unlink(missing_ok=True)
+        self.trace.unlink(missing_ok=True)
+        result = subprocess.run(["bash", str(WRAPPER), "true"], cwd=cwd or self.repo,
+                                env={**self.env, "GIT_TRACE": str(self.trace), **env},
+                                capture_output=True, timeout=20)
+        trace = self.trace.read_text()
+        for command in (" fetch ", " clone ", " submodule ", "credential-helper-must-not-run"):
+            self.assertNotIn(command, trace)
+        return result
+
+    def request(self, cwd=None, **env):
+        result = self.run_wrapper(cwd, **env)
+        self.assertEqual(result.returncode, 75, result.stderr.decode())
+        self.assertTrue(self.capture.is_file())
+        return json.loads(gzip.decompress(self.capture.read_bytes()))
+
+    def rejected(self, message, **env):
+        result = self.run_wrapper(**env)
+        self.assertEqual(result.returncode, 2, result.stderr.decode())
+        self.assertIn(message, result.stderr.decode())
+        self.assertFalse(self.capture.exists(), "invalid source reached submission")
+        self.assertNotIn(b"git-config-secret", result.stderr)
+
+    def test_recursive_wire_contents_and_digests(self):
+        request = self.request(self.repo / "Theory")
+        self.assertEqual(request["cwd_rel"], "Theory")
+        self.assertEqual(request["commit"], self.git(self.repo, "rev-parse", "HEAD"))
+        self.assertEqual(request["base_tree_sha"], self.git(self.repo, "rev-parse", "HEAD^{tree}"))
+        self.assertEqual(request["repo"], "https://example.invalid/private.git")
+        self.assertNotIn("source_archive", request)
+        bundle = request["source_bundle"]
+        self.assertTrue(bundle["complete"])
+        self.assertEqual(bundle["deleted_paths"], [])
+        expected = [".gitmodules", "Root.lean", "Theory/Proof.lean", "deps/sub/.gitmodules",
+                    "deps/sub/Sub.lean", "deps/sub/vendor/nested/Gone.lean",
+                    "deps/sub/vendor/nested/Nested.lean", "deps/sub/vendor/nested/assets/data.bin",
+                    "deps/sub/vendor/nested/run.sh", "lakefile.toml", "lean-toolchain"]
+        self.assertEqual([f["path"] for f in bundle["files"]], expected)
+        manifest = hashlib.sha256(b"sandboxed-source-bundle-v2-complete\n")
+        operations = hashlib.sha256(b"sandboxed-source-bundle-ops-v1\n")
+        for entry in bundle["files"]:
+            path = entry["path"]
+            data = base64.b64decode(entry["data_base64"], validate=True)
+            self.assertEqual(data, (self.repo / path).read_bytes())
+            self.assertNotIn(b"git-config-secret", data)
+            digest = hashlib.sha256(data).hexdigest()
+            self.assertEqual(entry["sha256"], digest)
+            manifest.update(f"{path}\0{digest}\n".encode())
+            operations.update(f"file\0{path}\0{'x' if entry['executable'] else '-'}\n".encode())
+            self.assertEqual(entry["executable"], path.endswith("run.sh"))
+        self.assertEqual(bundle["manifest_sha256"], manifest.hexdigest())
+        self.assertEqual(bundle["operations_sha256"], operations.hexdigest())
+        self.assertEqual(bundle, self.request()["source_bundle"])
+        wire = json.dumps(request)
+        for secret in ("root-secret", "query-secret", "git-config-secret"):
+            self.assertNotIn(secret, wire)
+
+    def test_local_sources_recursive_allowlist_deletions_and_modes(self):
+        baseline = self.request()["source_bundle"]
+        for checkout in (self.repo, self.sub, self.nested):
+            (checkout / "New.lean").write_text("new\n")
+            (checkout / "secret.txt").write_text("untracked-secret")
+            (checkout / ".gitignore").write_text("ignored.lean\n.lake/\n")
+            (checkout / "ignored.lean").write_text("ignored\n")
+            (checkout / ".lake").mkdir()
+            (checkout / ".lake" / "Cache.lean").write_text("cache\n")
+        (self.sub / "Sub.lean").write_text("dirty\n")
+        (self.nested / "Gone.lean").unlink()
+        self.git(self.nested, "add", "New.lean")
+        bundle = self.request()["source_bundle"]
+        paths = [f["path"] for f in bundle["files"]]
+        for prefix in ("", "deps/sub/", "deps/sub/vendor/nested/"):
+            self.assertIn(prefix + "New.lean", paths)
+            self.assertNotIn(prefix + "secret.txt", paths)
+            self.assertNotIn(prefix + "ignored.lean", paths)
+            self.assertNotIn(prefix + ".lake/Cache.lean", paths)
+        self.assertNotIn("deps/sub/vendor/nested/Gone.lean", paths)
+        self.assertNotEqual(baseline["manifest_sha256"], bundle["manifest_sha256"])
+        (self.nested / "run.sh").chmod(0o644)
+        mode_changed = self.request()["source_bundle"]
+        self.assertEqual(bundle["manifest_sha256"], mode_changed["manifest_sha256"])
+        self.assertNotEqual(bundle["operations_sha256"], mode_changed["operations_sha256"])
+
+    def test_uninitialized_submodule(self):
+        shutil.rmtree(self.sub)
+        self.sub.mkdir()
+        self.rejected("submodule deps/sub is not initialized")
+
+    def test_missing_nested_submodule(self):
+        shutil.rmtree(self.nested)
+        self.rejected("submodule deps/sub/vendor/nested is not initialized")
+
+    def test_wrong_submodule_revision(self):
+        self.git(self.sub, "checkout", "--detach", "HEAD^")
+        self.rejected("submodule deps/sub revision mismatch: expected")
+
+    def test_wrong_nested_revision(self):
+        self.git(self.nested, "checkout", "--detach", "HEAD^")
+        self.rejected("submodule deps/sub/vendor/nested revision mismatch: expected")
+
+    def test_staged_gitlink_change(self):
+        self.git(self.sub, "checkout", "--detach", "HEAD^")
+        self.git(self.repo, "add", "deps/sub")
+        self.rejected("gitlinks differ from pinned commit")
+
+    def test_new_nested_pin_is_bound_even_when_file_bytes_are_identical(self):
+        before = self.request()
+        for checkout in (self.nested, self.sub, self.repo):
+            self.git(checkout, "config", "user.name", "Source Test")
+            self.git(checkout, "config", "user.email", "source@example.invalid")
+            self.commit(checkout)
+        after = self.request()
+        self.assertEqual(before["source_bundle"], after["source_bundle"])
+        self.assertNotEqual(before["commit"], after["commit"])
+        self.assertNotEqual(before["base_tree_sha"], after["base_tree_sha"])
+
+    def test_replacement_refs_cannot_redefine_pinned_tree(self):
+        before = self.request()
+        self.git(self.repo, "replace", "HEAD", "HEAD^")
+        after = self.request()
+        self.assertEqual(before["base_tree_sha"], after["base_tree_sha"])
+        self.assertEqual(before["source_bundle"], after["source_bundle"])
+
+    def test_missing_promisor_tree_does_not_fetch(self):
+        tree = self.git(self.repo, "rev-parse", "HEAD^{tree}")
+        self.git(self.repo, "config", "remote.origin.promisor", "true")
+        self.git(self.repo, "config", "remote.origin.partialclonefilter", "blob:none")
+        (self.repo / ".git/objects" / tree[:2] / tree[2:]).unlink()
+        self.rejected("cannot inspect pinned Git source")
+
+    def test_staged_nested_gitlink_change(self):
+        self.git(self.nested, "checkout", "--detach", "HEAD^")
+        self.git(self.sub, "add", "vendor/nested")
+        self.rejected("gitlinks differ from pinned commit in deps/sub/")
+
+    def test_staged_gitlink_deletion(self):
+        self.git(self.repo, "rm", "--cached", "deps/sub")
+        self.rejected("gitlinks differ from pinned commit")
+
+    def test_sparse_submodule_cannot_silently_omit_sources(self):
+        self.git(self.sub, "update-index", "--skip-worktree", "Sub.lean")
+        (self.sub / "Sub.lean").unlink()
+        self.rejected("sparse source path is missing: deps/sub/Sub.lean")
+
+    def test_unmerged_nested_index(self):
+        blob = self.git(self.nested, "rev-parse", "HEAD:Nested.lean")
+        subprocess.run(
+            ["git", "-C", str(self.nested), "update-index", "--index-info"],
+            input=f"0 {'0' * 40}\tNested.lean\n100644 {blob} 1\tNested.lean\n".encode(),
+            env=self.env, check=True, capture_output=True,
+        )
+        self.rejected("unmerged source path: deps/sub/vendor/nested/Nested.lean")
+
+    def test_empty_full_source_cannot_fall_back_to_fetch(self):
+        self.repo = self.new_repo("empty", {})
+        self.git(self.repo, "remote", "add", "origin", "https://example.invalid/empty.git")
+        self.rejected("full-source bundle has no files")
+
+    def test_gitlink_directory_must_be_its_own_checkout(self):
+        (self.sub / ".git").unlink()
+        (self.sub / ".git").mkdir()
+        self.rejected("submodule deps/sub revision mismatch")
+
+    def test_symlinked_submodule(self):
+        moved = self.base / "moved"
+        self.sub.rename(moved)
+        self.sub.symlink_to(moved, target_is_directory=True)
+        self.rejected("must not traverse a symlink: deps/sub")
+
+    def test_symlinked_parent(self):
+        moved = self.base / "assets"
+        (self.nested / "assets").rename(moved)
+        (self.nested / "assets").symlink_to(moved, target_is_directory=True)
+        self.rejected("must not traverse a symlink: deps/sub/vendor/nested/assets/data.bin")
+
+    def test_symlinked_source_to_git_config(self):
+        source = self.sub / "Sub.lean"
+        source.unlink()
+        source.symlink_to(self.repo / ".git/config")
+        self.rejected("must not traverse a symlink")
+
+    def test_broken_symlink_is_not_a_deletion(self):
+        source = self.nested / "Nested.lean"
+        source.unlink()
+        source.symlink_to("missing")
+        self.rejected("must not traverse a symlink")
+
+    def test_toolchain_symlink_does_not_read_credentials(self):
+        source = self.repo / "lean-toolchain"
+        source.unlink()
+        source.symlink_to(self.repo / ".git/config")
+        self.rejected("must not traverse a symlink: lean-toolchain")
+
+    def test_special_file(self):
+        source = self.sub / "Sub.lean"
+        source.unlink()
+        os.mkfifo(source)
+        self.rejected("must be a regular file")
+
+    def test_unsafe_nested_path(self):
+        (self.nested / "unsafe name.lean").write_text("unsafe\n")
+        self.rejected("unsafe source bundle path")
+
+    def test_unsafe_gitlink_path(self):
+        self.git(self.repo, "mv", "deps/sub", "deps/unsafe name")
+        self.commit(self.repo)
+        self.rejected("unsafe source bundle path")
+
+    def test_tracked_lake_metadata_rejected(self):
+        (self.nested / ".lake").mkdir()
+        (self.nested / ".lake/Cache.lean").write_text("poison\n")
+        self.git(self.nested, "add", ".lake/Cache.lean")
+        self.rejected("unsafe source bundle path")
+
+    def test_global_file_limit(self):
+        self.rejected("operations; maximum is 10", REMOTE_BUILD_MAX_SOURCE_BUNDLE_FILES="10")
+
+    def test_global_byte_limit(self):
+        bundle = self.request()["source_bundle"]
+        total = sum(len(base64.b64decode(f["data_base64"])) for f in bundle["files"])
+        self.request(REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES=str(total))
+        self.rejected(f"maximum is {total - 1}", REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES=str(total - 1))
+
+    def test_full_and_overlay_without_submodules(self):
+        self.repo = self.new_repo("plain", {"Root.lean": b"root\n", "Gone.lean": b"gone\n"})
+        self.git(self.repo, "remote", "add", "origin", "https://example.invalid/plain.git")
+        (self.repo / "Root.lean").write_text("dirty\n")
+        (self.repo / "Gone.lean").unlink()
+        full = self.request()
+        self.assertEqual([f["path"] for f in full["source_bundle"]["files"]], ["Root.lean"])
+        overlay = self.request(REMOTE_BUILD_SOURCE_MODE="overlay")
+        self.assertIn("source_archive", overlay)
+        self.assertFalse(overlay["source_bundle"]["complete"])
+        self.assertEqual(overlay["source_bundle"]["deleted_paths"], ["Gone.lean"])
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--emit-fixture"]:
+        fixture = SourceTransportTest()
+        try:
+            fixture.setUp()
+            print(json.dumps(fixture.request()))
+        finally:
+            fixture.doCleanups()
+    else:
+        unittest.main()

--- a/src/api/projects_store.rs
+++ b/src/api/projects_store.rs
@@ -1582,6 +1582,7 @@ impl ProjectsStore {
     ///
     /// Idempotent on `(session_id, at)` — the ingestor replays an overlapping
     /// window every cycle. Retention is enforced here rather than by a sweeper.
+    #[allow(clippy::too_many_arguments)] // Mirrors the seven persisted delivery columns.
     pub fn record_unrouted(
         &self,
         session_id: &str,

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -2423,6 +2423,91 @@ mod tests {
         assert_eq!(tokio::fs::read(&victim).await.unwrap(), b"keep me");
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn complete_source_bundle_from_recursive_wrapper_materializes_without_fetch() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Exercise the real shell encoder and compressed request, then feed its
+        // wire bundle through the node's validation and checkout materializer.
+        let output = Command::new("python3")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/test_remote_lean_build_source.py"
+            ))
+            .arg("--emit-fixture")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let request: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(request.get("source_archive").is_none());
+        let bundle: SourceBundle =
+            serde_json::from_value(request["source_bundle"].clone()).unwrap();
+        assert!(bundle.complete);
+        assert_eq!(bundle.files.len(), 11);
+        validate_source_bundle(&bundle).unwrap();
+        let bundled_source = JobSource {
+            // This URL cannot supply the fixture. Successful materialization
+            // must use the complete bundle, with no source Git credentials.
+            repo: "https://example.invalid/private.git".to_string(),
+            commit: request["commit"].as_str().unwrap().to_string(),
+            base_tree_sha: Some(request["base_tree_sha"].as_str().unwrap().to_string()),
+            archive: None,
+            bundle: Some(bundle.clone()),
+        };
+        let temp = tempfile::tempdir().unwrap();
+        let log = temp.path().join("job.log");
+        let checkout = ensure_checkout(
+            temp.path(),
+            &bundled_source,
+            &log,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        for file in &bundle.files {
+            let path = checkout.join(&file.path);
+            let bytes = std::fs::read(&path).unwrap();
+            assert_eq!(hex::encode(Sha256::digest(&bytes)), file.sha256);
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o111 != 0,
+                file.executable.unwrap()
+            );
+        }
+        for root in ["", "deps/sub", "deps/sub/vendor/nested"] {
+            assert!(!checkout.join(root).join(".git").exists());
+        }
+        assert_eq!(
+            std::fs::read(checkout.join("Root.lean")).unwrap(),
+            b"root\n"
+        );
+        assert_eq!(
+            std::fs::read(checkout.join("deps/sub/Sub.lean")).unwrap(),
+            b"sub\n"
+        );
+        assert_eq!(
+            std::fs::read(checkout.join("deps/sub/vendor/nested/assets/data.bin")).unwrap(),
+            b"\x00\xffnested\n"
+        );
+
+        // The receiver still rejects tampering with nested bytes or modes.
+        let mut tampered = bundle.clone();
+        tampered.files[6].data_base64 =
+            base64::engine::general_purpose::STANDARD.encode(b"tampered");
+        assert!(validate_source_bundle(&tampered)
+            .unwrap_err()
+            .contains("content hash mismatch"));
+        let mut tampered = bundle;
+        tampered.files[8].executable = Some(false);
+        assert!(validate_source_bundle(&tampered)
+            .unwrap_err()
+            .contains("operations hash mismatch"));
+    }
+
     #[tokio::test]
     async fn complete_source_bundle_materializes_without_git_and_rebuilds_cleanly() {
         let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Full-source `remote-lean-build` currently passes tracked gitlinks to its regular-file encoder, so repositories with initialized submodules fail before submission. Expand pinned submodules recursively into the existing complete source bundle, validating each checkout's HEAD against its parent's gitlink and each index's gitlinks against its pinned tree. Local file edits and the existing narrow untracked-source allowlist remain supported at every level.

Missing initialization, wrong revisions, staged gitlink changes, unresolved index entries, sparse missing files, and empty snapshots now fail locally with actionable errors. Git metadata and credentials are excluded. Full mode ignores replacement refs and disables lazy fetching and Git transport protocols during object inspection. Parent-directory symlinks and broken symlinks are rejected before reading files, and reads remain bounded by the aggregate byte limit. The globally sorted content and executable-operation digests and existing complete-bundle wire format are preserved.

Reproduction and corrected behavior:

- Isolated clone of `lfglabs-dev/lido-srv3-proof-closure` at `b045cc055d0720db50412a1ba4877b01f8dcc280`.
- `lido-core` pins `17005714f151e5502c559932319a3f2f74ac2436`; its nested `foundry/lib/forge-std` pins `ffa2ee0d921b4163b7abd0f1122df93ead205805`.
- With dummy remote-build capability values and a loopback test URL, `REMOTE_BUILD_SOURCE_MODE=full /usr/local/lib/sandboxed-sh/bin/remote-lean-build true` exits 2: `source bundle path must be a regular file, not a symlink: lido-core`. Reproduced with both uninitialized and recursively initialized sources. Installed wrapper SHA-256: `83736ff6da600782680e9ce6f8d4e7b7e32f58acc5bbc6f0e127130088357d20`.
- Patched wrapper captures a gzip request containing 1,352 files / 14,714,375 bytes, including 932 files under `lido-core` and 56 in `forge-std`. Every path matches `git ls-files --recurse-submodules -z`; every decoded byte matches the source checkout. Repeated requests have identical bundles. No source archive, Git metadata, runner submission, or Lean compilation was involved.
- Complete manifest: `a47d90ca424a582f65cacb81218dd815277aec860d7aa59d08e8ed074f7dbeac`.
- Operations digest: `1f2f34c536b9dd79cc9c7cdd27f655584dad9bcd001da48887e7ff6bbb89fac7`.

Validation:

- `python3 scripts/test_remote_lean_build_source.py -v`: 28 passing offline tests. Covers recursive root/submodule/nested contents, non-Lean binary files, executable bits, deletions, untracked allowlists, deterministic digests, pin changes with identical file bytes, missing/wrong initialization, replacement refs, missing promisor trees, sparse/unmerged indexes, symlinks, special files, unsafe paths, file/byte limits, credential isolation, and ordinary full/overlay regression. Added to CI.
- Rust receiver test consumes a real request from the wrapper, validates and materializes its recursive source without fetching, checks bytes/modes and absent Git metadata at all levels, and rejects tampered nested contents/modes.
- `cargo +1.93.0 test --locked --lib node::lean::tests:: -- --test-threads=2`: 38 passed. Rust tests used two build jobs with debug information disabled; only the existing `current_disk_usage` dead-code warning was emitted.
- Existing `api::remote_build::tests::wrapper_` regressions: 3 passed using the compiled test binary as an unprivileged user. The initial root run passed 2 and failed the existing permission-based receipt-write-failure test because root bypasses its `chmod 500` fixture; the unprivileged rerun exercises that check and passes without code changes.
- `cargo fmt --all` and `cargo fmt --all --check`; `bash -n scripts/remote-lean-build`; `git diff --check`.

Rollout remains with the supervisor after independent review: ship the backend containing the embedded wrapper, then refresh mission-managed wrappers through normal mission setup. Deployed nodes must also run a compatible receiver: the supervisor canary found old node binaries without `operations_sha256`, losing executable bits despite correct source bytes. This PR introduces no node production behavior or protocol changes, but receiver rollout to an idle node and a repeated execute-bit canary are required. Preserve the active ALLOC2 old-agent job. Sources must already be initialized at their pinned revisions in an authorized source checkout. Source materialization does not fetch repositories, while Lake/Elan dependency and toolchain downloads remain subject to existing runner policy/cache availability. No workspace credentials are required by this transport.

No deployment, restart, force push, production edits, or Lido proof edits. Writer reuse and goal visibility are outside this PR.

Immutable successor review head: `d2cee8aa91f37cf3225190904adb3cce5fcdd481` (base `f8376365092d1372e919b5d41ea0071949d276a4`).

The separate successor commit adds only a function-local `allow(clippy::too_many_arguments)` on `ProjectsStore::record_unrouted`: its seven explicit arguments mirror the seven persisted delivery columns. This resolves the inherited baseline Clippy failure without importing writer continuation, lease, or isolation changes. It has no runtime behavior change. Formatting was applied. All seven checks passed in exact-head CI run https://github.com/Th0rgal/sandboxed.sh/actions/runs/34121896332, including workspace Clippy, workspace tests, full-source tests, harness contracts, format, dashboard, capability and policy checks. The local source transport suite also passed all 28 tests. Local Clippy 1.93.0 exits 101 on two pre-existing `unnecessary_cast` findings in `src/api/monitoring.rs:207-208`; CI stable (Rust 1.98.1) Clippy passes. Those unrelated lines are unchanged, and the debug artifact build remains pinned to Rust/Cargo 1.93.0 with two jobs.

Original `4c841866590d225f84de07232ffd499c4571c1e7` artifacts/evidence remain untouched and pinned as isolated canary candidates. Successor debug artifacts are staged separately in `output/transport-debug-d2cee8aa91f37cf3225190904adb3cce5fcdd481/`: all five binaries (`sandboxed-sh`, `orchestrator-mcp`, `assistant-mcp`, `palomactl`, `sandboxed-node`) plus `remote-lean-build`. Rust/Cargo 1.93.0, two build jobs, exit 0; clean source before and after, SHA-256 verification and build-host shared-library resolution pass. Manifest, hashes, build log, CI evidence, and validation logs are retained. Original evidence contents, modes, sizes, and mtimes were verified unchanged. Independent delta review and supervisor gates remain; no deployment is authorized here.

