### PR TITLE
fix(codex): enroll fresh missions with bookkeeping session IDs

### DIFF
--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -614,6 +614,24 @@ pub(crate) fn summarize_codex_usage_caps(
     msg
 }
 
+/// Select native continuity without mistaking MissionStore's initial UUID for
+/// evidence that Codex already ran. All stores allocate that bookkeeping id at
+/// creation. Prior assistant history or any legacy rollout directory still
+/// requires an explicit migration; unknown session identifiers stay legacy.
+pub(crate) fn native_continuity_enabled(
+    has_binding: bool,
+    session_id: Option<&str>,
+    is_continuation: bool,
+    legacy_rollouts: bool,
+) -> bool {
+    let unexecuted_bookkeeping_id = session_id.is_none_or(|id| {
+        Uuid::parse_str(id).is_ok_and(|id| id.get_version() == Some(uuid::Version::Random))
+    });
+    has_binding
+        || session_id.is_some_and(|id| id.starts_with(continuity::SESSION_PREFIX))
+        || (!is_continuation && unexecuted_bookkeeping_id && !legacy_rollouts)
+}
+
 /// Run a codex turn through the unified credential pool with rotation and
 /// account-level cooldown handling. Shared by the initial mission dispatch
 /// and the control-channel follow-up path so a usage-capped ChatGPT account
@@ -641,9 +659,12 @@ pub(crate) async fn run_codex_turn_with_rotation(
         Err(error) => return continuity_failure(error),
     };
     let legacy_rollouts = mission_work_dir.join(".codex/sessions").is_dir();
-    let enabled = binding.is_some()
-        || session_id.is_some_and(|id| id.starts_with(continuity::SESSION_PREFIX))
-        || (!is_continuation && session_id.is_none() && !legacy_rollouts);
+    let enabled = native_continuity_enabled(
+        binding.is_some(),
+        session_id,
+        is_continuation,
+        legacy_rollouts,
+    );
     let native_input = NativeTurnInput {
         path,
         current_message,

--- a/src/backend/codex/continuity_tests.rs
+++ b/src/backend/codex/continuity_tests.rs
@@ -507,3 +507,185 @@ async fn codex_continuity_projection_and_plain_hint_keep_native_goal_stopped_cla
     }
     assert!(projected);
 }
