### PR TITLE
fix(mcp): make durable workspace execution explicit

### DIFF
--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -101,6 +101,21 @@ actually required; full histories are not injected by the status tools.
 - `delete_workspace_template` — requires explicit confirmation
 - `rebuild_workspace_from_template` — reapplies template fields and force-rebuilds; requires explicit confirmation
 - `workspace_bash`
+- `start_workspace_job`, `get_workspace_job`, `cancel_workspace_job`
+
+`workspace_bash` selects execution mode explicitly. Without ownership fields it
+runs a short diagnostic (60 seconds by default, hard limit 120); it does not
+classify shell strings, so searches such as `rg 'lake build'` work normally.
+For a build or any command that must survive the MCP call, supply **both**
+`mission_id` and `idempotency_key`. This uses the same durable admission as
+`start_workspace_job` and returns a job ID immediately (runtime limit 7200
+seconds by default, maximum 86400). A partial or empty pair is rejected before
+execution. Reuse the key for a retry of the same command after a lost response;
+use a new key for different work. Inspect `get_workspace_job` for a bounded
+status/log read and consume its completion callback instead of polling in a loop.
+This does not promote a synchronous command after it starts: submission chooses
+one path once, avoiding duplicate effects. `start_workspace_job` remains useful
+for its explicit `argv` and `resource_class` parameters.
 
 Configuration:
 

--- a/skills/controllers-policy/SKILL.md
+++ b/skills/controllers-policy/SKILL.md
@@ -327,11 +327,16 @@ repeated failure `repeat-loop-guard` · tool-call limits `context-budget`.
 - **Do not abandon the objective.** If dispatch is refused (disk, auth, capacity): keep the original project on its objective with a named infra blocker (`blocked:disk`, `blocked:auth`, `blocked:capacity`); open or fix the platform work under its own project (`sandboxed-sh`). Do not retitle or reuse the campaign session. Lido “Corriger et merger les PRs” becoming a P0 disk ticket is the incident — a platform outage is not a new campaign.
 - **Harness ≠ project blocked.** Missing CLI, wrong-arch binary, container `nsenter` failure: `mode=active` + `next=` switch backend / repair harness, or trailer `blocked:harness` ≤ 3 ticks then workaround. Structured write: `update_project_status(..., mode=blocked, blocker=harness)`. See the trailer rule above.
 - **Never persist `mode=blocked` + `next=inspect <uuid>`.** That is a dead writer, not a no-lane. ACK or redispatch; stay `mode=active`. A tick whose only act is inspect-without-redispatch is a defect (same as two ticks with no dispatch).
-- **No foreground `timeout` > 180s / `make test*` / `lake build` inside Codex bash.** Fire `remote-lean-build` (or an existing remote job) and poll the receipt. A 2h `make` in the Codex session stream dies on every deploy (`pending tool not replayed`).
+- **Long builds need a durable job.** Use `start_workspace_job`, or
+  `workspace_bash` with both `mission_id` and `idempotency_key`, and consume the
+  completion callback. Use `remote-lean-build` when remote placement is needed.
+  Reuse the same key for retries of the same submission. `workspace_bash`
+  without that pair is a short diagnostic with a hard 120-second timeout;
+  command text does not make it durable.
 
 ## Optimisations d exécution (2026-08-10, leçons terrain)
 
-- **Jamais de polling de build en boucle.** Ne relance pas la même commande d inspection de build/CI de façon répétée (un writer a bouclé 14× sur le même poll — pur gaspillage de budget). Vérifie UNE fois avec une attente bornée (`timeout 120s lake build` ou lecture unique du receipt/log), puis poursuis le correctif ; ne re-sonde que si un délai substantiel s est écoulé.
+- **Jamais de polling de build en boucle.** Ne relance pas la même commande d inspection de build/CI de façon répétée. Lis une fois le statut et les logs du job existant, puis attends son callback ou poursuis un travail indépendant. Ne lance pas une seconde compilation pour vérifier si la première avance.
 - **Juge la vivacité d une mission par ses PROCESSUS, pas par son silence.** Les builds/preuves Lean ont de longues phases silencieuses tout en progressant. Avant de conclure qu une mission est bloquée : vérifie la présence d un process `lean`/`lake` vivant et la montée de la séquence d événements. Silence ≠ wedge. N interromps JAMAIS un `make check`/`lake build` en vol — tu perdrais des heures de calcul.
 - **La vivacité d un scan GPU n est pas un `pgrep` local.** Pour Coldcard, appelle `scripts/coldcard-skip-scan-status.sh` (SSH DGX, `scan.log` + process). Un `pgrep` sur agent-core a déclaré DEAD le 2026-08-13 alors que le scan CUDA avançait à 2.75B/4.29B.
 - **API GitHub non réactive = bascule sur git.** Si les appels `gh`/API GitHub pendent, utilise `git ls-remote`/`git fetch` comme source de vérité du head plutôt que d attendre l API ; ne bloque pas la progression sur une lenteur d API externe.

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -559,7 +559,13 @@ repeated.
 - `resume_mission` — restart interrupted/blocked/failed, optionally with a hint
 - `cancel_mission` — stop a running/pending mission (use before reconfiguring)
 - `start_mission` — create a new mission
