### PR TITLE
Authenticate idle continuations and preserve explicit reader admission

### DIFF
--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1008,28 +1008,30 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
             }
             use crate::api::control::UserMessageAck;
             match tokio::time::timeout(std::time::Duration::from_secs(15), rx).await {
-                Ok(Ok(UserMessageAck::Queued)) => match (interrupt, &interrupt_error) {
-                    (true, None) => {
-                        "Steering message delivered after interrupting the current turn — \
+                Ok(Ok(UserMessageAck::Queued | UserMessageAck::Continued { queued: true, .. })) => {
+                    match (interrupt, &interrupt_error) {
+                        (true, None) => {
+                            "Steering message delivered after interrupting the current turn — \
                          the agent will act on it as soon as the cancellation settles."
-                            .to_string()
-                    }
-                    (true, Some(err)) => format!(
-                        "Steering message queued, but the requested interrupt FAILED \
+                                .to_string()
+                        }
+                        (true, Some(err)) => format!(
+                            "Steering message queued, but the requested interrupt FAILED \
                          ({err}) — the agent may still be mid-turn and will only act on \
                          the message at the next turn boundary. Verify with read_history; \
                          retry stop_agent if it must stop now."
-                    ),
-                    (false, _) => {
-                        "Steering message queued — the working agent is mid-turn and will \
+                        ),
+                        (false, _) => {
+                            "Steering message queued — the working agent is mid-turn and will \
                          act on it at the next turn boundary. Pass interrupt=true if it \
                          must take effect immediately."
-                            .to_string()
+                                .to_string()
+                        }
                     }
-                },
-                Ok(Ok(UserMessageAck::Delivered)) => {
-                    "Steering message delivered — a turn is starting on it now.".to_string()
                 }
+                Ok(Ok(
+                    UserMessageAck::Delivered | UserMessageAck::Continued { queued: false, .. },
+                )) => "Steering message delivered — a turn is starting on it now.".to_string(),
                 Ok(Ok(UserMessageAck::Dropped)) => {
                     "Error: the steering message was DROPPED — it never reached the \
                      working agent (parallel mission cap, mission load failure, or a \

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -897,24 +897,26 @@ fn dispatch_board_outbox_item(
             let release_tx = cmd_tx.clone();
             tokio::spawn(async move {
                 match rx.await {
-                    Ok(UserMessageAck::Queued | UserMessageAck::Delivered) => {
-                        match store.acknowledge_board_outbox(&idempotency_key).await {
-                            Ok(()) => {
-                                inflight
-                                    .lock()
-                                    .expect("board outbox lock")
-                                    .remove(&delivery_id);
-                            }
-                            Err(error) => {
-                                tracing::warn!(target = %target_mission_id, %idempotency_key,
-                                    "board: accepted delivery acknowledgement failed: {error}");
-                                inflight
-                                    .lock()
-                                    .expect("board outbox lock")
-                                    .remove(&delivery_id);
-                            }
+                    Ok(
+                        UserMessageAck::Queued
+                        | UserMessageAck::Delivered
+                        | UserMessageAck::Continued { .. },
+                    ) => match store.acknowledge_board_outbox(&idempotency_key).await {
+                        Ok(()) => {
+                            inflight
+                                .lock()
+                                .expect("board outbox lock")
+                                .remove(&delivery_id);
                         }
-                    }
+                        Err(error) => {
+                            tracing::warn!(target = %target_mission_id, %idempotency_key,
+                                    "board: accepted delivery acknowledgement failed: {error}");
+                            inflight
+                                .lock()
+                                .expect("board outbox lock")
+                                .remove(&delivery_id);
+                        }
+                    },
                     Ok(UserMessageAck::Dropped) => {
                         let _ = release_tx
                             .send(ControlCommand::ReleaseUserMessageId { id: delivery_id })

--- a/src/api/control/dispatch_admission.rs
+++ b/src/api/control/dispatch_admission.rs
@@ -604,6 +604,31 @@ pub(super) async fn admit_dispatch_with_lifetime(
                     return None;
                 }
             };
+            // The actor's dispatch lock fences admission. Capture the completed
+            // predecessor now: after its acknowledgement a successor may already
+            // be running (or even finished). Busy steering and legacy runs do
+            // not authenticate a distinct callback reservation.
+            let previous_execution = if !actor_busy
+                && !matches!(
+                    receipt.before.status,
+                    MissionStatus::Pending
+                        | MissionStatus::Active
+                        | MissionStatus::WaitingBackground
+                ) {
+                match receipt
+                    .store
+                    .get_latest_mission_run(receipt.before.id)
+                    .await
+                {
+                    Ok(Some(run)) if run.ended_at.is_some() => Some(MessagePreviousExecution {
+                        run_id: run.run_id,
+                        generation: run.generation,
+                    }),
+                    _ => None,
+                }
+            } else {
+                None
+            };
             let (tx, rx) = oneshot::channel();
             tokio::spawn(async move {
                 let _guard = guard;
@@ -635,6 +660,21 @@ pub(super) async fn admit_dispatch_with_lifetime(
                     Err(error) => UserMessageAck::Rejected(format!(
                         "dispatch_recovery_required: ownership retained: {error}"
                     )),
+                };
+                let ack = match (ack, previous_execution) {
+                    (UserMessageAck::Queued, Some(previous_execution)) => {
+                        UserMessageAck::Continued {
+                            queued: true,
+                            previous_execution,
+                        }
+                    }
+                    (UserMessageAck::Delivered, Some(previous_execution)) => {
+                        UserMessageAck::Continued {
+                            queued: false,
+                            previous_execution,
+                        }
+                    }
+                    (ack, _) => ack,
                 };
                 let _ = respond.send(ack);
             });

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -567,6 +567,92 @@ fn isolated_track_http_test(test_name: &str) -> bool {
 }
 
 #[tokio::test]
+async fn explicit_reader_creation_without_pr_survives_queued_activation() {
+    if isolated_track_http_test("explicit_reader_creation_without_pr_survives_queued_activation") {
+        return;
+    }
+    for pr in [None, Some("repo#244")] {
+        let h = Harness::new().await;
+        h.state.backend_registry.write().await.register(Arc::new(
+            crate::backend::opencode::OpenCodeBackend::new(
+                "http://127.0.0.1:9".into(),
+                None,
+                false,
+            ),
+        ));
+        let prompt = "Read-only review in verity-integration-b. Write output/review.md; no repository edits.";
+        // This is the production trigger: the prose heuristic sees a writer,
+        // while the explicit capability admits only a reader.
+        assert!(inferred_pr_writer(None, Some("review"), Some(prompt)));
+        let response = h
+            .state
+            .http_client
+            .post(format!("{}/missions", h.url))
+            .json(&json!({
+                "title":"bounded read-only review", "backend":"opencode",
+                "project":"lido", "track":"independent-review", "intent":"review",
+                "github_pr":pr, "writer":false, "tags":["pr-writer", "ssz"],
+                "prompt":prompt, "estimated_disk_gib":1,
+                "not_before":(chrono::Utc::now()+chrono::Duration::hours(1)).to_rfc3339()
+            }))
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = response.text().await.unwrap();
+        assert!(status.is_success(), "{status}: {body}");
+        let created: Mission = serde_json::from_str(&body).unwrap();
+        let stored = h
+            .control
+            .mission_store
+            .get_mission(created.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(stored.project.tags.iter().any(|tag| tag == "pr-readonly"));
+        assert!(!stored.project.tags.iter().any(|tag| tag == "pr-writer"));
+        assert!(!mission_is_pr_writer_with_prompt(&stored, Some(prompt)));
+        h.control
+            .mission_store
+            .log_event(
+                created.id,
+                &AgentEvent::UserMessage {
+                    id: Uuid::new_v4(),
+                    content: prompt.into(),
+                    queued: true,
+                    mission_id: Some(created.id),
+                    source: None,
+                },
+            )
+            .await
+            .unwrap();
+        // Exercise the real dequeue revalidation against the lease acquired
+        // by HTTP creation, after the initial prompt is persisted.
+        activate_mission_for_message(
+            &h.state.control,
+            &h.control.mission_store,
+            &h.control.events_tx,
+            &stored,
+            prompt,
+        )
+        .await
+        .unwrap();
+        let leases = h.state.projects.live_leases(None).unwrap();
+        assert_eq!(leases.len(), 1);
+        assert_eq!(leases[0].attempt_id, created.id.to_string());
+        assert_eq!(leases[0].mode, "reader");
+        assert!(h
+            .control
+            .mission_store
+            .get_active_mission_run(created.id)
+            .await
+            .unwrap()
+            .is_none());
+    }
+}
+
+#[tokio::test]
 async fn track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock() {
     if isolated_track_http_test(
         "track_dispatch_http_creation_reconciles_without_deadlocking_actor_or_pr_lock",

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -4473,3 +4473,107 @@ async fn adversarial_pr_lookup_cannot_omit_parked_writer_moving_across_pages() {
     assert!(moved.load(std::sync::atomic::Ordering::SeqCst));
     assert_eq!(found.map(|writer| writer.id), Some(m.id));
 }
+
+#[tokio::test]
+async fn http_idle_message_continuation_captures_predecessor_before_delivery() {
+    for (busy, ended, actor_ack) in [
+        (false, true, UserMessageAck::Delivered),
+        (false, true, UserMessageAck::Queued),
+        (true, true, UserMessageAck::Queued),
+        (false, false, UserMessageAck::Delivered),
+        (false, true, UserMessageAck::Dropped),
+        (
+            false,
+            true,
+            UserMessageAck::Rejected("injected refusal".into()),
+        ),
+    ] {
+        let h = Harness::new().await;
+        let m = h
+            .writer(MissionStatus::AwaitingUser, Some("repo#244"))
+            .await;
+        let store = h.control.mission_store.clone();
+        let prior = store
+            .begin_mission_run(m.id, "prior-actor", None)
+            .await
+            .unwrap();
+        if ended {
+            store
+                .finish_mission_run(prior.run_id, prior.generation, Some("turn_complete"))
+                .await
+                .unwrap();
+        }
+        let (tx, mut rx) = mpsc::channel(1);
+        h.state
+            .control
+            .sessions
+            .write()
+            .await
+            .get_mut(&h.user.id)
+            .unwrap()
+            .cmd_tx = tx;
+        let should_accept = matches!(
+            actor_ack,
+            UserMessageAck::Delivered | UserMessageAck::Queued
+        );
+        let should_continue = !busy && ended && should_accept;
+        let expected_queued = actor_ack == UserMessageAck::Queued;
+        let mission_id = m.id;
+        let actor = tokio::spawn(async move {
+            let ControlCommand::AdmitDispatch { admission, command } = rx.recv().await.unwrap()
+            else {
+                panic!()
+            };
+            let command = dispatch_admission::admit_dispatch_with_lifetime(
+                *admission,
+                *command,
+                DISPATCH_ADMISSION.lock().await,
+                busy,
+                None,
+            )
+            .await
+            .unwrap();
+            if should_continue {
+                // The next native run can already finish before HTTP receives
+                // its acknowledgement. The reply must retain generation 1.
+                let successor = store
+                    .begin_mission_run(mission_id, "next-actor", None)
+                    .await
+                    .unwrap();
+                assert_eq!(successor.generation, 2);
+                store
+                    .finish_mission_run(
+                        successor.run_id,
+                        successor.generation,
+                        Some("turn_complete"),
+                    )
+                    .await
+                    .unwrap();
+            }
+            let ControlCommand::UserMessage { respond, .. } = command else {
+                panic!()
+            };
+            respond.send(actor_ack).unwrap();
+        });
+        let response = h.request(false, m.id, json!({"content":"Continue the same work", "continue_identity":Harness::assertion(&m)})).await;
+        actor.await.unwrap();
+        if !should_accept {
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+            continue;
+        }
+        assert!(response.status().is_success());
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["mission_id"], m.id.to_string());
+        assert_ne!(body["id"], m.id.to_string());
+        assert_eq!(body["message_accepted"], true);
+        assert_eq!(body["queued"], expected_queued);
+        if should_continue {
+            assert_eq!(
+                body["previous_execution"],
+                json!({"run_id":prior.run_id,"generation":prior.generation})
+            );
+        } else {
+            assert!(body.get("previous_execution").is_none());
+        }
+    }
+}

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -4575,9 +4575,7 @@ async fn http_idle_message_continuation_captures_predecessor_before_delivery() {
         ),
     ] {
         let h = Harness::new().await;
-        let m = h
-            .writer(MissionStatus::AwaitingUser, Some("repo#244"))
-            .await;
+        let m = h.writer(MissionStatus::Active, Some("repo#244")).await;
         let store = h.control.mission_store.clone();
         let prior = store
             .begin_mission_run(m.id, "prior-actor", None)
@@ -4586,6 +4584,10 @@ async fn http_idle_message_continuation_captures_predecessor_before_delivery() {
         if ended {
             store
                 .finish_mission_run(prior.run_id, prior.generation, Some("turn_complete"))
+                .await
+                .unwrap();
+            store
+                .update_mission_status(m.id, MissionStatus::AwaitingUser)
                 .await
                 .unwrap();
         }
@@ -4622,6 +4624,10 @@ async fn http_idle_message_continuation_captures_predecessor_before_delivery() {
             if should_continue {
                 // The next native run can already finish before HTTP receives
                 // its acknowledgement. The reply must retain generation 1.
+                store
+                    .update_mission_status(mission_id, MissionStatus::Active)
+                    .await
+                    .unwrap();
                 let successor = store
                     .begin_mission_run(mission_id, "next-actor", None)
                     .await
@@ -4633,6 +4639,10 @@ async fn http_idle_message_continuation_captures_predecessor_before_delivery() {
                         successor.generation,
                         Some("turn_complete"),
                     )
+                    .await
+                    .unwrap();
+                store
+                    .update_mission_status(mission_id, MissionStatus::AwaitingUser)
                     .await
                     .unwrap();
             }

--- a/src/api/control/dispatch_admission_tests.rs
+++ b/src/api/control/dispatch_admission_tests.rs
@@ -571,6 +571,18 @@ async fn explicit_reader_creation_without_pr_survives_queued_activation() {
     if isolated_track_http_test("explicit_reader_creation_without_pr_survives_queued_activation") {
         return;
     }
+    assert_explicit_creation_role_survives_queued_activation(false).await;
+}
+
+#[tokio::test]
+async fn explicit_writer_creation_without_pr_survives_queued_activation() {
+    if isolated_track_http_test("explicit_writer_creation_without_pr_survives_queued_activation") {
+        return;
+    }
+    assert_explicit_creation_role_survives_queued_activation(true).await;
+}
+
+async fn assert_explicit_creation_role_survives_queued_activation(writer: bool) {
     for pr in [None, Some("repo#244")] {
         let h = Harness::new().await;
         h.state.backend_registry.write().await.register(Arc::new(
@@ -580,10 +592,19 @@ async fn explicit_reader_creation_without_pr_survives_queued_activation() {
                 false,
             ),
         ));
-        let prompt = "Read-only review in verity-integration-b. Write output/review.md; no repository edits.";
-        // This is the production trigger: the prose heuristic sees a writer,
-        // while the explicit capability admits only a reader.
-        assert!(inferred_pr_writer(None, Some("review"), Some(prompt)));
+        let prompt = if writer {
+            "Read-only review and report findings without edits."
+        } else {
+            "Read-only review in verity-integration-b. Write output/review.md; no repository edits."
+        };
+        // Both directions must preserve explicit authority when the prose
+        // heuristic would infer the opposite role during queued activation.
+        assert_eq!(
+            inferred_pr_writer(None, Some("review"), Some(prompt)),
+            !writer
+        );
+        let expected_tag = if writer { "pr-writer" } else { "pr-readonly" };
+        let conflicting_tag = if writer { "pr-readonly" } else { "pr-writer" };
         let response = h
             .state
             .http_client
@@ -591,7 +612,7 @@ async fn explicit_reader_creation_without_pr_survives_queued_activation() {
             .json(&json!({
                 "title":"bounded read-only review", "backend":"opencode",
                 "project":"lido", "track":"independent-review", "intent":"review",
-                "github_pr":pr, "writer":false, "tags":["pr-writer", "ssz"],
+                "github_pr":pr, "writer":writer, "tags":[conflicting_tag, "ssz"],
                 "prompt":prompt, "estimated_disk_gib":1,
                 "not_before":(chrono::Utc::now()+chrono::Duration::hours(1)).to_rfc3339()
             }))
@@ -610,9 +631,12 @@ async fn explicit_reader_creation_without_pr_survives_queued_activation() {
             .await
             .unwrap()
             .unwrap();
-        assert!(stored.project.tags.iter().any(|tag| tag == "pr-readonly"));
-        assert!(!stored.project.tags.iter().any(|tag| tag == "pr-writer"));
-        assert!(!mission_is_pr_writer_with_prompt(&stored, Some(prompt)));
+        assert!(stored.project.tags.iter().any(|tag| tag == expected_tag));
+        assert!(!stored.project.tags.iter().any(|tag| tag == conflicting_tag));
+        assert_eq!(
+            mission_is_pr_writer_with_prompt(&stored, Some(prompt)),
+            writer
+        );
         h.control
             .mission_store
             .log_event(
@@ -641,7 +665,7 @@ async fn explicit_reader_creation_without_pr_survives_queued_activation() {
         let leases = h.state.projects.live_leases(None).unwrap();
         assert_eq!(leases.len(), 1);
         assert_eq!(leases[0].attempt_id, created.id.to_string());
-        assert_eq!(leases[0].mode, "reader");
+        assert_eq!(leases[0].mode, if writer { "writer" } else { "reader" });
         assert!(h
             .control
             .mission_store

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -365,6 +365,12 @@ pub enum UserMessageAck {
     Queued,
     /// The message was delivered and a turn is starting now.
     Delivered,
+    /// Accepted wake of an idle mission with an authenticated terminal
+    /// predecessor, captured before admission (never from later readback).
+    Continued {
+        queued: bool,
+        previous_execution: MessagePreviousExecution,
+    },
     /// The message was dropped (parallel cap reached, mission load failure,
     /// rejected goal kickoff, …). An `AgentEvent::Error` with details was
     /// emitted on the event stream.
@@ -372,6 +378,12 @@ pub enum UserMessageAck {
     /// The actor rejected the message after HTTP preflight. The reason is
     /// returned to synchronous callers instead of being visible only on SSE.
     Rejected(String),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MessagePreviousExecution {
+    pub run_id: Uuid,
+    pub generation: u64,
 }
 
 /// Internal control commands (queued and processed by the actor).

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -11453,7 +11453,11 @@ async fn deliver_remote_build_terminal_wake(
             .await
             .map_err(|_| "remote-build terminal control session unavailable".to_string())?;
         return match tokio::time::timeout(std::time::Duration::from_secs(10), response).await {
-            Ok(Ok(UserMessageAck::Queued | UserMessageAck::Delivered)) => Ok(true),
+            Ok(Ok(
+                UserMessageAck::Queued
+                | UserMessageAck::Delivered
+                | UserMessageAck::Continued { .. },
+            )) => Ok(true),
             Ok(Ok(UserMessageAck::Rejected(error))) => Err(error),
             Ok(Ok(UserMessageAck::Dropped)) => Ok(false),
             Ok(Err(_)) => Ok(false),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10709,10 +10709,14 @@ pub async fn create_mission(
             }
         }
     }
-    if req
-        .github_pr
-        .as_deref()
-        .is_some_and(|value| !value.trim().is_empty())
+    // Reader capability governs track admission and harness permissions even
+    // without PR metadata. Persist it before deferred dispatch can re-infer
+    // authority from an initial prompt such as "verity-integration-b".
+    if req.writer == Some(false)
+        || req
+            .github_pr
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
     {
         let capability = if request_is_writer {
             Some("pr-writer")

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3611,6 +3611,12 @@ pub struct ControlMessageRequest {
 pub struct ControlMessageResponse {
     pub id: Uuid,
     pub queued: bool,
+    pub message_accepted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mission_id: Option<Uuid>,
+    /// Only populated for an accepted idle wake, not an active queued steer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_execution: Option<MessagePreviousExecution>,
     /// Non-fatal request problems (e.g. unrecognized fields that were
     /// ignored). Empty on clean requests; omitted from the JSON then.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -4961,13 +4967,14 @@ pub async fn post_message(
     if let Some(mission_id) = target_mission_id {
         dispatch_admission_tests::notify_wait(mission_id, "enqueued");
     }
-    let queued = match queued_rx.await {
-        // The wire response keeps its historical bool shape: `queued` is true
-        // only when the message is waiting for the next turn boundary.
-        // Dropped messages surface as an `AgentEvent::Error` on the stream.
-        Ok(UserMessageAck::Queued) => true,
-        Ok(UserMessageAck::Delivered) => false,
-        Ok(UserMessageAck::Dropped) => false,
+    let (queued, message_accepted, previous_execution) = match queued_rx.await {
+        Ok(UserMessageAck::Queued) => (true, true, None),
+        Ok(UserMessageAck::Delivered) => (false, true, None),
+        Ok(UserMessageAck::Continued {
+            queued,
+            previous_execution,
+        }) => (queued, true, Some(previous_execution)),
+        Ok(UserMessageAck::Dropped) => (false, false, None),
         Ok(UserMessageAck::Rejected(reason)) => {
             return Err((StatusCode::CONFLICT, reason));
         }
@@ -4976,6 +4983,9 @@ pub async fn post_message(
     Ok(Json(ControlMessageResponse {
         id,
         queued,
+        message_accepted,
+        mission_id: target_mission_id,
+        previous_execution,
         warnings,
     }))
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10709,10 +10709,10 @@ pub async fn create_mission(
             }
         }
     }
-    // Reader capability governs track admission and harness permissions even
+    // Explicit capability governs track admission and harness permissions even
     // without PR metadata. Persist it before deferred dispatch can re-infer
     // authority from an initial prompt such as "verity-integration-b".
-    if req.writer == Some(false)
+    if req.writer.is_some()
         || req
             .github_pr
             .as_deref()

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -4831,6 +4831,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_message_preserves_authoritative_idle_continuation_receipt() {
+        let mission_id = Uuid::new_v4().to_string();
+        let reply = json!({
+            "id": Uuid::new_v4(), "mission_id": mission_id,
+            "queued": true, "message_accepted": true,
+            "previous_execution": {"run_id": Uuid::new_v4(), "generation": 7}
+        });
+        let (mcp, state, server) = mock_assistant(reply.clone(), false).await;
+        let result = mcp
+            .send_message(
+                parse_params(json!({
+                    "mission_id": mission_id, "content": "Continue the same work"
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result, reply);
+        let requests = state.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].0, "/api/control/message");
+        assert_eq!(requests[0].1["mission_id"], mission_id);
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn link_project_transports_explicit_reader_and_preserves_omission() {
         let id = Uuid::new_v4().to_string();
         let (mcp, state, server) = mock_assistant(json!({"id": id}), false).await;

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -4536,6 +4536,20 @@ fn build_recommendation(
     analysis: &TraceAnalysis,
 ) -> String {
     let live_state = live.get("state").and_then(Value::as_str);
+    if status == "pending"
+        && live_state != Some("running")
+        && analysis.recent_errors.iter().any(|error| {
+            error
+                .get("snippet")
+                .and_then(Value::as_str)
+                .is_some_and(|text| text.contains("queued_assignment_unowned:"))
+        })
+    {
+        return "Queued mission could not acquire its admitted track assignment. Inspect the \
+                recorded reader/writer capability and track lease before retrying; the \
+                queued_assignment_unowned error does not by itself prove the lease was released."
+            .to_string();
+    }
     if backend == Some("chatgpt_ui") && live_state == Some("running") {
         return "ChatGPT UI Pro is still generating. The web UI may expose only a generic \
                 `Pro thinking` marker until the final answer begins, so event silence is not \
@@ -5780,6 +5794,25 @@ mod tests {
         assert!(analysis.signals.contains("rate_limited"));
         assert_eq!(analysis.recent_errors.len(), 1);
         assert!(analysis.loop_tool.is_none());
+    }
+
+    #[test]
+    fn recommendation_reports_pending_assignment_failure_without_poisoning_active_run() {
+        let analysis = analyze_trace_events(&[json!({
+            "event_type":"error", "sequence":3,
+            "content":"Cannot activate mission: queued_assignment_unowned: original track claim is no longer held"
+        })]);
+        let pending = build_recommendation("pending", None, &Value::Null, &analysis);
+        assert!(pending.contains("Queued mission could not acquire"));
+        assert!(!pending.contains("healthy"));
+        let active = build_recommendation("active", None, &json!({"state":"running"}), &analysis);
+        assert!(!active.contains("Queued mission could not acquire"));
+        let starting =
+            build_recommendation("pending", None, &json!({"state":"running"}), &analysis);
+        assert!(!starting.contains("Queued mission could not acquire"));
+        let ordinary_pending =
+            build_recommendation("pending", None, &Value::Null, &TraceAnalysis::default());
+        assert!(!ordinary_pending.contains("Queued mission could not acquire"));
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -239,6 +239,8 @@ struct LinkMissionToProjectParams {
     slug: String,
     #[serde(default)]
     track: Option<String>,
+    #[serde(default)]
+    writer: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1921,14 +1923,15 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "link_mission_to_project".to_string(),
-                description: "Tag a mission as belonging to your project (and optionally a track), so it appears in the project's inventory. Use this for missions you dispatch that must be grouped under the project — a worker with no project tag is invisible in the roster.".to_string(),
+                description: "Tag a mission as belonging to your project (and optionally a track), so it appears in the project's inventory. Optional writer=false persists read-only capability, including when no PR is attached; writer=true requests writer capability through the existing ownership checks. Capability or assignment changes require stopped, drained work; Pending work must be cancelled first and resumed on the same mission after the update.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id", "slug"],
                     "properties": {
                         "mission_id": {"type": "string", "description": "Mission UUID or an unambiguous leading fragment."},
                         "slug": {"type": "string"},
-                        "track": {"type": "string"}
+                        "track": {"type": "string"},
+                        "writer": {"type": "boolean", "description": "Explicit capability update. False persists read-only; true requests writer ownership. Omit to preserve existing behavior."}
                     }
                 }),
             },
@@ -3175,6 +3178,9 @@ impl AssistantMcp {
             .filter(|t| !t.is_empty())
         {
             body.insert("track".to_string(), json!(track));
+        }
+        if let Some(writer) = params.writer {
+            body.insert("writer".to_string(), json!(writer));
         }
         let response = self
             .api_post(
@@ -4822,6 +4828,35 @@ mod tests {
             state,
             task,
         )
+    }
+
+    #[tokio::test]
+    async fn link_project_transports_explicit_reader_and_preserves_omission() {
+        let id = Uuid::new_v4().to_string();
+        let (mcp, state, server) = mock_assistant(json!({"id": id}), false).await;
+        let tool = AssistantMcp::tools()
+            .into_iter()
+            .find(|tool| tool.name == "link_mission_to_project")
+            .unwrap();
+        assert_eq!(tool.input_schema["properties"]["writer"]["type"], "boolean");
+        for writer in [None, Some(false), Some(true)] {
+            let mut input = json!({"mission_id":id,"slug":"lido","track":"review"});
+            if let Some(writer) = writer {
+                input["writer"] = json!(writer);
+            }
+            let params = parse_params::<LinkMissionToProjectParams>(input).unwrap();
+            mcp.link_mission_to_project(params).await.unwrap();
+            let requests = state.requests.lock().unwrap();
+            let (path, body) = requests.last().unwrap();
+            assert_eq!(path, &format!("/api/control/missions/{id}/project"));
+            assert_eq!(body["project"], "lido");
+            assert_eq!(body["track"], "review");
+            assert_eq!(
+                body.get("writer"),
+                writer.map(|value| json!(value)).as_ref()
+            );
+        }
+        server.abort();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Ordinary messages could restart an idle mission without identifying the accepted continuation, leaving Hermes unable to track its next result. The existing admission acknowledgment now carries the genuine terminal predecessor captured under the dispatch lock before delivery, only for accepted idle wakes. Active steering, rejected messages and old unbound runs do not claim a new execution. The HTTP/MCP reply includes explicit mission identity and acceptance while preserving the historical message `id` and `queued` fields.

The same batch fixes an independently reproduced admission stall: explicit `writer=false` and `writer=true` are now persisted without requiring PR metadata, so queued work cannot gain or lose writer authority from prompt wording. The existing project-link MCP tool forwards optional `writer`, and mission health reports the specific pending `queued_assignment_unowned` failure instead of saying healthy. Active missions are excluded from that diagnostic.

Validation targets at frozen `91c01281`: actual HTTP admission across accepted delivered/queued wakes, busy steering, live prior lease, rejected/dropped sends, and a successor finishing before acknowledgment; MCP response preservation; HTTP create-to-dequeue preservation of both explicit roles; role transport and narrow health regressions. Independent source review is clean. Author cached Rust compilation passed. Its first regression run caught a fixture setup error (acquiring a lease before activation), corrected in the final test-only commit; root Linux tests/all-four-binary build will verify that final source before merge/deployment acceptance.

Companion Hermes PR: https://github.com/Th0rgal/hermes-agent/pull/135. No new controller, routing store, mission mutation, or deployment is introduced by this PR.
