### PR TITLE
fix(remote-build): negotiate source capacity and enforce transport bounds

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -227,8 +227,9 @@ Node env vars for lean-build jobs:
   filesystem drops below it, checkout dirs then lake cache slots are
   LRU-deleted (by dir mtime) until the threshold is met.
 - `SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES` — maximum decoded size of a local
-  source bundle (default 1 MiB/256 files for overlays and 16 MiB/4096 files
-  for complete snapshots). Paths, per-file hashes and the manifest hash are
+  source bundle (default 1 MiB/256 files for overlays and 32 MiB/4096 files
+  for complete snapshots). An explicit positive byte override applies to both
+  modes; it does not raise either file-count cap or any HTTP/JSON ceiling. Paths, per-file hashes and the manifest hash are
   verified before any file is applied.
 - `SANDBOXED_NODE_GIT_SSH_KEY` — path to an SSH key used for git fetches
   (`GIT_SSH_COMMAND="ssh -i <key> -o IdentitiesOnly=yes -o
@@ -475,6 +476,39 @@ materialize without fetching the source repositories, but Lake/Elan may still
 need permitted dependency/toolchain downloads or existing caches. This mode
 does not supply runner credentials, transport dependency caches, or change
 network policy. It uses the existing complete-bundle protocol (node v4 or newer).
+
+Full snapshots default to **32 MiB decoded / 4096 files**, aggregated across
+all recursive submodules. Overlays remain **1 MiB / 256 operations**.
+`REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES` and
+`REMOTE_BUILD_MAX_SOURCE_BUNDLE_FILES` remain explicit sender overrides;
+`SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES` remains the receiver byte override
+for both modes. Existing smaller operator ceilings are respected. Raising a
+sender limit alone cannot raise the receiver's fixed file-count cap or its
+configured byte ceiling. No source or receipt should be removed to fit a cap.
+
+The wrapper gzip-compresses its base64 JSON. Core ingress has a **50 MiB HTTP
+body** cap and a separate **64 MiB decompressed JSON** cap, enforced while
+reading at most cap + 1 bytes. Core forwards ordinary uncompressed
+`SubmitJobRequest` JSON to the node; `/jobs` retains its **50 MiB HTTP body**
+cap. These HTTP/JSON ceilings are fixed, independent of operator byte overrides.
+32 MiB of decoded source occupies about 42.67 MiB in base64 before metadata;
+the unchanged 50 MiB body limits leave room for the measured manifests and job
+envelope. Path-heavy metadata or larger explicit overrides must still fit
+all layers. Check the actual serialized request sizes; compression is not a
+way to bypass decoded-source validation. Reverse proxies may impose smaller
+body limits and must be verified on the intended route before rollout.
+
+Roll out the backend (including its embedded sender and 64 MiB decoder),
+refresh mission-managed wrappers through normal mission setup, and update an
+idle node to the matching 32 MiB receiver before submitting larger snapshots.
+A v4 heartbeat proves protocol support, not this new byte default; older v4
+nodes may still reject above 16 MiB. Preserve explicit operator overrides,
+active jobs and receipt/resume state. Require a >16 MiB complete-source canary
+through the intended proxy/backend/node route, with source bytes, executable
+bits, manifest/operations digests and terminal receipts checked. Existing
+submodule initialization, path, symlink, replacement-ref and privacy checks
+remain mandatory. This development change does not install, restart or deploy
+production services. See [measured capacity evidence](REMOTE_SOURCE_CAPACITY.md).
 
 It submits asynchronously to
 `$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -131,6 +131,11 @@ To rotate a node token with zero downtime:
 `capacity_available`, `active_leases`, `version`) plus:
 
 - `protocol_version` (currently `4`; core treats a missing field as `1`).
+- `source_bundle_capacity`: `{ "overlay_bytes": 1048576, "complete_bytes": 33554432 }`
+  by default. These are effective decoded file-byte ceilings; positive
+  `SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES` overrides apply to both values.
+  The fleet API and `get_compute_fleet` expose this capability; legacy nodes
+  report it as absent/unknown.
   Version 3 is required for overlay jobs and version 4 for complete-source
   jobs, so a rolling deployment can never silently fetch a private repository
   or drop source content on an older node.
@@ -501,8 +506,21 @@ body limits and must be verified on the intended route before rollout.
 Roll out the backend (including its embedded sender and 64 MiB decoder),
 refresh mission-managed wrappers through normal mission setup, and update an
 idle node to the matching 32 MiB receiver before submitting larger snapshots.
-A v4 heartbeat proves protocol support, not this new byte default; older v4
-nodes may still reject above 16 MiB. Preserve explicit operator overrides,
+A v4 heartbeat proves payload semantics. Updated nodes additionally advertise
+`source_bundle_capacity`, computed by the same limit function as validation.
+Before dispatch, core sums the actual decoded file bytes and filters automatic
+placement (including re-probe selection) by the matching complete/overlay limit.
+Explicit nodes use the same capacity check. Insufficient capacity returns 503
+before a job is submitted, allowing the wrapper's existing local fallback;
+400/422 submission failures are still caller errors and are not retried.
+Legacy heartbeats remain eligible up to the historical 16 MiB complete / 1 MiB
+overlay defaults, subject to the existing protocol gates. Larger payloads require
+advertised capacity. Legacy private overrides cannot be inferred: upgrade nodes
+with smaller overrides to advertise them before relying on automatic placement.
+New nodes' explicit smaller ceilings are honored even below legacy defaults.
+Old backends ignore the additive heartbeat field, so install the corrected
+backend before enabling larger submissions; a node-only upgrade is insufficient.
+Preserve explicit operator overrides,
 active jobs and receipt/resume state. Require a >16 MiB complete-source canary
 through the intended proxy/backend/node route, with source bytes, executable
 bits, manifest/operations digests and terminal receipts checked. Existing

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -513,6 +513,12 @@ placement (including re-probe selection) by the matching complete/overlay limit.
 Explicit nodes use the same capacity check. Insufficient capacity returns 503
 before a job is submitted, allowing the wrapper's existing local fallback;
 400/422 submission failures are still caller errors and are not retried.
+Decoded-byte capability is separate from wire capacity: after minting the lease,
+core counts the exact compact JSON job envelope, including all metadata and
+escaping, before recording a tentative handle or submitting. An envelope above
+the unchanged 50 MiB node body cap returns 503 before dispatch even if an operator
+has raised decoded-byte capacity (for example, 38 MiB of source exceeds 50 MiB
+in base64 alone). This also protects metadata-heavy requests below the byte limit.
 Legacy heartbeats remain eligible up to the historical 16 MiB complete / 1 MiB
 overlay defaults, subject to the existing protocol gates. Larger payloads require
 advertised capacity. Legacy private overrides cannot be inferred: upgrade nodes

--- a/docs/REMOTE_SOURCE_CAPACITY.md
+++ b/docs/REMOTE_SOURCE_CAPACITY.md
@@ -80,7 +80,11 @@ Legacy v4 nodes without this field retain compatibility through 16 MiB complete
 Private lower overrides on legacy nodes remain unknowable and require updating
 those receivers to advertise them. Updated lower ceilings are enforced for all
 bundle sizes. Old backends ignore the new heartbeat field and must be updated
-before enabling larger bundles. The 32/64/50 MiB limits above are unchanged.
+before enabling larger bundles. The 32/64/50 MiB limits above are unchanged. Decoded-byte advertisements do not
+replace the wire bound: core counts the exact serialized node job, including
+lease and JSON escaping, before tentative admission and dispatch. Above 50 MiB
+it returns 503, including when a raised source override would otherwise admit
+a 38 MiB bundle. Counting uses a non-allocating writer, not an approximate ratio.
 
 ## Reproduction and receipts
 

--- a/docs/REMOTE_SOURCE_CAPACITY.md
+++ b/docs/REMOTE_SOURCE_CAPACITY.md
@@ -65,6 +65,23 @@ manifest and operation digests continue to identify literal paths. This closes
 the crafted `./Root.lean` / `Root.lean` destination alias; normal Git sender
 paths are unaffected. Build-directory path handling is unchanged.
 
