### PR TITLE
Preserve terminal native execution identity in callbacks

### DIFF
--- a/src/api/control/dispatch_admission.rs
+++ b/src/api/control/dispatch_admission.rs
@@ -144,6 +144,7 @@ async fn restore_status(
             continue;
         }
         let _ = session.events_tx.send(AgentEvent::MissionStatusChanged {
+            execution: None,
             mission_id: id,
             status: snapshot.status,
             summary: snapshot.terminal_reason.clone(),

--- a/src/api/control/dispatch_admission.rs
+++ b/src/api/control/dispatch_admission.rs
@@ -144,6 +144,7 @@ async fn restore_status(
             continue;
         }
         let _ = session.events_tx.send(AgentEvent::MissionStatusChanged {
+            completion: None,
             execution: None,
             mission_id: id,
             status: snapshot.status,

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -3796,6 +3796,7 @@ async fn assert_startup_identity_recovery(preceding_sweep: bool) {
     tokio::time::timeout(std::time::Duration::from_secs(15), async {
         loop {
             if let Ok(AgentEvent::MissionStatusChanged {
+                completion: None,
                 execution: None,
                 mission_id,
                 status: MissionStatus::Interrupted,

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -3796,6 +3796,7 @@ async fn assert_startup_identity_recovery(preceding_sweep: bool) {
     tokio::time::timeout(std::time::Duration::from_secs(15), async {
         loop {
             if let Ok(AgentEvent::MissionStatusChanged {
+                execution: None,
                 mission_id,
                 status: MissionStatus::Interrupted,
                 summary: Some(summary),

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -7,6 +7,14 @@
 #[allow(unused_imports)]
 use super::*;
 
+/// Immutable outcome coupled to a native execution at terminal publication.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MissionCompletionSnapshot {
+    pub result_summary: Option<String>,
+    pub terminal_reason: Option<String>,
+    pub terminal_evidence: Option<String>,
+}
+
 /// A structured event emitted by the control session.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -127,6 +135,8 @@ pub enum AgentEvent {
         /// Captured by the terminal writer, never inferred from a successor run.
         #[serde(skip_serializing_if = "Option::is_none")]
         execution: Option<MissionRun>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        completion: Option<MissionCompletionSnapshot>,
         mission_id: Uuid,
         status: MissionStatus,
         summary: Option<String>,

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -124,6 +124,9 @@ pub enum AgentEvent {
     },
     /// Mission status changed (by agent or user)
     MissionStatusChanged {
+        /// Captured by the terminal writer, never inferred from a successor run.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        execution: Option<MissionRun>,
         mission_id: Uuid,
         status: MissionStatus,
         summary: Option<String>,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -22585,6 +22585,9 @@ async fn control_actor_loop(
                                 }
                             }
 
+                            // Capture the actor-owned generation before any status-write await.
+                            let execution = running_run.as_ref().filter(|run| run.mission_id == id).cloned()
+                                .or_else(|| parallel_runners.get(&id).and_then(|runner| runner.durable_run.clone()));
                             if mission_store
                                 .update_mission_status(id, new_status)
                                 .await
@@ -22617,7 +22620,7 @@ async fn control_actor_loop(
                                 }
 
                                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                    execution: mission_store.get_latest_mission_run(id).await.ok().flatten(),
+                                    execution,
                                     mission_id: id,
                                     status: new_status,
                                     summary,
@@ -34061,6 +34064,92 @@ Investigate <service/> failures.
             !promoted.contains(&mission.id),
             "a freshly-resumed mission must not be ack-promoted after demotion"
         );
+    }
+
+    #[tokio::test]
+    async fn terminal_callback_identity_reaches_http_after_release_and_delayed_successor() {
+        for resume_before_delivery in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+            let mission = store
+                .create_mission(None, None, None, None, None, None, None)
+                .await
+                .unwrap();
+            let first = store
+                .begin_mission_run(mission.id, "test", None)
+                .await
+                .unwrap();
+            store
+                .finish_mission_run(first.run_id, first.generation, Some("native_goal_stopped"))
+                .await
+                .unwrap();
+            let (tx, rx) = tokio::sync::broadcast::channel(8);
+            maybe_finalize_terminal_mission(
+                &store,
+                &tx,
+                mission.id,
+                0,
+                Some(TerminalReason::NativeGoalStopped),
+                None,
+                None,
+                true,
+                Some("first generation result"),
+                "http callback test",
+            )
+            .await;
+            // Queue the actual finalizer event, then acquire a successor BEFORE
+            // starting the forwarder. This deterministically exercises delay.
+            if resume_before_delivery {
+                store
+                    .update_mission_status(mission.id, MissionStatus::Active)
+                    .await
+                    .unwrap();
+                let next = store
+                    .begin_mission_run(mission.id, "test", None)
+                    .await
+                    .unwrap();
+                assert_eq!(next.generation, 2);
+            }
+            let mut markers = super::super::webhook_markers::MarkerStore::load(dir.path());
+            markers.set(mission.id, MissionStatus::Active);
+            let (body_tx, mut body_rx) = tokio::sync::mpsc::channel(2);
+            let app = axum::Router::new().route(
+                "/",
+                axum::routing::post(move |axum::Json(body): axum::Json<serde_json::Value>| {
+                    let body_tx = body_tx.clone();
+                    async move {
+                        body_tx.send(body).await.unwrap();
+                        axum::http::StatusCode::OK
+                    }
+                }),
+            );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}/", listener.local_addr().unwrap());
+            let server = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            let workspaces =
+                Arc::new(workspace::WorkspaceStore::new(dir.path().to_path_buf()).await);
+            let forwarder = tokio::spawn(paloma_webhook_forwarder_loop(
+                rx,
+                store,
+                workspaces,
+                dir.path().to_path_buf(),
+                url,
+                None,
+                reqwest::Client::new(),
+            ));
+            let body = tokio::time::timeout(std::time::Duration::from_secs(5), body_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(body["mission_id"], mission.id.to_string());
+            assert_eq!(body["execution"]["run_id"], first.run_id.to_string());
+            assert_eq!(body["execution"]["generation"], 1);
+            assert_eq!(body["execution"]["state"], "terminal");
+            forwarder.abort();
+            server.abort();
+        }
     }
 
     #[tokio::test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -15914,19 +15914,13 @@ async fn current_callback_snapshot(
     store: &Arc<dyn MissionStore>,
     mission_id: Uuid,
     status: MissionStatus,
-) -> Option<(MissionRun, MissionCompletionSnapshot)> {
+) -> Option<(Option<MissionRun>, MissionCompletionSnapshot)> {
     let before = store.get_mission(mission_id).await.ok().flatten()?;
     if before.status != status {
         return None;
     }
-    let run = store
-        .get_latest_mission_run(mission_id)
-        .await
-        .ok()
-        .flatten()?;
-    // The assistant history can lag status publication. Only a persisted
-    // event for this exact generation authenticates its terminal outcome.
-    let completion = store
+    let run = store.get_latest_mission_run(mission_id).await.ok()?;
+    let events = store
         .get_events_before(
             mission_id,
             i64::MAX,
@@ -15934,38 +15928,82 @@ async fn current_callback_snapshot(
             Some(16),
         )
         .await
-        .ok()?
-        .into_iter()
-        .rev()
-        .find_map(|event| {
-            let captured: MissionRun =
-                serde_json::from_value(event.metadata.get("execution")?.clone()).ok()?;
-            if captured.run_id != run.run_id
-                || captured.generation != run.generation
-                || event.metadata.get("status")?.as_str()? != status.to_string()
-            {
-                return None;
+        .ok()?;
+    let event = events.into_iter().rev().find(|event| {
+        event
+            .metadata
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            == Some(status.to_string().as_str())
+            && before
+                .activity
+                .last_status_change_at
+                .as_ref()
+                .is_none_or(|changed| event.timestamp >= *changed)
+    });
+    let (captured, completion) = match (run.as_ref(), event) {
+        (Some(run), Some(event)) => {
+            let captured: Option<MissionRun> = event
+                .metadata
+                .get("execution")
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok());
+            let completion: Option<MissionCompletionSnapshot> = event
+                .metadata
+                .get("completion")
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok());
+            match (captured, completion) {
+                (Some(captured), Some(completion))
+                    if captured.run_id == run.run_id && captured.generation == run.generation =>
+                {
+                    (Some(captured), completion)
+                }
+                (None, None) => (
+                    None,
+                    MissionCompletionSnapshot {
+                        result_summary: (!event.content.trim().is_empty()).then_some(event.content),
+                        terminal_reason: before.terminal_reason.clone(),
+                        terminal_evidence: before.terminal_evidence.clone(),
+                    },
+                ),
+                _ => return None,
             }
-            serde_json::from_value::<MissionCompletionSnapshot>(
-                event.metadata.get("completion")?.clone(),
-            )
-            .ok()
-        })?;
+        }
+        (Some(_), None) if before.terminal_reason.as_deref() == Some("server_shutdown") => (
+            None,
+            MissionCompletionSnapshot {
+                // Startup/drain intentionally persist this status without a
+                // terminal event. Preserve its unbound outage notification.
+                result_summary: None,
+                terminal_reason: before.terminal_reason.clone(),
+                terminal_evidence: before.terminal_evidence.clone(),
+            },
+        ),
+        (Some(_), None) => return None, // exact event may still be in the logger queue
+        (None, event) => (
+            None,
+            MissionCompletionSnapshot {
+                result_summary: event
+                    .and_then(|event| (!event.content.trim().is_empty()).then_some(event.content)),
+                terminal_reason: before.terminal_reason.clone(),
+                terminal_evidence: before.terminal_evidence.clone(),
+            },
+        ),
+    };
     let after = store.get_mission(mission_id).await.ok().flatten()?;
-    let checked_run = store
-        .get_latest_mission_run(mission_id)
-        .await
-        .ok()
-        .flatten()?;
+    let checked_run = store.get_latest_mission_run(mission_id).await.ok()?;
     if before.updated_at != after.updated_at
         || after.status != status
-        || run.run_id != checked_run.run_id
-        || run.generation != checked_run.generation
-        || run.started_at > before.updated_at
+        || run.as_ref().map(|r| (r.run_id, r.generation))
+            != checked_run.as_ref().map(|r| (r.run_id, r.generation))
+        || run
+            .as_ref()
+            .is_some_and(|run| run.started_at > before.updated_at)
     {
         return None;
     }
-    Some((run, completion))
+    Some((captured, completion))
 }
 
 async fn callback_snapshot(
@@ -15978,7 +16016,7 @@ async fn callback_snapshot(
 ) -> (Option<MissionRun>, Option<MissionCompletionSnapshot>) {
     if reconcile_current {
         match current_callback_snapshot(store, mission_id, status).await {
-            Some((run, completion)) => (Some(run), Some(completion)),
+            Some((run, completion)) => (run, Some(completion)),
             None => (None, None),
         }
     } else {
@@ -16103,7 +16141,7 @@ async fn paloma_webhook_forwarder_loop(
                 reconcile_current,
             )
             .await;
-            if reconcile_current && run.is_none() {
+            if reconcile_current && completion.is_none() {
                 // Keep the marker pending until the precise event is persisted.
                 in_flight.lock().await.remove(&(mission_id, status));
                 return;
@@ -16148,7 +16186,7 @@ async fn paloma_webhook_forwarder_loop(
                     })
                 }),
             );
-            let terminal_reason = if run.is_some() {
+            let terminal_reason = if completion.is_some() || run.is_some() {
                 completion
                     .as_ref()
                     .and_then(|snapshot| snapshot.terminal_reason.as_deref())
@@ -16157,7 +16195,7 @@ async fn paloma_webhook_forwarder_loop(
                     .as_ref()
                     .and_then(|mission| mission.terminal_reason.as_deref())
             };
-            let terminal_evidence = if run.is_some() {
+            let terminal_evidence = if completion.is_some() || run.is_some() {
                 completion
                     .as_ref()
                     .and_then(|snapshot| snapshot.terminal_evidence.as_deref())
@@ -16191,7 +16229,7 @@ async fn paloma_webhook_forwarder_loop(
             // a mission-backed delegation returns a real work product to the
             // delegating Hermes agent (the fold prefers `result_summary`).
             // Fetched only for terminal (forwardable) transitions; best-effort.
-            let result_summary: Option<String> = if run.is_some() {
+            let result_summary: Option<String> = if completion.is_some() || run.is_some() {
                 completion
                     .as_ref()
                     .and_then(|snapshot| snapshot.result_summary.clone())
@@ -34267,6 +34305,56 @@ Investigate <service/> failures.
                 .await
                 .is_none(),
             "history text alone is not a generation receipt"
+        );
+        store
+            .update_mission_status_with_reason(
+                mission.id,
+                MissionStatus::Interrupted,
+                Some("server_shutdown"),
+            )
+            .await
+            .unwrap();
+        let (outage_run, outage) = callback_snapshot(
+            &store,
+            mission.id,
+            MissionStatus::Interrupted,
+            None,
+            None,
+            true,
+        )
+        .await;
+        assert!(outage_run.is_none());
+        assert_eq!(
+            outage.unwrap().terminal_reason.as_deref(),
+            Some("server_shutdown")
+        );
+        store
+            .update_mission_status_with_reason(
+                mission.id,
+                MissionStatus::Blocked,
+                Some("second reason"),
+            )
+            .await
+            .unwrap();
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::MissionStatusChanged {
+                    execution: None,
+                    completion: None,
+                    mission_id: mission.id,
+                    status: MissionStatus::Blocked,
+                    summary: Some("legacy current status".into()),
+                },
+            )
+            .await
+            .unwrap();
+        let (legacy_run, legacy_outcome) =
+            callback_snapshot(&store, mission.id, MissionStatus::Blocked, None, None, true).await;
+        assert!(legacy_run.is_none());
+        assert_eq!(
+            legacy_outcome.unwrap().result_summary.as_deref(),
+            Some("legacy current status")
         );
         store
             .log_event(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5553,7 +5553,9 @@ fn mission_execution_projection(run: &MissionRun, status: MissionStatus) -> serd
                 .max(0) as u64
         })
         .unwrap_or(u64::MAX);
-    let conflict = if status == MissionStatus::Acknowledged || status.is_terminal() {
+    let conflict = if run.execution_state.is_terminal() {
+        None
+    } else if status == MissionStatus::Acknowledged || status.is_terminal() {
         Some(format!("status_{status}_with_non_terminal_run"))
     } else if heartbeat_age > 60 && run.execution_state != MissionExecutionState::WaitingUser {
         Some(format!("run_heartbeat_stale_{heartbeat_age}s"))
@@ -5567,6 +5569,8 @@ fn mission_execution_projection(run: &MissionRun, status: MissionStatus) -> serd
         "health": if conflict.is_some() { "reconciling" } else { "healthy" },
         "heartbeat_at": run.heartbeat_at,
         "scope_unit": run.scope_unit,
+        "ended_at": run.ended_at,
+        "terminal_reason": run.terminal_reason,
         "status_conflict": conflict,
     })
 }
@@ -7461,19 +7465,19 @@ pub async fn get_mission_digest(
             }
         }
     }
-    let active_run = control
+    let latest_run = control
         .mission_store
-        .get_active_mission_run(mission.id)
+        .get_latest_mission_run(mission.id)
         .await
         .map_err(internal_error)?;
-    let waiting_for_user_tool = active_run
+    let waiting_for_user_tool = latest_run
         .as_ref()
         .is_some_and(|run| run.execution_state == MissionExecutionState::WaitingUser);
-    let wait_started_at = match active_run.as_ref() {
+    let wait_started_at = match latest_run.as_ref() {
         Some(run) => user_wait_tool_started_at(control.mission_store.as_ref(), run).await,
         None => None,
     };
-    let execution = active_run
+    let execution = latest_run
         .as_ref()
         .map(|run| mission_execution_projection(run, mission.status));
 
@@ -9263,6 +9267,7 @@ async fn activate_mission_for_message(
                     .await?;
                 store.set_deferred_goal(mission.id, None).await?;
                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Interrupted,
                     summary: Some(format!("{reason}: {error}")),
@@ -9283,6 +9288,7 @@ async fn activate_mission_for_message(
         // after the next failure.
         let _ = store.set_deferred_goal(mission.id, None).await;
         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+            execution: None,
             mission_id: mission.id,
             status: MissionStatus::Active,
             summary: None,
@@ -9317,6 +9323,7 @@ async fn restore_mission_after_failed_run_acquisition(
         )
         .await?;
     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+        execution: None,
         mission_id: mission.id,
         status: mission.status,
         summary: Some("Run acquisition failed; prior mission status restored".to_string()),
@@ -9720,6 +9727,7 @@ async fn interrupt_new_mission(control: &ControlState, mission_id: Uuid, reason:
         tracing::warn!(mission_id = %mission_id, %error, reason, "could not interrupt rejected mission");
     }
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        execution: None,
         mission_id,
         status: MissionStatus::Interrupted,
         summary: Some(reason.to_string()),
@@ -10528,6 +10536,7 @@ pub async fn create_mission(
                     )
                     .await?;
                 let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                    execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Interrupted,
                     summary: Some(reason.to_string()),
@@ -10576,6 +10585,7 @@ pub async fn create_mission(
                 .await
                 .map_err(internal_error)?;
             let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                execution: None,
                 mission_id: mission.id,
                 status: MissionStatus::Interrupted,
                 summary: Some(reason.to_string()),
@@ -10898,6 +10908,7 @@ pub async fn create_mission(
                     )
                     .await;
                 let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                    execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Failed,
                     summary: Some(message.clone()),
@@ -10965,6 +10976,7 @@ async fn dispatch_remote_mission_mvp(
         .update_mission_status(mission.id, MissionStatus::Active)
         .await?;
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        execution: None,
         mission_id: mission.id,
         status: MissionStatus::Active,
         summary: Some(format!("Dispatching to remote node '{}'", node.id)),
@@ -11136,6 +11148,7 @@ pub(crate) async fn ensure_remote_build_wait(
             .update_mission_status(mission_id, MissionStatus::Active)
             .await?;
         owner.send(AgentEvent::MissionStatusChanged {
+            execution: None,
             mission_id,
             status: MissionStatus::Active,
             summary: Some(format!(
@@ -11583,6 +11596,7 @@ async fn finalize_remote_mission(
         .update_mission_status_with_reason(mission_id, status, Some(status_reason))
         .await?;
     owner.send(AgentEvent::MissionStatusChanged {
+        execution: None,
         mission_id,
         status,
         summary: Some(format!("Remote node '{node_id}' finished")),
@@ -11768,6 +11782,7 @@ async fn dispatch_remote_job(
         return Err(err);
     }
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        execution: None,
         mission_id: mission.id,
         status: MissionStatus::Active,
         summary: Some(format!(
@@ -13158,6 +13173,7 @@ pub async fn mark_mission_opened(
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Mission {} not found", id)))?;
     if newly_set.is_some() {
         let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+            execution: None,
             mission_id: id,
             status: mission.status,
             summary: None,
@@ -14346,7 +14362,7 @@ pub async fn get_mission_snapshot(
         .find(|info| info.mission_id == mission_id);
     let execution = control
         .mission_store
-        .get_active_mission_run(mission_id)
+        .get_latest_mission_run(mission_id)
         .await
         .map_err(internal_error)?
         .as_ref()
@@ -15311,6 +15327,11 @@ fn stored_event_to_agent_event(event: &mission_store::StoredEvent) -> Option<Age
                 .and_then(|v| v.as_str())
                 .and_then(|s| serde_json::from_value::<MissionStatus>(serde_json::json!(s)).ok())?;
             Some(AgentEvent::MissionStatusChanged {
+                execution: event
+                    .metadata
+                    .get("execution")
+                    .cloned()
+                    .and_then(|value| serde_json::from_value(value).ok()),
                 mission_id: event.mission_id,
                 status,
                 summary: None,
@@ -15948,7 +15969,8 @@ async fn paloma_webhook_forwarder_loop(
     let in_flight_c = Arc::clone(&in_flight);
     let forward = move |mission_id: Uuid,
                         status: MissionStatus,
-                        old_status: Option<MissionStatus>| {
+                        old_status: Option<MissionStatus>,
+                        event_execution: Option<MissionRun>| {
         let http = http_c.clone();
         let url = url_c.clone();
         let secret = secret_c.clone();
@@ -15974,11 +15996,19 @@ async fn paloma_webhook_forwarder_loop(
                 .and_then(|mission| mission.title.clone())
                 .unwrap_or_else(|| mission_id.to_string());
             let project = mission.as_ref().map(|m| &m.project);
-            let run = mission_store
-                .get_active_mission_run(mission_id)
-                .await
-                .ok()
-                .flatten();
+            let run = match event_execution {
+                Some(run) => Some(run),
+                None => mission_store
+                    .get_latest_mission_run(mission_id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .filter(|run| {
+                        mission
+                            .as_ref()
+                            .is_some_and(|m| m.status == status && run.started_at <= m.updated_at)
+                    }),
+            };
             let mut remote_jobs = crate::remote_node::job_ledger::load(&working_dir)
                 .await
                 .unwrap_or_default()
@@ -16265,13 +16295,16 @@ async fn paloma_webhook_forwarder_loop(
                     "webhook reconcile: forwarding a status transition the \
                      broadcast never delivered"
                 );
-                forward(mission.id, status, prior);
+                forward(mission.id, status, prior, None);
             }
             continue;
         };
         match result {
             Ok(AgentEvent::MissionStatusChanged {
-                mission_id, status, ..
+                mission_id,
+                status,
+                execution,
+                ..
             }) => {
                 let old_status = markers.lock().await.get(mission_id);
                 if old_status == Some(status) {
@@ -16284,7 +16317,7 @@ async fn paloma_webhook_forwarder_loop(
                 if !in_flight.lock().await.insert((mission_id, status)) {
                     continue;
                 }
-                forward(mission_id, status, old_status);
+                forward(mission_id, status, old_status, execution);
             }
             Ok(_) => {}
             Err(broadcast::error::RecvError::Lagged(dropped)) => {
@@ -18374,6 +18407,11 @@ async fn maybe_finalize_terminal_mission(
                     tracing::warn!(mission_id = %mission_id, "failed to record terminal evidence: {e}");
                 }
             }
+            let execution = mission_store
+                .get_latest_mission_run(mission_id)
+                .await
+                .ok()
+                .flatten();
             if let Err(e) = mission_store
                 .update_mission_status_with_reason(
                     mission_id,
@@ -18413,6 +18451,7 @@ async fn maybe_finalize_terminal_mission(
                     new_status,
                 );
                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    execution,
                     mission_id,
                     status: new_status,
                     summary: mission_status_summary_for_terminal_reason(reason),
@@ -20036,6 +20075,7 @@ async fn control_actor_loop(
                                                 } else {
                                                     let _ = events_tx.send(
                                                         AgentEvent::MissionStatusChanged {
+                                                            execution: None,
                                                             mission_id: tid,
                                                             status: MissionStatus::Pending,
                                                             summary: Some(
@@ -21034,6 +21074,7 @@ async fn control_actor_loop(
                                 new_status,
                             );
                             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                execution: None,
                                 mission_id: id,
                                 status: new_status,
                                 summary: None,
@@ -21391,6 +21432,7 @@ async fn control_actor_loop(
                                     tracing::warn!("Failed to cancel child mission {}: {}", child.id, e);
                                 } else {
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        execution: None,
                                         mission_id: child.id,
                                         status: MissionStatus::Interrupted,
                                         summary: None,
@@ -21532,6 +21574,7 @@ async fn control_actor_loop(
                                             .await;
                                         let _ = events_tx.send(
                                             AgentEvent::MissionStatusChanged {
+                                                execution: None,
                                                 mission_id,
                                                 status: MissionStatus::Interrupted,
                                                 summary: None,
@@ -21634,6 +21677,7 @@ async fn control_actor_loop(
                                     )
                                     .await;
                                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                    execution: None,
                                     mission_id,
                                     status: MissionStatus::Paused,
                                     summary: None,
@@ -21825,6 +21869,7 @@ async fn control_actor_loop(
                                                 .await;
                                             let _ = events_tx.send(
                                                 AgentEvent::MissionStatusChanged {
+                                                    execution: None,
                                                     mission_id,
                                                     status: MissionStatus::Interrupted,
                                                     summary: None,
@@ -21934,6 +21979,7 @@ async fn control_actor_loop(
                                         MissionStatus::Active,
                                     );
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        execution: None,
                                         mission_id,
                                         status: MissionStatus::Active,
                                         summary: None,
@@ -22009,6 +22055,7 @@ async fn control_actor_loop(
                                     );
                                     // Send status changed event so UI updates
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        execution: None,
                                         mission_id,
                                         status: MissionStatus::Active,
                                         summary: None,
@@ -22570,6 +22617,7 @@ async fn control_actor_loop(
                                 }
 
                                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                    execution: mission_store.get_latest_mission_run(id).await.ok().flatten(),
                                     mission_id: id,
                                     status: new_status,
                                     summary,
@@ -22676,6 +22724,7 @@ async fn control_actor_loop(
                                         tracing::warn!(mission_id = %run.mission_id, %error, "Failed to keep remote-wait mission active");
                                     } else {
                                         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                            execution: None,
                                             mission_id: run.mission_id,
                                             status: MissionStatus::Active,
                                             summary: Some("Waiting for durable remote validation".to_string()),
@@ -22906,6 +22955,7 @@ async fn control_actor_loop(
                                         MissionStatus::Failed,
                                     );
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        execution: None,
                                         mission_id,
                                         status: MissionStatus::Failed,
                                         summary: Some("Task execution failed unexpectedly".to_string()),
@@ -23337,6 +23387,7 @@ async fn control_actor_loop(
                                 MissionStatus::Interrupted,
                             );
                             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                execution: None,
                                 mission_id: *mission_id,
                                 status: MissionStatus::Interrupted,
                                 summary: Some(
@@ -23397,6 +23448,7 @@ async fn control_actor_loop(
                                     tracing::warn!(mission_id = %mission_id, %error, "Failed to keep parallel remote-wait mission active");
                                 } else {
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        execution: None,
                                         mission_id: *mission_id,
                                         status: MissionStatus::Active,
                                         summary: Some("Waiting for durable remote validation".to_string()),
@@ -23821,6 +23873,7 @@ async fn control_actor_loop(
                                             MissionStatus::Failed,
                                         );
                                         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                            execution: None,
                                             mission_id: m.id,
                                             status: MissionStatus::Failed,
                                             summary: Some(
@@ -23995,6 +24048,7 @@ async fn control_actor_loop(
                             MissionStatus::Interrupted,
                         );
                         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                            execution: None,
                             mission_id: mid,
                             status: MissionStatus::Interrupted,
                             summary: Some(
@@ -34007,6 +34061,164 @@ Investigate <service/> failures.
             !promoted.contains(&mission.id),
             "a freshly-resumed mission must not be ack-promoted after demotion"
         );
+    }
+
+    #[tokio::test]
+    async fn terminal_callback_identity_persists_in_event_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let store =
+            mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "callback-event")
+                .await
+                .unwrap();
+        let mission = store
+            .create_mission(None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let run = store
+            .begin_mission_run(mission.id, "test", None)
+            .await
+            .unwrap();
+        store
+            .finish_mission_run(run.run_id, run.generation, None)
+            .await
+            .unwrap();
+        let event = AgentEvent::MissionStatusChanged {
+            execution: store.get_latest_mission_run(mission.id).await.unwrap(),
+            mission_id: mission.id,
+            status: MissionStatus::Blocked,
+            summary: None,
+        };
+        store.log_event(mission.id, &event).await.unwrap();
+        drop(store);
+        let reopened =
+            mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "callback-event")
+                .await
+                .unwrap();
+        let events = reopened
+            .get_events(mission.id, None, Some(10), None)
+            .await
+            .unwrap();
+        let restored = events.iter().find_map(stored_event_to_agent_event).unwrap();
+        let AgentEvent::MissionStatusChanged {
+            execution: Some(identity),
+            ..
+        } = restored
+        else {
+            panic!("persisted callback lost execution identity");
+        };
+        assert_eq!(identity.run_id, run.run_id);
+        assert_eq!(identity.generation, 1);
+        assert!(identity.execution_state.is_terminal());
+        assert_eq!(
+            reopened
+                .get_latest_mission_run(mission.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .run_id,
+            run.run_id
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_callback_identity_survives_lease_release_and_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let stores: Vec<Arc<dyn MissionStore>> = vec![
+            Arc::new(mission_store::InMemoryMissionStore::new()),
+            Arc::new(
+                mission_store::FileMissionStore::new(dir.path().join("file"), "callback")
+                    .await
+                    .unwrap(),
+            ),
+            Arc::new(
+                mission_store::SqliteMissionStore::new(dir.path().join("sqlite"), "callback")
+                    .await
+                    .unwrap(),
+            ),
+        ];
+        for store in stores {
+            let mission = store
+                .create_mission(None, None, None, None, None, None, None)
+                .await
+                .unwrap();
+            let first = store
+                .begin_mission_run(mission.id, "test", None)
+                .await
+                .unwrap();
+            store
+                .finish_mission_run(first.run_id, first.generation, Some("native_goal_stopped"))
+                .await
+                .unwrap();
+            assert!(store
+                .get_active_mission_run(mission.id)
+                .await
+                .unwrap()
+                .is_none());
+            let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+            maybe_finalize_terminal_mission(
+                &store,
+                &tx,
+                mission.id,
+                0,
+                Some(TerminalReason::NativeGoalStopped),
+                None,
+                None,
+                true,
+                Some("phase one stopped"),
+                "callback test",
+            )
+            .await;
+            let event = rx.try_recv().unwrap();
+            let AgentEvent::MissionStatusChanged {
+                execution: Some(ref captured),
+                ..
+            } = event
+            else {
+                panic!("terminal transition lost execution identity");
+            };
+            assert_eq!(captured.run_id, first.run_id);
+            assert_eq!(captured.generation, 1);
+            assert!(captured.execution_state.is_terminal());
+            let projection = mission_execution_projection(captured, MissionStatus::Blocked);
+            assert_eq!(projection["health"], "healthy");
+            assert!(projection["status_conflict"].is_null());
+            assert!(projection["ended_at"].is_string());
+            let serialized = serde_json::to_value(&event).unwrap();
+            store
+                .update_mission_status(mission.id, MissionStatus::Active)
+                .await
+                .unwrap();
+            let second = store
+                .begin_mission_run(mission.id, "test", None)
+                .await
+                .unwrap();
+            assert_eq!(second.generation, 2);
+            assert_eq!(
+                store
+                    .get_latest_mission_run(mission.id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .run_id,
+                second.run_id
+            );
+            // The queued event is an immutable first-generation receipt even
+            // if a same-mission successor has already acquired a live lease.
+            assert_eq!(serialized["execution"]["run_id"], first.run_id.to_string());
+            store
+                .finish_mission_run(second.run_id, second.generation, None)
+                .await
+                .unwrap();
+            assert_eq!(
+                store
+                    .get_latest_mission_run(mission.id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .run_id,
+                second.run_id
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -9267,6 +9267,7 @@ async fn activate_mission_for_message(
                     .await?;
                 store.set_deferred_goal(mission.id, None).await?;
                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    completion: None,
                     execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Interrupted,
@@ -9288,6 +9289,7 @@ async fn activate_mission_for_message(
         // after the next failure.
         let _ = store.set_deferred_goal(mission.id, None).await;
         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+            completion: None,
             execution: None,
             mission_id: mission.id,
             status: MissionStatus::Active,
@@ -9323,6 +9325,7 @@ async fn restore_mission_after_failed_run_acquisition(
         )
         .await?;
     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+        completion: None,
         execution: None,
         mission_id: mission.id,
         status: mission.status,
@@ -9727,6 +9730,7 @@ async fn interrupt_new_mission(control: &ControlState, mission_id: Uuid, reason:
         tracing::warn!(mission_id = %mission_id, %error, reason, "could not interrupt rejected mission");
     }
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        completion: None,
         execution: None,
         mission_id,
         status: MissionStatus::Interrupted,
@@ -10536,6 +10540,7 @@ pub async fn create_mission(
                     )
                     .await?;
                 let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                    completion: None,
                     execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Interrupted,
@@ -10585,6 +10590,7 @@ pub async fn create_mission(
                 .await
                 .map_err(internal_error)?;
             let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                completion: None,
                 execution: None,
                 mission_id: mission.id,
                 status: MissionStatus::Interrupted,
@@ -10908,6 +10914,7 @@ pub async fn create_mission(
                     )
                     .await;
                 let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                    completion: None,
                     execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Failed,
@@ -10976,6 +10983,7 @@ async fn dispatch_remote_mission_mvp(
         .update_mission_status(mission.id, MissionStatus::Active)
         .await?;
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        completion: None,
         execution: None,
         mission_id: mission.id,
         status: MissionStatus::Active,
@@ -11148,6 +11156,7 @@ pub(crate) async fn ensure_remote_build_wait(
             .update_mission_status(mission_id, MissionStatus::Active)
             .await?;
         owner.send(AgentEvent::MissionStatusChanged {
+            completion: None,
             execution: None,
             mission_id,
             status: MissionStatus::Active,
@@ -11596,6 +11605,7 @@ async fn finalize_remote_mission(
         .update_mission_status_with_reason(mission_id, status, Some(status_reason))
         .await?;
     owner.send(AgentEvent::MissionStatusChanged {
+        completion: None,
         execution: None,
         mission_id,
         status,
@@ -11782,6 +11792,7 @@ async fn dispatch_remote_job(
         return Err(err);
     }
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        completion: None,
         execution: None,
         mission_id: mission.id,
         status: MissionStatus::Active,
@@ -13173,6 +13184,7 @@ pub async fn mark_mission_opened(
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Mission {} not found", id)))?;
     if newly_set.is_some() {
         let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+            completion: None,
             execution: None,
             mission_id: id,
             status: mission.status,
@@ -15327,6 +15339,11 @@ fn stored_event_to_agent_event(event: &mission_store::StoredEvent) -> Option<Age
                 .and_then(|v| v.as_str())
                 .and_then(|s| serde_json::from_value::<MissionStatus>(serde_json::json!(s)).ok())?;
             Some(AgentEvent::MissionStatusChanged {
+                completion: event
+                    .metadata
+                    .get("completion")
+                    .cloned()
+                    .and_then(|value| serde_json::from_value(value).ok()),
                 execution: event
                     .metadata
                     .get("execution")
@@ -15893,6 +15910,82 @@ fn webhook_forwardable_status(status: MissionStatus) -> bool {
     )
 }
 
+async fn current_callback_snapshot(
+    store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+    status: MissionStatus,
+) -> Option<(MissionRun, MissionCompletionSnapshot)> {
+    let before = store.get_mission(mission_id).await.ok().flatten()?;
+    if before.status != status {
+        return None;
+    }
+    let run = store
+        .get_latest_mission_run(mission_id)
+        .await
+        .ok()
+        .flatten()?;
+    // The assistant history can lag status publication. Only a persisted
+    // event for this exact generation authenticates its terminal outcome.
+    let completion = store
+        .get_events_before(
+            mission_id,
+            i64::MAX,
+            Some(&["mission_status_changed"]),
+            Some(16),
+        )
+        .await
+        .ok()?
+        .into_iter()
+        .rev()
+        .find_map(|event| {
+            let captured: MissionRun =
+                serde_json::from_value(event.metadata.get("execution")?.clone()).ok()?;
+            if captured.run_id != run.run_id
+                || captured.generation != run.generation
+                || event.metadata.get("status")?.as_str()? != status.to_string()
+            {
+                return None;
+            }
+            serde_json::from_value::<MissionCompletionSnapshot>(
+                event.metadata.get("completion")?.clone(),
+            )
+            .ok()
+        })?;
+    let after = store.get_mission(mission_id).await.ok().flatten()?;
+    let checked_run = store
+        .get_latest_mission_run(mission_id)
+        .await
+        .ok()
+        .flatten()?;
+    if before.updated_at != after.updated_at
+        || after.status != status
+        || run.run_id != checked_run.run_id
+        || run.generation != checked_run.generation
+        || run.started_at > before.updated_at
+    {
+        return None;
+    }
+    Some((run, completion))
+}
+
+async fn callback_snapshot(
+    store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+    status: MissionStatus,
+    execution: Option<MissionRun>,
+    completion: Option<MissionCompletionSnapshot>,
+    reconcile_current: bool,
+) -> (Option<MissionRun>, Option<MissionCompletionSnapshot>) {
+    if reconcile_current {
+        match current_callback_snapshot(store, mission_id, status).await {
+            Some((run, completion)) => (Some(run), Some(completion)),
+            None => (None, None),
+        }
+    } else {
+        (execution, completion)
+    }
+}
+
 async fn paloma_webhook_forwarder_loop(
     mut events_rx: broadcast::Receiver<AgentEvent>,
     mission_store: Arc<dyn MissionStore>,
@@ -15970,7 +16063,9 @@ async fn paloma_webhook_forwarder_loop(
     let forward = move |mission_id: Uuid,
                         status: MissionStatus,
                         old_status: Option<MissionStatus>,
-                        event_execution: Option<MissionRun>| {
+                        event_execution: Option<MissionRun>,
+                        event_completion: Option<MissionCompletionSnapshot>,
+                        reconcile_current: bool| {
         let http = http_c.clone();
         let url = url_c.clone();
         let secret = secret_c.clone();
@@ -15996,19 +16091,23 @@ async fn paloma_webhook_forwarder_loop(
                 .and_then(|mission| mission.title.clone())
                 .unwrap_or_else(|| mission_id.to_string());
             let project = mission.as_ref().map(|m| &m.project);
-            let run = match event_execution {
-                Some(run) => Some(run),
-                None => mission_store
-                    .get_latest_mission_run(mission_id)
-                    .await
-                    .ok()
-                    .flatten()
-                    .filter(|run| {
-                        mission
-                            .as_ref()
-                            .is_some_and(|m| m.status == status && run.started_at <= m.updated_at)
-                    }),
-            };
+            // Live events can only carry producer-captured identity. In
+            // particular, an unbound historical event must not adopt a later
+            // generation just because that generation reached the same status.
+            let (run, completion) = callback_snapshot(
+                &mission_store,
+                mission_id,
+                status,
+                event_execution,
+                event_completion,
+                reconcile_current,
+            )
+            .await;
+            if reconcile_current && run.is_none() {
+                // Keep the marker pending until the precise event is persisted.
+                in_flight.lock().await.remove(&(mission_id, status));
+                return;
+            }
             let mut remote_jobs = crate::remote_node::job_ledger::load(&working_dir)
                 .await
                 .unwrap_or_default()
@@ -16049,9 +16148,24 @@ async fn paloma_webhook_forwarder_loop(
                     })
                 }),
             );
-            let terminal_reason = mission
-                .as_ref()
-                .and_then(|mission| mission.terminal_reason.as_deref());
+            let terminal_reason = if run.is_some() {
+                completion
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.terminal_reason.as_deref())
+            } else {
+                mission
+                    .as_ref()
+                    .and_then(|mission| mission.terminal_reason.as_deref())
+            };
+            let terminal_evidence = if run.is_some() {
+                completion
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.terminal_evidence.as_deref())
+            } else {
+                mission
+                    .as_ref()
+                    .and_then(|mission| mission.terminal_evidence.as_deref())
+            };
             let recommended_action = match terminal_reason {
                 Some("server_shutdown" | "orphan_no_runner") => "resume_once",
                 Some("native_goal_stopped") => "resolve_stop_then_resume",
@@ -16077,7 +16191,11 @@ async fn paloma_webhook_forwarder_loop(
             // a mission-backed delegation returns a real work product to the
             // delegating Hermes agent (the fold prefers `result_summary`).
             // Fetched only for terminal (forwardable) transitions; best-effort.
-            let result_summary: Option<String> = if webhook_forwardable_status(status) {
+            let result_summary: Option<String> = if run.is_some() {
+                completion
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.result_summary.clone())
+            } else if webhook_forwardable_status(status) {
                 mission_store
                     .latest_assistant_text(mission_id)
                     .await
@@ -16116,9 +16234,7 @@ async fn paloma_webhook_forwarder_loop(
                 // What the terminating guard OBSERVED. Without it, consumers
                 // invent causes: "transport bug", "GitHub is disabled",
                 // "pool needs re-provisioning" — all measured this week.
-                "terminal_evidence": mission
-                    .as_ref()
-                    .and_then(|mission| mission.terminal_evidence.as_deref()),
+                "terminal_evidence": terminal_evidence,
                 "resumable": matches!(status, MissionStatus::Interrupted | MissionStatus::Failed | MissionStatus::Blocked),
                 "recommended_action": recommended_action,
                 "execution": run.as_ref().map(|run| serde_json::json!({
@@ -16295,7 +16411,7 @@ async fn paloma_webhook_forwarder_loop(
                     "webhook reconcile: forwarding a status transition the \
                      broadcast never delivered"
                 );
-                forward(mission.id, status, prior, None);
+                forward(mission.id, status, prior, None, None, true);
             }
             continue;
         };
@@ -16304,6 +16420,7 @@ async fn paloma_webhook_forwarder_loop(
                 mission_id,
                 status,
                 execution,
+                completion,
                 ..
             }) => {
                 let old_status = markers.lock().await.get(mission_id);
@@ -16317,7 +16434,7 @@ async fn paloma_webhook_forwarder_loop(
                 if !in_flight.lock().await.insert((mission_id, status)) {
                     continue;
                 }
-                forward(mission_id, status, old_status, execution);
+                forward(mission_id, status, old_status, execution, completion, false);
             }
             Ok(_) => {}
             Err(broadcast::error::RecvError::Lagged(dropped)) => {
@@ -18451,6 +18568,11 @@ async fn maybe_finalize_terminal_mission(
                     new_status,
                 );
                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    completion: Some(MissionCompletionSnapshot {
+                        result_summary: final_output.map(str::to_owned),
+                        terminal_reason: Some(terminal_reason_str.to_owned()),
+                        terminal_evidence: terminal_evidence.map(str::to_owned),
+                    }),
                     execution,
                     mission_id,
                     status: new_status,
@@ -20075,6 +20197,7 @@ async fn control_actor_loop(
                                                 } else {
                                                     let _ = events_tx.send(
                                                         AgentEvent::MissionStatusChanged {
+                                                            completion: None,
                                                             execution: None,
                                                             mission_id: tid,
                                                             status: MissionStatus::Pending,
@@ -21074,6 +21197,7 @@ async fn control_actor_loop(
                                 new_status,
                             );
                             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                completion: None,
                                 execution: None,
                                 mission_id: id,
                                 status: new_status,
@@ -21432,6 +21556,7 @@ async fn control_actor_loop(
                                     tracing::warn!("Failed to cancel child mission {}: {}", child.id, e);
                                 } else {
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        completion: None,
                                         execution: None,
                                         mission_id: child.id,
                                         status: MissionStatus::Interrupted,
@@ -21574,6 +21699,7 @@ async fn control_actor_loop(
                                             .await;
                                         let _ = events_tx.send(
                                             AgentEvent::MissionStatusChanged {
+                                                completion: None,
                                                 execution: None,
                                                 mission_id,
                                                 status: MissionStatus::Interrupted,
@@ -21677,6 +21803,7 @@ async fn control_actor_loop(
                                     )
                                     .await;
                                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                    completion: None,
                                     execution: None,
                                     mission_id,
                                     status: MissionStatus::Paused,
@@ -21869,6 +21996,7 @@ async fn control_actor_loop(
                                                 .await;
                                             let _ = events_tx.send(
                                                 AgentEvent::MissionStatusChanged {
+                                                    completion: None,
                                                     execution: None,
                                                     mission_id,
                                                     status: MissionStatus::Interrupted,
@@ -21979,6 +22107,7 @@ async fn control_actor_loop(
                                         MissionStatus::Active,
                                     );
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        completion: None,
                                         execution: None,
                                         mission_id,
                                         status: MissionStatus::Active,
@@ -22055,6 +22184,7 @@ async fn control_actor_loop(
                                     );
                                     // Send status changed event so UI updates
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        completion: None,
                                         execution: None,
                                         mission_id,
                                         status: MissionStatus::Active,
@@ -22620,6 +22750,11 @@ async fn control_actor_loop(
                                 }
 
                                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                    completion: Some(MissionCompletionSnapshot {
+                                        result_summary: summary.clone(),
+                                        terminal_reason: None,
+                                        terminal_evidence: None,
+                                    }),
                                     execution,
                                     mission_id: id,
                                     status: new_status,
@@ -22727,6 +22862,7 @@ async fn control_actor_loop(
                                         tracing::warn!(mission_id = %run.mission_id, %error, "Failed to keep remote-wait mission active");
                                     } else {
                                         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                            completion: None,
                                             execution: None,
                                             mission_id: run.mission_id,
                                             status: MissionStatus::Active,
@@ -22958,6 +23094,7 @@ async fn control_actor_loop(
                                         MissionStatus::Failed,
                                     );
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        completion: None,
                                         execution: None,
                                         mission_id,
                                         status: MissionStatus::Failed,
@@ -23390,6 +23527,7 @@ async fn control_actor_loop(
                                 MissionStatus::Interrupted,
                             );
                             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                completion: None,
                                 execution: None,
                                 mission_id: *mission_id,
                                 status: MissionStatus::Interrupted,
@@ -23451,6 +23589,7 @@ async fn control_actor_loop(
                                     tracing::warn!(mission_id = %mission_id, %error, "Failed to keep parallel remote-wait mission active");
                                 } else {
                                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                        completion: None,
                                         execution: None,
                                         mission_id: *mission_id,
                                         status: MissionStatus::Active,
@@ -23876,6 +24015,7 @@ async fn control_actor_loop(
                                             MissionStatus::Failed,
                                         );
                                         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                            completion: None,
                                             execution: None,
                                             mission_id: m.id,
                                             status: MissionStatus::Failed,
@@ -24051,6 +24191,7 @@ async fn control_actor_loop(
                             MissionStatus::Interrupted,
                         );
                         let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                            completion: None,
                             execution: None,
                             mission_id: mid,
                             status: MissionStatus::Interrupted,
@@ -34067,10 +34208,103 @@ Investigate <service/> failures.
     }
 
     #[tokio::test]
+    async fn terminal_callback_identity_never_infers_unbound_live_event_from_same_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn MissionStore> = Arc::new(
+            mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "unbound")
+                .await
+                .unwrap(),
+        );
+        let mission = store
+            .create_mission(None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        for _ in 0..2 {
+            store
+                .update_mission_status(mission.id, MissionStatus::Active)
+                .await
+                .unwrap();
+            let run = store
+                .begin_mission_run(mission.id, "test", None)
+                .await
+                .unwrap();
+            store
+                .finish_mission_run(run.run_id, run.generation, None)
+                .await
+                .unwrap();
+            store
+                .update_mission_status_with_reason(
+                    mission.id,
+                    MissionStatus::Blocked,
+                    Some("second reason"),
+                )
+                .await
+                .unwrap();
+        }
+        store
+            .update_mission_history(
+                mission.id,
+                &[MissionHistoryEntry {
+                    role: "assistant".into(),
+                    content: "second result".into(),
+                }],
+            )
+            .await
+            .unwrap();
+        let (execution, completion) = callback_snapshot(
+            &store,
+            mission.id,
+            MissionStatus::Blocked,
+            None,
+            None,
+            false,
+        )
+        .await;
+        assert!(execution.is_none());
+        assert!(completion.is_none());
+        assert!(
+            current_callback_snapshot(&store, mission.id, MissionStatus::Blocked)
+                .await
+                .is_none(),
+            "history text alone is not a generation receipt"
+        );
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::MissionStatusChanged {
+                    execution: store.get_latest_mission_run(mission.id).await.unwrap(),
+                    completion: Some(MissionCompletionSnapshot {
+                        result_summary: Some("second result".into()),
+                        terminal_reason: Some("second reason".into()),
+                        terminal_evidence: None,
+                    }),
+                    mission_id: mission.id,
+                    status: MissionStatus::Blocked,
+                    summary: None,
+                },
+            )
+            .await
+            .unwrap();
+        // Only the explicitly current reconciliation observation may acquire
+        // the current generation. It is never treated as the old live event.
+        let (execution, completion) =
+            callback_snapshot(&store, mission.id, MissionStatus::Blocked, None, None, true).await;
+        assert_eq!(execution.unwrap().generation, 2);
+        assert_eq!(
+            completion.unwrap().result_summary.as_deref(),
+            Some("second result")
+        );
+    }
+
+    #[tokio::test]
     async fn terminal_callback_identity_reaches_http_after_release_and_delayed_successor() {
         for resume_before_delivery in [false, true] {
             let dir = tempfile::tempdir().unwrap();
-            let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+            let store: Arc<dyn MissionStore> = Arc::new(
+                mission_store::SqliteMissionStore::new(dir.path().join("db"), "http-callback")
+                    .await
+                    .unwrap(),
+            );
             let mission = store
                 .create_mission(None, None, None, None, None, None, None)
                 .await
@@ -34083,20 +34317,35 @@ Investigate <service/> failures.
                 .finish_mission_run(first.run_id, first.generation, Some("native_goal_stopped"))
                 .await
                 .unwrap();
+            store
+                .update_mission_history(
+                    mission.id,
+                    &[MissionHistoryEntry {
+                        role: "assistant".into(),
+                        content: "first generation result".into(),
+                    }],
+                )
+                .await
+                .unwrap();
             let (tx, rx) = tokio::sync::broadcast::channel(8);
+            let mut persist_rx = tx.subscribe();
             maybe_finalize_terminal_mission(
                 &store,
                 &tx,
                 mission.id,
                 0,
                 Some(TerminalReason::NativeGoalStopped),
-                None,
+                Some("first evidence"),
                 None,
                 true,
                 Some("first generation result"),
                 "http callback test",
             )
             .await;
+            store
+                .log_event(mission.id, &persist_rx.try_recv().unwrap())
+                .await
+                .unwrap();
             // Queue the actual finalizer event, then acquire a successor BEFORE
             // starting the forwarder. This deterministically exercises delay.
             if resume_before_delivery {
@@ -34109,9 +34358,42 @@ Investigate <service/> failures.
                     .await
                     .unwrap();
                 assert_eq!(next.generation, 2);
+                store
+                    .finish_mission_run(next.run_id, next.generation, Some("RateLimited"))
+                    .await
+                    .unwrap();
+                store
+                    .update_mission_history(
+                        mission.id,
+                        &[MissionHistoryEntry {
+                            role: "assistant".into(),
+                            content: "SECOND generation result".into(),
+                        }],
+                    )
+                    .await
+                    .unwrap();
+                store
+                    .set_terminal_evidence(mission.id, "SECOND evidence")
+                    .await
+                    .unwrap();
+                store
+                    .update_mission_status_with_reason(
+                        mission.id,
+                        MissionStatus::Failed,
+                        Some("rate_limited"),
+                    )
+                    .await
+                    .unwrap();
             }
             let mut markers = super::super::webhook_markers::MarkerStore::load(dir.path());
-            markers.set(mission.id, MissionStatus::Active);
+            markers.set(
+                mission.id,
+                if resume_before_delivery {
+                    MissionStatus::Failed
+                } else {
+                    MissionStatus::Active
+                },
+            );
             let (body_tx, mut body_rx) = tokio::sync::mpsc::channel(2);
             let app = axum::Router::new().route(
                 "/",
@@ -34147,6 +34429,9 @@ Investigate <service/> failures.
             assert_eq!(body["execution"]["run_id"], first.run_id.to_string());
             assert_eq!(body["execution"]["generation"], 1);
             assert_eq!(body["execution"]["state"], "terminal");
+            assert_eq!(body["result_summary"], "first generation result");
+            assert_eq!(body["terminal_reason"], "native_goal_stopped");
+            assert_eq!(body["terminal_evidence"], "first evidence");
             forwarder.abort();
             server.abort();
         }
@@ -34172,6 +34457,11 @@ Investigate <service/> failures.
             .await
             .unwrap();
         let event = AgentEvent::MissionStatusChanged {
+            completion: Some(MissionCompletionSnapshot {
+                result_summary: Some("original result".into()),
+                terminal_reason: Some("native_goal_stopped".into()),
+                terminal_evidence: Some("original evidence".into()),
+            }),
             execution: store.get_latest_mission_run(mission.id).await.unwrap(),
             mission_id: mission.id,
             status: MissionStatus::Blocked,
@@ -34190,6 +34480,7 @@ Investigate <service/> failures.
         let restored = events.iter().find_map(stored_event_to_agent_event).unwrap();
         let AgentEvent::MissionStatusChanged {
             execution: Some(identity),
+            completion: Some(completion),
             ..
         } = restored
         else {
@@ -34197,6 +34488,18 @@ Investigate <service/> failures.
         };
         assert_eq!(identity.run_id, run.run_id);
         assert_eq!(identity.generation, 1);
+        assert_eq!(
+            completion.result_summary.as_deref(),
+            Some("original result")
+        );
+        assert_eq!(
+            completion.terminal_reason.as_deref(),
+            Some("native_goal_stopped")
+        );
+        assert_eq!(
+            completion.terminal_evidence.as_deref(),
+            Some("original evidence")
+        );
         assert!(identity.execution_state.is_terminal());
         assert_eq!(
             reopened

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -199,6 +199,17 @@ impl MissionStore for FileMissionStore {
             .cloned())
     }
 
+    async fn get_latest_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        Ok(self
+            .runs
+            .read()
+            .await
+            .values()
+            .filter(|run| run.mission_id == mission_id)
+            .max_by_key(|run| run.generation)
+            .cloned())
+    }
+
     async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
         Ok(self
             .runs

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -167,6 +167,17 @@ impl MissionStore for InMemoryMissionStore {
             .cloned())
     }
 
+    async fn get_latest_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        Ok(self
+            .runs
+            .read()
+            .await
+            .values()
+            .filter(|run| run.mission_id == mission_id)
+            .max_by_key(|run| run.generation)
+            .cloned())
+    }
+
     async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
         Ok(self
             .runs

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -2135,6 +2135,12 @@ pub trait MissionStore: Send + Sync {
         Ok(None)
     }
 
+    /// Most recent durable generation, including a settled run. Read-only
+    /// reporting must retain identity after the active lease has been released.
+    async fn get_latest_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        self.get_active_mission_run(mission_id).await
+    }
+
     async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
         Ok(Vec::new())
     }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -5522,6 +5522,7 @@ impl MissionStore for SqliteMissionStore {
                 status,
                 summary,
                 execution,
+                completion,
                 ..
             } => (
                 "mission_status_changed",
@@ -5529,7 +5530,7 @@ impl MissionStore for SqliteMissionStore {
                 None,
                 None,
                 summary.clone().unwrap_or_default(),
-                serde_json::json!({ "status": status.to_string(), "execution": execution }),
+                serde_json::json!({ "status": status.to_string(), "execution": execution, "completion": completion }),
             ),
             AgentEvent::MissionMetadataUpdated {
                 title,
@@ -12322,6 +12323,7 @@ mod tests {
                 .log_event(
                     mission.id,
                     &AgentEvent::MissionStatusChanged {
+                        completion: None,
                         execution: None,
                         mission_id: mission.id,
                         status: *status,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3518,6 +3518,23 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|error| error.to_string())?
     }
 
+    async fn get_latest_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.query_row(
+                "SELECT run_id, mission_id, generation, execution_state, owner_actor_id, scope_unit, started_at, heartbeat_at, stopping_at, ended_at, terminal_reason
+                 FROM mission_runs WHERE mission_id = ?1 ORDER BY generation DESC LIMIT 1",
+                params![mission_id.to_string()],
+                parse_mission_run_row,
+            )
+            .optional()
+            .map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
     async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
         let conn = self.conn.clone();
         tokio::task::spawn_blocking(move || {
@@ -5502,14 +5519,17 @@ impl MissionStore for SqliteMissionStore {
             ),
             AgentEvent::TextOp { .. } => return Ok(()),
             AgentEvent::MissionStatusChanged {
-                status, summary, ..
+                status,
+                summary,
+                execution,
+                ..
             } => (
                 "mission_status_changed",
                 None,
                 None,
                 None,
                 summary.clone().unwrap_or_default(),
-                serde_json::json!({ "status": status.to_string() }),
+                serde_json::json!({ "status": status.to_string(), "execution": execution }),
             ),
             AgentEvent::MissionMetadataUpdated {
                 title,
@@ -12302,6 +12322,7 @@ mod tests {
                 .log_event(
                     mission.id,
                     &AgentEvent::MissionStatusChanged {
+                        execution: None,
                         mission_id: mission.id,
                         status: *status,
                         summary: Some(format!("{title} status change")),

--- a/src/api/reconcile.rs
+++ b/src/api/reconcile.rs
@@ -610,6 +610,7 @@ pub async fn run(state: &Arc<AppState>) -> ReconcileReport {
             }
             report.missions_interrupted += 1;
             let _ = session.events_tx.send(AgentEvent::MissionStatusChanged {
+                execution: None,
                 mission_id: mission.id,
                 status: MissionStatus::Interrupted,
                 summary: Some(

--- a/src/api/reconcile.rs
+++ b/src/api/reconcile.rs
@@ -610,6 +610,7 @@ pub async fn run(state: &Arc<AppState>) -> ReconcileReport {
             }
             report.missions_interrupted += 1;
             let _ = session.events_tx.send(AgentEvent::MissionStatusChanged {
+                completion: None,
                 execution: None,
                 mission_id: mission.id,
                 status: MissionStatus::Interrupted,

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -163,6 +163,7 @@ pub(crate) async fn recover_server_shutdown_missions(
                     MissionStatus::Interrupted,
                 );
                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Interrupted,
                     summary: Some(
@@ -370,6 +371,7 @@ pub(crate) async fn cleanup_stale_active_missions_once(
                         MissionStatus::Completed,
                     );
                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                        execution: None,
                         mission_id: mission.id,
                         status: MissionStatus::Completed,
                         summary: Some(format!(
@@ -425,6 +427,7 @@ pub(crate) async fn ack_promotion_loop(
             Ok(promoted) => {
                 for mission_id in promoted {
                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                        execution: None,
                         mission_id,
                         status: MissionStatus::Acknowledged,
                         summary: None,
@@ -700,6 +703,7 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 continue;
             }
             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                execution: None,
                 mission_id: info.mission_id,
                 status: MissionStatus::Interrupted,
                 summary: Some(format!(
@@ -769,6 +773,7 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 continue;
             }
             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                execution: None,
                 mission_id: mission.id,
                 status: MissionStatus::Interrupted,
                 summary: Some(

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -163,6 +163,7 @@ pub(crate) async fn recover_server_shutdown_missions(
                     MissionStatus::Interrupted,
                 );
                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    completion: None,
                     execution: None,
                     mission_id: mission.id,
                     status: MissionStatus::Interrupted,
@@ -371,6 +372,7 @@ pub(crate) async fn cleanup_stale_active_missions_once(
                         MissionStatus::Completed,
                     );
                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                        completion: None,
                         execution: None,
                         mission_id: mission.id,
                         status: MissionStatus::Completed,
@@ -427,6 +429,7 @@ pub(crate) async fn ack_promotion_loop(
             Ok(promoted) => {
                 for mission_id in promoted {
                     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                        completion: None,
                         execution: None,
                         mission_id,
                         status: MissionStatus::Acknowledged,
@@ -703,6 +706,7 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 continue;
             }
             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                completion: None,
                 execution: None,
                 mission_id: info.mission_id,
                 status: MissionStatus::Interrupted,
@@ -773,6 +777,7 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 continue;
             }
             let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                completion: None,
                 execution: None,
                 mission_id: mission.id,
                 status: MissionStatus::Interrupted,

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -229,6 +229,7 @@ async fn apply_reconciled_status(
         "bg-autoresume: reconciled mission background status"
     );
     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+        completion: None,
         execution: None,
         mission_id,
         status: next,

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -229,6 +229,7 @@ async fn apply_reconciled_status(
         "bg-autoresume: reconciled mission background status"
     );
     let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+        execution: None,
         mission_id,
         status: next,
         summary: None,


### PR DESCRIPTION
A mission releases its durable execution lease before its completion webhook is built. The webhook and digest previously queried only the active lease, returning `execution: null`; Hermes then could not safely rearm callbacks after resuming the same mission.

Keep active-lease ownership unchanged and expose the latest generation for reporting. Terminal status events capture the actual run and a compact outcome snapshot (result, terminal reason, evidence). SQLite persists/replays those fields, and delayed HTTP delivery cannot combine an old generation with a newer result. Explicit agent status changes use the actor-owned run. Digest/snapshot responses retain terminal execution identity and diagnostics.

Unbound live events never acquire an inferred generation. Reconciliation uses a matching persisted frozen event and checks stable status/run identity; stable legacy and row-only shutdown notifications remain explicitly unbound. This does not redesign status-coalescing webhook markers into an exactly-once outbox or repair previously delivered Hermes rows.

Validation: independent source review CLEAN at `70d5fcb497f01db6bd53de78ea7a2f7d97b8df12`; formatting and whitespace checks pass. Exact-head targeted Rust tests pass: four callback regressions, four lease regressions, and two existing finalizer regressions (10 passed, 0 failed; macOS/aarch64). Tests exercise real HTTP after a successor replaces output/reason/evidence, memory/file/SQLite terminal identity, durable SQLite replay, same-status unbound events, and shutdown reconciliation. No production services or mission ledgers changed by this PR author.