-- `workspace_bash` — run commands in the mission's workspace (verify real state)
+- `workspace_bash` — bounded diagnostic by default (60s, maximum 120s). For
+  builds or work that must survive the call, pass both `mission_id` and
+  `idempotency_key`; it returns a durable job ID immediately. Shell text does
+  not select the mode. Reuse the same key when retrying the same submission.
+- `start_workspace_job`, `get_workspace_job`, `cancel_workspace_job` — durable
+  execution with explicit ownership; consume completion callbacks, not a model
+  polling loop. `start_workspace_job` also accepts `argv` and `resource_class`.
 - `list_workspaces`, `list_mission_shared_files`, `download_shared_file`
 
 ## Installation

--- a/skills/sandboxed-sh-missions/SKILL.md
+++ b/skills/sandboxed-sh-missions/SKILL.md
@@ -21,6 +21,14 @@ reusing the key returns the original launch instead of duplicating work.
 Mission completion alone does not satisfy the track. Accepted criterion
 evidence at the governed artifact version must be recorded separately.
 
+For long workspace commands, use `start_workspace_job`, or pass both
+`mission_id` and `idempotency_key` to `workspace_bash`. Both return a durable
+job ID immediately through the same admission path; retry the same submission
+with the same key. Without that pair, `workspace_bash` is a short diagnostic
+(60 seconds by default, maximum 120) that is killed at timeout. Shell command
+text is not used to infer durability. Consume the job completion callback;
+do not keep an agent polling or launch another build to inspect the first.
+
 This is **not** the same as delegating to a CLI coding agent (Claude Code, Codex, OpenCode) via the `terminal` tool. The MCP runs an entire conversation loop inside the container; the CLI agents are interactive programs you spawn in a single `terminal()` call. Use this skill for isolated multi-step research/coding, or work that needs a specific pre-baked workspace (e.g. `tailscale-ubuntu`, `minecraft`, `dgx-spark`).
 
 ## When to use

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -629,6 +629,11 @@ struct WorkspaceBashParams {
     cwd: Option<String>,
     #[serde(default)]
     timeout_secs: Option<u64>,
+    /// Supplying both ownership fields selects restart-safe execution.
+    #[serde(default)]
+    mission_id: Option<String>,
+    #[serde(default)]
+    idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -681,25 +686,6 @@ fn workspace_job_command(
         (Some(_), Some(_)) => Err("Pass exactly one of command or argv, not both".to_string()),
         _ => Err("Pass a non-empty command or argv".to_string()),
     }
-}
-
-fn is_heavy_workspace_command(command: &str) -> bool {
-    let normalized = command
-        .split_whitespace()
-        .map(|part| part.to_ascii_lowercase())
-        .collect::<Vec<_>>()
-        .join(" ");
-    [
-        "lake build",
-        "lake test",
-        "cargo build --release",
-        "cargo test --all",
-        "npm run build",
-        "bun run build",
-        "next build",
-    ]
-    .iter()
-    .any(|needle| normalized.contains(needle))
 }
 
 fn compact_workspace_job(job: Value) -> Value {
@@ -2085,7 +2071,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "workspace_bash".to_string(),
-                description: "Run a short diagnostic command inside a sandboxed.sh workspace. Defaults to 60 seconds and never exceeds 120 seconds. Heavy commands such as `lake build` are rejected; use start_workspace_job for long work.".to_string(),
+                description: "Run a command inside a sandboxed.sh workspace. For builds or any work that must survive this call, supply both mission_id and idempotency_key: returns a durable job id immediately, with no polling. Without those fields, runs a bounded diagnostic (default 60 seconds, maximum 120) and kills it at timeout. Command text is never used to guess execution mode.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["command"],
@@ -2093,7 +2079,9 @@ impl AssistantMcp {
                         "command": {"type": "string", "description": "Shell command to run in the workspace."},
                         "workspace_id": {"type": "string", "description": "Workspace UUID. Defaults to the assistant's default workspace."},
                         "cwd": {"type": "string", "description": "Working directory relative to the workspace root."},
-                        "timeout_secs": {"type": "integer", "description": "Timeout in seconds, default 60, max 120."}
+                        "timeout_secs": {"type": "integer", "description": "Runtime limit: diagnostic default 60/max 120; durable default 7200/max 86400."},
+                        "mission_id": {"type": "string", "description": "Owning mission UUID; supply together with idempotency_key for durable execution."},
+                        "idempotency_key": {"type": "string", "description": "Stable retry key for durable execution; requires mission_id. Reuse after a lost response."}
                     }
                 }),
             },