+## Placement capacity contract
+
+Complete bundles retain protocol v4. Receivers now advertise effective decoded
+file-byte limits in `source_bundle_capacity` (`complete_bytes`, `overlay_bytes`),
+including positive operator overrides. Core measures actual base64-decoded file
+contents before dispatch and excludes insufficient receivers in automatic and
+explicit placement. Auto re-probing retains the same constraint. With no capable
+node, placement returns 503 before submission; accepted jobs and receipt reuse
+keep their existing behavior. Fleet/tool output carries the same capability.
+
+Legacy v4 nodes without this field retain compatibility through 16 MiB complete
+(and v3 overlays through 1 MiB); larger bundles require explicit capacity.
+Private lower overrides on legacy nodes remain unknowable and require updating
+those receivers to advertise them. Updated lower ceilings are enforced for all
+bundle sizes. Old backends ignore the new heartbeat field and must be updated
+before enabling larger bundles. The 32/64/50 MiB limits above are unchanged.
+
 ## Reproduction and receipts
 
 From this transport checkout (Git credentials are used only for the authorized

--- a/docs/REMOTE_SOURCE_CAPACITY.md
+++ b/docs/REMOTE_SOURCE_CAPACITY.md
@@ -1,0 +1,101 @@
+# Complete-source transport capacity evidence
+
+Measured 2026-09-07 in an isolated development mission, from sandboxed.sh base
+`8302c6dd3dd87eacbc4c04b32d307231e39e4632` (PR890 merged; no PR889 changes).
+Sources are pristine pinned checkouts of `lfglabs-dev/lido-srv3-proof-closure`.
+Both recursive pins are included: `lido-core` at
+`17005714f151e5502c559932319a3f2f74ac2436`, and its nested
+`foundry/lib/forge-std` at `ffa2ee0d921b4163b7abd0f1122df93ead205805`.
+
+The originally supplied RESERVE1 pin
+`2e4b6a50f68077d65a3d716522f9818fafd50073` was unavailable: direct `git fetch
+origin <sha>` returned `not our ref`, and GitHub's commit API returned HTTP 422.
+The current PR244 head below was fetched and measured instead. PR245 and PR246
+heads were pinned at the same observation. These are transport fixtures, not
+new Lido proof commits or claims about proof completion.
+
+| Fixture | Pinned head | Files | Decoded bytes | Wrapper JSON bytes | Gzip bytes |
+| --- | --- | ---: | ---: | ---: | ---: |
+| reserve-current | `f27b39d8f12b1d8b5947c7f664ebfc33e0183019` | 2,075 | 21,265,880 | 28,748,779 | 6,084,229 |
+| alloc2 | `2bb0a7dc7bf009333ba925b2a3a2e02503297b76` | 1,551 | 17,130,069 | 23,126,604 | 5,729,317 |
+| alloc1 | `8691c7881a863715ab5ec9b39631ab41243e7c91` | 1,423 | 15,309,625 | 20,675,025 | 5,282,749 |
+| combined | `b6c9ad041fa8b7ee4a098b5b21ff3009026175f2` | 2,382 | 25,322,173 | 34,213,451 | 7,285,251 |
+
+The combined fixture retains every unique `(original path, bytes, executable
+mode)` from the three snapshots. Identical shared entries occur once; differing
+versions at the same path are retained under `fixture-variants/<label>/`.
+It is a conservative capacity fixture, not a semantic merge. Every tracked
+source and receipt is retained, including binary files, logs, and nested
+submodules. Staging uses `git add --force -A` because inherited ignore rules
+otherwise hide already-tracked receipt logs. An explicit union assertion
+checks that no source version was omitted. The actual Lido checkouts stay
+pristine. No proof code is modified or compiled.
+
+## Bounded limits
+
+Complete decoded source grows from 16 MiB to **32 MiB** at both sender and
+receiver. The combined fixture leaves 8,232,259 bytes (about 7.85 MiB) of decoded
+headroom; its 2,382 files leave 1,714 slots under the unchanged 4,096 file cap.
+The core gzip decoder grows from 32 MiB to **64 MiB**: the combined JSON already
+exceeds the old cap, and 32 MiB of raw bytes alone needs about 42.67 MiB in
+base64. This is bounded headroom for the current deliverable, not a guarantee
+for arbitrary future growth.
+
+Both existing **50 MiB HTTP body caps remain unchanged** and now share a
+constant. Core reads gzip through `Bytes`; the decoder reads at most 64 MiB + 1
+and rejects expansion over 64 MiB. `RemoteNodeClient::submit_job` forwards plain
+JSON via reqwest, and the node's `Json<SubmitJobRequest>` extractor has the
+50 MiB cap. Tests exercise both extractors over loopback HTTP with a real
+32 MiB recursive wrapper request and the serialized node envelope. Each
+route rejects body cap + 1. No proxy configuration has been changed; the
+intended production route still needs a rollout canary.
+
+Overlay defaults remain 1 MiB / 256 operations. Full snapshots retain the
+4,096-file ceiling. Existing sender byte/file and receiver byte overrides,
+path restrictions, recursive pin/index checks, missing-submodule failures,
+symlink and replacement-ref protections, privacy rules, receipt identity and
+resume semantics remain intact. See [operator limits and coordinated
+rollout](REMOTE_NODES.md#remote-lean-build-wrapper).
+
+## Reproduction and receipts
+
+From this transport checkout (Git credentials are used only for the authorized
+clone/submodule initialization; captured requests contain dummy capabilities):
+
+```bash
+git clone https://github.com/lfglabs-dev/lido-srv3-proof-closure.git ../lido-fixture
+git -C ../lido-fixture fetch origin f27b39d8f12b1d8b5947c7f664ebfc33e0183019
+git -C ../lido-fixture fetch origin 2bb0a7dc7bf009333ba925b2a3a2e02503297b76
+git -C ../lido-fixture fetch origin 8691c7881a863715ab5ec9b39631ab41243e7c91
+python3 scripts/measure_remote_source_capacity.py ../lido-fixture ../lido-capacity
+python3 scripts/test_remote_lean_build_source.py -v
+cargo fmt --all --check
+cargo test --locked --lib api::remote_build::tests:: -- --test-threads=2
+cargo test --locked --lib node::lean::tests:: -- --test-threads=2
+# Repeat for reserve-current, alloc2, alloc1, combined:
+REMOTE_BUILD_MEASURED_FIXTURE=../lido-capacity/combined.request.gz \
+  cargo test --locked --lib measured_complete_fixture -- --ignored --test-threads=1
+```
+
+Use debug Rust builds only. The fixture script writes `sizes.json`, every
+`*.files.json` (path, bytes, executable mode, SHA-256), actual `*.request.gz`
+captures and `union-provenance.json`. Captures are local source evidence and
+are not checked into this transport repository. File paths, decoded bytes,
+modes and both digests are verified against the recursive checkouts. The
+manual Rust tests pass each captured request through the actual API decoder
+and receiver validator, then materialize and compare every byte and mode
+without source fetching. Run the permission-based wrapper regression as an
+unprivileged user; root bypasses its chmod-based failure fixture.
+
+The offline CI suite includes exact 32 MiB sender/API/receiver acceptance,
+32 MiB + 1 rejection, explicit lower sender/receiver overrides, a raised
+sender override, exact 64 MiB valid JSON and gzip expansion max + 1 rejection,
+and byte/mode/manifest tamper rejection. Existing recursive-submodule and
+full/overlay fidelity regressions remain in the required CI suite.
+
+Manifest / operations digests for the measured captures:
+
+- reserve-current: `29d2ebcea8a18aa1a26ccef32241872a229555cc059a52b16fd48afb0cf425e1` / `8755a4d7a258b6cc69eff78f7debb57d00a8d91bbe8d447752408b89534969de`
+- alloc2: `85263f0ee092971dc46aabcf04c4cbebeb5be804478ce6d01051cd0045d82433` / `87a048184bf9459365950a3947b15fe8240207da76c69a133d1d0b2b8dc4916c`
+- alloc1: `02a61d583e976f76535656e6a840101387543ad6df035c9180d73466dc7e5aca` / `b881aed46a63c5059ac63ed1790d36928317eaa9d087fe9e5580f6df690c1374`
+- combined: `895328fdae836f7189a79ef8e1ef1a76bc4c2f64c98b4a14fef5333736f45028` / `364f62fecf4d295a1c81cbd331e7ab4943fe7653b914da04c503b1f4c8f02bb1`

--- a/docs/REMOTE_SOURCE_CAPACITY.md
+++ b/docs/REMOTE_SOURCE_CAPACITY.md
@@ -57,6 +57,14 @@ symlink and replacement-ref protections, privacy rules, receipt identity and
 resume semantics remain intact. See [operator limits and coordinated
 rollout](REMOTE_NODES.md#remote-lean-build-wrapper).
 
+Bundle entry and deletion paths must be canonical relative paths: no empty,
+`.` or `..` components, including leading/trailing slashes and repeated
+separators. The receiver rejects the entire bundle before any writes or
+deletions when a path violates this contract. Paths are never normalized;
+manifest and operation digests continue to identify literal paths. This closes
+the crafted `./Root.lean` / `Root.lean` destination alias; normal Git sender
+paths are unaffected. Build-directory path handling is unchanged.
+
 ## Reproduction and receipts
 
 From this transport checkout (Git credentials are used only for the authorized

--- a/scripts/measure_remote_source_capacity.py
+++ b/scripts/measure_remote_source_capacity.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Measure pinned recursive fixtures and a conservative union without proof edits."""
+import argparse
+import base64
+import gzip
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from test_remote_lean_build_source import SourceTransportTest
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("repo", type=Path, help="pristine authorized Lido clone (checkout will change)")
+parser.add_argument("output", type=Path, help="new directory for captures and combined fixture")
+args = parser.parse_args()
+repo = args.repo.resolve()
+output = args.output.resolve()
+output.mkdir(parents=True, exist_ok=False)
+union = output / 'combined-fixture'
+union.mkdir()
+seen = {}
+rows = []
+def git(*args):
+    return subprocess.check_output(['git', '-C', str(repo), *args]).decode().strip()
+def measure(checkout, label):
+    fixture = SourceTransportTest()
+    try:
+        fixture.setUp()
+        # Test capture uses dummy capabilities and fake curl: no remote jobs.
+        fixture.repo = checkout
+        fixture.command = ["lake", "build"]
+        request = fixture.request()
+        bundle = request['source_bundle']
+        paths = subprocess.check_output(['git','-C',str(checkout),'ls-files','--recurse-submodules','-z']).split(b'\0')[:-1]
+        assert sorted(p.decode() for p in paths) == [f['path'] for f in bundle['files']]
+        manifest = hashlib.sha256(b'sandboxed-source-bundle-v2-complete\n')
+        operations = hashlib.sha256(b'sandboxed-source-bundle-ops-v1\n')
+        entries = []
+        for f in bundle['files']:
+            p = checkout / f['path']
+            data = base64.b64decode(f['data_base64'], validate=True)
+            assert data == p.read_bytes()
+            assert f['executable'] == bool(p.stat().st_mode & 0o111)
+            digest = hashlib.sha256(data).hexdigest()
+            assert digest == f['sha256']
+            manifest.update(f"{f['path']}\0{digest}\n".encode())
+            operations.update(f"file\0{f['path']}\0{'x' if f['executable'] else '-'}\n".encode())
+            entries.append({'path':f['path'], 'bytes':len(data), 'sha256':digest, 'executable':f['executable']})
+            if checkout != union:
+                key = (f['path'],digest,f['executable'])
+                if key not in seen:
+                    target = union / f['path']
+                    if target.exists():
+                        target = union / 'fixture-variants' / label / f['path']
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_bytes(data)
+                    target.chmod(0o755 if f['executable'] else 0o644)
+                    seen[key] = str(target.relative_to(union))
+        if checkout == union:
+            assert set(seen.values()) == {e['path'] for e in entries}, 'all source/receipt versions must be included'
+        assert manifest.hexdigest() == bundle['manifest_sha256']
+        assert operations.hexdigest() == bundle['operations_sha256']
+        wire = fixture.capture.read_bytes()
+        (output / (label + '.request.gz')).write_bytes(wire)
+        (output / (label + '.files.json')).write_text(json.dumps(entries,indent=2)+'\n')
+        row = dict(label=label,head=request['commit'],files=len(entries),decoded_bytes=sum(e['bytes'] for e in entries),json_bytes=len(gzip.decompress(wire)),gzip_bytes=len(wire),manifest_sha256=manifest.hexdigest(),operations_sha256=operations.hexdigest(),request_gzip_sha256=hashlib.sha256(wire).hexdigest())
+        if checkout != union:
+            row['submodules'] = git('submodule','status','--recursive')
+            assert not git('status','--porcelain'), 'fixture must remain pristine'
+        rows.append(row)
+        (output / 'sizes.json').write_text(json.dumps(rows,indent=2)+'\n')
+        print(json.dumps(row), flush=True)
+    finally:
+        fixture.doCleanups()
+assert not git('status', '--porcelain'), 'input checkout must be pristine'
+for label, ref in [('reserve-current','f27b39d8f12b1d8b5947c7f664ebfc33e0183019'),('alloc2','2bb0a7dc7bf009333ba925b2a3a2e02503297b76'),('alloc1','8691c7881a863715ab5ec9b39631ab41243e7c91')]:
+    git('checkout','--detach',ref)
+    git('submodule','update','--init','--recursive')
+    measure(repo,label)
+# All shared path/byte/mode triples appear once. Different versions at the same
+# path are retained under fixture-variants; this is a capacity fixture, not a merge.
+for args in [('init',),('add','--force','-A'),('-c','user.name=Transport Fixture','-c','user.email=fixture@example.invalid','commit','-m','Conservative current trio transport fixture'),('remote','add','origin','https://example.invalid/trio.git')]:
+    subprocess.run(['git','-C',str(union),*args],check=True,stdout=subprocess.DEVNULL)
+measure(union,'combined')
+(output / 'union-provenance.json').write_text(json.dumps([{'source_path':k[0],'sha256':k[1],'executable':k[2],'fixture_path':v} for k,v in seen.items()],indent=2)+'\n')

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -14,6 +14,12 @@
 #   REMOTE_BUILD_NODE_ID     explicit runner id or "auto" (default)
 #   REMOTE_BUILD_REQUIREMENTS JSON array of runner labels (default: ["lean"])
 #
+# Source limits (decoded bytes across the entire recursive snapshot):
+#   full: 32 MiB / 4096 files; overlay: 1 MiB / 256 operations.
+#   REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES / _FILES override sender limits.
+#   Coordinate byte overrides with SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES;
+#   HTTP bodies remain capped at 50 MiB and core-expanded JSON at 64 MiB.
+#
 # Exit codes:
 #   remote build's exit code on success/failure of the build itself
 #   2   unsafe symlink or oversized source overlay
@@ -341,7 +347,7 @@ untracked_source = [] if source_mode == "full" else select_untracked_sources(
 paths = sorted(set(tracked + untracked_source))
 deleted = sorted(set(deleted) - set(paths))
 default_max_files = "4096" if source_mode == "full" else "256"
-default_max_bytes = str(16 << 20) if source_mode == "full" else str(1 << 20)
+default_max_bytes = str(32 << 20) if source_mode == "full" else str(1 << 20)
 max_files = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_FILES", default_max_files))
 max_bytes = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES", default_max_bytes))
 if max_files <= 0 or max_bytes <= 0:

--- a/scripts/test_remote_lean_build_source.py
+++ b/scripts/test_remote_lean_build_source.py
@@ -105,7 +105,7 @@ printf '503'
     def run_wrapper(self, cwd=None, **env):
         self.capture.unlink(missing_ok=True)
         self.trace.unlink(missing_ok=True)
-        result = subprocess.run(["bash", str(WRAPPER), "true"], cwd=cwd or self.repo,
+        result = subprocess.run(["bash", str(WRAPPER), *getattr(self, "command", ["true"])], cwd=cwd or self.repo,
                                 env={**self.env, "GIT_TRACE": str(self.trace), **env},
                                 capture_output=True, timeout=20)
         trace = self.trace.read_text()
@@ -326,6 +326,29 @@ printf '503'
         self.request(REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES=str(total))
         self.rejected(f"maximum is {total - 1}", REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES=str(total - 1))
 
+    def add_large_receipt(self):
+        self.command = ["lake", "build"]
+        # Preserve every recursive source file; fill the remaining aggregate
+        # budget with a tracked binary receipt, including executable metadata.
+        bundle = self.request()["source_bundle"]
+        total = sum(len(base64.b64decode(f["data_base64"])) for f in bundle["files"])
+        receipt = self.nested / "receipt.bin"
+        receipt.write_bytes(bytes(range(256)) * ((32 << 20) // 256))
+        with receipt.open("r+b") as out:
+            out.truncate((32 << 20) - total)
+        self.git(self.nested, "add", "receipt.bin")
+        return receipt
+
+    def test_complete_default_byte_boundary_and_explicit_override(self):
+        receipt = self.add_large_receipt()
+        bundle = self.request()["source_bundle"]
+        self.assertEqual(sum(len(base64.b64decode(f["data_base64"])) for f in bundle["files"]), 32 << 20)
+        self.rejected("maximum is 16777216", REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES=str(16 << 20))
+        with receipt.open("ab") as out:
+            out.write(b"x")
+        self.rejected("maximum is 33554432")
+        self.request(REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES=str((32 << 20) + 1))
+
     def test_full_and_overlay_without_submodules(self):
         self.repo = self.new_repo("plain", {"Root.lean": b"root\n", "Gone.lean": b"gone\n"})
         self.git(self.repo, "remote", "add", "origin", "https://example.invalid/plain.git")
@@ -340,11 +363,16 @@ printf '503'
 
 
 if __name__ == "__main__":
-    if sys.argv[1:] == ["--emit-fixture"]:
+    if sys.argv[1:] in (["--emit-fixture"], ["--emit-large-fixture"]):
         fixture = SourceTransportTest()
         try:
             fixture.setUp()
-            print(json.dumps(fixture.request()))
+            if sys.argv[1:] == ["--emit-large-fixture"]:
+                fixture.add_large_receipt()
+                fixture.request()
+                sys.stdout.buffer.write(fixture.capture.read_bytes())
+            else:
+                print(json.dumps(fixture.request()))
         finally:
             fixture.doCleanups()
     else:

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -752,6 +752,37 @@ fn check_node_source_capacity(
     Ok(())
 }
 
+/// The node receives compact JSON, not the gzip body accepted by core.
+/// Count the exact final envelope (including lease, metadata and JSON escaping)
+/// without allocating another payload-sized buffer. Byte capacity alone cannot
+/// guarantee transportability when an operator raises the decoded-source limit.
+fn check_node_submission_size(request: &SubmitJobRequest) -> Result<(), (StatusCode, String)> {
+    struct Counter(usize);
+    impl std::io::Write for Counter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0 = self.0.saturating_add(bytes.len());
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut counter = Counter(0);
+    serde_json::to_writer(&mut counter, request)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+    let limit = crate::remote_node::protocol::MAX_SOURCE_REQUEST_BODY_BYTES;
+    if counter.0 > limit {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "remote job requires {} bytes of node JSON; transport capacity is {limit} bytes",
+                counter.0,
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
     match err {
         // DNS/connect failures happen before an HTTP request reaches the node,
@@ -1336,6 +1367,11 @@ async fn submit_remote_build(
         },
     };
 
+    // Fail before recording a tentative job or issuing any submission. Every
+    // receiver uses this same HTTP limit, regardless of its source override.
+    if let Err((status, message)) = check_node_submission_size(&submit) {
+        return (status, message).into_response();
+    }
     let client = RemoteNodeClient::default();
     let started_at = chrono::Utc::now();
     if let Err(error) = crate::remote_node::job_ledger::record(
@@ -2368,6 +2404,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                 env: HashMap::new(),
             },
         };
+        check_node_submission_size(&job).unwrap();
         let json = serde_json::to_vec(&job).unwrap();
         assert!(json.len() > 32 << 20);
         assert!(json.len() < MAX_SOURCE_REQUEST_BODY_BYTES);
@@ -2456,6 +2493,98 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                 "{mutation}"
             );
         }
+    }
+
+    #[test]
+    fn node_submission_gate_counts_exact_wire_boundary_and_escaping() {
+        use crate::remote_node::protocol::MAX_SOURCE_REQUEST_BODY_BYTES;
+        let mut request = SubmitJobRequest {
+            job_id: Uuid::nil(),
+            mission_id: Uuid::nil(),
+            lease_token: String::new(),
+            payload: JobPayload::RawCommand {
+                command: "true".into(),
+                timeout_secs: None,
+                env: None,
+            },
+        };
+        let overhead = serde_json::to_vec(&request).unwrap().len();
+        request.lease_token = "x".repeat(MAX_SOURCE_REQUEST_BODY_BYTES - overhead);
+        assert_eq!(
+            serde_json::to_vec(&request).unwrap().len(),
+            MAX_SOURCE_REQUEST_BODY_BYTES
+        );
+        check_node_submission_size(&request).unwrap();
+        request.lease_token.push('x');
+        assert_eq!(
+            check_node_submission_size(&request).unwrap_err().0,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        request.lease_token.pop();
+        // Same string length, but a quote adds a JSON escape byte to the wire.
+        request.lease_token.pop();
+        request.lease_token.push('"');
+        assert_eq!(
+            check_node_submission_size(&request).unwrap_err().0,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn raised_decoded_capacity_cannot_bypass_node_json_transport_gate() {
+        use crate::remote_node::protocol::{NodeHeartbeat, SourceBundleRequirement};
+        use base64::Engine;
+        let raw = vec![b'x'; 38 << 20];
+        let file = crate::remote_node::SourceBundleFile {
+            path: "Main.lean".into(),
+            sha256: hex::encode(sha2::Sha256::digest(&raw)),
+            data_base64: base64::engine::general_purpose::STANDARD.encode(&raw),
+            executable: None,
+        };
+        drop(raw);
+        let bundle = SourceBundle {
+            manifest_sha256: crate::node::lean::bundle_manifest_sha256_for_mode(
+                &[(file.path.clone(), file.sha256.clone())],
+                true,
+            ),
+            files: vec![file],
+            complete: true,
+            deleted_paths: vec![],
+            operations_sha256: None,
+        };
+        let requirement = SourceBundleRequirement::from_bundle(&bundle).unwrap();
+        assert_eq!(requirement.bytes, 38 << 20);
+        let hb: NodeHeartbeat = serde_json::from_value(serde_json::json!({
+            "node_id":"raised", "online":true, "capacity_total":1, "capacity_available":1,
+            "active_leases":0, "version":"test", "protocol_version":4,
+            "source_bundle_capacity":{"complete_bytes": 64 << 20, "overlay_bytes":64 << 20},
+        }))
+        .unwrap();
+        check_node_source_capacity(&hb, Some(requirement)).unwrap();
+        let request = SubmitJobRequest {
+            job_id: Uuid::nil(),
+            mission_id: Uuid::nil(),
+            lease_token: "lease".into(),
+            payload: JobPayload::LeanBuild {
+                source: Box::new(JobSource {
+                    repo: "https://example.invalid/repo.git".into(),
+                    commit: "a".repeat(40),
+                    base_tree_sha: None,
+                    archive: None,
+                    bundle: Some(bundle),
+                }),
+                cwd_rel: None,
+                command: vec!["lake".into(), "build".into()],
+                timeout_secs: None,
+                estimated_disk_bytes: Some(GIB),
+                cache_key: None,
+                artifacts: vec![],
+                env: HashMap::new(),
+            },
+        };
+        let (status, reason) = check_node_submission_size(&request).unwrap_err();
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(reason.contains("transport capacity is 52428800"));
     }
 
     #[test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -54,7 +54,7 @@ const DEFAULT_NODE_DISK_EMERGENCY_GB: u64 = 10;
 // 32 MiB of complete source needs ~43 MiB after base64, plus metadata.
 const MAX_REMOTE_BUILD_JSON_BYTES: u64 = 64 * 1024 * 1024;
 
-fn parse_remote_build_request(
+pub(crate) fn parse_remote_build_request(
     headers: &HeaderMap,
     body: &[u8],
 ) -> Result<RemoteBuildRequest, (StatusCode, String)> {

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -621,6 +621,7 @@ async fn resolve_node(
     requirements: &[String],
     min_disk_bytes: u64,
     min_protocol_version: u32,
+    source: Option<crate::remote_node::protocol::SourceBundleRequirement>,
 ) -> Result<RemoteNodeConfig, (StatusCode, String)> {
     let settings = &state.config.remote_nodes;
     if !settings.enabled || settings.nodes.is_empty() {
@@ -635,11 +636,12 @@ async fn resolve_node(
             .map_err(|message| (StatusCode::SERVICE_UNAVAILABLE, message))?;
         let first = state
             .fleet
-            .place_auto_with_protocol_and_resource_reservations(
+            .place_auto_with_source_and_resource_reservations(
                 settings,
                 requirements,
                 min_disk_bytes,
                 min_protocol_version,
+                source,
                 &reservations.jobs,
                 &reservations.disk_bytes,
             );
@@ -676,11 +678,12 @@ async fn resolve_node(
                     .map_err(|message| (StatusCode::SERVICE_UNAVAILABLE, message))?;
                 state
                     .fleet
-                    .place_auto_with_protocol_and_resource_reservations(
+                    .place_auto_with_source_and_resource_reservations(
                         settings,
                         requirements,
                         min_disk_bytes,
                         min_protocol_version,
+                        source,
                         &reservations.jobs,
                         &reservations.disk_bytes,
                     )
@@ -716,6 +719,7 @@ async fn resolve_node(
             ),
         ));
     }
+    check_node_source_capacity(&heartbeat, source)?;
     let reserved = reservations.disk_bytes.get(&node.id).copied().unwrap_or(0);
     let effective = heartbeat.disk_available_bytes.saturating_sub(reserved);
     if effective < min_disk_bytes {
@@ -731,6 +735,21 @@ async fn resolve_node(
         ));
     }
     Ok(node)
+}
+
+fn check_node_source_capacity(
+    heartbeat: &crate::remote_node::protocol::NodeHeartbeat,
+    source: Option<crate::remote_node::protocol::SourceBundleRequirement>,
+) -> Result<(), (StatusCode, String)> {
+    if let Some(source) = source {
+        source.check(heartbeat).map_err(|reason| {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("remote node '{}': {reason}", heartbeat.node_id),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
@@ -1213,6 +1232,15 @@ async fn submit_remote_build(
         )
             .into_response();
     }
+    let source = match req
+        .source_bundle
+        .as_ref()
+        .map(crate::remote_node::protocol::SourceBundleRequirement::from_bundle)
+        .transpose()
+    {
+        Ok(source) => source,
+        Err(error) => return (StatusCode::BAD_REQUEST, error).into_response(),
+    };
     let min_disk_bytes = required_node_disk_bytes(req.estimated_disk_bytes);
     let min_protocol_version = if req.source_archive.is_some() {
         crate::remote_node::protocol::NODE_PROTOCOL_VERSION
@@ -1257,6 +1285,7 @@ async fn submit_remote_build(
         &requirements,
         min_disk_bytes,
         min_protocol_version,
+        source,
     )
     .await
     {
@@ -2167,6 +2196,10 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             })
             .sum();
         assert_eq!(total, 32 << 20);
+        let requirement =
+            crate::remote_node::protocol::SourceBundleRequirement::from_bundle(bundle).unwrap();
+        assert_eq!(requirement.bytes, total as u64);
+
         assert!(bundle.files.iter().any(|f| f.path.ends_with("receipt.bin")));
         assert!(bundle.files.iter().any(|f| f.executable == Some(true)));
 
@@ -2203,9 +2236,37 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
             Ok(StatusCode::OK)
         }
+        use crate::remote_node::protocol::NodeHeartbeat;
+        let old: NodeHeartbeat = serde_json::from_value(serde_json::json!({
+            "node_id":"a-old", "online":true, "capacity_total":1,
+            "capacity_available":1, "active_leases":0, "version":"old", "protocol_version":4,
+            "labels":["lean"], "disk_available_bytes": 1000 * GIB,
+            "mem_available_bytes": 1000 * GIB,
+        }))
+        .unwrap();
+        let mut capable = old.clone();
+        capable.node_id = "z-capable".into();
+        capable.source_bundle_capacity = Some(crate::node::lean::source_bundle_capacity());
+        let old_posts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let old_posts_route = old_posts.clone();
         let app = Router::new()
             .route("/", post(ingress))
             .route("/jobs", post(node_ingress))
+            .route(
+                "/heartbeat",
+                axum::routing::get(move || async move { Json(capable) }),
+            )
+            .route(
+                "/old/heartbeat",
+                axum::routing::get(move || async move { Json(old) }),
+            )
+            .route(
+                "/old/jobs",
+                post(move || async move {
+                    old_posts_route.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    StatusCode::UNPROCESSABLE_ENTITY
+                }),
+            )
             .layer(axum::extract::DefaultBodyLimit::max(
                 MAX_SOURCE_REQUEST_BODY_BYTES,
             ));
@@ -2214,6 +2275,55 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
         let client = reqwest::Client::new();
         let url = format!("http://{address}/");
+        let old_node = RemoteNodeConfig {
+            id: "a-old".into(),
+            base_url: format!("http://{address}/old"),
+            token_env: "UNUSED_TEST_TOKEN".into(),
+            labels: None,
+        };
+        let capable_node = RemoteNodeConfig {
+            id: "z-capable".into(),
+            base_url: format!("http://{address}"),
+            token_env: "UNUSED_TEST_TOKEN".into(),
+            labels: None,
+        };
+        let fleet = crate::remote_node::FleetMonitor::new();
+        let node_client = RemoteNodeClient::default();
+        for node in [&old_node, &capable_node] {
+            let hb = node_client.heartbeat(node, "test").await.unwrap();
+            fleet.record_heartbeat(&node.id, hb);
+        }
+        let mut settings = crate::remote_node::RemoteNodeSettings {
+            enabled: true,
+            nodes: vec![old_node.clone()],
+        };
+        let pick = |settings: &crate::remote_node::RemoteNodeSettings| {
+            fleet.place_auto_with_source_and_resource_reservations(
+                settings,
+                &["lean".into()],
+                GIB,
+                minimum_node_protocol_version(Some(bundle)),
+                Some(requirement),
+                &HashMap::new(),
+                &HashMap::new(),
+            )
+        };
+        assert!(pick(&settings).is_err()); // no dispatch when fleet capacity is insufficient
+        let old_hb = fleet.get(&old_node.id).unwrap().last_heartbeat.unwrap();
+        assert_eq!(
+            check_node_source_capacity(&old_hb, Some(requirement))
+                .unwrap_err()
+                .0,
+            StatusCode::SERVICE_UNAVAILABLE
+        ); // explicit node has the same pre-dispatch gate
+        settings.nodes.push(capable_node.clone());
+        assert_eq!(pick(&settings).unwrap(), capable_node.id);
+        let selected_url = settings
+            .node(&pick(&settings).unwrap())
+            .unwrap()
+            .base_url
+            .clone();
+
         let response = client
             .post(&url)
             .header("Content-Encoding", "gzip")
@@ -2266,7 +2376,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         drop(json);
         drop(roundtrip);
         let response = client
-            .post(format!("{url}jobs"))
+            .post(format!("{selected_url}/jobs"))
             .json(&job)
             .send()
             .await
@@ -2278,13 +2388,14 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             response.text().await.unwrap()
         );
         let response = client
-            .post(format!("{url}jobs"))
+            .post(format!("{selected_url}/jobs"))
             .header("Content-Type", "application/json")
             .body(vec![b' '; MAX_SOURCE_REQUEST_BODY_BYTES + 1])
             .send()
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(old_posts.load(std::sync::atomic::Ordering::SeqCst), 0);
         server.abort();
         drop(job);
 
@@ -2382,6 +2493,44 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                 result.unwrap();
             }
         }
+    }
+
+    #[test]
+    #[ignore = "local measured wrapper request; set REMOTE_BUILD_MEASURED_FIXTURE"]
+    fn measured_fixture_capacity_matches_receiver_and_explicit_placement() {
+        use crate::remote_node::protocol::{NodeHeartbeat, SourceBundleRequirement};
+        let bytes = std::fs::read(std::env::var("REMOTE_BUILD_MEASURED_FIXTURE").unwrap()).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let request = parse_remote_build_request(&headers, &bytes).unwrap();
+        let requirement =
+            SourceBundleRequirement::from_bundle(request.source_bundle.as_ref().unwrap()).unwrap();
+        let mut hb: NodeHeartbeat = serde_json::from_value(serde_json::json!({
+            "node_id":"receiver", "online":true, "capacity_total":1,
+            "capacity_available":1, "active_leases":0, "version":"test", "protocol_version":4,
+            "source_bundle_capacity": crate::node::lean::source_bundle_capacity(),
+        }))
+        .unwrap();
+        let placement = check_node_source_capacity(&hb, Some(requirement));
+        let receiver = validate_parsed_source(request);
+        assert_eq!(placement.is_ok(), receiver.is_ok());
+        if let Err((status, reason)) = placement {
+            assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+            assert!(reason.contains("receiver capacity"));
+            assert!(receiver.unwrap_err().contains("maximum is"));
+        }
+        // Exact explicit-node gate also preserves legacy compatibility.
+        hb.source_bundle_capacity = None;
+        assert_eq!(
+            check_node_source_capacity(&hb, Some(requirement)).is_ok(),
+            requirement.bytes <= 16 << 20
+        );
+        check_node_source_capacity(&hb, None).unwrap();
+        println!(
+            "decoded bytes: {}; effective capacity: {:?}",
+            requirement.bytes,
+            crate::node::lean::source_bundle_capacity()
+        );
     }
 
     #[test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -50,7 +50,9 @@ const DEFAULT_ESTIMATED_DISK_GB: u64 = 12;
 const MAX_ESTIMATED_DISK_GB: u64 = 512;
 const DEFAULT_NODE_MIN_DISK_GB: u64 = 20;
 const DEFAULT_NODE_DISK_EMERGENCY_GB: u64 = 10;
-const MAX_REMOTE_BUILD_JSON_BYTES: u64 = 32 * 1024 * 1024;
+// Independent of the 50 MiB wire ceiling: gzip can expand beyond its body size.
+// 32 MiB of complete source needs ~43 MiB after base64, plus metadata.
+const MAX_REMOTE_BUILD_JSON_BYTES: u64 = 64 * 1024 * 1024;
 
 fn parse_remote_build_request(
     headers: &HeaderMap,
@@ -2114,6 +2116,282 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         let oversized = vec![b' '; MAX_REMOTE_BUILD_JSON_BYTES as usize + 1];
         let error = parse_remote_build_request(&HeaderMap::new(), &oversized).unwrap_err();
         assert_eq!(error.0, StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    fn validate_parsed_source(request: RemoteBuildRequest) -> Result<(), String> {
+        crate::node::lean::validate_lean_build(
+            &JobSource {
+                repo: request.repo,
+                commit: request.commit,
+                base_tree_sha: request.base_tree_sha,
+                archive: request.source_archive.map(Box::new),
+                bundle: request.source_bundle,
+            },
+            request.cwd_rel.as_deref(),
+            &request.command,
+            &HashMap::new(),
+            &[],
+        )
+    }
+
+    #[tokio::test]
+    async fn complete_32_mib_wrapper_crosses_api_decoder_and_receiver_with_strict_identity() {
+        use crate::remote_node::protocol::MAX_SOURCE_REQUEST_BODY_BYTES;
+        use base64::Engine;
+
+        let output = std::process::Command::new("python3")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/test_remote_lean_build_source.py"
+            ))
+            .arg("--emit-large-fixture")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let parsed = parse_remote_build_request(&headers, &output.stdout).unwrap();
+        let bundle = parsed.source_bundle.as_ref().unwrap();
+        let total: usize = bundle
+            .files
+            .iter()
+            .map(|f| {
+                base64::engine::general_purpose::STANDARD
+                    .decode(&f.data_base64)
+                    .unwrap()
+                    .len()
+            })
+            .sum();
+        assert_eq!(total, 32 << 20);
+        assert!(bundle.files.iter().any(|f| f.path.ends_with("receipt.bin")));
+        assert!(bundle.files.iter().any(|f| f.executable == Some(true)));
+
+        // Use the same Bytes extractor and body ceiling as core ingress, and
+        // the actual gzip decoder and receiver validation. No dispatch/build.
+        async fn ingress(
+            headers: HeaderMap,
+            body: Bytes,
+        ) -> Result<StatusCode, (StatusCode, String)> {
+            validate_parsed_source(parse_remote_build_request(&headers, &body)?)
+                .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+            Ok(StatusCode::OK)
+        }
+        async fn node_ingress(
+            Json(job): Json<SubmitJobRequest>,
+        ) -> Result<StatusCode, (StatusCode, String)> {
+            let JobPayload::LeanBuild {
+                source,
+                cwd_rel,
+                command,
+                env,
+                ..
+            } = job.payload
+            else {
+                panic!("expected lean build");
+            };
+            crate::node::lean::validate_lean_build(
+                &source,
+                cwd_rel.as_deref(),
+                &command,
+                &env,
+                &[],
+            )
+            .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+            Ok(StatusCode::OK)
+        }
+        let app = Router::new()
+            .route("/", post(ingress))
+            .route("/jobs", post(node_ingress))
+            .layer(axum::extract::DefaultBodyLimit::max(
+                MAX_SOURCE_REQUEST_BODY_BYTES,
+            ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = reqwest::Client::new();
+        let url = format!("http://{address}/");
+        let response = client
+            .post(&url)
+            .header("Content-Encoding", "gzip")
+            .body(output.stdout.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "{}",
+            response.text().await.unwrap()
+        );
+        let response = client
+            .post(&url)
+            .body(vec![b' '; MAX_SOURCE_REQUEST_BODY_BYTES + 1])
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+        // The node client sends plain JSON. Its unchanged 50 MiB body ceiling
+        // includes the real SubmitJobRequest envelope, not just the bundle.
+        let job = SubmitJobRequest {
+            job_id: Uuid::new_v4(),
+            mission_id: parsed.mission_id,
+            lease_token: "test-lease".to_string(),
+            payload: JobPayload::LeanBuild {
+                source: Box::new(JobSource {
+                    repo: parsed.repo,
+                    commit: parsed.commit,
+                    base_tree_sha: parsed.base_tree_sha,
+                    archive: None,
+                    bundle: parsed.source_bundle,
+                }),
+                cwd_rel: None,
+                command: vec!["lake".to_string(), "build".to_string()],
+                timeout_secs: None,
+                estimated_disk_bytes: None,
+                cache_key: None,
+                artifacts: vec![],
+                env: HashMap::new(),
+            },
+        };
+        let json = serde_json::to_vec(&job).unwrap();
+        assert!(json.len() > 32 << 20);
+        assert!(json.len() < MAX_SOURCE_REQUEST_BODY_BYTES);
+        let roundtrip: SubmitJobRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(roundtrip, job);
+        drop(json);
+        drop(roundtrip);
+        let response = client
+            .post(format!("{url}jobs"))
+            .json(&job)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "{}",
+            response.text().await.unwrap()
+        );
+        let response = client
+            .post(format!("{url}jobs"))
+            .header("Content-Type", "application/json")
+            .body(vec![b' '; MAX_SOURCE_REQUEST_BODY_BYTES + 1])
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        server.abort();
+        drop(job);
+
+        // An explicit operator ceiling must still win over the new default.
+        // Isolate the environment in a child, avoiding process-global test races.
+        let fixture = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(fixture.path(), &output.stdout).unwrap();
+        let child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "api::remote_build::tests::measured_complete_fixture_crosses_api_decoder_and_receiver", "--ignored"])
+            .env("REMOTE_BUILD_MEASURED_FIXTURE", fixture.path())
+            .env("SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES", (16 << 20).to_string())
+            .output().unwrap();
+        assert!(!child.status.success());
+        assert!(String::from_utf8_lossy(&child.stdout).contains("maximum is 16777216"));
+
+        for (mutation, expected) in [
+            ("byte", "content hash mismatch"),
+            ("mode", "operations hash mismatch"),
+            ("manifest", "manifest hash mismatch"),
+            ("max+1", "maximum is 33554432"),
+        ] {
+            let mut request = parse_remote_build_request(&headers, &output.stdout).unwrap();
+            let bundle = request.source_bundle.as_mut().unwrap();
+            match mutation {
+                "byte" => {
+                    bundle.files[0].data_base64 =
+                        base64::engine::general_purpose::STANDARD.encode(b"tampered")
+                }
+                "mode" => bundle.files[0].executable = Some(!bundle.files[0].executable.unwrap()),
+                "manifest" => bundle.manifest_sha256 = "0".repeat(64),
+                "max+1" => {
+                    let file = bundle
+                        .files
+                        .iter_mut()
+                        .find(|f| f.path.ends_with("receipt.bin"))
+                        .unwrap();
+                    let mut data = base64::engine::general_purpose::STANDARD
+                        .decode(&file.data_base64)
+                        .unwrap();
+                    data.push(b'x');
+                    file.sha256 = hex::encode(sha2::Sha256::digest(&data));
+                    file.data_base64 = base64::engine::general_purpose::STANDARD.encode(data);
+                    bundle.manifest_sha256 = crate::node::lean::bundle_manifest_sha256_for_mode(
+                        &bundle
+                            .files
+                            .iter()
+                            .map(|f| (f.path.clone(), f.sha256.clone()))
+                            .collect::<Vec<_>>(),
+                        true,
+                    );
+                }
+                _ => unreachable!(),
+            }
+            assert!(
+                validate_parsed_source(request)
+                    .unwrap_err()
+                    .contains(expected),
+                "{mutation}"
+            );
+        }
+    }
+
+    #[test]
+    fn remote_build_json_boundary_and_gzip_expansion_are_bounded() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+        let mut plain = serde_json::to_vec(&serde_json::json!({
+            "mission_id": Uuid::nil(), "token": "test", "repo": "https://example.invalid/repo.git",
+            "commit": "a".repeat(40), "command": ["lake", "build"],
+        }))
+        .unwrap();
+        plain.resize(MAX_REMOTE_BUILD_JSON_BYTES as usize, b' ');
+        // Whitespace makes a valid JSON request at the exact expansion cap.
+        parse_remote_build_request(&HeaderMap::new(), &plain).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        for extra in [false, true] {
+            if extra {
+                plain.push(b' ');
+            }
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+            encoder.write_all(&plain).unwrap();
+            let compressed = encoder.finish().unwrap();
+            assert!(compressed.len() < 1 << 20);
+            let result = parse_remote_build_request(&headers, &compressed);
+            if extra {
+                assert_eq!(result.unwrap_err().0, StatusCode::PAYLOAD_TOO_LARGE);
+                assert_eq!(
+                    parse_remote_build_request(&HeaderMap::new(), &plain)
+                        .unwrap_err()
+                        .0,
+                    StatusCode::PAYLOAD_TOO_LARGE
+                );
+            } else {
+                result.unwrap();
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "local measured wrapper request; set REMOTE_BUILD_MEASURED_FIXTURE"]
+    fn measured_complete_fixture_crosses_api_decoder_and_receiver() {
+        let path = std::env::var("REMOTE_BUILD_MEASURED_FIXTURE").unwrap();
+        let bytes = std::fs::read(path).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        validate_parsed_source(parse_remote_build_request(&headers, &bytes).unwrap()).unwrap();
     }
 
     #[test]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -751,7 +751,9 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         // and manifest instead of Axum's 2 MiB default.
         .nest(
             "/api/remote-build",
-            super::remote_build::routes().layer(DefaultBodyLimit::max(50 * 1024 * 1024)),
+            super::remote_build::routes().layer(DefaultBodyLimit::max(
+                crate::remote_node::protocol::MAX_SOURCE_REQUEST_BODY_BYTES,
+            )),
         );
 
     // File upload routes with increased body limit (10GB)

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -3901,6 +3901,7 @@ fn compact_compute_fleet(fleet: &Value) -> Value {
                 "disk_available_bytes": node.get("disk_available_bytes").cloned().unwrap_or(Value::Null),
                 "cached_toolchains": node.get("cached_toolchains").cloned().unwrap_or_else(|| json!([])),
                 "lean_runtime_ready": node.get("lean_runtime_ready").cloned().unwrap_or(Value::Null),
+                "source_bundle_capacity": node.get("source_bundle_capacity").cloned().unwrap_or(Value::Null),
                 "error": node.get("error").cloned().unwrap_or(Value::Null),
             })
         })
@@ -5472,6 +5473,7 @@ mod tests {
                     "disk_available_bytes": 100_u64 << 30,
                     "cached_toolchains": ["leanprover--lean4---v4.24.0"],
                     "lean_runtime_ready": true,
+                    "source_bundle_capacity": {"overlay_bytes": 1048576, "complete_bytes": 8388608},
                     "base_url": "must-not-leak"
                 },
                 {
@@ -5515,6 +5517,11 @@ mod tests {
         assert_eq!(compact["summary"]["lean_slots_available"], 2);
         assert_eq!(compact["summary"]["active_remote_jobs"], 1);
         assert!(compact["nodes"][0].get("base_url").is_none());
+        assert_eq!(
+            compact["nodes"][0]["source_bundle_capacity"]["complete_bytes"],
+            8388608
+        );
+        assert!(compact["nodes"][3]["source_bundle_capacity"].is_null());
         assert_eq!(compact["nodes"][2]["error"], "probe degraded");
         assert_eq!(compact["recent_jobs"][0]["node_id"], "cpu");
     }

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -245,6 +245,7 @@ async fn heartbeat(
         active_jobs: state.runner.active_count(),
         queued_jobs: state.runner.queued_count(),
         cached_toolchains: sandboxed_sh::node::cached_toolchains(&state.work_root),
+        source_bundle_capacity: Some(sandboxed_sh::node::lean::source_bundle_capacity()),
         lean_runtime_ready: Some(lean_runtime_ready),
     }))
 }
@@ -597,6 +598,10 @@ mod tests {
         assert_eq!(busy.capacity_total, 2);
         assert_eq!(busy.capacity_available, 1);
         assert_eq!(busy.protocol_version, NODE_PROTOCOL_VERSION);
+        assert_eq!(
+            busy.source_bundle_capacity,
+            Some(sandboxed_sh::node::lean::source_bundle_capacity())
+        );
         assert_eq!(busy.labels, vec!["test".to_string()]);
         let _response = running
             .await

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -142,7 +142,9 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/jobs",
             post(submit_job)
-                .layer(DefaultBodyLimit::max(50 * 1024 * 1024))
+                .layer(DefaultBodyLimit::max(
+                    sandboxed_sh::remote_node::protocol::MAX_SOURCE_REQUEST_BODY_BYTES,
+                ))
                 .get(list_jobs),
         )
         .route("/jobs/:id", get(get_job))

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -111,12 +111,31 @@ pub fn rel_path_is_safe(rel_clean: &str) -> bool {
         })
 }
 
+pub fn source_bundle_capacity() -> crate::remote_node::protocol::SourceBundleCapacity {
+    crate::remote_node::protocol::SourceBundleCapacity {
+        overlay_bytes: source_bundle_mode_max_bytes(false),
+        complete_bytes: source_bundle_mode_max_bytes(true),
+    }
+}
+
 fn source_bundle_max_bytes(bundle: &SourceBundle) -> u64 {
-    std::env::var("SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES")
-        .ok()
+    source_bundle_mode_max_bytes(bundle.complete)
+}
+
+fn source_bundle_mode_max_bytes(complete: bool) -> u64 {
+    configured_source_bundle_max_bytes(
+        complete,
+        std::env::var("SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn configured_source_bundle_max_bytes(complete: bool, configured: Option<&str>) -> u64 {
+    configured
         .and_then(|raw| raw.trim().parse::<u64>().ok())
         .filter(|bytes| *bytes > 0)
-        .unwrap_or(if bundle.complete {
+        .unwrap_or(if complete {
             DEFAULT_MAX_COMPLETE_SOURCE_BUNDLE_BYTES
         } else {
             DEFAULT_MAX_SOURCE_BUNDLE_BYTES
@@ -2147,6 +2166,29 @@ mod tests {
             error.contains("does not contain requested commit"),
             "{error}; original commit was {commit}"
         );
+    }
+
+    #[test]
+    fn source_capacity_preserves_operator_ceilings() {
+        for (configured, overlay, complete) in [
+            (None, 1 << 20, 32 << 20),
+            (Some("8388608"), 8 << 20, 8 << 20),
+            (Some(" 17 "), 17, 17),
+            (Some("0"), 1 << 20, 32 << 20),
+            (Some("invalid"), 1 << 20, 32 << 20),
+        ] {
+            assert_eq!(
+                configured_source_bundle_max_bytes(false, configured),
+                overlay
+            );
+            assert_eq!(
+                configured_source_bundle_max_bytes(true, configured),
+                complete
+            );
+        }
+        let capacity = source_bundle_capacity();
+        assert_eq!(capacity.overlay_bytes, source_bundle_mode_max_bytes(false));
+        assert_eq!(capacity.complete_bytes, source_bundle_mode_max_bytes(true));
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -2463,7 +2463,7 @@ mod tests {
                         }
                         assert!(!checkout.join("B.new").exists());
                         assert!(!log.exists());
-                        assert_eq!(std::fs::read_dir(&checkout).unwrap().count(), 4);
+                        assert_eq!(std::fs::read_dir(&checkout).unwrap().count(), 3);
                         assert_eq!(
                             std::fs::read_dir(checkout.join("nested")).unwrap().count(),
                             1

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -188,12 +188,14 @@ fn decode_source_archive(source: &JobSource, archive: &SourceArchive) -> Result<
     Ok(bytes)
 }
 
+// Bundle paths are literal manifest identities: never normalize aliases before
+// writing. Validate every entry and deletion before any filesystem mutation.
 fn bundle_path_is_safe(path: &str) -> bool {
     rel_path_is_safe(path)
         && !path.is_empty()
         && !path
             .split('/')
-            .any(|component| matches!(component, ".git" | ".lake"))
+            .any(|component| matches!(component, "." | ".git" | ".lake"))
 }
 
 pub(crate) fn bundle_manifest_sha256_for_mode(
@@ -2346,6 +2348,187 @@ mod tests {
         )
         .unwrap_err()
         .contains("unsafe source bundle path"));
+    }
+
+    // Re-sign every crafted request so rejection proves path validation, not
+    // stale content/manifest/operation hashes. Exercise the actual API decoder.
+    fn decode_path_fixture(mut bundle: SourceBundle, gzip: bool) -> JobSource {
+        use std::io::Write;
+        bundle.files.sort_by(|a, b| a.path.cmp(&b.path));
+        bundle.deleted_paths.sort();
+        bundle.manifest_sha256 = bundle_manifest_sha256_for_mode(
+            &bundle
+                .files
+                .iter()
+                .map(|f| (f.path.clone(), f.sha256.clone()))
+                .collect::<Vec<_>>(),
+            bundle.complete,
+        );
+        bundle.operations_sha256 = Some(bundle_operations_sha256(&bundle));
+        let mut body = serde_json::to_vec(&serde_json::json!({
+            "mission_id": uuid::Uuid::new_v4(),
+            "token": "fixture-capability",
+            "repo": "https://example.invalid/no-fetch.git",
+            "commit": "a".repeat(40),
+            "base_tree_sha": "b".repeat(40),
+            "command": ["lake", "build"],
+            "source_bundle": bundle,
+        }))
+        .unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        if gzip {
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(&body).unwrap();
+            body = encoder.finish().unwrap();
+            headers.insert(
+                axum::http::header::CONTENT_ENCODING,
+                "gzip".parse().unwrap(),
+            );
+        }
+        let request =
+            crate::api::remote_build::parse_remote_build_request(&headers, &body).unwrap();
+        JobSource {
+            repo: request.repo,
+            commit: request.commit,
+            base_tree_sha: request.base_tree_sha,
+            archive: None,
+            bundle: request.source_bundle,
+        }
+    }
+
+    #[tokio::test]
+    async fn source_bundle_path_aliases_fail_before_any_mutation() {
+        for complete in [false, true] {
+            for gzip in [false, true] {
+                for alias in [
+                    "./Root.lean",
+                    "nested/./Root.lean",
+                    "nested//Root.lean",
+                    "nested/Root.lean/.",
+                    "nested/Root.lean/",
+                    ".",
+                    "nested/../Root.lean",
+                    "/Root.lean",
+                    ".git/config",
+                    ".lake/build/Root.lean",
+                ] {
+                    // Cover aliases in entries, deletions, and between an entry
+                    // and a deletion, as well as the original two-file overwrite.
+                    for deletion in [false, true] {
+                        let temp = tempfile::tempdir().unwrap();
+                        let checkout = temp.path().join("checkout");
+                        std::fs::create_dir_all(checkout.join("nested")).unwrap();
+                        for path in ["A.keep", "Root.lean", "nested/Root.lean"] {
+                            std::fs::write(checkout.join(path), b"original\0bytes").unwrap();
+                        }
+                        let log = temp.path().join("job.log");
+                        let mut bundle = source_bundle("Root.lean", b"second\n");
+                        bundle.complete = complete;
+                        bundle.files[0].executable = Some(true);
+                        bundle.files.push(
+                            source_bundle("B.new", b"must not be created")
+                                .files
+                                .remove(0),
+                        );
+                        bundle.deleted_paths = vec!["A.keep".into()];
+                        if deletion {
+                            bundle.deleted_paths.push(alias.into());
+                        } else {
+                            bundle
+                                .files
+                                .push(source_bundle(alias, b"first\n").files.remove(0));
+                        }
+                        let source = decode_path_fixture(bundle, gzip);
+                        let error = validate_lean_build(
+                            &source,
+                            None,
+                            &["lake".into(), "build".into()],
+                            &HashMap::new(),
+                            &allowlist(),
+                        )
+                        .unwrap_err();
+                        assert!(error.contains("unsafe"), "{alias}: {error}");
+                        let error =
+                            apply_source_bundle(&checkout, source.bundle.as_ref().unwrap(), &log)
+                                .await
+                                .unwrap_err()
+                                .to_string();
+                        assert!(error.contains("unsafe"), "{alias}: {error}");
+                        for path in ["A.keep", "Root.lean", "nested/Root.lean"] {
+                            assert_eq!(
+                                std::fs::read(checkout.join(path)).unwrap(),
+                                b"original\0bytes"
+                            );
+                        }
+                        assert!(!checkout.join("B.new").exists());
+                        assert!(!log.exists());
+                        assert_eq!(std::fs::read_dir(&checkout).unwrap().count(), 4);
+                        assert_eq!(
+                            std::fs::read_dir(checkout.join("nested")).unwrap().count(),
+                            1
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn canonical_source_bundle_paths_preserve_exact_bytes_and_modes() {
+        use std::os::unix::fs::PermissionsExt;
+        for complete in [false, true] {
+            for gzip in [false, true] {
+                let temp = tempfile::tempdir().unwrap();
+                let checkout = temp.path().join("checkout");
+                std::fs::create_dir_all(checkout.join("nested/deeper")).unwrap();
+                std::fs::write(checkout.join("nested/deeper/obsolete"), b"delete").unwrap();
+                let mut bundle = source_bundle("Root.lean", b"first\n");
+                bundle.complete = complete;
+                bundle.files[0].executable = Some(false);
+                for (path, bytes, executable) in [
+                    ("nested/Root.lean", b"second\0\xff\n".as_slice(), true),
+                    ("nested/deeper/.hidden-file_v2", b"third".as_slice(), false),
+                ] {
+                    let mut file = source_bundle(path, bytes).files.remove(0);
+                    file.executable = Some(executable);
+                    bundle.files.push(file);
+                }
+                bundle.deleted_paths = vec!["nested/deeper/obsolete".into()];
+                let source = decode_path_fixture(bundle, gzip);
+                validate_lean_build(
+                    &source,
+                    None,
+                    &["lake".into(), "build".into()],
+                    &HashMap::new(),
+                    &allowlist(),
+                )
+                .unwrap();
+                let bundle = source.bundle.unwrap();
+                apply_source_bundle(&checkout, &bundle, &temp.path().join("job.log"))
+                    .await
+                    .unwrap();
+                assert!(!checkout.join("nested/deeper/obsolete").exists());
+                for file in &bundle.files {
+                    let path = checkout.join(&file.path);
+                    assert_eq!(
+                        std::fs::read(&path).unwrap(),
+                        base64::engine::general_purpose::STANDARD
+                            .decode(&file.data_base64)
+                            .unwrap()
+                    );
+                    assert_eq!(
+                        std::fs::metadata(path).unwrap().permissions().mode() & 0o111,
+                        if file.executable == Some(true) {
+                            0o111
+                        } else {
+                            0
+                        }
+                    );
+                }
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -42,7 +42,7 @@ pub const ALLOWED_COMMANDS: [&str; 2] = ["lake", "lean"];
 /// filesystem backing the work dir (`SANDBOXED_NODE_MIN_FREE_GB` overrides).
 const DEFAULT_MIN_FREE_GB: u64 = 10;
 const DEFAULT_MAX_SOURCE_BUNDLE_BYTES: u64 = 1 << 20;
-const DEFAULT_MAX_COMPLETE_SOURCE_BUNDLE_BYTES: u64 = 16 << 20;
+const DEFAULT_MAX_COMPLETE_SOURCE_BUNDLE_BYTES: u64 = 32 << 20;
 const MAX_SOURCE_BUNDLE_FILES: usize = 256;
 const DEFAULT_MAX_SOURCE_ARCHIVE_BYTES: u64 = 32 << 20;
 const DEFAULT_MAX_SOURCE_ARCHIVE_EXPANDED_BYTES: u64 = 2 << 30;
@@ -2506,6 +2506,62 @@ mod tests {
         assert!(validate_source_bundle(&tampered)
             .unwrap_err()
             .contains("operations hash mismatch"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore = "local measured wrapper request; set REMOTE_BUILD_MEASURED_FIXTURE"]
+    async fn measured_complete_fixture_materializes_every_byte_and_mode() {
+        use std::io::Read;
+        use std::os::unix::fs::PermissionsExt;
+        let input = std::fs::read(std::env::var("REMOTE_BUILD_MEASURED_FIXTURE").unwrap()).unwrap();
+        let mut json = Vec::new();
+        flate2::read::GzDecoder::new(input.as_slice())
+            .take((64 << 20) + 1)
+            .read_to_end(&mut json)
+            .unwrap();
+        assert!(json.len() <= 64 << 20);
+        let request: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        let bundle: SourceBundle =
+            serde_json::from_value(request["source_bundle"].clone()).unwrap();
+        assert!(bundle.complete);
+        validate_source_bundle(&bundle).unwrap();
+        let source = JobSource {
+            repo: "https://example.invalid/no-fetch.git".to_string(),
+            commit: request["commit"].as_str().unwrap().to_string(),
+            base_tree_sha: Some(request["base_tree_sha"].as_str().unwrap().to_string()),
+            archive: None,
+            bundle: Some(bundle.clone()),
+        };
+        let temp = tempfile::tempdir().unwrap();
+        let checkout = ensure_checkout(
+            temp.path(),
+            &source,
+            &temp.path().join("job.log"),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        for file in &bundle.files {
+            let path = checkout.join(&file.path);
+            assert_eq!(
+                std::fs::read(&path).unwrap(),
+                base64::engine::general_purpose::STANDARD
+                    .decode(&file.data_base64)
+                    .unwrap(),
+                "{}",
+                file.path
+            );
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o111 != 0,
+                file.executable.unwrap(),
+                "{}",
+                file.path
+            );
+        }
+        assert!(!walkdir::WalkDir::new(checkout)
+            .into_iter()
+            .any(|entry| entry.unwrap().file_name() == ".git"));
     }
 
     #[tokio::test]

--- a/src/remote_node/client.rs
+++ b/src/remote_node/client.rs
@@ -223,6 +223,7 @@ mod tests {
                 active_jobs: 0,
                 queued_jobs: 0,
                 cached_toolchains: vec![],
+                source_bundle_capacity: Some(crate::node::lean::source_bundle_capacity()),
                 lean_runtime_ready: Some(true),
             })
         }
@@ -242,6 +243,10 @@ mod tests {
         };
         let heartbeat = client.heartbeat(&node, "unused").await.unwrap();
         assert_eq!(heartbeat.capacity_available, 1);
+        assert_eq!(
+            heartbeat.source_bundle_capacity,
+            Some(crate::node::lean::source_bundle_capacity())
+        );
         assert_eq!(heartbeat.labels, vec!["lean".to_string()]);
         assert_eq!(heartbeat.lean_runtime_ready, Some(true));
     }

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use super::client::RemoteNodeClient;
-use super::protocol::NodeHeartbeat;
+use super::protocol::{NodeHeartbeat, SourceBundleRequirement};
 use super::{RemoteNodeConfig, RemoteNodeSettings, RemoteNodeStatus};
 
 /// Consecutive missed probes after which a node is considered `Offline`
@@ -398,6 +398,31 @@ pub fn select_node_auto_with_protocol_and_resource_reservations(
     reservations: &HashMap<String, u32>,
     disk_reservations: &HashMap<String, u64>,
 ) -> Result<String, PlacementError> {
+    select_node_auto_with_source_and_resource_reservations(
+        nodes,
+        statuses,
+        requirements,
+        min_disk_bytes,
+        min_mem_bytes,
+        min_protocol_version,
+        None,
+        reservations,
+        disk_reservations,
+    )
+}
+
+#[allow(clippy::too_many_arguments)] // Pure placement inputs stay explicit for auditability.
+pub fn select_node_auto_with_source_and_resource_reservations(
+    nodes: &[RemoteNodeConfig],
+    statuses: &HashMap<String, CachedNodeStatus>,
+    requirements: &[String],
+    min_disk_bytes: u64,
+    min_mem_bytes: u64,
+    min_protocol_version: u32,
+    source: Option<SourceBundleRequirement>,
+    reservations: &HashMap<String, u32>,
+    disk_reservations: &HashMap<String, u64>,
+) -> Result<String, PlacementError> {
     let mut reasons: Vec<(String, String)> = Vec::new();
     // (queued, specialized, load, capacity, mem_avail, id)
     //
@@ -430,6 +455,12 @@ pub fn select_node_auto_with_protocol_and_resource_reservations(
                 ),
             ));
             continue;
+        }
+        if let Some(source) = source {
+            if let Err(reason) = source.check(heartbeat) {
+                reasons.push((node.id.clone(), reason));
+                continue;
+            }
         }
         if requirements.iter().any(|requirement| requirement == "lean")
             && heartbeat.lean_runtime_ready == Some(false)
@@ -609,15 +640,38 @@ impl FleetMonitor {
         reservations: &HashMap<String, u32>,
         disk_reservations: &HashMap<String, u64>,
     ) -> Result<String, PlacementError> {
+        self.place_auto_with_source_and_resource_reservations(
+            settings,
+            requirements,
+            min_disk_bytes,
+            min_protocol_version,
+            None,
+            reservations,
+            disk_reservations,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn place_auto_with_source_and_resource_reservations(
+        &self,
+        settings: &RemoteNodeSettings,
+        requirements: &[String],
+        min_disk_bytes: u64,
+        min_protocol_version: u32,
+        source: Option<SourceBundleRequirement>,
+        reservations: &HashMap<String, u32>,
+        disk_reservations: &HashMap<String, u64>,
+    ) -> Result<String, PlacementError> {
         let (nodes, mut cordoned_reasons) = self.partition_cordoned(&settings.nodes);
         let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
-        select_node_auto_with_protocol_and_resource_reservations(
+        select_node_auto_with_source_and_resource_reservations(
             &nodes,
             &statuses,
             requirements,
             min_disk_bytes,
             env_gb_bytes("REMOTE_NODE_MIN_MEM_GB", DEFAULT_MIN_MEM_GB),
             min_protocol_version,
+            source,
             reservations,
             disk_reservations,
         )
@@ -665,6 +719,7 @@ pub struct RemoteNodeView {
     pub disk_available_bytes: Option<u64>,
     pub cached_toolchains: Vec<String>,
     pub lean_runtime_ready: Option<bool>,
+    pub source_bundle_capacity: Option<super::protocol::SourceBundleCapacity>,
     pub last_seen: Option<DateTime<Utc>>,
     pub error: Option<String>,
     /// Operator-cordoned: still probed and listed, but excluded from
@@ -706,6 +761,7 @@ impl RemoteNodeView {
                 .map(|h| h.cached_toolchains.clone())
                 .unwrap_or_default(),
             lean_runtime_ready: heartbeat.and_then(|h| h.lean_runtime_ready),
+            source_bundle_capacity: heartbeat.and_then(|h| h.source_bundle_capacity),
             last_seen: cached.and_then(|c| c.last_seen),
             error: cached.and_then(|c| c.last_error.clone()),
             cordoned: false,
@@ -1268,6 +1324,90 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.reasons[0].1.contains("85 GiB reserved"));
+    }
+
+    #[test]
+    fn source_capacity_filters_mixed_fleet_before_ranking() {
+        use super::super::protocol::SourceBundleCapacity;
+        let nodes = vec![
+            node_config("a-old"),
+            node_config("b-small"),
+            node_config("z-capable"),
+        ];
+        let mut statuses = HashMap::new();
+        for node in &nodes {
+            let mut status = cached_online(&node.id, &["lean"], 100, 32, 2, 0, 0);
+            let hb = status.last_heartbeat.as_mut().unwrap();
+            hb.protocol_version = 4;
+            hb.source_bundle_capacity = match node.id.as_str() {
+                "b-small" => Some(SourceBundleCapacity {
+                    overlay_bytes: 8 << 20,
+                    complete_bytes: 8 << 20,
+                }),
+                "z-capable" => Some(SourceBundleCapacity {
+                    overlay_bytes: 1 << 20,
+                    complete_bytes: 32 << 20,
+                }),
+                _ => None,
+            };
+            statuses.insert(node.id.clone(), status);
+        }
+        let pick = |statuses: &HashMap<String, CachedNodeStatus>, bytes, complete| {
+            select_node_auto_with_source_and_resource_reservations(
+                &nodes,
+                statuses,
+                &["lean".to_string()],
+                20 * GIB,
+                8 * GIB,
+                if complete { 4 } else { 3 },
+                Some(SourceBundleRequirement { bytes, complete }),
+                &HashMap::new(),
+                &HashMap::new(),
+            )
+        };
+        // Old v4 remains compatible at its historical complete ceiling.
+        assert_eq!(pick(&statuses, 16 << 20, true).unwrap(), "a-old");
+        assert_eq!(pick(&statuses, (16 << 20) + 1, true).unwrap(), "z-capable");
+        assert_eq!(pick(&statuses, 32 << 20, true).unwrap(), "z-capable");
+        assert_eq!(pick(&statuses, 1 << 20, false).unwrap(), "a-old");
+        assert_eq!(pick(&statuses, (1 << 20) + 1, false).unwrap(), "b-small");
+        assert!(pick(&statuses, (32 << 20) + 1, true)
+            .unwrap_err()
+            .reasons
+            .iter()
+            .all(|(_, reason)| reason.contains("receiver capacity")));
+        // Ranking and even spare slots must never rescue an undersized node.
+        statuses
+            .get_mut("z-capable")
+            .unwrap()
+            .last_heartbeat
+            .as_mut()
+            .unwrap()
+            .active_jobs = 2;
+        assert_eq!(pick(&statuses, 25 << 20, true).unwrap(), "z-capable");
+        statuses.get_mut("z-capable").unwrap().status = RemoteNodeStatus::Offline;
+        let err = pick(&statuses, 25 << 20, true).unwrap_err();
+        assert_eq!(err.reasons.len(), 3);
+        assert!(err
+            .reasons
+            .iter()
+            .any(|(id, reason)| id == "b-small" && reason.contains("8388608")));
+        // Configured ceilings below legacy defaults apply to small payloads too.
+        let hb = statuses["b-small"].last_heartbeat.as_ref().unwrap();
+        assert!(SourceBundleRequirement {
+            bytes: (8 << 20) + 1,
+            complete: true
+        }
+        .check(hb)
+        .is_err());
+        assert!(SourceBundleRequirement {
+            bytes: 8 << 20,
+            complete: true
+        }
+        .check(hb)
+        .is_ok());
+        let view = RemoteNodeView::from_cache(&nodes[1], statuses.get("b-small"));
+        assert_eq!(view.source_bundle_capacity, hb.source_bundle_capacity);
     }
 
     #[test]

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -85,6 +85,7 @@ pub struct NodeHeartbeat {
 }
 
 /// Decoded file-byte limits enforced by the receiver for each bundle mode.
+/// Core separately gates the exact serialized job against the HTTP body limit.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceBundleCapacity {
     pub overlay_bytes: u64,

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -19,6 +19,10 @@ pub const NODE_PROTOCOL_VERSION: u32 = 4;
 /// First protocol that reports `active_jobs` and `queued_jobs` in heartbeats.
 pub const NODE_JOB_COUNTER_PROTOCOL_VERSION: u32 = 2;
 
+/// HTTP body ceiling for source submissions: gzip on core ingress, plain JSON
+/// on node ingress. Keep independent from the decoded-source and gzip expansion caps.
+pub const MAX_SOURCE_REQUEST_BODY_BYTES: usize = 50 * 1024 * 1024;
+
 /// Lease scope for the synchronous `/execute` path.
 pub const SCOPE_MISSION_EXECUTE: &str = "mission:execute";
 

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -34,7 +34,7 @@ fn default_protocol_version() -> u32 {
     1
 }
 
-/// Node heartbeat payload (v2).
+/// Node heartbeat payload (v4 with additive capacity reporting).
 ///
 /// All fields beyond the original v1 set are `#[serde(default)]`-tolerant so
 /// core can parse heartbeats from nodes that were not yet upgraded, and old
@@ -78,6 +78,72 @@ pub struct NodeHeartbeat {
     /// older node that predates readiness reporting.
     #[serde(default)]
     pub lean_runtime_ready: Option<bool>,
+    /// Effective decoded file-byte ceilings, including positive operator overrides.
+    /// Absent on legacy receivers; additive to v4, not a new payload protocol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_bundle_capacity: Option<SourceBundleCapacity>,
+}
+
+/// Decoded file-byte limits enforced by the receiver for each bundle mode.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceBundleCapacity {
+    pub overlay_bytes: u64,
+    pub complete_bytes: u64,
+}
+
+/// Placement input derived from actual base64 contents, never a caller estimate.
+#[derive(Debug, Clone, Copy)]
+pub struct SourceBundleRequirement {
+    pub complete: bool,
+    pub bytes: u64,
+}
+
+impl SourceBundleRequirement {
+    pub fn from_bundle(bundle: &SourceBundle) -> Result<Self, String> {
+        let mut bytes = 0u64;
+        for file in &bundle.files {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(&file.data_base64)
+                .map_err(|_| format!("invalid source bundle base64 for '{}'", file.path))?;
+            bytes = bytes
+                .checked_add(decoded.len() as u64)
+                .ok_or_else(|| "source bundle size overflow".to_string())?;
+        }
+        Ok(Self {
+            complete: bundle.complete,
+            bytes,
+        })
+    }
+
+    /// Legacy compatibility assumes the historical default ceilings. A legacy
+    /// heartbeat cannot reveal private overrides; larger payloads require an
+    /// explicit advertisement. Updated nodes always advertise their overrides.
+    pub fn check(self, heartbeat: &NodeHeartbeat) -> Result<(), String> {
+        let capacity = heartbeat
+            .source_bundle_capacity
+            .unwrap_or(SourceBundleCapacity {
+                overlay_bytes: 1 << 20,
+                complete_bytes: 16 << 20,
+            });
+        let limit = if self.complete {
+            capacity.complete_bytes
+        } else {
+            capacity.overlay_bytes
+        };
+        if self.bytes > limit {
+            return Err(format!(
+                "source bundle requires {} decoded bytes; receiver capacity is {}{}",
+                self.bytes,
+                limit,
+                if heartbeat.source_bundle_capacity.is_none() {
+                    " (legacy, unadvertised)"
+                } else {
+                    ""
+                }
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Legacy per-node status shape (kept for API compatibility).
@@ -374,6 +440,56 @@ mod tests {
     use super::*;
 
     #[test]
+    fn source_capacity_wire_and_actual_payload_size() {
+        let legacy = serde_json::json!({"node_id":"old", "online":true,
+            "capacity_total":1, "capacity_available":1, "active_leases":0,
+            "version":"old", "protocol_version":4});
+        let old: NodeHeartbeat = serde_json::from_value(legacy.clone()).unwrap();
+        assert_eq!(old.source_bundle_capacity, None);
+        let mut updated = legacy;
+        updated["source_bundle_capacity"] =
+            serde_json::json!({"overlay_bytes":2,"complete_bytes":3});
+        let hb: NodeHeartbeat = serde_json::from_value(updated.clone()).unwrap();
+        assert_eq!(
+            serde_json::to_value(&hb).unwrap()["source_bundle_capacity"],
+            updated["source_bundle_capacity"]
+        );
+        let mut bundle = SourceBundle {
+            manifest_sha256: String::new(),
+            complete: true,
+            deleted_paths: vec!["deleted".into()],
+            operations_sha256: None,
+            files: vec![
+                SourceBundleFile {
+                    path: "binary".into(),
+                    sha256: String::new(),
+                    data_base64: "AP8=".into(),
+                    executable: None,
+                },
+                SourceBundleFile {
+                    path: "text".into(),
+                    sha256: String::new(),
+                    data_base64: "YQ==".into(),
+                    executable: Some(true),
+                },
+            ],
+        };
+        let source = SourceBundleRequirement::from_bundle(&bundle).unwrap();
+        assert_eq!(source.bytes, 3); // decoded bytes, not base64 length or deletion metadata
+        assert!(source.check(&hb).is_ok());
+        bundle.complete = false;
+        assert!(SourceBundleRequirement::from_bundle(&bundle)
+            .unwrap()
+            .check(&hb)
+            .is_err());
+        bundle.files[0].data_base64 = "!bad".into();
+        assert!(SourceBundleRequirement::from_bundle(&bundle).is_err());
+        let mut zero = hb;
+        zero.source_bundle_capacity.as_mut().unwrap().complete_bytes = 0;
+        assert!(source.check(&zero).is_err()); // zero is not a missing capability
+    }
+
+    #[test]
     fn validates_scoped_lease_token() {
         let mission_id = Uuid::new_v4();
         let claims = LeaseClaims {
@@ -657,6 +773,7 @@ mod tests {
             active_jobs: 1,
             queued_jobs: 2,
             cached_toolchains: vec![],
+            source_bundle_capacity: None,
             lean_runtime_ready: Some(true),
         };
         let json = serde_json::to_string(&heartbeat).unwrap();


### PR DESCRIPTION
Complete recursive source and receipt snapshots exceed the old 16 MiB decoded-source default, and the combined fixture exceeds the old 32 MiB JSON decoder cap. This PR raises complete-source defaults to 32 MiB at sender and receiver and bounds API JSON decoding at 64 MiB, preserving both 50 MiB HTTP caps, overlay limits, operator overrides, recursive source fidelity, and receipt/resume semantics.

During rolling upgrades, old v4 receivers still have a 16 MiB default. Nodes now advertise `source_bundle_capacity` with their effective complete/overlay byte ceilings, using the receiver's validation limit function. Core measures actual decoded payload bytes before dispatch and gates automatic selection, re-probe selection, and explicit placement. A 25 MiB complete bundle skips an old v4 receiver and a configured 8 MiB receiver, selecting an advertised capable receiver; if none is eligible, placement returns 503 before submission. Receiver 400/422 errors retain their caller-error behavior and accepted jobs are not resubmitted.

The additive heartbeat field preserves protocol v4 for full snapshots and v3 for basic overlays. Legacy nodes remain compatible through the historical 16 MiB complete / 1 MiB overlay defaults. Legacy private overrides cannot be inferred; receivers with smaller overrides must be updated to advertise them. Updated ceilings are honored even below legacy defaults. Fleet API and `get_compute_fleet` expose the capability. Old backends ignore it and must be updated before enabling larger submissions.

Core also counts the exact serialized node job after minting its lease and before recording a tentative job or dispatching. A raised decoded-byte override cannot bypass the unchanged 50 MiB node JSON limit: a 38 MiB source bundle, metadata inflation, or JSON escaping that pushes the final envelope above the limit returns 503 before any submission. The count uses a non-allocating writer and the same compact JSON serialization as the node client.

The receiver also rejects noncanonical bundle entry/deletion paths before any filesystem mutation. Crafted `./Root.lean` and `Root.lean` aliases are rejected without normalizing manifest identity. Existing path, privacy, symlink, recursive pin/index, and source-mode checks remain intact.

The four preserved pristine recursive captures contain 15,309,625 to 25,322,173 decoded bytes. The combined capture retains all 2,382 file byte/mode versions, including pinned `lido-core`, nested `forge-std`, and receipts. Reproduction commands, pins, counts, digests, and union provenance are described in `docs/REMOTE_SOURCE_CAPACITY.md`. No source was pruned and no Lido proof code was changed.

Validation covers mixed old/new fleets, explicit nodes, insufficient capacity, a busy capable receiver, smaller configured limits, actual binary payload sizes, old/new heartbeat parsing, and fleet-tool output. The 32 MiB loopback test fetches both heartbeat shapes, rejects old-only placement, selects the capable receiver, validates its serialized job envelope, and asserts zero requests to the old `/jobs` route. Existing boundary, canonical-path, recursive-source, privacy, and receipt tests remain.

Review head: `ca22aa28c3196f4c38c0ba889706705c7a0e70e6`, tree `59a386ba9b2cd6b98397736f45e7fb35ad058534`.

Validation on this source: 25 API, 41 receiver, 55 fleet/protocol/client, six node-binary and one fleet-tool tests passed. All four preserved captures additionally passed exact byte/mode materialization and capacity/receiver agreement under default and 16 MiB ceilings. Exact 50 MiB JSON succeeds; +1, escaping overhead, and a 38 MiB bundle under a 64 MiB decoded advertisement are rejected before dispatch. All seven current [CI jobs](https://github.com/Th0rgal/sandboxed.sh/actions/runs/34138884736) passed, including full Rust, Clippy, harness, and the 29 Python source tests.

DEBUG Linux node and wrapper are staged from this exact successor in the isolated mission at `output/transport-debug-ca22aa28c3196f4c38c0ba889706705c7a0e70e6/`. Source, test-binary, CI, preservation and staged-artifact receipts are in `output/wire-size-fix/`. The earlier local Rust 1.93 strict Clippy failure on two unchanged monitoring casts is preserved separately; final GitHub strict Clippy passed without unrelated source edits.

The `6a96a171` and intermediate `75f90428` stages remain preserved superseded candidates. Independent successor re-review remains required; both P2 threads are left open for disposition. Supervisor backend integration must use this successor's transport changes or a reviewed descendant. No merge, installation, deployment, production changes, source pruning, or accepted-job resubmission.
