### PR TITLE
Preserve healthy Grok ACP tools and bound transport recovery

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -18020,7 +18020,11 @@ async fn reserve_transport_auto_resume(
     attempts: &mut HashMap<Uuid, u8>,
     mission_id: Uuid,
     grok_acp: bool,
+    cancellation_requested: bool,
 ) -> bool {
+    if cancellation_requested {
+        return false;
+    }
     let count = attempts.entry(mission_id).or_insert(0);
     if *count >= if grok_acp { 1 } else { 3 } {
         return false;
@@ -22575,6 +22579,9 @@ async fn control_actor_loop(
                     // Save the running mission ID before clearing it - we need it for persist and auto-complete
                     // (current_mission can change if user clicks "New Mission" while task was running)
                     let completed_mission_id = running_mission_id;
+                    let completed_cancellation_requested = running_cancel
+                        .as_ref()
+                        .is_some_and(CancellationToken::is_cancelled);
                     running = None;
                     running_cancel = None;
                     if let Some(mid) = running_mission_id {
@@ -22917,6 +22924,7 @@ async fn control_actor_loop(
                                 &mut transport_auto_resumed_missions,
                                 mission_id,
                                 completed_grok_acp_transport_failure,
+                                completed_cancellation_requested,
                             ).await
                         {
                             let resume_message = transport_auto_resume_message_for_mission(
@@ -23523,6 +23531,7 @@ async fn control_actor_loop(
                                     &mut transport_auto_resumed_missions,
                                     *mission_id,
                                     is_grok_acp_transport_failure(&result),
+                                    cancellation_requested,
                                 ).await
                             {
                                 tracing::info!(
@@ -34207,8 +34216,12 @@ Investigate <service/> failures.
                 .unwrap();
         }
         let mut attempts = HashMap::new();
-        assert!(reserve_transport_auto_resume(&store, &mut attempts, mission.id, true).await);
-        assert!(!reserve_transport_auto_resume(&store, &mut attempts, mission.id, true).await);
+        assert!(
+            reserve_transport_auto_resume(&store, &mut attempts, mission.id, true, false).await
+        );
+        assert!(
+            !reserve_transport_auto_resume(&store, &mut attempts, mission.id, true, false).await
+        );
         drop(store);
         let reopened =
             mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "grok-retry")
@@ -34216,7 +34229,14 @@ Investigate <service/> failures.
                 .unwrap();
         let mut restarted_actor = HashMap::new();
         assert!(
-            !reserve_transport_auto_resume(&reopened, &mut restarted_actor, mission.id, true).await
+            !reserve_transport_auto_resume(
+                &reopened,
+                &mut restarted_actor,
+                mission.id,
+                true,
+                false
+            )
+            .await
         );
         let reservations = reopened
             .get_events(mission.id, Some(&["error"]), None, None)
@@ -34243,12 +34263,16 @@ Investigate <service/> failures.
         let db = rusqlite::Connection::open(dir.path().join("missions-grok-retry.db")).unwrap();
         db.execute("DROP TABLE mission_events", []).unwrap();
         let mut attempts = HashMap::new();
-        assert!(!reserve_transport_auto_resume(&store, &mut attempts, mission.id, true).await);
+        assert!(
+            !reserve_transport_auto_resume(&store, &mut attempts, mission.id, true, false).await
+        );
         let other = Uuid::new_v4();
         for _ in 0..3 {
-            assert!(reserve_transport_auto_resume(&store, &mut attempts, other, false).await);
+            assert!(
+                reserve_transport_auto_resume(&store, &mut attempts, other, false, false).await
+            );
         }
-        assert!(!reserve_transport_auto_resume(&store, &mut attempts, other, false).await);
+        assert!(!reserve_transport_auto_resume(&store, &mut attempts, other, false, false).await);
     }
 
     #[tokio::test]
@@ -34275,7 +34299,33 @@ Investigate <service/> failures.
             .await
             .unwrap();
         assert!(
-            !reserve_transport_auto_resume(&store, &mut HashMap::new(), mission.id, true).await
+            !reserve_transport_auto_resume(&store, &mut HashMap::new(), mission.id, true, false)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn grok_transport_recovery_cancelled_completion_does_not_consume_or_queue_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "grok-retry")
+            .await
+            .unwrap();
+        let mission = store
+            .create_mission(None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let mut attempts = HashMap::new();
+        assert!(
+            !reserve_transport_auto_resume(&store, &mut attempts, mission.id, true, true).await
+        );
+        assert!(attempts.is_empty());
+        assert!(store
+            .get_events(mission.id, Some(&["error"]), None, None)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(
+            reserve_transport_auto_resume(&store, &mut attempts, mission.id, true, false).await
         );
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -17968,6 +17968,100 @@ fn is_transport_failure_evidence(evidence: &crate::agents::CompletionEvidence) -
     )
 }
 
+fn is_grok_acp_transport_failure(result: &crate::agents::AgentResult) -> bool {
+    result
+        .data
+        .as_ref()
+        .and_then(|data| data.get("grok_acp_transport_failure"))
+        .and_then(serde_json::Value::as_bool)
+        == Some(true)
+}
+
+const GROK_TRANSPORT_RECOVERY_RESERVED: &str = "Grok ACP transport recovery reserved (1/1 for this mission). Reconcile the existing checkout and jobs before continuing; automatic recovery will not repeat.";
+
+async fn grok_transport_recovery_was_reserved(
+    store: &dyn MissionStore,
+    mission_id: Uuid,
+) -> Result<bool, String> {
+    // Page only messages/errors, not a bounded tail that could forget an old
+    // attempt. Include legacy recovery messages when upgrading an actor.
+    let mut offset = 0;
+    loop {
+        let events = store
+            .get_events(
+                mission_id,
+                Some(&["user_message", "error"]),
+                Some(100),
+                Some(offset),
+            )
+            .await?;
+        if events.iter().any(|event| {
+            (event.event_type == "error" && event.content == GROK_TRANSPORT_RECOVERY_RESERVED)
+                || (event.event_type == "user_message"
+                    && event.metadata.get("source").and_then(|v| v.as_str())
+                        == Some("transport_auto_resume"))
+        }) {
+            return Ok(true);
+        }
+        if events.len() < 100 {
+            return Ok(false);
+        }
+        offset += events.len();
+    }
+}
+
+/// Shared by the serial and parallel completion paths in the single control
+/// actor. Grok gets one recovery per mission, deliberately stricter than a
+/// budget reset at each new checkpoint. Persist the reservation before queueing
+/// so an actor restart (or a crash between reservation and queueing) cannot
+/// replay the same incident. Other backends retain their existing three tries.
+async fn reserve_transport_auto_resume(
+    store: &dyn MissionStore,
+    attempts: &mut HashMap<Uuid, u8>,
+    mission_id: Uuid,
+    grok_acp: bool,
+) -> bool {
+    let count = attempts.entry(mission_id).or_insert(0);
+    if *count >= if grok_acp { 1 } else { 3 } {
+        return false;
+    }
+    *count += 1;
+    if !grok_acp {
+        return true;
+    }
+
+    let reserve = async {
+        if grok_transport_recovery_was_reserved(store, mission_id).await? {
+            return Ok(false);
+        }
+        // Queued UserMessage events intentionally are not persisted. Record
+        // the reservation as an error diagnostic instead of falsely claiming
+        // that a recovery message has already started executing.
+        store
+            .log_event(
+                mission_id,
+                &AgentEvent::Error {
+                    message: GROK_TRANSPORT_RECOVERY_RESERVED.to_string(),
+                    mission_id: Some(mission_id),
+                    resumable: true,
+                },
+            )
+            .await?;
+        if !grok_transport_recovery_was_reserved(store, mission_id).await? {
+            return Err("mission store did not persist the Grok recovery reservation".to_string());
+        }
+        Ok(true)
+    }
+    .await;
+    match reserve {
+        Ok(reserved) => reserved,
+        Err(error) => {
+            tracing::warn!(%mission_id, %error, "Grok transport recovery withheld: durable budget unavailable");
+            false
+        }
+    }
+}
+
 const TRANSPORT_AUTO_RESUME_PROMPT: &str = "The previous turn ended because its provider transport disconnected. Reconcile the current workspace, remote jobs, and repository head, then resume the same task. Do not duplicate an accepted job or create a replacement writer.";
 
 const CHATGPT_UI_TRANSPORT_FALLBACK_PROMPT: &str = "The previous ChatGPT UI turn failed to start. Repeat the original user request exactly. Do not reconcile git, PRs, Lean, remote jobs, or repository head.";
@@ -18818,7 +18912,6 @@ async fn control_actor_loop(
     // quota/capacity, source failures, stalls, and loops are deliberately not
     // eligible. Writer leases are re-acquired by the normal start path.
     let mut transport_auto_resumed_missions: HashMap<Uuid, u8> = HashMap::new();
-    const TRANSPORT_AUTO_RESUME_MAX: u8 = 3;
     // Track subtasks for the main runner
     let mut main_runner_subtasks: Vec<super::mission_runner::SubtaskInfo> = Vec::new();
     // Track number of in-flight tool calls on the main runner so the stall
@@ -22499,6 +22592,7 @@ async fn control_actor_loop(
                     let mut completed_terminal_evidence = None;
                     let mut completed_completion_confidence = None;
                     let mut completed_transport_failure = false;
+                    let mut completed_grok_acp_transport_failure = false;
                     let mut completed_waiting_remote_job = false;
                     // Captured for the post-turn `grok_goal` sentinel hook (see
                     // `post_turn_handle_grok_goal`), which runs after this
@@ -22516,6 +22610,8 @@ async fn control_actor_loop(
                                 Some(completion_evidence.completion_confidence);
                             completed_transport_failure =
                                 is_transport_failure_evidence(&completion_evidence);
+                            completed_grok_acp_transport_failure =
+                                is_grok_acp_transport_failure(&agent_result);
                             completed_agent_output = agent_result.output.clone();
                             if let Some(run) = running_run.take() {
                                 completed_waiting_remote_job =
@@ -22815,16 +22911,13 @@ async fn control_actor_loop(
                     if !completed_waiting_remote_job {
                         if let Some(mission_id) = completed_mission_id {
                         if completed_transport_failure
-                            && {
-                                let count = transport_auto_resumed_missions
-                                    .entry(mission_id)
-                                    .or_insert(0);
-                                *count < TRANSPORT_AUTO_RESUME_MAX && {
-                                    *count += 1;
-                                    true
-                                }
-                            }
                             && !queue_has_pending_target_mission(&queue, mission_id)
+                            && reserve_transport_auto_resume(
+                                mission_store.as_ref(),
+                                &mut transport_auto_resumed_missions,
+                                mission_id,
+                                completed_grok_acp_transport_failure,
+                            ).await
                         {
                             let resume_message = transport_auto_resume_message_for_mission(
                                 mission_store.as_ref(),
@@ -23425,15 +23518,12 @@ async fn control_actor_loop(
                                 && is_transport_failure_evidence(&completion_evidence)
                                 && !cancellation_requested
                                 && was_queue_empty
-                                && {
-                                    let count = transport_auto_resumed_missions
-                                        .entry(*mission_id)
-                                        .or_insert(0);
-                                    *count < TRANSPORT_AUTO_RESUME_MAX && {
-                                        *count += 1;
-                                        true
-                                    }
-                                }
+                                && reserve_transport_auto_resume(
+                                    mission_store.as_ref(),
+                                    &mut transport_auto_resumed_missions,
+                                    *mission_id,
+                                    is_grok_acp_transport_failure(&result),
+                                ).await
                             {
                                 tracing::info!(
                                     mission_id = %mission_id,
@@ -34079,6 +34169,131 @@ Investigate <service/> failures.
         ));
         assert!(!is_transport_failure_evidence(
             &completion_evidence_for_agent_result(&auth)
+        ));
+    }
+
+    #[tokio::test]
+    async fn grok_transport_recovery_budget_survives_restart_and_event_pagination() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "grok-retry")
+            .await
+            .unwrap();
+        let mission = store
+            .create_mission(
+                Some("grok retry"),
+                None,
+                None,
+                None,
+                None,
+                Some("grok"),
+                None,
+            )
+            .await
+            .unwrap();
+        // The reservation must be found beyond an arbitrary first page.
+        for _ in 0..110 {
+            store
+                .log_event(
+                    mission.id,
+                    &AgentEvent::UserMessage {
+                        id: Uuid::new_v4(),
+                        content: "checkpoint".to_string(),
+                        queued: false,
+                        mission_id: Some(mission.id),
+                        source: Some("api:test".to_string()),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        let mut attempts = HashMap::new();
+        assert!(reserve_transport_auto_resume(&store, &mut attempts, mission.id, true).await);
+        assert!(!reserve_transport_auto_resume(&store, &mut attempts, mission.id, true).await);
+        drop(store);
+        let reopened =
+            mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "grok-retry")
+                .await
+                .unwrap();
+        let mut restarted_actor = HashMap::new();
+        assert!(
+            !reserve_transport_auto_resume(&reopened, &mut restarted_actor, mission.id, true).await
+        );
+        let reservations = reopened
+            .get_events(mission.id, Some(&["error"]), None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            reservations.len(),
+            1,
+            "serial/parallel retries must share one durable reservation"
+        );
+        assert_eq!(reservations[0].content, GROK_TRANSPORT_RECOVERY_RESERVED);
+    }
+
+    #[tokio::test]
+    async fn grok_transport_recovery_gate_fails_closed_without_changing_other_backends() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "grok-retry")
+            .await
+            .unwrap();
+        let mission = store
+            .create_mission(None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let db = rusqlite::Connection::open(dir.path().join("missions-grok-retry.db")).unwrap();
+        db.execute("DROP TABLE mission_events", []).unwrap();
+        let mut attempts = HashMap::new();
+        assert!(!reserve_transport_auto_resume(&store, &mut attempts, mission.id, true).await);
+        let other = Uuid::new_v4();
+        for _ in 0..3 {
+            assert!(reserve_transport_auto_resume(&store, &mut attempts, other, false).await);
+        }
+        assert!(!reserve_transport_auto_resume(&store, &mut attempts, other, false).await);
+    }
+
+    #[tokio::test]
+    async fn grok_transport_recovery_respects_preexisting_recovery_messages() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "grok-retry")
+            .await
+            .unwrap();
+        let mission = store
+            .create_mission(None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::UserMessage {
+                    id: Uuid::new_v4(),
+                    content: "prior recovery".to_string(),
+                    queued: false,
+                    mission_id: Some(mission.id),
+                    source: Some("transport_auto_resume".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            !reserve_transport_auto_resume(&store, &mut HashMap::new(), mission.id, true).await
+        );
+    }
+
+    #[test]
+    fn grok_transport_timeout_cannot_be_promoted_to_success() {
+        let mut result = crate::agents::AgentResult::failure("Grok ACP transport-idle timeout after 600s without a protocol event; checkout preserved", 0)
+            .with_terminal_reason(TerminalReason::LlmError)
+            .with_data(serde_json::json!({
+                "failure_class": "transport_error",
+                "transport_failure_stage": "grok_acp_transport_idle",
+                "grok_acp_transport_failure": true,
+            }));
+        maybe_recover_soft_llm_error(&mut result);
+        assert!(!result.success);
+        assert_eq!(result.terminal_reason, Some(TerminalReason::LlmError));
+        assert!(is_grok_acp_transport_failure(&result));
+        assert!(is_transport_failure_evidence(
+            &completion_evidence_for_agent_result(&result)
         ));
     }
 

--- a/src/api/runners/fixtures/grok_acp.py
+++ b/src/api/runners/fixtures/grok_acp.py
@@ -57,7 +57,10 @@ for line in sys.stdin:
             emit({"jsonrpc": "2.0", "id": 22, "method": "session/request_input",
                   "params": {"sessionId": "fixture-session"}})
             time.sleep(3)
-        elif scenario == "eof":
+        elif scenario in ("eof", "eof_cancel"):
+            if scenario == "eof_cancel":
+                update({"sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": "closing stdout"}})
             os.close(sys.stdout.fileno())
             time.sleep(3)
             break

--- a/src/api/runners/fixtures/grok_acp.py
+++ b/src/api/runners/fixtures/grok_acp.py
@@ -1,0 +1,77 @@
+"""Offline ACP peer for Grok runner lifecycle tests; never invokes a model/tool."""
+
+import json
+import os
+import sys
+import time
+
+
+def emit(value):
+    print(json.dumps(value), flush=True)
+
+
+def update(value):
+    emit({"jsonrpc": "2.0", "method": "session/update",
+          "params": {"sessionId": "fixture-session", "update": value}})
+
+
+scenario = sys.argv[1]
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {"protocolVersion": 1}
+    elif method in ("session/new", "session/load"):
+        result = {"sessionId": "fixture-session"}
+    elif method == "session/set_model":
+        result = {}
+    elif method == "session/prompt":
+        with open("accepted-prompts", "a", encoding="utf-8") as receipt:
+            receipt.write("accepted\n")
+        print("fixture stderr diagnostic", file=sys.stderr, flush=True)
+        if scenario == "silent_success":
+            time.sleep(0.30)
+        elif scenario in ("long_tool", "cancel", "completed_tool_dead", "missing_status", "expired_tool"):
+            call = {"sessionUpdate": "tool_call", "toolCallId": "build-1",
+                    "title": "run_terminal_command", "kind": "execute", "status": "pending",
+                    "rawInput": {"command": "fixture build", "timeout": 1200}}
+            if scenario == "missing_status":
+                call.pop("status")
+            update(call)
+            if scenario != "missing_status":
+                update({"sessionUpdate": "tool_call_update", "toolCallId": "build-1",
+                        "status": "in_progress"})
+            if scenario == "completed_tool_dead":
+                update({"sessionUpdate": "tool_call_update", "toolCallId": "build-1",
+                        "status": "completed"})
+            time.sleep(0.80 if scenario == "long_tool" else 3)
+            update({"sessionUpdate": "tool_call_update", "toolCallId": "build-1",
+                    "status": "completed"})
+        elif scenario == "junk":
+            for _ in range(40):
+                print("not a protocol event", flush=True)
+                emit({"unrelated": True})
+                time.sleep(0.05)
+        elif scenario == "input":
+            emit({"jsonrpc": "2.0", "id": 22, "method": "session/request_input",
+                  "params": {"sessionId": "fixture-session"}})
+            time.sleep(3)
+        elif scenario == "eof":
+            os.close(sys.stdout.fileno())
+            time.sleep(3)
+            break
+        elif scenario == "prompt_error":
+            emit({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32000, "message": "fixture provider failure"}})
+            break
+        else:
+            time.sleep(3)
+        update({"sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "fixture completed"}})
+        result = {"stopReason": "end_turn", "_meta": {"modelId": "fixture-model"}}
+        emit({"jsonrpc": "2.0", "id": request_id, "result": result})
+        break
+    else:
+        continue
+    emit({"jsonrpc": "2.0", "id": request_id, "result": result})

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -1846,11 +1846,18 @@ async fn run_grok_acp_process(
     // EOF and a terminal response must not hang forever on a CLI/descendant
     // that keeps the process alive. This tears down only our harness process;
     // it never resets or removes the mission checkout/session.
-    if tokio::time::timeout(idle_policy.shutdown, child.wait())
-        .await
-        .is_err()
-    {
-        let _ = child.kill().await;
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            let _ = child.kill().await;
+            return Ok(AgentResult::failure("Mission cancelled", 0)
+                .with_terminal_reason(TerminalReason::Cancelled));
+        }
+        exit = tokio::time::timeout(idle_policy.shutdown, child.wait()) => {
+            if exit.is_err() {
+                let _ = child.kill().await;
+            }
+        }
     }
 
     // The CLI doesn't always stamp a terminal status on the last
@@ -2046,6 +2053,12 @@ mod tests {
                         cancel.cancel();
                         break;
                     }
+                    if matches!(event, AgentEvent::TextDelta { ref content, .. } if content == "closing stdout")
+                    {
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        cancel.cancel();
+                        break;
+                    }
                 }
             });
         }
@@ -2170,6 +2183,14 @@ mod tests {
             "stream_closed"
         );
         assert!(elapsed < std::time::Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn grok_acp_cancellation_during_eof_teardown_is_not_a_transport_retry() {
+        let (result, _, elapsed) = grok_acp_fixture("eof_cancel", true).await;
+        assert_eq!(result.terminal_reason, Some(TerminalReason::Cancelled));
+        assert!(result.data.is_none());
+        assert!(elapsed < std::time::Duration::from_millis(600));
     }
 
     #[tokio::test]

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -1130,6 +1130,101 @@ struct GrokAcpToolCall {
     name: String,
     latest_update: serde_json::Value,
     result_emitted: bool,
+    started_at: Option<tokio::time::Instant>,
+    deadline: Option<tokio::time::Instant>,
+    in_progress: bool,
+}
+
+#[derive(Clone, Copy)]
+struct GrokAcpIdlePolicy {
+    diagnostic: std::time::Duration,
+    transport: std::time::Duration,
+    tool_grace: std::time::Duration,
+    shutdown: std::time::Duration,
+}
+
+impl Default for GrokAcpIdlePolicy {
+    fn default() -> Self {
+        Self {
+            diagnostic: std::time::Duration::from_secs(180),
+            transport: std::time::Duration::from_secs(600),
+            tool_grace: std::time::Duration::from_secs(30),
+            shutdown: std::time::Duration::from_secs(10),
+        }
+    }
+}
+
+impl GrokAcpToolCall {
+    fn observe(
+        &mut self,
+        update: &serde_json::Value,
+        now: tokio::time::Instant,
+        policy: GrokAcpIdlePolicy,
+    ) {
+        // ACP updates are partial. In particular, the in_progress update can
+        // omit the rawInput supplied with the original pending tool call.
+        if let (Some(current), Some(delta)) =
+            (self.latest_update.as_object_mut(), update.as_object())
+        {
+            current.extend(delta.clone());
+        } else {
+            self.latest_update = update.clone();
+        }
+        match update.get("status").and_then(|v| v.as_str()) {
+            Some("in_progress") if !self.result_emitted => {
+                self.in_progress = true;
+                let started = *self.started_at.get_or_insert(now);
+                // Grok Bash `timeout` and task-output `timeout_ms` are in
+                // milliseconds. Zero/missing/invalid means no observed finite
+                // deadline, not an unlimited exemption from transport checks.
+                let input = &self.latest_update["rawInput"];
+                let timeout = input.get("timeout_ms").or_else(|| input.get("timeout"));
+                let millis = timeout.and_then(|v| {
+                    v.as_u64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
+                });
+                self.deadline = millis.filter(|ms| *ms > 0).and_then(|ms| {
+                    started
+                        .checked_add(std::time::Duration::from_millis(ms))?
+                        .checked_add(policy.tool_grace)
+                });
+            }
+            Some("completed" | "failed" | "pending") => {
+                self.in_progress = false;
+                self.deadline = None;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn grok_acp_idle_deadline(
+    last_event: tokio::time::Instant,
+    calls: &HashMap<String, GrokAcpToolCall>,
+    policy: GrokAcpIdlePolicy,
+) -> tokio::time::Instant {
+    calls
+        .values()
+        .filter(|call| call.in_progress && !call.result_emitted)
+        .filter_map(|call| call.deadline)
+        .fold(last_event + policy.transport, std::cmp::max)
+}
+
+fn grok_acp_note_activity(
+    last_event: &mut tokio::time::Instant,
+    diagnostic_emitted: &mut bool,
+    events: &broadcast::Sender<AgentEvent>,
+    mission_id: Uuid,
+) {
+    *last_event = tokio::time::Instant::now();
+    if std::mem::take(diagnostic_emitted) {
+        let _ = events.send(AgentEvent::AgentPhase {
+            phase: "executing".to_string(),
+            detail: Some("Grok activity resumed".to_string()),
+            agent: Some("grok".to_string()),
+            mission_id: Some(mission_id),
+        });
+    }
 }
 
 fn grok_acp_update_is_terminal(update: &serde_json::Value) -> bool {
@@ -1157,8 +1252,6 @@ async fn run_grok_acp_turn(
     session_id: Option<&str>,
     is_continuation: bool,
 ) -> Result<AgentResult, GrokAcpFallback> {
-    use tokio::io::{AsyncBufReadExt, BufReader};
-
     let workspace_exec = WorkspaceExec::new(workspace.clone());
 
     let cli_path =
@@ -1178,10 +1271,42 @@ async fn run_grok_acp_turn(
     // --no-auto-update). cwd comes from spawn_streaming's working dir and
     // the session/new params.
     let args = vec!["agent".to_string(), "stdio".to_string()];
-    let mut child = workspace_exec
+    let child = workspace_exec
         .spawn_streaming(work_dir, &cli_path, &args, env)
         .await
         .map_err(|e| format!("failed to spawn grok agent stdio: {e}"))?;
+
+    run_grok_acp_process(
+        child,
+        &workspace_exec.translate_path_for_container(work_dir),
+        message,
+        model,
+        mission_id,
+        events_tx,
+        cancel,
+        session_id,
+        is_continuation,
+        GrokAcpIdlePolicy::default(),
+    )
+    .await
+}
+
+// Kept below discovery/auth so the real protocol and process lifecycle can be
+// exercised with a local ACP fixture, without credentials or inference calls.
+#[allow(clippy::too_many_arguments)]
+async fn run_grok_acp_process(
+    mut child: tokio::process::Child,
+    acp_cwd: &str,
+    message: &str,
+    model: Option<&str>,
+    mission_id: Uuid,
+    events_tx: broadcast::Sender<AgentEvent>,
+    cancel: CancellationToken,
+    session_id: Option<&str>,
+    is_continuation: bool,
+    idle_policy: GrokAcpIdlePolicy,
+) -> Result<AgentResult, GrokAcpFallback> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
 
     let mut stdin = child
         .stdin
@@ -1284,7 +1409,6 @@ async fn run_grok_acp_turn(
         .await?;
         let _ = await_response(&mut lines, GROK_ACP_INIT_ID, 30).await?;
 
-        let acp_cwd = workspace_exec.translate_path_for_container(work_dir);
         let mut acp_session_id: Option<String> = None;
         if let Some(sid) = session_id.filter(|s| !s.trim().is_empty()) {
             // Sessions persist server-side; `session/load` resumes prior context.
@@ -1451,13 +1575,18 @@ async fn run_grok_acp_turn(
     let mut usage = crate::cost::TokenUsage::default();
     let mut stop_reason: Option<String> = None;
     let mut transport_error: Option<String> = None;
-
-    // Idle guard: tool executions stream tool_call_update events, so a long
-    // silent gap means the CLI is stuck (or waiting on something that will
-    // never arrive in headless mode).
-    let idle_limit = std::time::Duration::from_secs(180);
+    let mut transport_failure_stage = "stream_closed";
+    let mut last_event = tokio::time::Instant::now();
+    let mut idle_diagnostic_emitted = false;
+    let mut awaiting_input = false;
 
     loop {
+        let deadline = grok_acp_idle_deadline(last_event, &tool_calls, idle_policy);
+        let next_check = if idle_diagnostic_emitted {
+            deadline
+        } else {
+            last_event + idle_policy.diagnostic
+        };
         let line = tokio::select! {
             biased;
             _ = cancel.cancelled() => {
@@ -1475,27 +1604,60 @@ async fn run_grok_acp_turn(
                 )
                 .with_terminal_reason(TerminalReason::AuthError));
             }
-            line = tokio::time::timeout(idle_limit, lines.next_line()) => match line {
-                Err(_) => {
+            _ = tokio::time::sleep_until(next_check) => {
+                let idle_secs = last_event.elapsed().as_secs();
+                let wait_state = if awaiting_input {
+                    "awaiting_client_input"
+                } else if tool_calls.values().any(|call| call.in_progress && !call.result_emitted) {
+                    "awaiting_tool_results"
+                } else {
+                    "awaiting_inference"
+                };
+                if tokio::time::Instant::now() >= deadline {
+                    transport_failure_stage = "grok_acp_transport_idle";
                     transport_error = Some(format!(
-                        "Grok ACP produced no events for {}s; killing the CLI",
-                        idle_limit.as_secs()
+                        "Grok ACP transport-idle timeout after {idle_secs}s without a protocol event \
+                         ({wait_state}); no active tool has an unexpired observed deadline. \
+                         Checkout and session are preserved; reconcile existing work before recovery."
                     ));
                     let _ = child.kill().await;
                     break;
                 }
-                Ok(Err(e)) => {
+                // Process existence is diagnostic, not proof of useful work.
+                // A healthy inference or foreground tool can be silent for
+                // longer than 180s. Only its hard deadline can terminate it.
+                let process_running = matches!(child.try_wait(), Ok(None));
+                tracing::warn!(
+                    %mission_id,
+                    idle_secs,
+                    wait_state,
+                    process_running,
+                    remaining_secs = deadline.saturating_duration_since(tokio::time::Instant::now()).as_secs(),
+                    "Grok ACP is silent; continuing to observe until the transport/tool deadline"
+                );
+                let _ = events_tx.send(AgentEvent::AgentPhase {
+                    phase: "waiting".to_string(),
+                    detail: Some(format!("Grok has been silent for {idle_secs}s ({wait_state}); observing until its deadline.")),
+                    agent: Some("grok".to_string()),
+                    mission_id: Some(mission_id),
+                });
+                idle_diagnostic_emitted = true;
+                continue;
+            }
+            line = lines.next_line() => match line {
+                Err(e) => {
+                    transport_failure_stage = "stdout_read";
                     transport_error = Some(format!("Grok ACP stdout read failed: {e}"));
                     break;
                 }
-                Ok(Ok(None)) => {
+                Ok(None) => {
                     if stop_reason.is_none() {
                         transport_error =
                             Some("Grok ACP stream closed before the prompt completed".to_string());
                     }
                     break;
                 }
-                Ok(Ok(Some(line))) => line,
+                Ok(Some(line)) => line,
             }
         };
 
@@ -1507,6 +1669,13 @@ async fn run_grok_acp_turn(
         // one we expect is a permission prompt — auto-approve it, mirroring
         // the streaming path's --always-approve.
         if let (Some(req_id), Some(method)) = (value.get("id"), value.get("method")) {
+            grok_acp_note_activity(
+                &mut last_event,
+                &mut idle_diagnostic_emitted,
+                &events_tx,
+                mission_id,
+            );
+            awaiting_input = true;
             if method == "session/request_permission" {
                 let option_id = value
                     .pointer("/params/options")
@@ -1523,16 +1692,26 @@ async fn run_grok_acp_turn(
                     .and_then(|o| o.get("optionId"))
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
-                let _ = send(
-                    &mut stdin,
-                    serde_json::json!({
+                let response = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        let _ = child.kill().await;
+                        return Ok(AgentResult::failure("Mission cancelled", 0)
+                            .with_terminal_reason(TerminalReason::Cancelled));
+                    }
+                    response = tokio::time::timeout(idle_policy.transport, send(&mut stdin, serde_json::json!({
                         "jsonrpc": "2.0",
                         "id": req_id,
                         "params": null,
                         "result": { "outcome": { "outcome": "selected", "optionId": option_id } }
-                    }),
-                )
-                .await;
+                    }))) => response.unwrap_or_else(|_| Err("permission response write timed out".to_string())),
+                };
+                if let Err(error) = response {
+                    transport_failure_stage = "permission_response";
+                    transport_error = Some(format!("Grok ACP permission response failed: {error}"));
+                    break;
+                }
+                awaiting_input = false;
             }
             continue;
         }
@@ -1540,6 +1719,9 @@ async fn run_grok_acp_turn(
         // Prompt completion.
         if value.get("id").and_then(|v| v.as_u64()) == Some(GROK_ACP_PROMPT_ID) {
             if let Some(err) = value.get("error") {
+                // A JSON-RPC error is a provider/agent response, not proof of
+                // a broken transport. Do not auto-replay it as an idle retry.
+                transport_failure_stage = "prompt_error";
                 transport_error = Some(format!("Grok ACP prompt failed: {err}"));
                 break;
             }
@@ -1572,6 +1754,13 @@ async fn run_grok_acp_turn(
             _ => None,
         };
         let Some(update) = update else { continue };
+        grok_acp_note_activity(
+            &mut last_event,
+            &mut idle_diagnostic_emitted,
+            &events_tx,
+            mission_id,
+        );
+        awaiting_input = false;
         match update.get("sessionUpdate").and_then(|v| v.as_str()) {
             Some("agent_thought_chunk") => {
                 if let Some(text) = update.pointer("/content/text").and_then(|v| v.as_str()) {
@@ -1623,14 +1812,9 @@ async fn run_grok_acp_turn(
                     args,
                     mission_id: Some(mission_id),
                 });
-                tool_calls.insert(
-                    id,
-                    GrokAcpToolCall {
-                        name,
-                        latest_update: update,
-                        result_emitted: false,
-                    },
-                );
+                let entry = tool_calls.entry(id).or_default();
+                entry.name = name;
+                entry.observe(&update, last_event, idle_policy);
             }
             Some("tool_call_update") => {
                 let Some(id) = update.get("toolCallId").and_then(|v| v.as_str()) else {
@@ -1644,7 +1828,7 @@ async fn run_grok_acp_turn(
                         .unwrap_or("tool")
                         .to_string();
                 }
-                entry.latest_update = update.clone();
+                entry.observe(&update, last_event, idle_policy);
                 if grok_acp_update_is_terminal(&update) && !entry.result_emitted {
                     entry.result_emitted = true;
                     let _ = events_tx.send(AgentEvent::ToolResult {
@@ -1659,7 +1843,15 @@ async fn run_grok_acp_turn(
         }
     }
     drop(stdin);
-    let _ = child.wait().await;
+    // EOF and a terminal response must not hang forever on a CLI/descendant
+    // that keeps the process alive. This tears down only our harness process;
+    // it never resets or removes the mission checkout/session.
+    if tokio::time::timeout(idle_policy.shutdown, child.wait())
+        .await
+        .is_err()
+    {
+        let _ = child.kill().await;
+    }
 
     // The CLI doesn't always stamp a terminal status on the last
     // tool_call_update — flush whatever we have so every ToolCall gets a
@@ -1685,8 +1877,21 @@ async fn run_grok_acp_turn(
         } else {
             format!("{err}\nstderr tail:\n{stderr_tail}")
         };
-        return Ok(AgentResult::failure(detail, 0)
+        return Ok(AgentResult::failure(detail.clone(), 0)
             .with_terminal_reason(TerminalReason::LlmError)
+            .with_terminal_evidence(detail)
+            .with_data(serde_json::json!({
+                "failure_class": if transport_failure_stage == "prompt_error" {
+                    "provider_error"
+                } else {
+                    "transport_error"
+                },
+                "transport_failure_stage": transport_failure_stage,
+                "grok_acp_transport_failure": true,
+                "pending_tools": tool_calls.values().filter(|call| !call.result_emitted).count(),
+                "idle_seconds": last_event.elapsed().as_secs(),
+                "awaiting_input": awaiting_input,
+            }))
             .with_model(model_used.unwrap_or_else(|| "grok-build".to_string())));
     }
 
@@ -1735,6 +1940,244 @@ mod tests {
     use super::*;
     use crate::workspace::WorkspaceType;
     use std::fs;
+
+    #[test]
+    fn grok_acp_idle_deadlines_distinguish_pending_running_and_finished_tools() {
+        use std::time::Duration;
+        let policy = GrokAcpIdlePolicy::default();
+        let now = tokio::time::Instant::now();
+        let mut calls = HashMap::new();
+        assert_eq!(policy.diagnostic, Duration::from_secs(180));
+        assert_eq!(
+            grok_acp_idle_deadline(now, &calls, policy),
+            now + Duration::from_secs(600)
+        );
+
+        let call = calls
+            .entry("build".to_string())
+            .or_insert_with(GrokAcpToolCall::default);
+        call.observe(
+            &serde_json::json!({"status": "pending", "rawInput": {"timeout": "3600000"}}),
+            now,
+            policy,
+        );
+        assert_eq!(
+            grok_acp_idle_deadline(now, &calls, policy),
+            now + Duration::from_secs(600)
+        );
+        calls.get_mut("build").unwrap().observe(
+            &serde_json::json!({"status": "in_progress"}),
+            now,
+            policy,
+        );
+        let tool_deadline = now + Duration::from_secs(3630);
+        assert_eq!(grok_acp_idle_deadline(now, &calls, policy), tool_deadline);
+        // Repeated status updates cannot restart the tool's own timeout.
+        calls.get_mut("build").unwrap().observe(
+            &serde_json::json!({"status": "in_progress"}),
+            now + Duration::from_secs(200),
+            policy,
+        );
+        assert_eq!(grok_acp_idle_deadline(now, &calls, policy), tool_deadline);
+        calls.get_mut("build").unwrap().observe(
+            &serde_json::json!({"status": "completed"}),
+            now,
+            policy,
+        );
+        assert_eq!(
+            grok_acp_idle_deadline(now, &calls, policy),
+            now + Duration::from_secs(600)
+        );
+    }
+
+    #[test]
+    fn grok_acp_unknown_or_unbounded_tools_do_not_disable_idle_guard() {
+        let policy = GrokAcpIdlePolicy::default();
+        let now = tokio::time::Instant::now();
+        for input in [
+            serde_json::json!({}),
+            serde_json::json!({"timeout": 0}),
+            serde_json::json!({"timeout": -1}),
+            serde_json::json!({"timeout": "forever"}),
+        ] {
+            let mut calls = HashMap::new();
+            let mut call = GrokAcpToolCall::default();
+            call.observe(
+                &serde_json::json!({"status": "in_progress", "rawInput": input}),
+                now,
+                policy,
+            );
+            calls.insert("tool".to_string(), call);
+            assert_eq!(
+                grok_acp_idle_deadline(now, &calls, policy),
+                now + policy.transport
+            );
+        }
+    }
+
+    async fn grok_acp_fixture(
+        scenario: &str,
+        cancel_after_tool: bool,
+    ) -> (AgentResult, Vec<AgentEvent>, std::time::Duration) {
+        use std::process::Stdio;
+        use std::time::Duration;
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("proof-artifact"), "preserved checkout").unwrap();
+        let child = tokio::process::Command::new("python3")
+            .arg("-u")
+            .arg("-c")
+            .arg(include_str!("fixtures/grok_acp.py"))
+            .arg(scenario)
+            .current_dir(root.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        let (events_tx, mut events_rx) = broadcast::channel(64);
+        let cancel = CancellationToken::new();
+        if cancel_after_tool {
+            let mut cancel_rx = events_tx.subscribe();
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                while let Ok(event) = cancel_rx.recv().await {
+                    if matches!(event, AgentEvent::ToolCall { .. }) {
+                        cancel.cancel();
+                        break;
+                    }
+                }
+            });
+        }
+        let start = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            run_grok_acp_process(
+                child,
+                root.path().to_str().unwrap(),
+                "fixture prompt",
+                Some("fixture-model"),
+                Uuid::new_v4(),
+                events_tx,
+                cancel,
+                None,
+                false,
+                GrokAcpIdlePolicy {
+                    diagnostic: Duration::from_millis(180),
+                    transport: Duration::from_millis(600),
+                    tool_grace: Duration::from_millis(30),
+                    shutdown: Duration::from_millis(120),
+                },
+            ),
+        )
+        .await
+        .expect("ACP lifecycle must remain bounded")
+        .unwrap_or_else(|e| panic!("unexpected pre-prompt fallback: {}", e.reason));
+        let elapsed = start.elapsed();
+        // Post-prompt recovery belongs to the control actor; the protocol
+        // runner must never replay a prompt itself, even after repeated EOF.
+        assert_eq!(
+            fs::read_to_string(root.path().join("accepted-prompts")).unwrap(),
+            "accepted\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("proof-artifact")).unwrap(),
+            "preserved checkout"
+        );
+        let mut events = Vec::new();
+        while let Ok(event) = events_rx.try_recv() {
+            events.push(event);
+        }
+        (result, events, elapsed)
+    }
+
+    #[tokio::test]
+    async fn grok_acp_silent_inference_survives_diagnostic_deadline() {
+        let (result, events, _) = grok_acp_fixture("silent_success", false).await;
+        assert!(result.success, "{}", result.output);
+        assert_eq!(result.output, "fixture completed");
+        assert!(events.iter().any(|event| matches!(event, AgentEvent::AgentPhase { detail: Some(detail), .. } if detail.contains("awaiting_inference"))));
+    }
+
+    #[tokio::test]
+    async fn grok_acp_dead_transport_times_out_with_evidence_and_no_replay() {
+        for scenario in ["dead", "junk", "missing_status", "completed_tool_dead"] {
+            let (result, _, elapsed) = grok_acp_fixture(scenario, false).await;
+            assert!(!result.success, "scenario: {scenario}");
+            assert!(elapsed >= std::time::Duration::from_millis(600));
+            assert!(
+                elapsed < std::time::Duration::from_secs(2),
+                "{scenario}: {elapsed:?}"
+            );
+            assert_eq!(
+                result.data.as_ref().unwrap()["transport_failure_stage"],
+                "grok_acp_transport_idle"
+            );
+            assert_eq!(
+                result.data.as_ref().unwrap()["failure_class"],
+                "transport_error"
+            );
+            assert!(result
+                .terminal_evidence
+                .unwrap()
+                .contains("fixture stderr diagnostic"));
+        }
+    }
+
+    #[tokio::test]
+    async fn grok_acp_long_tool_survives_transport_idle_under_its_own_deadline() {
+        let (result, events, elapsed) = grok_acp_fixture("long_tool", false).await;
+        assert!(result.success, "{}", result.output);
+        assert!(elapsed > std::time::Duration::from_millis(600));
+        assert!(events.iter().any(|event| matches!(event, AgentEvent::AgentPhase { detail: Some(detail), .. } if detail.contains("awaiting_tool_results"))));
+        assert!(events.iter().any(|event| matches!(event, AgentEvent::ToolResult { result, .. } if result["status"] == "completed")));
+    }
+
+    #[tokio::test]
+    async fn grok_acp_stale_running_tool_times_out_after_its_deadline() {
+        let (result, _, elapsed) = grok_acp_fixture("expired_tool", false).await;
+        assert!(!result.success);
+        assert_eq!(
+            result.data.unwrap()["transport_failure_stage"],
+            "grok_acp_transport_idle"
+        );
+        assert!(elapsed >= std::time::Duration::from_millis(1200));
+        assert!(elapsed < std::time::Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn grok_acp_cancellation_interrupts_a_long_tool_without_recovery() {
+        let (result, _, elapsed) = grok_acp_fixture("cancel", true).await;
+        assert_eq!(result.terminal_reason, Some(TerminalReason::Cancelled));
+        assert!(elapsed < std::time::Duration::from_millis(600));
+        assert!(result.data.is_none());
+    }
+
+    #[tokio::test]
+    async fn grok_acp_input_wait_is_distinct_from_inference_idle() {
+        let (result, events, _) = grok_acp_fixture("input", false).await;
+        assert!(result.output.contains("awaiting_client_input"));
+        assert_eq!(result.data.unwrap()["awaiting_input"], true);
+        assert!(events.iter().any(|event| matches!(event, AgentEvent::AgentPhase { detail: Some(detail), .. } if detail.contains("awaiting_client_input"))));
+    }
+
+    #[tokio::test]
+    async fn grok_acp_closed_stdout_does_not_hang_waiting_for_process_exit() {
+        let (result, _, elapsed) = grok_acp_fixture("eof", false).await;
+        assert!(!result.success);
+        assert_eq!(
+            result.data.unwrap()["transport_failure_stage"],
+            "stream_closed"
+        );
+        assert!(elapsed < std::time::Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn grok_acp_prompt_error_is_not_retried_as_a_transport_failure() {
+        let (result, _, _) = grok_acp_fixture("prompt_error", false).await;
+        assert!(!result.success);
+        assert_eq!(result.data.unwrap()["failure_class"], "provider_error");
+    }
 
     fn container_workspace_at(path: &std::path::Path) -> Workspace {
         Workspace {


### PR DESCRIPTION
Grok ACP sessions could be killed after 180 seconds of quiet output even while a tool was running, and a transport failure could trigger repeated recovery after a restart. The runner now emits a diagnostic at 180 seconds, treats 600 seconds without protocol activity as an explicit transport failure, and respects a bounded deadline for an observed in-progress tool. EOF, cancellation and provider errors keep distinct outcomes; the checkout is preserved and the prompt is not submitted twice after acceptance.

The existing serial and parallel recovery paths share a durable one-retry limit for Grok ACP transport failures. The reservation is written and read back before queueing, survives SQLite reopen, and fails closed when storage is unavailable. Other backends retain their existing policy. An independently found cancellation/recovery race is covered and fixed. The limit is deliberately one retry per mission, stricter than resetting it at each checkpoint.

Validation: 113 `grok_` tests independently pass on b673a3807ae03aa6f6045f9f5285f8beadec0ace, including real fake-ACP subprocesses and temporary SQLite reopen/pagination tests. Independent review is CLEAN. The exact deployed f837 backport is 2cb354076f5e1e310a559421c705ce0f7cd60295, with an identical added/removed-line delta. Linux build and guarded deployment are tracked separately; activation will preserve the currently installed companion binaries, including the standalone MCP resume-readback fix.