@@ -2508,12 +2496,26 @@ impl AssistantMcp {
         if params.command.trim().is_empty() {
             return Err("Command is empty".to_string());
         }
-        if is_heavy_workspace_command(&params.command) {
-            return Err(serde_json::to_string(&json!({
-                "error": "heavy_command_requires_durable_job",
-                "message": "This command can outlive a synchronous Hermes MCP call. Use start_workspace_job and poll get_workspace_job.",
-                "tool": "start_workspace_job"
-            })).unwrap_or_else(|_| "heavy command requires start_workspace_job".to_string()));
+        match (params.mission_id, params.idempotency_key) {
+            (Some(mission_id), Some(idempotency_key)) => {
+                if mission_id.trim().is_empty() || idempotency_key.trim().is_empty() {
+                    return Err("mission_id and idempotency_key must both be non-empty".into());
+                }
+                // Reuse the durable admission API: never submit synchronously first
+                // and then retry in the background, which could execute twice.
+                return self.start_workspace_job(StartWorkspaceJobParams {
+                    command: Some(params.command),
+                    argv: None,
+                    workspace_id: params.workspace_id,
+                    mission_id,
+                    cwd: params.cwd,
+                    timeout_secs: params.timeout_secs,
+                    resource_class: None,
+                    idempotency_key,
+                }).await;
+            }
+            (None, None) => {}
+            _ => return Err("Supply both mission_id and idempotency_key for durable execution, or omit both for a bounded diagnostic".into()),
         }
         let workspace_id = resolve_default_workspace_id(params.workspace_id).ok_or_else(|| {
             "No workspace_id given and no default workspace configured \
@@ -2548,6 +2550,7 @@ impl AssistantMcp {
         })?;
         let workspace_id = parse_uuid(&workspace_id)?;
         let mission_id = self.resolve_mission_id(&params.mission_id).await?;
+        self.assert_mission_scope(mission_id).await?;
         let command = workspace_job_command(params.command, params.argv)?;
         let key = params.idempotency_key.trim();
         if key.is_empty() {
@@ -5920,16 +5923,125 @@ mod tests {
     }
 
     #[test]
-    fn workspace_bash_rejects_heavy_commands_and_job_argv_is_quoted() {
-        assert!(is_heavy_workspace_command("lake build Verity"));
-        assert!(is_heavy_workspace_command("cd repo && cargo test --all"));
-        assert!(!is_heavy_workspace_command("git status --short"));
+    fn workspace_job_argv_is_quoted() {
         assert_eq!(
             workspace_job_command(None, Some(vec!["printf".into(), "%s".into(), "a'b".into()]))
                 .unwrap(),
             "'printf' '%s' 'a'\\''b'"
         );
         assert!(workspace_job_command(Some("true".into()), Some(vec!["true".into()])).is_err());
+    }
+
+    #[tokio::test]
+    async fn workspace_diagnostics_do_not_classify_quoted_command_text() {
+        let workspace_id = Uuid::new_v4().to_string();
+        let (mcp, state, task) = mock_assistant(json!({"exit_code": 0}), false).await;
+        let command = "ps -eo pid,args | rg 'lake build|cargo test --all'";
+        mcp.workspace_bash(
+            parse_params(json!({
+                "workspace_id": workspace_id, "command": command, "timeout_secs": 1000
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+        let requests = state.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].0,
+            format!("/api/workspaces/{workspace_id}/exec")
+        );
+        assert_eq!(requests[0].1["command"], command);
+        assert_eq!(requests[0].1["timeout_secs"], 120);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn workspace_durable_execution_routes_each_call_with_the_same_retry_key() {
+        let mission_id = Uuid::new_v4().to_string();
+        let workspace_id = Uuid::new_v4().to_string();
+        let (mcp, state, task) =
+            mock_assistant(json!({"id": mission_id, "status": "queued"}), false).await;
+        // A build and an unrecognizable script use exactly the same durable route.
+        for (index, command) in ["lake build Target", "./long-running-script"]
+            .iter()
+            .enumerate()
+        {
+            for _ in 0..2 {
+                let result = mcp.workspace_bash(parse_params(json!({
+                    "workspace_id": workspace_id, "mission_id": mission_id,
+                    "idempotency_key": format!("build-input-sha-{index}"), "command": command,
+                    "cwd": "/workspaces/proof"
+                })).unwrap()).await.unwrap();
+                assert_eq!(result["job"]["id"], mission_id);
+            }
+        }
+        let requests = state.requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        for (index, (path, body)) in requests.iter().enumerate() {
+            assert_eq!(path, "/api/durable-jobs");
+            assert_eq!(
+                body["idempotency_key"],
+                format!("build-input-sha-{}", index / 2)
+            );
+            assert_eq!(body["started_by_mission_id"], mission_id);
+            assert_eq!(body["workspace_id"], workspace_id);
+            assert_eq!(body["cwd"], "/workspaces/proof");
+            assert_eq!(body["timeout_secs"], 7200);
+        }
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn workspace_partial_durable_ownership_never_executes_a_command() {
+        let (mcp, state, task) = mock_assistant(json!({}), false).await;
+        for fields in [
+            json!({"mission_id": Uuid::new_v4().to_string()}),
+            json!({"idempotency_key": "input-sha"}),
+            json!({"mission_id": "", "idempotency_key": "input-sha"}),
+            json!({"mission_id": Uuid::new_v4().to_string(), "idempotency_key": " "}),
+        ] {
+            let mut input = fields;
+            input["command"] = json!("./long-running-script");
+            assert!(mcp
+                .workspace_bash(parse_params(input).unwrap())
+                .await
+                .is_err());
+        }
+        assert!(state.requests.lock().unwrap().is_empty());
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn workspace_durable_execution_respects_project_scope_on_both_entrypoints() {
+        let mission_id = Uuid::new_v4().to_string();
+        let workspace_id = Uuid::new_v4().to_string();
+        for project in [json!("eip-8282"), Value::Null, json!("verity-lido")] {
+            let (mut mcp, state, task) = mock_assistant(
+                json!({
+                    "id": mission_id, "project": project
+                }),
+                false,
+            )
+            .await;
+            mcp.project_scope = Some(["verity-lido".to_string()].into_iter().collect());
+            let input = json!({
+                "workspace_id": workspace_id, "mission_id": mission_id,
+                "idempotency_key": "same-command", "command": "./build"
+            });
+            let via_bash = mcp
+                .workspace_bash(parse_params(input.clone()).unwrap())
+                .await;
+            let direct = mcp.start_workspace_job(parse_params(input).unwrap()).await;
+            let allowed = project == json!("verity-lido");
+            assert_eq!(via_bash.is_ok(), allowed);
+            assert_eq!(direct.is_ok(), allowed);
+            assert_eq!(
+                state.requests.lock().unwrap().len(),
+                if allowed { 2 } else { 0 }
+            );
+            task.abort();
+        }
     }
 
     #[test]


### PR DESCRIPTION
Workspace diagnostics such as `ps | rg 'lake build'` were rejected by a substring-based build detector. Execution mode is now explicit: `workspace_bash` remains a bounded diagnostic by default, while supplying a mission and retry key submits a durable job and returns its ID immediately. It never executes synchronously before submitting the job.

Both durable entry points now enforce the MCP project scope before submission. Controller and mission documentation describe the two modes and callback-based completion. Existing durable-job ownership, idempotency and runtime limits are preserved.

Validation: `cargo fmt --all`, `git diff --check`, and all 63 `cargo test --bin assistant-mcp` tests passed on e6a8b20a18c6c9597ee9c96d2d516f330c39697f. Independent source review is CLEAN at that commit. Regression tests cover quoted build names in diagnostics, stable retry-key forwarding, incomplete ownership fields and cross-project denial. The MCP tests verify routing; process deduplication remains the responsibility of the existing durable backend.

No production deployment performed.
