### PR TITLE
fix: distinguish project ACKs from pending decisions

### DIFF
--- a/docs/plans/DEFECT_CALLBACK_CONTROLLER_WAKE.md
+++ b/docs/plans/DEFECT_CALLBACK_CONTROLLER_WAKE.md
@@ -1,0 +1,46 @@
+# Defect: callback-to-controller wake gap
+
+Filed: 2026-09-09
+Severity: P2
+Status: open
+
+## Problem
+
+`patches/hermes/mission_status_route.py:46` defines the wake prompt for
+mission-complete callbacks routed into the operator chat. That prompt
+forbids tools (`"do not run tools"`), so the woken assistant can only
+summarise the completion — it cannot trigger the project controller to
+process the finished mission.
+
+The hourly controller cron is currently the only mechanism that picks up
+completions. Between hourly ticks, finished missions sit idle.
+
+## Constraint
+
+The operator chat is a single-writer session. Allowing the wake prompt
+to run tools would create two concurrent writers (the operator and the
+wake-triggered assistant), which risks interleaving, lock contention on
+the session DB, and duplicate work.
+
+## Required fix
+
+A deterministic, deduped wake of the **owner controller** — not the
+operator chat. When a terminal callback arrives:
+
+1. Identify the owning project's controller cron job.
+2. Schedule an immediate (or near-immediate) one-shot wake of that
+   controller, deduped so multiple callbacks within the same window
+   collapse into one wake.
+3. The controller processes completions in its own single-writer session.
+
+### What NOT to do
+
+- Do **not** enable tools in the operator wake prompt (two writers).
+- Do **not** increase hourly polling frequency (wasteful, still has a
+  latency window, and scales poorly with project count).
+
+## Affected paths
+
+- `patches/hermes/mission_status_route.py` — callback routing and wake
+- Controller cron scheduling (needs a "wake now" trigger)
+- Possibly `src/api/control/mod.rs` — controller dispatch

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4496,103 +4496,68 @@ impl ControlHub {
         &self,
         project: &str,
     ) -> Result<Vec<Mission>, String> {
-        const PAGE_SIZE: usize = 200;
         let keys = super::projects_overview::project_tag_keys(project);
         if keys.is_empty() {
             return Ok(Vec::new());
         }
-        let inventory = self.mission_store_inventory().await?;
+        Self::collect_attention_inventory(self.mission_store_inventory().await?, &keys).await
+    }
+
+    /// A roster is usable as negative evidence only when every store and page
+    /// was read successfully. Never turn a skipped store into an empty result.
+    async fn collect_attention_inventory(
+        inventory: MissionStoreInventory,
+        keys: &[String],
+    ) -> Result<Vec<Mission>, String> {
+        const PAGE_SIZE: usize = 200;
         let mut collected = Vec::new();
-        let mut seen: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
-        let mut push = |mission: Mission| {
-            if seen.insert(mission.id) {
-                collected.push(mission);
-            }
-        };
-        for store in inventory.live {
-            for key in &keys {
-                let filter = mission_store::MissionFilter {
-                    project: Some(key.clone()),
-                    attention_only: true,
-                    ..Default::default()
-                };
-                let mut offset = 0;
-                loop {
-                    let page = match store
-                        .list_missions_filtered(&filter, PAGE_SIZE, offset)
-                        .await
-                    {
-                        Ok(page) => page,
-                        Err(error) => {
-                            tracing::warn!(
-                                project = %key,
-                                %error,
-                                "attention collect: live store list failed"
-                            );
-                            break;
-                        }
-                    };
-                    let page_len = page.len();
-                    for mission in page {
-                        push(mission);
-                    }
-                    if page_len < PAGE_SIZE {
-                        break;
-                    }
-                    offset += page_len;
-                }
-            }
-        }
+        let mut seen = std::collections::HashSet::new();
+        let mut stores = inventory.live;
         for user in inventory.offline_file_users {
-            let store =
-                match mission_store::FileMissionStore::new(inventory.base_dir.clone(), &user).await
-                {
-                    Ok(store) => store,
-                    Err(error) => {
-                        tracing::warn!(%user, %error, "attention collect: file store skipped");
-                        continue;
-                    }
-                };
-            for key in &keys {
-                let filter = mission_store::MissionFilter {
-                    project: Some(key.clone()),
-                    attention_only: true,
-                    ..Default::default()
-                };
-                if let Ok(page) = store.list_missions_filtered(&filter, PAGE_SIZE, 0).await {
-                    for mission in page {
-                        push(mission);
+            stores.push(Arc::new(
+                mission_store::FileMissionStore::new(inventory.base_dir.clone(), &user).await?,
+            ));
+        }
+        let filters: Vec<_> = keys
+            .iter()
+            .map(|key| mission_store::MissionFilter {
+                project: Some(key.clone()),
+                attention_only: true,
+                ..Default::default()
+            })
+            .collect();
+        for store in stores {
+            let mut offset = 0;
+            loop {
+                // The trait's filtered-list fallback stops after 5000 raw
+                // rows. Scan raw pages once so old waits cannot disappear.
+                let page = store.list_missions(PAGE_SIZE, offset).await?;
+                let page_len = page.len();
+                for mission in page {
+                    if filters.iter().any(|filter| filter.matches(&mission))
+                        && seen.insert(mission.id)
+                    {
+                        collected.push(mission);
                     }
                 }
+                if page_len < PAGE_SIZE {
+                    break;
+                }
+                offset += page_len;
             }
         }
         for path in inventory.offline_sqlite {
-            for key in keys.clone() {
-                let path_for_scan = path.clone();
-                let path_label = path.display().to_string();
-                match tokio::task::spawn_blocking(move || {
-                    collect_attention_missions_from_sqlite(&path_for_scan, &key)
+            for key in keys {
+                let path = path.clone();
+                let key = key.clone();
+                let rows = tokio::task::spawn_blocking(move || {
+                    collect_attention_missions_from_sqlite(&path, &key)
                 })
                 .await
-                {
-                    Ok(Ok(rows)) => {
-                        for mission in rows {
-                            push(mission);
-                        }
-                    }
-                    Ok(Err(error)) => {
-                        tracing::warn!(
-                            path = %path_label,
-                            %error,
-                            "attention collect: offline sqlite skipped"
-                        );
-                    }
-                    Err(error) => {
-                        tracing::warn!(
-                            path = %path_label,
-                            %error,
-                            "attention collect: offline sqlite join failed"
-                        );
+                .map_err(|error| error.to_string())??;
+                for mission in rows {
+                    if seen.insert(mission.id) {
+                        collected.push(mission);
                     }
                 }
             }
@@ -7255,56 +7220,65 @@ fn collect_attention_missions_from_sqlite(
     if !columns.contains("project") {
         return Ok(Vec::new());
     }
-    let has_tags = columns.contains("tags");
-    let sql = if has_tags {
-        "SELECT id, status, title, workspace_id, backend, created_at, updated_at, \
-         project, track, intent, github_pr, tags \
-         FROM missions WHERE project = ?1 AND status NOT IN ('acknowledged', 'completed')"
-    } else {
-        "SELECT id, status, title, workspace_id, backend, created_at, updated_at, \
-         project, track, intent, github_pr, NULL \
-         FROM missions WHERE project = ?1 AND status NOT IN ('acknowledged', 'completed')"
+    let optional = |name: &str| {
+        if columns.contains(name) {
+            name.to_string()
+        } else {
+            "NULL".into()
+        }
     };
-    let mut statement = connection.prepare(sql).map_err(|error| error.to_string())?;
+    let sql = format!(
+        "SELECT id, status, title, workspace_id, backend, created_at, updated_at, \
+         project, track, intent, github_pr, {}, {}, {}, {} \
+         FROM missions WHERE project = ?1 AND status NOT IN ('acknowledged', 'completed')",
+        optional("tags"),
+        optional("awaiting_kind"),
+        optional("origin_session_id"),
+        optional("last_status_change_at")
+    );
+    let mut statement = connection
+        .prepare(&sql)
+        .map_err(|error| error.to_string())?;
     let rows = statement
         .query_map([project], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, Option<String>>(2)?,
-                row.get::<_, Option<String>>(3)?,
-                row.get::<_, Option<String>>(4)?,
-                row.get::<_, Option<String>>(5)?,
-                row.get::<_, Option<String>>(6)?,
-                row.get::<_, Option<String>>(7)?,
-                row.get::<_, Option<String>>(8)?,
-                row.get::<_, Option<String>>(9)?,
-                row.get::<_, Option<String>>(10)?,
-                row.get::<_, Option<String>>(11)?,
-            ))
+            let mut fields = Vec::new();
+            for index in 0..15 {
+                fields.push(row.get::<_, Option<String>>(index)?);
+            }
+            Ok(fields)
         })
         .map_err(|error| error.to_string())?;
     let mut collected = Vec::new();
     for row in rows {
-        let (
-            id,
-            status,
-            title,
-            workspace_id,
-            backend,
-            created_at,
-            updated_at,
-            project,
-            track,
-            intent,
-            github_pr,
-            tags_raw,
-        ) = row.map_err(|error| error.to_string())?;
-        let Ok(id) = Uuid::parse_str(&id) else {
-            continue;
-        };
-        let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status))
-            .unwrap_or(MissionStatus::Active);
+        let fields = row.map_err(|error| error.to_string())?;
+        let mut fields = fields.into_iter();
+        let id = fields.next().flatten().ok_or("missing mission id")?;
+        let status_raw = fields.next().flatten().ok_or("missing mission status")?;
+        let title = fields.next().flatten();
+        let workspace_id = fields.next().flatten();
+        let backend = fields.next().flatten();
+        let created_at = fields.next().flatten();
+        let updated_at = fields.next().flatten();
+        let project = fields.next().flatten();
+        let track = fields.next().flatten();
+        let intent = fields.next().flatten();
+        let github_pr = fields.next().flatten();
+        let tags_raw = fields.next().flatten();
+        let awaiting_kind_raw = fields.next().flatten();
+        let origin_session_id = fields.next().flatten();
+        let last_status_change_at = fields.next().flatten();
+        let id = Uuid::parse_str(&id).map_err(|error| error.to_string())?;
+        let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status_raw))
+            .map_err(|error| error.to_string())?;
+        let awaiting_kind = awaiting_kind_raw
+            .map(|raw| {
+                serde_json::from_value::<AwaitingKind>(serde_json::Value::String(raw))
+                    .map_err(|error| error.to_string())
+            })
+            .transpose()?;
+        if status == MissionStatus::AwaitingUser && awaiting_kind.is_none() {
+            return Err(format!("offline mission {id} has unknown awaiting kind"));
+        }
         let tags: Vec<String> = tags_raw
             .as_deref()
             .and_then(|raw| serde_json::from_str(raw).ok())
@@ -7328,6 +7302,9 @@ fn collect_attention_missions_from_sqlite(
         mission.project.intent = intent;
         mission.project.github_pr = github_pr;
         mission.project.tags = tags;
+        mission.awaiting_kind = awaiting_kind;
+        mission.origin_session_id = origin_session_id;
+        mission.activity.last_status_change_at = last_status_change_at;
         if crate::api::mission_store::default_attention_keeps(&mission) {
             collected.push(mission);
         }
@@ -29052,6 +29029,86 @@ mod tests {
         assert!(mission_is_pr_writer_in_store(&store, &projected)
             .await
             .unwrap());
+    }
+
+    #[tokio::test]
+    async fn attention_inventory_rejects_partial_store_results() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(Some("visible worker"), None, None, None, None, None, None)
+            .await
+            .unwrap();
+        store
+            .update_mission_project(
+                mission.id,
+                MissionProjectPatch {
+                    project: Some(Some("eip-8282".into())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        for _ in 0..5001 {
+            store
+                .create_mission(
+                    Some("unrelated newer work"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+        let keys = vec!["eip-8282".to_string()];
+        let inventory = |paths| MissionStoreInventory {
+            live: vec![store.clone()],
+            offline_sqlite: paths,
+            offline_file_users: vec![],
+            base_dir: dir.path().to_path_buf(),
+        };
+        let complete = ControlHub::collect_attention_inventory(inventory(vec![]), &keys)
+            .await
+            .unwrap();
+        assert_eq!(complete.len(), 1);
+        let unavailable = dir.path().join("missing.db");
+        let partial =
+            ControlHub::collect_attention_inventory(inventory(vec![unavailable]), &keys).await;
+        assert!(
+            partial.is_err(),
+            "successful live rows cannot hide an unavailable offline store"
+        );
+    }
+
+    #[test]
+    fn offline_attention_preserves_decision_and_grace_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions.db");
+        let db = rusqlite::Connection::open(&path).unwrap();
+        db.execute_batch("CREATE TABLE missions (id TEXT, status TEXT, title TEXT, workspace_id TEXT, backend TEXT, created_at TEXT, updated_at TEXT, project TEXT, track TEXT, intent TEXT, github_pr TEXT, awaiting_kind TEXT, origin_session_id TEXT, last_status_change_at TEXT);").unwrap();
+        let id = Uuid::new_v4().to_string();
+        let now = chrono::Utc::now();
+        let recent = now.to_rfc3339();
+        let expired = (now - chrono::Duration::hours(1)).to_rfc3339();
+        db.execute("INSERT INTO missions(id,status,project,awaiting_kind,origin_session_id,last_status_change_at,updated_at) VALUES (?1,'awaiting_user','eip-8282','decision','hermes-session',?2,?3)", rusqlite::params![id,recent,expired]).unwrap();
+        let rows = collect_attention_missions_from_sqlite(&path, "eip-8282").unwrap();
+        assert_eq!(rows[0].awaiting_kind, Some(AwaitingKind::Decision));
+        assert_eq!(rows[0].origin_session_id.as_deref(), Some("hermes-session"));
+        assert!(!crate::api::operator_attention::mission_needs_operator(
+            &rows[0], false, None, now
+        ));
+        db.execute("UPDATE missions SET last_status_change_at=?1", [&expired])
+            .unwrap();
+        let rows = collect_attention_missions_from_sqlite(&path, "eip-8282").unwrap();
+        assert!(crate::api::operator_attention::mission_needs_operator(
+            &rows[0], false, None, now
+        ));
+        db.execute("UPDATE missions SET awaiting_kind=NULL", [])
+            .unwrap();
+        assert!(collect_attention_missions_from_sqlite(&path, "eip-8282").is_err());
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4435,19 +4435,26 @@ impl ControlHub {
     /// Live AskUserQuestion waits: mission id → user-wait tool `started_at`.
     /// Presence means `WaitingUser`; the value is the grace clock (None if the
     /// tool row is not registered yet — treated as just started).
-    pub(crate) async fn collect_waiting_user_waits(&self) -> HashMap<Uuid, Option<String>> {
+    ///
+    /// Returns `(waits, complete)`. When `complete` is false at least one store
+    /// or page failed — the map is a best-effort subset, not negative evidence.
+    pub(crate) async fn collect_waiting_user_waits(
+        &self,
+    ) -> (HashMap<Uuid, Option<String>>, bool) {
         let mut waits = HashMap::new();
         let Ok(inventory) = self.mission_store_inventory().await else {
-            return waits;
+            return (waits, false);
         };
+        let mut complete = true;
         for store in inventory.live {
             let Ok(runs) = store.list_active_mission_runs().await else {
+                complete = false;
                 continue;
             };
             let store_waits = user_wait_starts_for_runs(store.as_ref(), &runs).await;
             waits.extend(store_waits);
         }
-        waits
+        (waits, complete)
     }
 
     /// Board tasks across every store whose boss mission belongs to this

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -628,15 +628,15 @@ pub async fn get_project(
     let requested = slug;
     let resolved = resolve_roster_slug(&state.projects, &requested).map_err(store_err)?;
     let lookup = resolved.as_deref().unwrap_or(&requested).to_string();
-    let missions = match state
+    let (missions, missions_available) = match state
         .control
         .collect_attention_missions_for_project(&lookup)
         .await
     {
-        Ok(missions) => missions,
+        Ok(missions) => (missions, true),
         Err(error) => {
             tracing::warn!(project = %lookup, %error, "get_project: attention collect failed");
-            Vec::new()
+            (Vec::new(), false)
         }
     };
     let slug = match resolved {
@@ -685,20 +685,11 @@ pub async fn get_project(
     ) {
         project.next_action = Some(derived);
     }
-    let has_live = missions
-        .iter()
-        .any(|mission| super::controller_honesty::is_live_writer_status(mission.status));
-    let needs_operator = missions.iter().any(|mission| {
-        mission.awaiting_kind.is_some()
-            && matches!(
-                mission.status,
-                crate::api::control::events::MissionStatus::AwaitingUser
-            )
-    });
-    project.mode = honest_controller_mode(
+    let waiting_user_waits = state.control.collect_waiting_user_waits().await;
+    project.mode = project_mode_from_missions(
         project.mode.as_deref(),
-        has_live,
-        needs_operator,
+        missions_available.then_some(missions.as_slice()),
+        &waiting_user_waits,
         decisions.len() as u32,
     );
     Ok(Json(serde_json::json!({
@@ -2816,7 +2807,42 @@ pub(crate) fn honest_controller_mode(
     if pending_decisions > 0 || needs_operator {
         return Some("blocked:decision".to_string());
     }
+    // A prior decision block is a derived state, not a durable pause. Once
+    // its evidence disappears, clear it rather than making the controller
+    // wait for a decision that no longer exists. Other blockers remain intact.
+    if store_mode.is_some_and(|mode| mode.eq_ignore_ascii_case("blocked:decision")) {
+        return None;
+    }
     store_mode.map(str::to_string)
+}
+
+/// Use the same qualified mission attention as the board, including live
+/// AskUserQuestion waits. A completed report awaiting ACK is not a decision.
+fn project_mode_from_missions(
+    store_mode: Option<&str>,
+    missions: Option<&[Mission]>,
+    waiting_user_waits: &HashMap<uuid::Uuid, Option<String>>,
+    pending_decisions: u32,
+) -> Option<String> {
+    // A failed collection is unknown evidence, not an empty roster. Preserve
+    // the last mode until a successful read can establish that a wait ended.
+    let Some(missions) = missions else {
+        return store_mode.map(str::to_string);
+    };
+    let has_live = missions
+        .iter()
+        .any(|mission| super::controller_honesty::is_live_writer_status(mission.status));
+    let needs_operator = missions.iter().any(|mission| {
+        mission_chip(
+            mission,
+            waiting_user_waits.contains_key(&mission.id),
+            waiting_user_waits
+                .get(&mission.id)
+                .and_then(|started| started.as_deref()),
+        )
+        .needs_operator
+    });
+    honest_controller_mode(store_mode, has_live, needs_operator, pending_decisions)
 }
 
 struct ProjectRowBuilder {
@@ -3002,7 +3028,7 @@ impl ProjectRowBuilder {
         let has_live_mission = self
             .missions
             .iter()
-            .any(|chip| !chip.status.is_terminal() && chip.status != MissionStatus::Acknowledged);
+            .any(|chip| super::controller_honesty::is_live_writer_status(chip.status));
         // Live work and parked decisions beat the last CTRL trailer. A
         // writer already running is `active` even if the last cron said
         // `blocked:cannot-merge`; a pending question with no writer is
@@ -5346,6 +5372,122 @@ mod tests {
         assert_eq!(
             honest_controller_mode(Some("active"), true, false, 0).as_deref(),
             Some("active")
+        );
+    }
+
+    #[test]
+    fn project_detail_and_board_agree_on_ack_decision_and_live_waits() {
+        let now = chrono::Utc::now();
+        let old = (now - chrono::Duration::hours(1)).to_rfc3339();
+        let fresh = now.to_rfc3339();
+        for (kind, origin, timestamp, live_wait, expected) in [
+            ("ack", Some("hermes-session"), old.as_str(), false, None),
+            (
+                "decision",
+                None,
+                old.as_str(),
+                false,
+                Some("blocked:decision"),
+            ),
+            (
+                "decision",
+                Some("hermes-session"),
+                fresh.as_str(),
+                false,
+                None,
+            ),
+            (
+                "decision",
+                Some("hermes-session"),
+                old.as_str(),
+                false,
+                Some("blocked:decision"),
+            ),
+            ("ack", None, old.as_str(), true, Some("blocked:decision")),
+        ] {
+            let mission: Mission = serde_json::from_value(serde_json::json!({
+                "id": uuid::Uuid::new_v4(), "status": if live_wait { "active" } else { "awaiting_user" },
+                "history": [], "created_at": timestamp, "updated_at": timestamp,
+                "last_status_change_at": timestamp,
+                "awaiting_kind": kind, "origin_session_id": origin,
+            }))
+            .unwrap();
+            let mut waits = HashMap::new();
+            if live_wait {
+                waits.insert(mission.id, Some(timestamp.to_string()));
+            }
+            let mut board = ProjectRowBuilder::new("verity".into());
+            board.mode = Some("blocked:decision".into());
+            board.missions.push(mission_chip(
+                &mission,
+                live_wait,
+                live_wait.then_some(timestamp),
+            ));
+            let detail = project_mode_from_missions(
+                Some("blocked:decision"),
+                Some(std::slice::from_ref(&mission)),
+                &waits,
+                0,
+            );
+            assert_eq!(
+                detail.as_deref(),
+                expected,
+                "kind={kind}, origin={origin:?}"
+            );
+            assert_eq!(board.finish(&[], None, None, &fresh).mode, detail);
+            if kind == "ack" && !live_wait {
+                let mut active = mission.clone();
+                active.id = uuid::Uuid::new_v4();
+                active.status = MissionStatus::Active;
+                active.awaiting_kind = None;
+                let mut board = ProjectRowBuilder::new("verity".into());
+                board.mode = Some("blocked:decision".into());
+                board.missions.push(mission_chip(&mission, false, None));
+                board.missions.push(mission_chip(&active, false, None));
+                let detail = project_mode_from_missions(
+                    Some("blocked:decision"),
+                    Some(&[mission, active]),
+                    &waits,
+                    0,
+                );
+                assert_eq!(detail.as_deref(), Some("active"));
+                assert_eq!(board.finish(&[], None, None, &fresh).mode, detail);
+            }
+        }
+    }
+
+    #[test]
+    fn expired_decision_mode_clears_without_changing_pauses_or_other_blockers() {
+        assert_eq!(
+            project_mode_from_missions(Some("blocked:decision"), None, &HashMap::new(), 0)
+                .as_deref(),
+            Some("blocked:decision"),
+            "unavailable mission evidence cannot clear a real question"
+        );
+        assert_eq!(
+            project_mode_from_missions(Some("blocked:decision"), Some(&[]), &HashMap::new(), 0),
+            None,
+            "a successful empty roster can clear stale decision state"
+        );
+        assert_eq!(
+            honest_controller_mode(Some("blocked:decision"), false, false, 0),
+            None
+        );
+        assert_eq!(
+            honest_controller_mode(Some("blocked:decision"), true, false, 0).as_deref(),
+            Some("active")
+        );
+        assert_eq!(
+            honest_controller_mode(Some("paused:owner"), false, false, 0).as_deref(),
+            Some("paused:owner")
+        );
+        assert_eq!(
+            honest_controller_mode(Some("blocked:decision"), false, false, 1).as_deref(),
+            Some("blocked:decision")
+        );
+        assert_eq!(
+            honest_controller_mode(Some("blocked:transport-cap"), false, false, 0).as_deref(),
+            Some("blocked:transport-cap")
         );
     }
 

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -2827,6 +2827,9 @@ fn project_mode_from_missions(
     // A failed collection is unknown evidence, not an empty roster. Preserve
     // the last mode until a successful read can establish that a wait ended.
     let Some(missions) = missions else {
+        if pending_decisions > 0 {
+            return honest_controller_mode(store_mode, false, false, pending_decisions);
+        }
         return store_mode.map(str::to_string);
     };
     let has_live = missions
@@ -2963,7 +2966,6 @@ impl ProjectRowBuilder {
 
         self.missions
             .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-        self.missions.truncate(8);
 
         let mut attention: Vec<String> = Vec::new();
         let mut items: Vec<AttentionItem> = Vec::new();
@@ -3379,6 +3381,9 @@ impl ProjectRowBuilder {
         )
         .or(self.next_action);
 
+        // Truncation is display-only: mode, attention and next action above
+        // must use the complete roster, including older long-running work.
+        self.missions.truncate(8);
         ProjectRow {
             slug: self.slug,
             title,
@@ -5457,7 +5462,39 @@ mod tests {
     }
 
     #[test]
+    fn old_live_work_remains_visible_to_mode_under_eight_new_acks() {
+        let mut builder = ProjectRowBuilder::new("verity".into());
+        builder.mode = Some("blocked:decision".into());
+        let mut active = awaiting_chip("old-writer", false);
+        active.status = MissionStatus::Active;
+        active.updated_at = "2026-08-04T10:00:00Z".into();
+        builder.missions.push(active);
+        for i in 0..8 {
+            builder
+                .missions
+                .push(awaiting_chip(&format!("ack-{i}"), false));
+        }
+        let row = builder.finish(&[], None, None, "2026-08-04T12:00:00Z");
+        assert_eq!(row.mode.as_deref(), Some("active"));
+        assert_eq!(row.missions.len(), 8);
+        assert!(row
+            .missions
+            .iter()
+            .all(|mission| mission.id != "old-writer"));
+    }
+
+    #[test]
     fn expired_decision_mode_clears_without_changing_pauses_or_other_blockers() {
+        for stored in [None, Some("active"), Some("blocked:decision")] {
+            assert_eq!(
+                project_mode_from_missions(stored, None, &HashMap::new(), 1).as_deref(),
+                Some("blocked:decision")
+            );
+        }
+        assert_eq!(
+            project_mode_from_missions(Some("paused:owner"), None, &HashMap::new(), 1).as_deref(),
+            Some("paused:owner")
+        );
         assert_eq!(
             project_mode_from_missions(Some("blocked:decision"), None, &HashMap::new(), 0)
                 .as_deref(),

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -655,7 +655,22 @@ pub async fn get_project(
     };
     let grant = state.projects.get_grant(&slug).map_err(store_err)?;
     let tracks = collect_family_tracks(&state.projects, &slug).map_err(store_err)?;
-    let decisions = state.projects.open_decisions(&slug).map_err(store_err)?;
+    let decisions = {
+        let mut all = state.projects.open_decisions(&slug).map_err(store_err)?;
+        let mut seen: std::collections::HashSet<String> =
+            all.iter().map(|d| d.at.clone()).collect();
+        for key in project_tag_keys(&slug) {
+            if key == slug {
+                continue;
+            }
+            for d in state.projects.open_decisions(&key).map_err(store_err)? {
+                if seen.insert(d.at.clone()) {
+                    all.push(d);
+                }
+            }
+        }
+        all
+    };
     let recent = state
         .projects
         .recent_activity(&slug, 20)
@@ -685,10 +700,16 @@ pub async fn get_project(
     ) {
         project.next_action = Some(derived);
     }
-    let waiting_user_waits = state.control.collect_waiting_user_waits().await;
+    let (waiting_user_waits, waits_complete) =
+        state.control.collect_waiting_user_waits().await;
+    let effective_missions = if missions_available && waits_complete {
+        Some(missions.as_slice())
+    } else {
+        None
+    };
     project_mode_projection(
         &mut project,
-        missions_available.then_some(missions.as_slice()),
+        effective_missions,
         &waiting_user_waits,
         decisions.len() as u32,
     );
@@ -2357,7 +2378,8 @@ pub async fn projects_overview(
         .collect_project_missions(chrono::Duration::hours(TERMINAL_MISSION_HORIZON_HOURS))
         .await
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?;
-    let waiting_user_waits = state.control.collect_waiting_user_waits().await;
+    let (waiting_user_waits, _waits_complete) =
+        state.control.collect_waiting_user_waits().await;
 
     // Delivery-derived facts come from the projects store, which the
     // background ingestor keeps current — the overview never scans the Hermes
@@ -7265,5 +7287,59 @@ mod tests {
             vec!["mission_failed|a".to_string(), "no_controller|".to_string()]
         );
         assert!(resolved_keys(&current, &current).is_empty());
+    }
+
+    #[test]
+    fn incomplete_wait_inventory_preserves_stored_decision_mode() {
+        let store =
+            super::super::projects_store::ProjectsStore::open_in_memory().unwrap();
+        store
+            .upsert_project("verity", None, None, None, None)
+            .unwrap();
+        store
+            .set_mode("verity", "blocked", None, Some("decision"))
+            .unwrap();
+        let record = store.get_project("verity").unwrap().unwrap();
+        let mut with_complete = record.clone();
+        project_mode_projection(&mut with_complete, Some(&[]), &HashMap::new(), 0);
+        assert_eq!(with_complete.mode, None, "complete empty roster clears decision");
+
+        let mut with_incomplete = record.clone();
+        project_mode_projection(&mut with_incomplete, None, &HashMap::new(), 0);
+        assert_eq!(
+            with_incomplete.mode.as_deref(),
+            Some("blocked"),
+            "unavailable evidence preserves stored mode"
+        );
+        assert_eq!(with_incomplete.blocker.as_deref(), Some("decision"));
+    }
+
+    #[test]
+    fn alias_decisions_aggregate_across_tag_keys() {
+        let store =
+            super::super::projects_store::ProjectsStore::open_in_memory().unwrap();
+        store
+            .upsert_project("verity", None, None, None, None)
+            .unwrap();
+        store
+            .upsert_project("verity-lido", None, None, None, None)
+            .unwrap();
+        store
+            .record_decision(
+                "verity-lido",
+                &super::super::projects_store::NewDecision {
+                    question: "merge lido PR?".into(),
+                    rationale: None,
+                    kind: None,
+                    authority: "escalation".into(),
+                    status: "pending_user".into(),
+                    evidence: None,
+                },
+            )
+            .unwrap();
+        let canonical_only = store.open_decisions("verity").unwrap();
+        let alias_only = store.open_decisions("verity-lido").unwrap();
+        assert!(canonical_only.is_empty());
+        assert_eq!(alias_only.len(), 1);
     }
 }

--- a/src/api/projects_overview.rs
+++ b/src/api/projects_overview.rs
@@ -686,8 +686,8 @@ pub async fn get_project(
         project.next_action = Some(derived);
     }
     let waiting_user_waits = state.control.collect_waiting_user_waits().await;
-    project.mode = project_mode_from_missions(
-        project.mode.as_deref(),
+    project_mode_projection(
+        &mut project,
         missions_available.then_some(missions.as_slice()),
         &waiting_user_waits,
         decisions.len() as u32,
@@ -2784,6 +2784,44 @@ fn synthetic_project_record(slug: &str) -> super::projects_store::ProjectRecord 
     }
 }
 
+/// Persisted state uses a mode/blocker pair; legacy delivery strings may
+/// carry the reason after a colon. An explicit blocker wins over that suffix.
+fn is_decision_block(mode: Option<&str>, blocker: Option<&str>) -> bool {
+    let Some(mode) = mode else {
+        return false;
+    };
+    let (base, suffix) = mode
+        .split_once(':')
+        .map_or((mode, None), |(base, why)| (base, Some(why)));
+    base.eq_ignore_ascii_case("blocked")
+        && blocker
+            .or(suffix)
+            .is_some_and(|why| why.eq_ignore_ascii_case("decision"))
+}
+
+fn project_mode_projection(
+    project: &mut ProjectRecord,
+    missions: Option<&[Mission]>,
+    waits: &HashMap<uuid::Uuid, Option<String>>,
+    pending_decisions: u32,
+) {
+    let was_decision = is_decision_block(project.mode.as_deref(), project.blocker.as_deref());
+    project.mode = project_mode_from_missions(
+        project.mode.as_deref(),
+        project.blocker.as_deref(),
+        missions,
+        waits,
+        pending_decisions,
+    );
+    let decision_evidence = pending_decisions > 0
+        || missions.is_some_and(|rows| mission_roster_needs_operator(rows, waits));
+    if project.mode.as_deref() == Some("blocked:decision") && decision_evidence {
+        project.blocker = Some("decision".into());
+    } else if missions.is_some() && was_decision {
+        project.blocker = None;
+    }
+}
+
 /// Roster/CTRL mode is the default; live work and parked decisions win.
 /// `paused` is never overridden — the operator (or controller) parked it.
 /// Raw `awaiting_user` is not a decision block. A `pending_user` ledger row
@@ -2791,6 +2829,7 @@ fn synthetic_project_record(slug: &str) -> super::projects_store::ProjectRecord 
 /// qualified `needs_operator` page). Live work still wins.
 pub(crate) fn honest_controller_mode(
     store_mode: Option<&str>,
+    store_blocker: Option<&str>,
     has_live_mission: bool,
     needs_operator: bool,
     pending_decisions: u32,
@@ -2810,7 +2849,7 @@ pub(crate) fn honest_controller_mode(
     // A prior decision block is a derived state, not a durable pause. Once
     // its evidence disappears, clear it rather than making the controller
     // wait for a decision that no longer exists. Other blockers remain intact.
-    if store_mode.is_some_and(|mode| mode.eq_ignore_ascii_case("blocked:decision")) {
+    if is_decision_block(store_mode, store_blocker) {
         return None;
     }
     store_mode.map(str::to_string)
@@ -2820,6 +2859,7 @@ pub(crate) fn honest_controller_mode(
 /// AskUserQuestion waits. A completed report awaiting ACK is not a decision.
 fn project_mode_from_missions(
     store_mode: Option<&str>,
+    store_blocker: Option<&str>,
     missions: Option<&[Mission]>,
     waiting_user_waits: &HashMap<uuid::Uuid, Option<String>>,
     pending_decisions: u32,
@@ -2828,14 +2868,34 @@ fn project_mode_from_missions(
     // the last mode until a successful read can establish that a wait ended.
     let Some(missions) = missions else {
         if pending_decisions > 0 {
-            return honest_controller_mode(store_mode, false, false, pending_decisions);
+            return honest_controller_mode(
+                store_mode,
+                store_blocker,
+                false,
+                false,
+                pending_decisions,
+            );
         }
         return store_mode.map(str::to_string);
     };
     let has_live = missions
         .iter()
         .any(|mission| super::controller_honesty::is_live_writer_status(mission.status));
-    let needs_operator = missions.iter().any(|mission| {
+    let needs_operator = mission_roster_needs_operator(missions, waiting_user_waits);
+    honest_controller_mode(
+        store_mode,
+        store_blocker,
+        has_live,
+        needs_operator,
+        pending_decisions,
+    )
+}
+
+fn mission_roster_needs_operator(
+    missions: &[Mission],
+    waiting_user_waits: &HashMap<uuid::Uuid, Option<String>>,
+) -> bool {
+    missions.iter().any(|mission| {
         mission_chip(
             mission,
             waiting_user_waits.contains_key(&mission.id),
@@ -2844,8 +2904,7 @@ fn project_mode_from_missions(
                 .and_then(|started| started.as_deref()),
         )
         .needs_operator
-    });
-    honest_controller_mode(store_mode, has_live, needs_operator, pending_decisions)
+    })
 }
 
 struct ProjectRowBuilder {
@@ -2855,6 +2914,7 @@ struct ProjectRowBuilder {
     next_action: Option<String>,
     /// Roster mode + controller link, attached alongside title/next_action.
     mode: Option<String>,
+    mode_blocker: Option<String>,
     controller_cron_id: Option<String>,
     /// Last successful run of the linked controller job (scheduler-side
     /// heartbeat), resolved by the handler from the Hermes cron jobs file.
@@ -2886,6 +2946,7 @@ impl ProjectRowBuilder {
             title: None,
             next_action: None,
             mode: None,
+            mode_blocker: None,
             controller_cron_id: None,
             controller_heartbeat_at: None,
             tracker: None,
@@ -2917,6 +2978,7 @@ impl ProjectRowBuilder {
             self.title = record.title;
             self.next_action = record.next_action;
             self.mode = record.mode;
+            self.mode_blocker = record.blocker;
             self.controller_cron_id = record.controller_cron_id;
             self.mode_signal_at = mode_signal_at;
             return;
@@ -2925,9 +2987,12 @@ impl ProjectRowBuilder {
         if !canonical_has_roster {
             self.next_action = self.next_action.take().or(record.next_action);
         }
-        self.mode = self.mode.take().or(record.mode);
+        if self.mode.is_none() && record.mode.is_some() {
+            self.mode = record.mode;
+            self.mode_blocker = record.blocker;
+            self.mode_signal_at = mode_signal_at.clone();
+        }
         self.controller_cron_id = self.controller_cron_id.take().or(record.controller_cron_id);
-        self.mode_signal_at = self.mode_signal_at.take().or(mode_signal_at);
     }
 
     /// Attach the store-derived latest update: the newest state event plus the
@@ -2966,6 +3031,46 @@ impl ProjectRowBuilder {
 
         self.missions
             .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+
+        // Only qualified operator pages count as "awaiting user". Ack and
+        // in-grace controller-owned questions stay off the attention shelf.
+        let awaiting_user = self
+            .missions
+            .iter()
+            .filter(|chip| chip.needs_operator)
+            .count();
+        let has_live_mission = self
+            .missions
+            .iter()
+            .any(|chip| super::controller_honesty::is_live_writer_status(chip.status));
+        // Live work and parked decisions beat the last CTRL trailer. A
+        // writer already running is `active` even if the last cron said
+        // `blocked:cannot-merge`; a pending question with no writer is
+        // `blocked:decision`. Operator `paused` is never overridden.
+        let (stored_mode, stored_blocker) = if self.mode.is_some() {
+            (self.mode.as_deref(), self.mode_blocker.as_deref())
+        } else {
+            self.latest_update.as_ref().map_or((None, None), |update| {
+                (update.mode.as_deref(), update.blocker.as_deref())
+            })
+        };
+        let was_decision = is_decision_block(stored_mode, stored_blocker);
+        self.mode = honest_controller_mode(
+            stored_mode,
+            stored_blocker,
+            has_live_mission,
+            awaiting_user > 0,
+            self.pending_decisions,
+        );
+        if was_decision && self.mode.as_deref() != Some("blocked:decision") {
+            self.mode_blocker = None;
+            if let Some(update) = self.latest_update.as_mut() {
+                if is_decision_block(update.mode.as_deref(), update.blocker.as_deref()) {
+                    update.mode = self.mode.clone();
+                    update.blocker = None;
+                }
+            }
+        }
 
         let mut attention: Vec<String> = Vec::new();
         let mut items: Vec<AttentionItem> = Vec::new();
@@ -3020,31 +3125,6 @@ impl ProjectRowBuilder {
                 });
             }
         }
-        // Only qualified operator pages count as "awaiting user". Ack and
-        // in-grace controller-owned questions stay off the attention shelf.
-        let awaiting_user = self
-            .missions
-            .iter()
-            .filter(|chip| chip.needs_operator)
-            .count();
-        let has_live_mission = self
-            .missions
-            .iter()
-            .any(|chip| super::controller_honesty::is_live_writer_status(chip.status));
-        // Live work and parked decisions beat the last CTRL trailer. A
-        // writer already running is `active` even if the last cron said
-        // `blocked:cannot-merge`; a pending question with no writer is
-        // `blocked:decision`. Operator `paused` is never overridden.
-        self.mode = honest_controller_mode(
-            self.mode.as_deref().or_else(|| {
-                self.latest_update
-                    .as_ref()
-                    .and_then(|update| update.mode.as_deref())
-            }),
-            has_live_mission,
-            awaiting_user > 0,
-            self.pending_decisions,
-        );
         if awaiting_user > 0 {
             attention.push(match awaiting_user {
                 1 => "1 mission awaiting user input".to_string(),
@@ -5355,27 +5435,27 @@ mod tests {
     #[test]
     fn honest_mode_prefers_live_work_and_parked_decisions_over_cron_prose() {
         assert_eq!(
-            honest_controller_mode(Some("blocked:cannot-merge"), true, false, 1).as_deref(),
+            honest_controller_mode(Some("blocked:cannot-merge"), None, true, false, 1).as_deref(),
             Some("active")
         );
         assert_eq!(
-            honest_controller_mode(Some("active"), false, false, 2).as_deref(),
+            honest_controller_mode(Some("active"), None, false, false, 2).as_deref(),
             Some("blocked:decision")
         );
         assert_eq!(
-            honest_controller_mode(Some("paused:owner"), true, false, 1).as_deref(),
+            honest_controller_mode(Some("paused:owner"), None, true, false, 1).as_deref(),
             Some("paused:owner")
         );
         assert_eq!(
-            honest_controller_mode(Some("blocked:transport-cap"), false, false, 0).as_deref(),
+            honest_controller_mode(Some("blocked:transport-cap"), None, false, false, 0).as_deref(),
             Some("blocked:transport-cap")
         );
         assert_eq!(
-            honest_controller_mode(Some("active"), true, true, 0).as_deref(),
+            honest_controller_mode(Some("active"), None, true, true, 0).as_deref(),
             Some("blocked:decision")
         );
         assert_eq!(
-            honest_controller_mode(Some("active"), true, false, 0).as_deref(),
+            honest_controller_mode(Some("active"), None, true, false, 0).as_deref(),
             Some("active")
         );
     }
@@ -5430,6 +5510,7 @@ mod tests {
             ));
             let detail = project_mode_from_missions(
                 Some("blocked:decision"),
+                None,
                 Some(std::slice::from_ref(&mission)),
                 &waits,
                 0,
@@ -5451,6 +5532,7 @@ mod tests {
                 board.missions.push(mission_chip(&active, false, None));
                 let detail = project_mode_from_missions(
                     Some("blocked:decision"),
+                    None,
                     Some(&[mission, active]),
                     &waits,
                     0,
@@ -5459,6 +5541,123 @@ mod tests {
                 assert_eq!(board.finish(&[], None, None, &fresh).mode, detail);
             }
         }
+    }
+
+    #[test]
+    fn persisted_decision_pairs_project_consistently_after_http_and_ctrl_writes() {
+        let now = chrono::Utc::now();
+        let timestamp = now.to_rfc3339();
+        for via_ctrl in [false, true] {
+            let store = ProjectsStore::open_in_memory().unwrap();
+            store
+                .upsert_project("verity", None, None, None, None)
+                .unwrap();
+            if via_ctrl {
+                ingest_deliveries(&store, &HashMap::new(), &HashMap::new(), vec![parse_delivery(
+                    "session", now.timestamp() as f64 + 1.0,
+                    "[Cron delivery: Verity]\nWaiting\n[CTRL: verity | mode=blocked:decision | wait=0 | next=wait]\n[STATE_SIGNATURE: verity|waiting]\n"
+                )]);
+            } else {
+                store
+                    .set_mode("verity", "blocked", None, Some("decision"))
+                    .unwrap();
+                store
+                    .record_state(
+                        "verity",
+                        "waiting",
+                        Some("Waiting"),
+                        &timestamp,
+                        Some("session"),
+                    )
+                    .unwrap();
+            }
+            let record = store.get_project("verity").unwrap().unwrap();
+            assert_eq!(record.mode.as_deref(), Some("blocked"));
+            assert_eq!(record.blocker.as_deref(), Some("decision"));
+            for (available, pending, expected_mode, expected_blocker) in [
+                (true, 0, None, None),
+                (false, 0, Some("blocked"), Some("decision")),
+                (false, 1, Some("blocked:decision"), Some("decision")),
+                (true, 1, Some("blocked:decision"), Some("decision")),
+            ] {
+                let mut projected = record.clone();
+                project_mode_projection(
+                    &mut projected,
+                    available.then_some(&[]),
+                    &HashMap::new(),
+                    pending,
+                );
+                assert_eq!(projected.mode.as_deref(), expected_mode);
+                assert_eq!(projected.blocker.as_deref(), expected_blocker);
+            }
+            let state = store.latest_states().unwrap().remove("verity").unwrap();
+            let mut board = ProjectRowBuilder::new("verity".into());
+            board.apply_roster(record.clone(), true);
+            board.attach_store_update(
+                store_update(
+                    "verity",
+                    &state,
+                    record.mode.clone(),
+                    record.blocker.clone(),
+                ),
+                1,
+                1,
+            );
+            let row = board.finish(&[], None, None, &timestamp);
+            assert_eq!(row.mode, None);
+            assert!(row
+                .attention_reasons
+                .iter()
+                .all(|reason| !reason.contains("blocker reported")));
+            let update = row.latest_update.unwrap();
+            assert_eq!(update.mode, None);
+            assert_eq!(update.blocker, None);
+            // These are read projections: controller history stays intact.
+            assert_eq!(store.get_project("verity").unwrap().unwrap(), record);
+        }
+    }
+
+    #[test]
+    fn persisted_nondecision_pairs_and_canonical_alias_provenance_are_preserved() {
+        let store = ProjectsStore::open_in_memory().unwrap();
+        store
+            .upsert_project("verity", None, None, None, None)
+            .unwrap();
+        store
+            .upsert_project("alias", None, None, None, None)
+            .unwrap();
+        for (mode, blocker) in [
+            ("blocked", "transport-cap"),
+            ("blocked", "manual"),
+            ("paused", "decision"),
+        ] {
+            store.set_mode("verity", mode, None, Some(blocker)).unwrap();
+            store
+                .set_mode("alias", "blocked", None, Some("decision"))
+                .unwrap();
+            let record = store.get_project("verity").unwrap().unwrap();
+            let mut projected = record.clone();
+            project_mode_projection(&mut projected, Some(&[]), &HashMap::new(), 0);
+            assert_eq!(projected.mode.as_deref(), Some(mode));
+            assert_eq!(projected.blocker.as_deref(), Some(blocker));
+            let mut board = ProjectRowBuilder::new("verity".into());
+            board.apply_roster(record, true);
+            board.apply_roster(store.get_project("alias").unwrap().unwrap(), true);
+            let row = board.finish(&[], None, None, &chrono::Utc::now().to_rfc3339());
+            assert_eq!(row.mode.as_deref(), Some(mode));
+        }
+        store
+            .set_mode("verity", "blocked:decision", None, Some("manual"))
+            .unwrap();
+        let mut conflicting = store.get_project("verity").unwrap().unwrap();
+        project_mode_projection(&mut conflicting, Some(&[]), &HashMap::new(), 0);
+        assert_eq!(conflicting.blocker.as_deref(), Some("manual"));
+        project_mode_projection(&mut conflicting, None, &HashMap::new(), 1);
+        assert_eq!(conflicting.blocker.as_deref(), Some("decision"));
+        assert!(
+            !is_decision_block(Some("blocked:decision"), Some("manual")),
+            "explicit provenance wins over legacy suffix"
+        );
     }
 
     #[test]
@@ -5487,43 +5686,50 @@ mod tests {
     fn expired_decision_mode_clears_without_changing_pauses_or_other_blockers() {
         for stored in [None, Some("active"), Some("blocked:decision")] {
             assert_eq!(
-                project_mode_from_missions(stored, None, &HashMap::new(), 1).as_deref(),
+                project_mode_from_missions(stored, None, None, &HashMap::new(), 1).as_deref(),
                 Some("blocked:decision")
             );
         }
         assert_eq!(
-            project_mode_from_missions(Some("paused:owner"), None, &HashMap::new(), 1).as_deref(),
+            project_mode_from_missions(Some("paused:owner"), None, None, &HashMap::new(), 1)
+                .as_deref(),
             Some("paused:owner")
         );
         assert_eq!(
-            project_mode_from_missions(Some("blocked:decision"), None, &HashMap::new(), 0)
+            project_mode_from_missions(Some("blocked:decision"), None, None, &HashMap::new(), 0)
                 .as_deref(),
             Some("blocked:decision"),
             "unavailable mission evidence cannot clear a real question"
         );
         assert_eq!(
-            project_mode_from_missions(Some("blocked:decision"), Some(&[]), &HashMap::new(), 0),
+            project_mode_from_missions(
+                Some("blocked:decision"),
+                None,
+                Some(&[]),
+                &HashMap::new(),
+                0
+            ),
             None,
             "a successful empty roster can clear stale decision state"
         );
         assert_eq!(
-            honest_controller_mode(Some("blocked:decision"), false, false, 0),
+            honest_controller_mode(Some("blocked:decision"), None, false, false, 0),
             None
         );
         assert_eq!(
-            honest_controller_mode(Some("blocked:decision"), true, false, 0).as_deref(),
+            honest_controller_mode(Some("blocked:decision"), None, true, false, 0).as_deref(),
             Some("active")
         );
         assert_eq!(
-            honest_controller_mode(Some("paused:owner"), false, false, 0).as_deref(),
+            honest_controller_mode(Some("paused:owner"), None, false, false, 0).as_deref(),
             Some("paused:owner")
         );
         assert_eq!(
-            honest_controller_mode(Some("blocked:decision"), false, false, 1).as_deref(),
+            honest_controller_mode(Some("blocked:decision"), None, false, false, 1).as_deref(),
             Some("blocked:decision")
         );
         assert_eq!(
-            honest_controller_mode(Some("blocked:transport-cap"), false, false, 0).as_deref(),
+            honest_controller_mode(Some("blocked:transport-cap"), None, false, false, 0).as_deref(),
             Some("blocked:transport-cap")
         );
     }


### PR DESCRIPTION
An administrative mission ACK could make the project report a pending decision. Detail and board now derive status from qualified waits and the persisted mode/blocker pair. Real decisions and explicit pauses remain effective; stale decision mode, returned blocker and board fallback are cleared together without modifying controller history.

Inventory errors cannot masquerade as complete results. Raw pagination avoids the default 5000-row cap, offline SQLite retains decision and grace metadata, and display truncation happens after full-roster state derivation. Canonical/alias mode, blocker and clock stay paired.

Validation at `23d182926e0008215726d858aaed981f9ba9fd57`:94 project-overview and31 attention-related tests passed (overlapping filters); formatting and diff checks passed. Tests include actual HTTP-style store writes and CTRL-ingest roundtrips, unknown/partial sources, decision evidence, manual/paused provenance, offline decision/grace, a worker beyond5000 newer rows and an older active worker behind eight ACK chips.

Independent read-only review: CLEAN on this exact head for the ACK/decision/provenance/completeness scope. Four GitHub findings have been addressed; fresh GitHub review requested. Full-fleet scan latency has not been benchmarked. No deployment or merge; DEV promotion remains gated by its pending missions and deployed-source provenance.
