### PR TITLE
fix(codex): ignore restored goal snapshots before reactivation

### DIFF
--- a/src/backend/codex/app_server.rs
+++ b/src/backend/codex/app_server.rs
@@ -162,7 +162,7 @@ pub struct ThreadHandle {
     pub turns: Vec<Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadGoal {
     pub thread_id: String,

--- a/src/backend/codex/continuity_tests.rs
+++ b/src/backend/codex/continuity_tests.rs
@@ -689,3 +689,97 @@ async fn codex_continuity_enrollment_keeps_existing_legacy_and_unknown_sessions_
         .expect("missing binding is refused");
     assert!(failure.to_string().contains("codex_continuity_missing"));
 }
+
+#[tokio::test]
+async fn codex_continuity_resume_restored_goal_snapshot_does_not_drop_current_hint() {
+    let mut f = Fixture::new();
+    f.run("normal", "/goal preserve this exact objective").await;
+    let before = f.state()["goal"].clone();
+    f.config.current_message = "CONTINUE-CANARY".into();
+    let events = f.run("restored-goal-hint", "old outer transcript").await;
+    assert_eq!(f.state()["hints"], json!(["CONTINUE-CANARY"]));
+    assert_eq!(f.requests("thread/start").len(), 1);
+    assert_eq!(f.requests("thread/resume").len(), 1);
+    assert_eq!(f.requests("turn/steer").len(), 1);
+    assert_eq!(
+        f.requests("thread/goal/set")[1],
+        json!({"threadId":"native-thread-1", "status":"active"})
+    );
+    assert_eq!(f.state()["goal"]["objective"], before["objective"]);
+    assert_eq!(f.state()["goal"]["tokenBudget"], before["tokenBudget"]);
+    assert!(
+        f.state()["goal"]["tokensUsed"].as_i64().unwrap() >= before["tokensUsed"].as_i64().unwrap()
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, ExecutionEvent::Error { .. })),
+        "{events:?}"
+    );
+    assert!(events.iter().any(
+        |event| matches!(event, ExecutionEvent::GoalStatus { status, .. } if status == "blocked")
+    ));
+    f.assert_processes_stopped();
+}
+
+#[tokio::test]
+async fn codex_continuity_resume_keeps_real_stop_after_reactivation() {
+    let mut f = Fixture::new();
+    f.run("normal", "/goal preserve this exact objective").await;
+    f.config.current_message = "current hint".into();
+    let events = f.run("restored-goal-stopped", "old transcript").await;
+    assert!(f.requests("turn/steer").is_empty());
+    assert!(events.iter().any(
+        |event| matches!(event, ExecutionEvent::GoalStatus { status, .. } if status == "blocked")
+    ));
+    assert!(events.iter().any(|event| matches!(event, ExecutionEvent::Error { message } if message.contains("steer_unconfirmed"))));
+    assert_eq!(f.state()["goal"]["status"], "blocked");
+    f.assert_processes_stopped();
+}
+
+#[tokio::test]
+async fn codex_continuity_snapshot_drain_retains_errors_requests_and_nonmatching_goals() {
+    use super::app_server::{InboundMessage, ThreadGoal};
+    let goal = ThreadGoal {
+        thread_id: "native-thread".into(),
+        objective: "goal".into(),
+        status: "blocked".into(),
+        token_budget: Some(100),
+        tokens_used: 7,
+        time_used_seconds: 2,
+    };
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    tx.send(InboundMessage::Notification {
+        method: "thread/goal/updated".into(),
+        params: json!({"threadId":goal.thread_id,"goal":goal}),
+    })
+    .await
+    .unwrap();
+    let retained = vec![
+        InboundMessage::Notification {
+            method: "error".into(),
+            params: json!({"error":{"message":"real error"}}),
+        },
+        InboundMessage::ServerRequest {
+            id: json!(9),
+            method: "item/tool/call".into(),
+            params: json!({"callId":"real-tool"}),
+        },
+        InboundMessage::Notification {
+            method: "thread/goal/updated".into(),
+            params: json!({"threadId":goal.thread_id,"turnId":"real-turn","goal":goal}),
+        },
+        InboundMessage::Notification {
+            method: "thread/goal/updated".into(),
+            params: json!({"threadId":"another-thread","goal":goal}),
+        },
+    ];
+    for message in &retained {
+        tx.send(message.clone()).await.unwrap();
+    }
+    let actual = super::drain_restored_goal_snapshot(&mut rx, &goal);
+    assert_eq!(
+        format!("{actual:?}"),
+        format!("{:?}", std::collections::VecDeque::from(retained))
+    );
+}

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -330,7 +330,7 @@ async fn send_message_streaming_app_server(
 
         // Take the inbound channel before issuing any further RPC — `goal/set`
         // and `turn/start` start emitting notifications before they return.
-        let inbound = match session_arc.take_inbound().await {
+        let mut inbound = match session_arc.take_inbound().await {
             Some(rx) => rx,
             None => {
                 let _ = session_arc.shutdown().await;
@@ -357,6 +357,7 @@ async fn send_message_streaming_app_server(
         // Issue the priming RPC. For goal missions, codex auto-starts the first
         // turn after `goal/set`; for non-goal, we explicitly send `turn/start`.
         let mut pending_steer = None;
+        let mut pre_activation_messages = std::collections::VecDeque::new();
         let mut existing_objective = None;
         let mut already_primed = false;
         if let Some(lease) = native_lease.as_mut() {
@@ -387,6 +388,11 @@ async fn send_message_streaming_app_server(
                     let active = thread.status.as_ref().is_some_and(|s| s.get("type").and_then(|t| t.as_str()) == Some("active"))
                         || thread.turns.iter().any(|t| t["status"] == "inProgress");
                     if !active {
+                        // thread/resume publishes the restored goal before our
+                        // goal/get response. It is a snapshot, not a new stop
+                        // after this explicit resume. Keep every other queued
+                        // notification/request and all post-activation events.
+                        pre_activation_messages = drain_restored_goal_snapshot(&mut inbound, &goal);
                         session_for_rpc.goal_status(&thread_id, "active").await?;
                         let after = session_for_rpc.goal_get(&thread_id).await?.goal
                             .ok_or_else(|| anyhow::anyhow!("codex_continuity_goal_missing: goal disappeared while resuming"))?;
@@ -475,10 +481,16 @@ async fn send_message_streaming_app_server(
         } else {
             String::new()
         };
-        Ok((thread, inbound, is_goal_mission, pending_steer, initial_objective))
+        Ok((thread, inbound, is_goal_mission, pending_steer, initial_objective, pre_activation_messages))
     }.await;
-    let (thread, inbound, is_goal_mission, mut pending_steer, initial_objective) = match preparation
-    {
+    let (
+        thread,
+        inbound,
+        is_goal_mission,
+        mut pending_steer,
+        initial_objective,
+        pre_activation_messages,
+    ) = match preparation {
         Ok(prepared) => prepared,
         Err(error) => {
             session_arc.shutdown().await;
@@ -524,7 +536,7 @@ async fn send_message_streaming_app_server(
                 translator.goal_active_turns.insert(id.clone());
             }
         }
-        let mut recovered_notifications = std::collections::VecDeque::new();
+        let mut recovered_notifications = pre_activation_messages;
         let steer_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
         let mut terminal = false;
         let mut stream_closed_unexpectedly = false;
@@ -1628,6 +1640,34 @@ impl AppServerEventTranslator {
                 .is_none_or(|id| self.goal_completed_turns.contains(id));
         TranslateOutcome { events, terminal }
     }
+}
+
+/// Retain the pre-activation queue, except an exact restored-goal snapshot.
+/// Called only for an idle persisted goal, after goal/get and before goal/set.
+/// The RPC response acts as an ordering boundary: later real stop notifications
+/// stay in `inbound` and are interpreted normally, even with the same status.
+fn drain_restored_goal_snapshot(
+    inbound: &mut mpsc::Receiver<app_server::InboundMessage>,
+    goal: &app_server::ThreadGoal,
+) -> std::collections::VecDeque<app_server::InboundMessage> {
+    let mut retained = std::collections::VecDeque::new();
+    while let Ok(message) = inbound.try_recv() {
+        let restored = match &message {
+            app_server::InboundMessage::Notification { method, params }
+                if method == "thread/goal/updated"
+                    && params["threadId"] == goal.thread_id
+                    && params.get("turnId").is_none_or(serde_json::Value::is_null) =>
+            {
+                serde_json::from_value::<app_server::ThreadGoal>(params["goal"].clone())
+                    .is_ok_and(|snapshot| snapshot == *goal)
+            }
+            _ => false,
+        };
+        if !restored {
+            retained.push_back(message);
+        }
+    }
+    retained
 }
 
 /// Create a registry entry for the Codex backend.

--- a/tests/fixtures/codex_continuity_app_server.py
+++ b/tests/fixtures/codex_continuity_app_server.py
@@ -66,6 +66,10 @@ for line in sys.stdin:
             save()
         else:
             assert params['threadId'] == state['id']
+            if mode in ('restored-goal-hint', 'restored-goal-stopped'):
+                # Real CLI 0.153.0 publishes the restored goal at resume,
+                # before goal/get and the subsequent explicit activation.
+                notify('thread/goal/updated', {'threadId': state['id'], 'goal': state['goal']})
         active = mode in ('active', 'active-no-id')
         turns = [{'id': 'active-turn', 'status': 'inProgress'}] if mode == 'active' else []
         if method == 'thread/resume' and mode == 'goal-snapshot':
@@ -96,6 +100,12 @@ for line in sys.stdin:
         save()
     emit({'id': req['id'], 'result': result})
     if method in ('turn/start', 'thread/goal/set') and (method == 'turn/start' or params['status'] == 'active'):
+        if mode == 'restored-goal-stopped':
+            # A real stop after activation, before a turn starts, must survive.
+            state['goal']['status'] = 'blocked'
+            save()
+            notify('thread/goal/updated', {'threadId': state['id'], 'goal': state['goal']})
+            continue
         started()
         if mode in ('goal-snapshot', 'goal-snapshot-no-turn'):
             state['goal']['status'] = 'blocked'
@@ -108,7 +118,7 @@ for line in sys.stdin:
             os._exit(0)
         if mode == 'crash-once':
             os._exit(0)
-        if mode not in ('hold', 'hint', 'pause-error'):
+        if mode not in ('hold', 'hint', 'pause-error', 'restored-goal-hint'):
             finish()
     elif method == 'turn/steer':
         finish()


### PR DESCRIPTION
Resuming a blocked native goal immediately ended the driver with `codex_continuity_steer_unconfirmed`, before its current hint reached Codex. The installed CLI 0.153.0 reproduces the cause without inference: `thread/resume` publishes the stored blocked-goal snapshot without a turn ID. That queued snapshot was interpreted as a new terminal event after we had explicitly activated the goal.

Before reactivating an idle persisted goal, filter only already-queued snapshots that exactly match the authoritative `goal/get` result, thread ID and absent turn ID. Retain every other queued notification and server request, and interpret all notifications received after activation normally. Preserve the same native thread, goal, objective, budget and usage; do not replay an unconfirmed hint automatically.

Validation: real stdio fixtures reproduce the installed snapshot ordering and verify delivery of the current hint once. Additional regressions preserve a genuine post-activation stop, queued errors, tool requests and nonmatching goal notifications. The installed zero-inference reproduction used a separate empty CODEX_HOME and never touched the retained production canary.

`cargo test --lib codex_continuity_ -- --test-threads=2`: 22 passed, 0 failed. `cargo fmt --all` and `git diff --check` pass; independent root source review found no blocker. Production canary `bf12489c` remains preserved pending deployment and explicit state reconciliation; this PR does not claim its resume has passed yet.