+
+/// Regression for the production create_mission -> first dispatch -> native
+/// projection -> persisted mission reload path. A hand-built None session id
+/// missed this: the real SQLite store creates a UUID before Codex ever runs.
+#[tokio::test]
+async fn codex_continuity_fresh_sqlite_mission_enrolls_and_reloads_same_thread() {
+    use crate::api::mission_store::{MissionStore, SqliteMissionStore};
+    use crate::api::runners::codex::native_continuity_enabled;
+
+    let mut f = Fixture::new();
+    let store = SqliteMissionStore::new(f.dir.path().join("store"), "native-enrollment")
+        .await
+        .unwrap();
+    let mission = store
+        .create_mission(
+            Some("fresh native goal"),
+            None,
+            None,
+            Some("synthetic-model"),
+            None,
+            Some("codex"),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        mission.session_id.is_some(),
+        "exercise the real bookkeeping UUID"
+    );
+    assert!(mission.history.is_empty());
+    assert!(native_continuity_enabled(
+        false,
+        mission.session_id.as_deref(),
+        mission
+            .history
+            .iter()
+            .any(|entry| entry.role == "assistant"),
+        false
+    ));
+    f.config.identity.mission_id = mission.id;
+    f.config.path = continuity::binding_path(f.dir.path(), mission.id);
+    f.config.projected_session = mission.session_id;
+    let events = f
+        .run("normal", "/goal real store creation regression")
+        .await;
+    let native_id = events
+        .iter()
+        .find_map(|event| match event {
+            ExecutionEvent::CodexSessionBound {
+                thread_id,
+                goal_mode: true,
+            } => Some(thread_id.clone()),
+            _ => None,
+        })
+        .expect("fresh stored mission emits a real native binding");
+    let projected = format!("{}{}", continuity::SESSION_PREFIX, native_id);
+    store
+        .update_mission_session_id(mission.id, &projected)
+        .await
+        .unwrap();
+    let persisted = store.get_mission(mission.id).await.unwrap().unwrap();
+    f.config.projected_session = persisted.session_id;
+    let before = f.state()["goal"].clone();
+    f.config.current_message = "current checkpoint hint".into();
+    assert!(native_continuity_enabled(
+        true,
+        f.config.projected_session.as_deref(),
+        true,
+        true
+    ));
+    f.run(
+        "normal",
+        "stale outer transcript must not become a new goal",
+    )
+    .await;
+    assert_eq!(f.requests("thread/start").len(), 1);
+    assert_eq!(f.requests("thread/resume").len(), 1);
+    assert_eq!(
+        continuity::read(&f.config.path)
+            .unwrap()
+            .unwrap()
+            .thread_id
+            .as_deref(),
+        Some(native_id.as_str())
+    );
+    assert_eq!(f.state()["goal"]["objective"], before["objective"]);
+    assert_eq!(f.state()["goal"]["tokenBudget"], before["tokenBudget"]);
+    assert!(
+        f.state()["goal"]["tokensUsed"].as_u64().unwrap() >= before["tokensUsed"].as_u64().unwrap()
+    );
+    f.assert_processes_stopped();
+}
+
+#[tokio::test]
+async fn codex_continuity_enrollment_keeps_existing_legacy_and_unknown_sessions_fenced() {
+    use crate::api::mission_store::{MissionStore, SqliteMissionStore};
+    use crate::api::runners::codex::native_continuity_enabled;
+    let f = Fixture::new();
+    let store = SqliteMissionStore::new(f.dir.path().join("store"), "legacy-enrollment")
+        .await
+        .unwrap();
+    let mission = store
+        .create_mission(
+            Some("existing legacy"),
+            None,
+            None,
+            None,
+            None,
+            Some("codex"),
+            None,
+        )
+        .await
+        .unwrap();
+    store
+        .log_event(
+            mission.id,
+            &crate::api::control::AgentEvent::AssistantMessage {
+                id: Uuid::new_v4(),
+                content: "prior executed work".into(),
+                success: true,
+                cost_cents: 0,
+                cost_source: crate::agents::CostSource::Unknown,
+                usage: None,
+                model: None,
+                model_normalized: None,
+                mission_id: Some(mission.id),
+                shared_files: None,
+                resumable: false,
+                completion_evidence: None,
+            },
+        )
+        .await
+        .unwrap();
+    let persisted = store.get_mission(mission.id).await.unwrap().unwrap();
+    assert_eq!(persisted.history.len(), 1);
+    assert!(!native_continuity_enabled(
+        false,
+        persisted.session_id.as_deref(),
+        persisted
+            .history
+            .iter()
+            .any(|entry| entry.role == "assistant"),
+        false
+    ));
+    // A legacy run can crash after a tool but before its first assistant final.
+    // Its rollout storage remains a fence even with no assistant history.
+    std::fs::create_dir(f.dir.path().join(".codex/sessions")).unwrap();
+    assert!(!native_continuity_enabled(
+        false,
+        mission.session_id.as_deref(),
+        false,
+        f.dir.path().join(".codex/sessions").is_dir()
+    ));
+    assert!(!native_continuity_enabled(
+        false,
+        Some("unknown-harness-session"),
+        false,
+        false
+    ));
+    assert!(!native_continuity_enabled(
+        false,
+        Some("01900000-0000-7000-8000-000000000001"),
+        false,
+        false
+    ));
+    // A native projection with a lost binding must enter the native path and
+    // fail closed there, never fall back to legacy or create a fresh thread.
+    let projected = format!("{}missing-native-thread", continuity::SESSION_PREFIX);
+    assert!(native_continuity_enabled(
+        false,
+        Some(&projected),
+        true,
+        false
+    ));
+    let mut cfg = f.config.clone();
+    cfg.projected_session = Some(projected);
+    let failure = continuity::Lease::acquire(&cfg)
+        .await
+        .err()
+        .expect("missing binding is refused");
+    assert!(failure.to_string().contains("codex_continuity_missing"));
+}


### PR DESCRIPTION
A new Codex mission was taking the legacy execution path immediately after creation. MissionStore already assigns a UUIDv4 session ID at creation, while native enrollment required no session ID. The deployed canary reproduced this before its first turn, so the native binding was never created.

Recognize the store's initial bookkeeping UUID only when there is no prior assistant history and no legacy rollout directory. Keep unknown session identifiers and existing legacy sessions on the migration path; native projections still enter the native path and refuse a missing binding.

Validation: a regression creates a real SQLite mission, enters the native stdio fixture with its actual initial session ID, persists the emitted native projection, reloads the mission and resumes the same native thread without replacing its goal or budget. Additional cases cover prior legacy history, a crash after a tool with rollout storage, unknown IDs, and a lost native binding. `cargo test --lib codex_continuity_ -- --test-threads=2`: 19 passed, 0 failed. `cargo fmt --all` and `git diff --check` pass. Independent root source review found no blocker.

This does not adopt or erase existing legacy sessions. The failed production canary remains preserved and blocked; the new production canary will run only after this correction is deployed.
