### PR TITLE
fix: reconcile terminal track owners during mission creation

### DIFF
--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -540,19 +540,18 @@ async fn track_dispatch_unreadable_store_cannot_release_terminal_owner() {
     );
 }
 
-#[tokio::test]
-async fn track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock() {
+fn isolated_track_http_test(test_name: &str) -> bool {
     // Keep this HTTP/lock regression independent of the production 150 GiB
     // disk floor without changing environment shared by other parallel tests.
     const CHILD: &str = "TERMINAL_TRACK_LEASE_HTTP_TEST_CHILD";
-    if std::env::var_os(CHILD).is_none() {
+    if std::env::var(CHILD).ok().as_deref() != Some(test_name) {
         let output = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
                 "--exact",
-                "api::control::dispatch_admission_tests::track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock",
+                &format!("api::control::dispatch_admission_tests::{test_name}"),
                 "--nocapture",
             ])
-            .env(CHILD, "1")
+            .env(CHILD, test_name)
             .env("MISSION_DISK_EMERGENCY_RESERVE_GB", "0")
             .output()
             .unwrap();
@@ -562,6 +561,16 @@ async fn track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        return true;
+    }
+    false
+}
+
+#[tokio::test]
+async fn track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock() {
+    if isolated_track_http_test(
+        "track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock",
+    ) {
         return;
     }
     for pr in [None, Some("repo#244")] {
@@ -587,6 +596,65 @@ async fn track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr
         assert_eq!(leases.len(), 1);
         assert_eq!(leases[0].attempt_id, mission.id.to_string());
     }
+}
+
+#[tokio::test]
+async fn track_dispatch_lock_failure_interrupts_candidate_and_releases_disk() {
+    if isolated_track_http_test(
+        "track_dispatch_lock_failure_interrupts_candidate_and_releases_disk",
+    ) {
+        return;
+    }
+    let h = Harness::new().await;
+    h.state.backend_registry.write().await.register(Arc::new(
+        crate::backend::opencode::OpenCodeBackend::new("http://127.0.0.1:9".into(), None, false),
+    ));
+    let old = h.writer(MissionStatus::Acknowledged, None).await;
+    // A directory at the lock-file path makes the real open fail, while
+    // leaving the actor's separate disk ledger and mission store writable.
+    let admission_guard = DISPATCH_ADMISSION.lock().await;
+    let file_guard = dispatch_admission::durable_lock(&h.state.config)
+        .await
+        .unwrap();
+    let lock_path = h
+        .state
+        .config
+        .working_dir
+        .join(".sandboxed-sh/missions/.dispatch-admission.lock");
+    std::fs::remove_file(&lock_path).unwrap();
+    std::fs::create_dir(&lock_path).unwrap();
+    drop(file_guard);
+    drop(admission_guard);
+    let response = h.state.http_client.post(format!("{}/missions", h.url))
+        .json(&json!({"title":"rejected replacement", "backend":"opencode", "project":"lido", "track":"trio-reserve1", "writer":true, "estimated_disk_gib":1}))
+        .timeout(std::time::Duration::from_secs(10)).send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = response.text().await.unwrap();
+    let candidates = h
+        .control
+        .mission_store
+        .list_missions_filtered(&Default::default(), 10, 0)
+        .await
+        .unwrap();
+    let candidate = candidates.iter().find(|m| m.id != old.id).unwrap();
+    assert_eq!(candidate.status, MissionStatus::Interrupted);
+    assert_eq!(
+        candidate.terminal_reason.as_deref(),
+        Some("dispatch_admission_unavailable")
+    );
+    let body: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(body["mission_id"], candidate.id.to_string());
+    assert!(body["cleanup_error"].is_null());
+    assert!(!read_disk_reservation_ledger(&h.state.config)
+        .unwrap()
+        .reservations
+        .contains_key(&candidate.id));
+    assert_eq!(
+        h.state.projects.live_leases(None).unwrap()[0].attempt_id,
+        old.id.to_string()
+    );
+    assert!(candidate.project.track.is_none());
+    assert!(candidate.history.is_empty());
 }
 
 #[tokio::test]

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -165,6 +165,7 @@ impl Harness {
         let app = axum::Router::new()
             .nest("/remote-build", crate::api::remote_build::routes())
             .route("/message", axum::routing::post(post_message))
+            .route("/missions", axum::routing::post(create_mission))
             .route("/missions/:id/resume", axum::routing::post(resume_mission))
             .route(
                 "/missions/:id/title",
@@ -297,6 +298,308 @@ fn assert_status_metadata_eq(before: &Mission, after: &Mission) {
     ] {
         assert_eq!(after[field], before[field], "status metadata {field}");
     }
+}
+
+async fn track_dispatch_candidate(h: &Harness) -> Mission {
+    h.control
+        .mission_store
+        .create_mission(
+            Some("replacement"),
+            None,
+            None,
+            None,
+            None,
+            Some("test-no-execution"),
+            None,
+        )
+        .await
+        .unwrap()
+}
+
+async fn bind_track_dispatch(
+    h: &Harness,
+    candidate: &Mission,
+) -> Result<String, (StatusCode, String)> {
+    // Same boundary as create_mission, including the admission/file/PR order.
+    let _admission = DISPATCH_ADMISSION.lock().await;
+    let _file_guard = dispatch_admission::durable_lock(&h.state.config)
+        .await
+        .unwrap();
+    let _pr_guard = acquire_durable_pr_writer_lock(&h.state.control)
+        .await
+        .unwrap();
+    bind_mission_to_track(
+        &h.state,
+        &h.control,
+        candidate,
+        "lido",
+        Some("trio-reserve1"),
+        candidate.title.as_deref(),
+        None,
+        Some("implementation"),
+        Some(true),
+        &[],
+        true,
+        None,
+        &[],
+    )
+    .await
+}
+
+#[tokio::test]
+async fn track_dispatch_replaces_cancelled_and_acknowledged_owner_without_timer() {
+    for acknowledge in [false, true] {
+        let h = Harness::new().await;
+        let old = h.writer(MissionStatus::Active, None).await;
+        h.control
+            .mission_store
+            .update_mission_status(old.id, MissionStatus::Interrupted)
+            .await
+            .unwrap();
+        if acknowledge {
+            h.control
+                .mission_store
+                .update_mission_status(old.id, MissionStatus::Acknowledged)
+                .await
+                .unwrap();
+        }
+        let candidate = track_dispatch_candidate(&h).await;
+        let old_lease = h.state.projects.live_leases(None).unwrap().remove(0);
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&old_lease.lease_until).unwrap()
+                > chrono::Utc::now()
+        );
+        assert!(
+            h.state
+                .projects
+                .acquire_track_lease(&crate::api::track_leases::lease_request(
+                    "lido",
+                    "trio-reserve1",
+                    &candidate.id.to_string(),
+                    "writer",
+                    None,
+                ))
+                .is_err(),
+            "the unswept lease reproduces the original conflict"
+        );
+
+        assert_eq!(
+            bind_track_dispatch(&h, &candidate).await.unwrap(),
+            "trio-reserve1"
+        );
+        let leases = h.state.projects.live_leases(None).unwrap();
+        assert_eq!(leases.len(), 1);
+        assert_eq!(leases[0].attempt_id, candidate.id.to_string());
+        assert_ne!(leases[0].id, old_lease.id);
+        // A late cleanup for the cancelled attempt cannot revoke its successor.
+        h.state
+            .projects
+            .release_leases_for_attempt(&old.id.to_string())
+            .unwrap();
+        assert!(bind_track_dispatch(&h, &candidate).await.is_ok());
+        assert_eq!(
+            h.state.projects.live_leases(None).unwrap()[0].id,
+            leases[0].id
+        );
+    }
+}
+
+#[tokio::test]
+async fn track_dispatch_retains_nonterminal_and_native_goal_owners() {
+    for status in [
+        MissionStatus::Active,
+        MissionStatus::Pending,
+        MissionStatus::AwaitingUser,
+        MissionStatus::WaitingBackground,
+        MissionStatus::Paused,
+        MissionStatus::Blocked,
+    ] {
+        let h = Harness::new().await;
+        let old = h.writer(status, None).await;
+        if status == MissionStatus::Blocked {
+            h.control
+                .mission_store
+                .update_mission_status_with_reason(old.id, status, Some("native_goal_stopped"))
+                .await
+                .unwrap();
+        }
+        let candidate = track_dispatch_candidate(&h).await;
+        let (status, body) = bind_track_dispatch(&h, &candidate).await.unwrap_err();
+        assert_eq!(status, StatusCode::CONFLICT);
+        let body: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(body["holder_mission_id"], old.id.to_string());
+        assert_eq!(
+            h.state.projects.live_leases(None).unwrap()[0].attempt_id,
+            old.id.to_string()
+        );
+    }
+}
+
+#[tokio::test]
+async fn track_dispatch_terminal_presentation_does_not_override_unresolved_execution() {
+    use crate::remote_node::job_ledger::{self, JobHandle, JobHandleKind};
+    for evidence in ["run", "actor", "remote", "admission"] {
+        let h = Harness::new().await;
+        let old = h
+            .writer(
+                if evidence == "run" {
+                    MissionStatus::Active
+                } else {
+                    MissionStatus::Acknowledged
+                },
+                None,
+            )
+            .await;
+        match evidence {
+            "run" => {
+                h.control
+                    .mission_store
+                    .begin_mission_run(old.id, "old-actor", None)
+                    .await
+                    .unwrap();
+                h.control
+                    .mission_store
+                    .update_mission_status(old.id, MissionStatus::Interrupted)
+                    .await
+                    .unwrap();
+            }
+            "actor" => {
+                h.control.assignment_owners.write().await.insert(old.id);
+            }
+            "remote" => {
+                job_ledger::record(
+                    &h.state.config.working_dir,
+                    JobHandle {
+                        mission_id: old.id,
+                        node_id: "unreachable-node".into(),
+                        job_id: Uuid::new_v4(),
+                        started_at: chrono::Utc::now(),
+                        submission_sequence: 0,
+                        accepted_at: Some(chrono::Utc::now()),
+                        heartbeat_at: None,
+                        disk_reservation_bytes: 0,
+                        kind: JobHandleKind::Mission,
+                        identity: None,
+                        wait_for_completion: None,
+                        wake_on_terminal: false,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            "admission" => {
+                h.state
+                    .projects
+                    .save_dispatch_admission(&old.id.to_string(), &json!({"phase":"pending"}))
+                    .unwrap();
+            }
+            _ => unreachable!(),
+        }
+        let candidate = track_dispatch_candidate(&h).await;
+        assert_eq!(
+            bind_track_dispatch(&h, &candidate).await.unwrap_err().0,
+            StatusCode::CONFLICT,
+            "{evidence}"
+        );
+        assert_eq!(
+            h.state.projects.live_leases(None).unwrap()[0].attempt_id,
+            old.id.to_string()
+        );
+    }
+}
+
+#[tokio::test]
+async fn track_dispatch_unreadable_store_cannot_release_terminal_owner() {
+    let h = Harness::new().await;
+    let old = h.writer(MissionStatus::Acknowledged, None).await;
+    let base = h.state.config.working_dir.join(".sandboxed-sh/missions");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("missions-unreadable.json"),
+        b"incomplete snapshot",
+    )
+    .unwrap();
+    let candidate = track_dispatch_candidate(&h).await;
+    assert_eq!(
+        bind_track_dispatch(&h, &candidate).await.unwrap_err().0,
+        StatusCode::INTERNAL_SERVER_ERROR
+    );
+    assert_eq!(
+        h.state.projects.live_leases(None).unwrap()[0].attempt_id,
+        old.id.to_string()
+    );
+    assert_eq!(
+        h.control
+            .mission_store
+            .get_mission(candidate.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        MissionStatus::Interrupted
+    );
+}
+
+#[tokio::test]
+async fn track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock() {
+    for pr in [None, Some("repo#244")] {
+        let h = Harness::new().await;
+        h.state.backend_registry.write().await.register(Arc::new(
+            crate::backend::opencode::OpenCodeBackend::new(
+                "http://127.0.0.1:9".into(),
+                None,
+                false,
+            ),
+        ));
+        let old = h.writer(MissionStatus::Acknowledged, pr).await;
+        let response = h.state.http_client.post(format!("{}/missions", h.url))
+            .json(&json!({"title":"new replacement", "backend":"opencode", "project":"lido", "track":"trio-reserve1", "github_pr":pr, "writer":true, "estimated_disk_gib":1}))
+            .timeout(std::time::Duration::from_secs(10)).send().await.unwrap();
+        let status = response.status();
+        let body = response.text().await.unwrap();
+        assert!(status.is_success(), "{status}: {body}");
+        let mission: Mission = serde_json::from_str(&body).unwrap();
+        assert_ne!(mission.id, old.id);
+        assert_eq!(mission.project.track.as_deref(), Some("trio-reserve1"));
+        let leases = h.state.projects.live_leases(None).unwrap();
+        assert_eq!(leases.len(), 1);
+        assert_eq!(leases[0].attempt_id, mission.id.to_string());
+    }
+}
+
+#[tokio::test]
+async fn track_dispatch_concurrent_replacements_admit_exactly_one_writer() {
+    let h = Harness::new().await;
+    let old = h.writer(MissionStatus::Acknowledged, None).await;
+    let mut candidates = Vec::new();
+    for _ in 0..8 {
+        candidates.push(track_dispatch_candidate(&h).await);
+    }
+    let results = futures::future::join_all(
+        candidates
+            .iter()
+            .map(|candidate| bind_track_dispatch(&h, candidate)),
+    )
+    .await;
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert!(results
+        .iter()
+        .filter_map(|result| result.as_ref().err())
+        .all(|error| error.0 == StatusCode::CONFLICT));
+    let winner = candidates
+        .iter()
+        .zip(&results)
+        .find(|(_, result)| result.is_ok())
+        .unwrap()
+        .0;
+    h.state
+        .projects
+        .release_leases_for_attempt(&old.id.to_string())
+        .unwrap();
+    crate::api::track_leases::sweep(&h.state).await.unwrap();
+    let leases = h.state.projects.live_leases(None).unwrap();
+    assert_eq!(leases.len(), 1);
+    assert_eq!(leases[0].attempt_id, winner.id.to_string());
 }
 
 #[tokio::test]

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -542,6 +542,28 @@ async fn track_dispatch_unreadable_store_cannot_release_terminal_owner() {
 
 #[tokio::test]
 async fn track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock() {
+    // Keep this HTTP/lock regression independent of the production 150 GiB
+    // disk floor without changing environment shared by other parallel tests.
+    const CHILD: &str = "TERMINAL_TRACK_LEASE_HTTP_TEST_CHILD";
+    if std::env::var_os(CHILD).is_none() {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "api::control::dispatch_admission_tests::track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .env("MISSION_DISK_EMERGENCY_RESERVE_GB", "0")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "isolated HTTP regression failed: {}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
     for pr in [None, Some("repo#244")] {
         let h = Harness::new().await;
         h.state.backend_registry.write().await.register(Arc::new(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10506,9 +10506,43 @@ pub async fn create_mission(
     // conflict path may reconcile a terminal predecessor, so admission must
     // remain serialized until the new lease and assignment are both persisted.
     let admission_guard = DISPATCH_ADMISSION.lock().await;
-    let admission_file_guard = dispatch_admission::durable_lock(&state.config)
-        .await
-        .map_err(internal_error)?;
+    let admission_file_guard = match dispatch_admission::durable_lock(&state.config).await {
+        Ok(guard) => guard,
+        Err(error) => {
+            // The actor already persisted this candidate and its scratch
+            // reservation. It has received no prompt or writer assignment.
+            // Compensate directly: an actor roundtrip under admission can
+            // deadlock, and the durable admission file itself is unavailable.
+            let cleanup: Result<(), String> = async {
+                let reason = "dispatch_admission_unavailable";
+                control
+                    .mission_store
+                    .update_mission_status_with_reason(
+                        mission.id,
+                        MissionStatus::Interrupted,
+                        Some(reason),
+                    )
+                    .await?;
+                let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                    mission_id: mission.id,
+                    status: MissionStatus::Interrupted,
+                    summary: Some(reason.to_string()),
+                });
+                release_local_mission_disk(&state.config, mission.id).await
+            }
+            .await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                serde_json::json!({
+                    "error": "dispatch_admission_unavailable",
+                    "mission_id": mission.id,
+                    "detail": error,
+                    "cleanup_error": cleanup.err(),
+                })
+                .to_string(),
+            ));
+        }
+    };
     // Close the preflight-to-create race under the store-only mutex. Exactly
     // one concurrent creator wins; a loser is durably interrupted before it
     // can receive a goal or become a writer.

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -9685,9 +9685,12 @@ async fn bind_mission_to_track(
     }
     let request =
         track_leases::lease_request(project, &outcome.key, &mission_id, mode, idempotency_key);
-    match state.projects.acquire_track_lease(&request) {
+    match track_leases::acquire_locked(state, &request).await {
         Ok(_) => Ok(outcome.key),
-        Err(super::projects_store::LeaseError::Store(error)) => Err(internal_error(error)),
+        Err(super::projects_store::LeaseError::Store(error)) => {
+            interrupt_new_mission(control, mission.id, "track_lease_unavailable").await;
+            Err(internal_error(error))
+        }
         Err(super::projects_store::LeaseError::NotFound) => Err(internal_error(format!(
             "track '{}' of '{project}' vanished between absorption and lease",
             outcome.key
@@ -10499,6 +10502,13 @@ pub async fn create_mission(
         }
     };
 
+    // Match actor/sweep lock order before taking the PR-writer lock. The track
+    // conflict path may reconcile a terminal predecessor, so admission must
+    // remain serialized until the new lease and assignment are both persisted.
+    let admission_guard = DISPATCH_ADMISSION.lock().await;
+    let admission_file_guard = dispatch_admission::durable_lock(&state.config)
+        .await
+        .map_err(internal_error)?;
     // Close the preflight-to-create race under the store-only mutex. Exactly
     // one concurrent creator wins; a loser is durably interrupted before it
     // can receive a goal or become a writer.
@@ -10739,6 +10749,8 @@ pub async fn create_mission(
         }
     }
     drop(pr_writer_guard);
+    drop(admission_file_guard);
+    drop(admission_guard);
 
     // Creation origin ("hermes" + owning session id). Written once here so
     // clients can group foreign-origin missions under their conversation.

--- a/src/api/track_leases.rs
+++ b/src/api/track_leases.rs
@@ -138,9 +138,10 @@ pub fn owned_body(slug: &str, track: &str, error: &LeaseError) -> serde_json::Va
             "lease_until": lease_until,
             "lease_id": lease_id,
             "message": format!(
-                "track '{track}' of '{slug}' is owned by mission {holder_attempt_id} until {lease_until}; \
-                 attach to it (send_message_to_mission), wait for it to end, or dispatch a read-only \
-                 intent (writer=false)"
+                "track '{track}' of '{slug}' is owned by mission {holder_attempt_id}; \
+                 ownership is released after execution is confirmed stopped, not at the renewal \
+                 deadline {lease_until}. Attach to it (send_message_to_mission), wait for it to end, \
+                 or dispatch a read-only intent (writer=false)"
             ),
         }),
         other => serde_json::json!({ "error": "lease_failed", "message": other.to_string() }),
@@ -165,6 +166,28 @@ pub struct LeaseSweepReport {
 pub async fn sweep(state: &Arc<AppState>) -> Result<LeaseSweepReport, String> {
     let _admission = super::control::DISPATCH_ADMISSION.lock().await;
     let _file_guard = super::control::dispatch_admission::durable_lock(&state.config).await?;
+    sweep_locked(state).await
+}
+
+/// Retry a conflicting acquisition after the same execution-evidence check as
+/// the periodic sweep. Callers must hold the admission mutex and durable file
+/// lock through both attempts, acquired before any PR-writer lock. A concurrent
+/// resume or creator must not slip between terminal cleanup and acquisition.
+/// The acquisition itself stays transactional in projects.db.
+pub(crate) async fn acquire_locked(
+    state: &Arc<AppState>,
+    request: &LeaseRequest,
+) -> Result<TrackLease, LeaseError> {
+    match state.projects.acquire_track_lease(request) {
+        Err(LeaseError::Owned { .. }) => {
+            sweep_locked(state).await.map_err(LeaseError::Store)?;
+            state.projects.acquire_track_lease(request)
+        }
+        result => result,
+    }
+}
+
+async fn sweep_locked(state: &Arc<AppState>) -> Result<LeaseSweepReport, String> {
     super::control::dispatch_admission::recover_sweep(state).await?;
     let ownership = super::control::execution_ownership::snapshot(&state.control).await?;
     let mut report = LeaseSweepReport::default();


### PR DESCRIPTION
Creating a replacement immediately after cancelling or acknowledging a track writer could return `track_owned` until the ten-minute lease sweep. The error also described the six-hour renewal deadline as the end of ownership.

On a conflicting fresh creation, run the existing conservative ownership reconciliation and retry acquisition while retaining the admission mutex and durable admission file. Acquire those guards before the PR writer lock and retain them through assignment persistence. Active missions, native stopped goals, actor assignments, durable runs, remote jobs, unresolved admissions, and unreadable stores continue to fence replacement. A failed evidence lookup interrupts the unadmitted new mission and preserves the predecessor lease. If the durable admission file cannot open after creation, interrupt the candidate and release its disk reservation; return its ID and any cleanup error so partial cleanup remains recoverable. The 409 text now explains the renewal deadline correctly.

Validation: all 65 admission tests pass, including seven new regressions for immediate cancel/ACK replacement, nonterminal and native-goal owners, terminal presentations with unresolved execution, unavailable-store handling, eight concurrent replacements and delayed predecessor cleanup, actual HTTP creation with and without a PR, and a real lock-file open failure leaving no pending candidate or disk reservation. HTTP fixtures set their disk reserve in isolated children so they work on smaller CI runners without changing other tests or production policy. `cargo fmt --all --check` and `git diff --check` pass.
